### PR TITLE
dependabot: create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "**/*" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "**/*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR creates a dependabot configuration to open PRs for rust crates/go modules for packages that contain security vulnerabilities/need to be updated. This runs weekly.