### PR TITLE
actions: add missing go.{mod,sum} path

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "controlplane/**"
       - "smartcontract/sdk/go/**"
+      - "go.mod"
+      - "go.sum"
     branches: [ main ]
 
 permissions:


### PR DESCRIPTION
I missed the paths to the root go.mod/go.sum files in the repo so github actions run on dependency changes. This is needed so tests run when dependabot opens PRs for potential package upgrades.