### PR TITLE
dependabot: use directories keyword

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "**/*" # Location of package manifests
+    directories: "**/*" # Location of package manifests
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo"
-    directory: "**/*"
+    directories: "**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The `directory` keyword doesn't support a glob pattern so `directories` is needed. Also, apparently there's no way to validate a dependabot config until it's landed onto the main branch per:

https://github.com/dependabot/dependabot-core/issues/4605