### PR TITLE
client: pass config file to goreleaser in action

### DIFF
--- a/.github/workflows/release.client.yml
+++ b/.github/workflows/release.client.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.24.x
       - name: install rust for cli
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: install dependencies for rpm packaging
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          args: release --clean
+          args: release -f .goreleaser.client.yaml --clean
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.client.yaml
+++ b/.goreleaser.client.yaml
@@ -3,6 +3,8 @@
 
 version: 2
 
+project_name: doublezero
+
 monorepo:
   tag_prefix: client/
   dir: client/


### PR DESCRIPTION
When doublezero client was migrated over to this repo, the goreleaser file was renamed from `.goreleaser.yaml` to fit the `goreleaser.{component}.yaml` scheme. Unfortunately, in the github action, we weren't explicitly passing the config file by name, which would cause the build job to fail.