### PR TITLE
dependabot: add json schema for local validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directories: "**/*" # Location of package manifests
+    directories: 
+    - "**/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo"
-    directories: "**/*"
+    directories:
+    - "**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This adds the json schema for dependabot configuration so one can validate configuration locally.