### PR TITLE
fix status error

### DIFF
--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -21,8 +21,12 @@ impl StatusArgs {
         match controller.status().await {
             Ok(status) => {
                 println!(
-                    "Tunnel name: {}\nTunnel src: {}\nTunnel dst: {}\nDoublezero IP: {}",
-                    status.tunnel_name, status.tunnel_src, status.tunnel_dst, status.doublezero_ip
+                    "Tunnel status: {}\nName: {}\nTunnel src: {}\nTunnel dst: {}\nDoublezero IP: {}",
+                    status.status, 
+                    status.tunnel_name.unwrap_or_default(), 
+                    status.tunnel_src.unwrap_or_default(), 
+                    status.tunnel_dst.unwrap_or_default(), 
+                    status.doublezero_ip.unwrap_or_default()
                 );
             }
             Err(e) => {

--- a/smartcontract/sdk/rs/src/servicecontroller.rs
+++ b/smartcontract/sdk/rs/src/servicecontroller.rs
@@ -60,10 +60,11 @@ pub struct RemoveResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct StatusResponse {
-    pub tunnel_name: String,
-    pub tunnel_src: String,
-    pub tunnel_dst: String,
-    pub doublezero_ip: String,
+    pub status: String,
+    pub tunnel_name: Option<String>,
+    pub tunnel_src: Option<String>,
+    pub tunnel_dst: Option<String>,
+    pub doublezero_ip: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
When the service is not connected, the `status` command returns an error because it expects the other arguments. They have been modified to be optional.