### PR TITLE
telemetry: add initial clickhouse schema

### DIFF
--- a/.github/workflows/flow_schema_migrations.yml
+++ b/.github/workflows/flow_schema_migrations.yml
@@ -1,0 +1,60 @@
+name: flow pipeline schema migrations
+on:
+  push:
+    paths:
+      - "telemetry/enricher/clickhouse/**"
+    branches: [ main ]
+  pull_request:
+    paths:
+      - "telemetry/enricher/clickhouse/**"
+    branches: [ main ]
+
+jobs:
+  validate:
+    name: schema:validate
+    runs-on: ubuntu-24.04-16c-64gb
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - name: install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+      - name: validate
+        working-directory: "telemetry/enricher/clickhouse/"
+        run: goose validate
+  status:
+    name: schema:status
+    runs-on: ubuntu-24.04-16c-64gb
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - name: install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+      - name: status
+        working-directory: "telemetry/enricher/clickhouse/"
+        run: goose status
+        env:
+          GOOSE_DRIVER: "clickhouse"
+          GOOSE_DBSTRING: ${{ secrets.GOOSE_DBSTRING }}
+  migrate:
+    name: schema:migrate
+    needs: [ validate, status ]
+    runs-on: ubuntu-24.04-16c-64gb
+    environment: testnet
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - name: install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+      - name: migrate
+        working-directory: "telemetry/enricher/clickhouse/"
+        run: goose up
+        env:
+          GOOSE_DRIVER: "clickhouse"
+          GOOSE_DBSTRING: ${{ secrets.GOOSE_DBSTRING }}

--- a/telemetry/enricher/clickhouse/20250303200212_flows_init.sql
+++ b/telemetry/enricher/clickhouse/20250303200212_flows_init.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS default.flows
+(
+    `as_path` Array(String),
+    `bgp_communities` Array(String),
+    `bgp_next_hop` String,
+    `bytes` Int64,
+    `dst_addr` String,
+    `dst_as` Int64,
+    `dst_mac` String,
+    `dst_net` String,
+    `dst_port` Int64,
+    `dst_vlan` Int64,
+    `etype` String,
+    `forwarding_status` Int64,
+    `fragment_id` Int64,
+    `fragment_offset` Int64,
+    `icmp_code` Int64,
+    `icmp_type` Int64,
+    `in_if` Int64,
+    `in_ifname` String,
+    `ip_flags` Int64,
+    `ip_tos` Int64,
+    `ip_ttl` Int64,
+    `ipv6_flow_label` Int64,
+    `ipv6_routing_header_addresses` Array(String),
+    `ipv6_routing_header_seg_left` Int64,
+    `layer_size` Array(Int64),
+    `layer_stack` Array(String),
+    `mpls_ip` Array(String),
+    `mpls_label` Array(String),
+    `mpls_ttl` Array(String),
+    `next_hop` String,
+    `next_hop_as` Int64,
+    `observation_domain_id` Int64,
+    `observation_point_id` Int64,
+    `out_if` Int64,
+    `out_ifname` String,
+    `packets` Int64,
+    `proto` String,
+    `sampler_address` String,
+    `sampling_rate` Int64,
+    `sequence_num` Int64,
+    `src_addr` String,
+    `src_as` Int64,
+    `src_mac` String,
+    `src_net` String,
+    `src_port` Int64,
+    `src_vlan` Int64,
+    `tcp_flags` Int64,
+    `time_flow_end_ns` DateTime64(9),
+    `time_flow_start_ns` DateTime64(9),
+    `time_received_ns` DateTime64(9),
+    `type` String,
+    `vlan_id` Int64,
+    `_key` String,
+    `_timestamp` DateTime64(3),
+    `_partition` Int32,
+    `_offset` Int64,
+    `_topic` String,
+    `_header_keys` Array(String),
+    `_header_values` Array(String)
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+PARTITION BY toYYYYMM(time_received_ns)
+ORDER BY (time_received_ns, sampler_address, etype, proto, in_ifname, out_ifname, src_as, dst_as, sampling_rate)
+TTL toDateTime(time_received_ns) + toIntervalMonth(1)
+SETTINGS index_granularity = 8192;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE default.flows;
+-- +goose StatementEnd


### PR DESCRIPTION
This PR adds an initial clickhouse schema to be used to ingest flow data from doublezero devices. A github action has also been created to handle schema migrations once approved. The migration job will only run once merged onto main.