### PR TITLE
Removing Colors from Logs for Better Compatibility

### DIFF
--- a/activator/Cargo.lock
+++ b/activator/Cargo.lock
@@ -3828,9 +3828,9 @@ checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -3846,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3857,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use colored::Colorize;
 
 use double_zero_sdk::*;
 use solana_sdk::pubkey::Pubkey;
@@ -51,7 +50,7 @@ impl Activator {
     }
 
     pub async fn init(&mut self) -> eyre::Result<()> {
-        print!("Connected to url: {} ws: {} program_id: {} ", self.client.get_rpc().green(), self.client.get_ws().green(), self.client.get_program_id().to_string().green());
+        print!("Connected to url: {} ws: {} program_id: {} ", self.client.get_rpc(), self.client.get_ws(), self.client.get_program_id().to_string());
 
         // Fetch the list of tunnels, devices, and users from the client
         let devices = self.client.get_devices()?;
@@ -83,7 +82,7 @@ impl Activator {
                 self.user_tunnel_ips.assign_block(user.tunnel_net);
             });
 
-        println!("devices: {} tunnels: {} users: {}", devices.len().to_string().green(), tunnels.len().to_string().green(), users.len().to_string().green());
+        println!("devices: {} tunnels: {} users: {}", devices.len().to_string(), tunnels.len().to_string(), users.len().to_string());
 
         Ok(())
     }
@@ -97,20 +96,20 @@ impl Activator {
     pub fn run(&mut self) -> eyre::Result<()> {
         self.devices.iter().for_each(|(_pubkey,device)| {
 
-            print!("Device code: {} public_ip: {} dz_prefix: {} tunnels: ", device.device.code.green(), ipv4_to_string(&device.device.public_ip).green(), networkv4_to_string(&device.device.dz_prefix).green());            
+            print!("Device code: {} public_ip: {} dz_prefix: {} tunnels: ", device.device.code, ipv4_to_string(&device.device.public_ip), networkv4_to_string(&device.device.dz_prefix));            
             
             if device.tunnel_ids.assigned.len() == 0 {
-                print!("{},", "-".green());
+                print!("{},", "-");
             }            
             device.tunnel_ids.assigned.iter().for_each(|tunnel_id| {
-                print!("{},", tunnel_id.to_string().green());
+                print!("{},", tunnel_id.to_string());
             });
             println!("\x08 ");
         });
 
-        print!("tunnel_net: {} assigned: ", self.user_tunnel_ips.base_block.to_string().green());
+        print!("tunnel_net: {} assigned: ", self.user_tunnel_ips.base_block.to_string());
         if self.user_tunnel_ips.assigned_ips.len() == 0 {
-            print!("{},", "-".green());
+            print!("{},", "-");
         }
         self.user_tunnel_ips.print_assigned_ips();
         println!("\x08 ");
@@ -125,31 +124,31 @@ impl Activator {
                         // Device Event
                         match device.status {
                             DeviceStatus::Pending => {
-                                print!("New Device [{}] ", device.code);
+                                print!("New Device {} ", device.code);
                                 match client.activate_device(device.index) {
                                     Ok(signature) => {
-                                        println!("Activated {}", signature.to_string().green());
+                                        println!("Activated {}", signature.to_string());
 
-                                        println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code.green(), ipv4_to_string(&device.public_ip).green(), networkv4_to_string(&device.dz_prefix).green());
+                                        println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code, ipv4_to_string(&device.public_ip), networkv4_to_string(&device.dz_prefix));
                                         self.devices.insert(*pubkey, DeviceState::new(device));
                             
                                     },
-                                    Err(e) => println!("Error: {}", e.to_string().red()),
+                                    Err(e) => println!("Error: {}", e.to_string()),
                                 }
                             }
                             DeviceStatus::Activated => {
                                 if !self.devices.contains_key(pubkey) {
-                                    println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code.green(), ipv4_to_string(&device.public_ip).green(), networkv4_to_string(&device.dz_prefix).green());
+                                    println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code, ipv4_to_string(&device.public_ip), networkv4_to_string(&device.dz_prefix));
 
                                     self.devices
                                         .insert(*pubkey, DeviceState::new(device));
                                 }
                             }
                             DeviceStatus::Deleting => {
-                                print!("Deleting Device {} ", device.code.green());
+                                print!("Deleting Device {} ", device.code);
                                 match client.deactivate_device(device.index, device.owner) {
                                     Ok(signature) => {
-                                        println!("Deactivated {}", signature.to_string().green());
+                                        println!("Deactivated {}", signature.to_string());
                                         self.devices.remove(pubkey);
                                     },
                                     Err(e) => println!("Error: {}", e),
@@ -161,11 +160,10 @@ impl Activator {
                     /**********************************************************************************************************************/
                     // TUNNEL
                     /**********************************************************************************************************************/
-                    
                     AccountData::Tunnel(tunnel) => {
                         match tunnel.status {
                             TunnelStatus::Pending => {
-                                print!("New Tunnel {} ", tunnel.code.green());
+                                print!("New Tunnel {} ", tunnel.code);
     
                                 match self
                                     .tunnel_tunnel_ips
@@ -178,38 +176,37 @@ impl Activator {
                                             tunnel_id,
                                             tunnel_net,
                                         ) {
-                                            Ok(signature) => println!("Activated {}", signature.to_string().green()),
-                                            Err(e) => println!("Error: activate_tunnel: {}", e.to_string().red()),
+                                            Ok(signature) => println!("Activated {}", signature.to_string()),
+                                            Err(e) => println!("Error: activate_tunnel: {}", e.to_string()),
                                         }
             
                                     },
                                     None => { 
-                                        println!("{}", "Error: No available tunnel block".red());
+                                        println!("{}", "Error: No available tunnel block");
 
                                         match self.client.reject_tunnel(
                                             tunnel.index, "Error: No available tunnel block".to_string()
                                         ) {
-                                            Ok(signature) => println!("Rejected {}", signature.to_string().red()),
-                                            Err(e) => println!("Error: reject_tunnel: {}", e.to_string().red()),
+                                            Ok(signature) => println!("Rejected {}", signature.to_string()),
+                                            Err(e) => println!("Error: reject_tunnel: {}", e.to_string()),
                                         }
                                 },
                                 }                            
                             },
                             TunnelStatus::Deleting => {
-                                print!("Deleting Tunnel {} ", tunnel.code.green());
+                                print!("Deleting Tunnel {} ", tunnel.code);
 
                                 self.tunnel_tunnel_ids.unassign(tunnel.tunnel_id);
                                 self.tunnel_tunnel_ips.unassign_block(tunnel.tunnel_net);
     
                                 match client.deactivate_tunnel(tunnel.index, tunnel.owner) {
-                                    Ok(signature) => println!("Deactivated {}", signature.to_string().green()),
-                                    Err(e) => println!("{}: {}", "Error: deactivate_tunnel:".red(), e.to_string().red()),
+                                    Ok(signature) => println!("Deactivated {}", signature.to_string()),
+                                    Err(e) => println!("{}: {}", "Error: deactivate_tunnel:", e.to_string()),
                                 }
                             },
                             _ => {}
                         }
                     }
-                    
                     /**********************************************************************************************************************/
                     // USER
                     /**********************************************************************************************************************/
@@ -218,36 +215,36 @@ impl Activator {
                         match user.status {
                             // Create User
                             UserStatus::Pending => {
-                                print!("Activating User   {} ", ipv4_to_string(&user.client_ip).green());
+                                print!("Activating User   {} ", ipv4_to_string(&user.client_ip));
                                 // Load Device if not exists
                                 if !self.devices.contains_key(&user.device_pk) {
                                     match client.get_device(&user.device_pk) {
                                         Ok(device) => {
-                                            println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code.green(), ipv4_to_string(&device.public_ip).green(), networkv4_to_string(&device.dz_prefix).green());
+                                            println!("Add Device: {} public_ip: {} dz_prefix: {} ", device.code, ipv4_to_string(&device.public_ip), networkv4_to_string(&device.dz_prefix));
 
                                             self.devices
                                                 .insert(*pubkey, DeviceState::new(&device));
                                             }
                                         Err(e) => {
-                                            println!("Error: {}", e.to_string().red());
+                                            println!("Error: {}", e.to_string());
                                         }
                                     }
                                 }
 
                                 match self.devices.get_mut(&user.device_pk) {
                                     Some(device_state) => {
-                                        print!("for {} ", device_state.device.code.green());
+                                        print!("for {} ", device_state.device.code);
 
                                         match self
                                             .user_tunnel_ips
                                             .next_available_block(0, 2) {
                                                 Some(tunnel_net) => {
         
-                                                    print!("tunnel_net: {} ", networkv4_to_string(&tunnel_net).green());
+                                                    print!("tunnel_net: {} ", networkv4_to_string(&tunnel_net));
                                                     match device_state.get_next() {
                                                         Some((tunnel_id, dz_ip)) => {
         
-                                                            print!("tunnel_id: {} tunnel_id: {} ", tunnel_id.to_string().green(), ipv4_to_string(&dz_ip).green());
+                                                            print!("tunnel_id: {} tunnel_id: {} ", tunnel_id.to_string(), ipv4_to_string(&dz_ip));
         
                                                             match client.activate_user(
                                                                 user.index,
@@ -255,54 +252,54 @@ impl Activator {
                                                                 tunnel_net,
                                                                 dz_ip,
                                                             ) {
-                                                                Ok(signature) => println!("Activated   {}", signature.to_string().green()),
-                                                                Err(e) => println!("Error: {}", e.to_string().red()),
+                                                                Ok(signature) => println!("Activated   {}", signature.to_string()),
+                                                                Err(e) => println!("Error: {}", e.to_string()),
                                                             }        
                                                         },
                                                         None => {
-                                                            eprintln!("{}", "Error: No available tunnel block".red());
+                                                            eprintln!("{}", "Error: No available tunnel block");
         
                                                             match client.reject_user(
                                                                 user.index,
                                                                 "Error: No available tunnel block".to_string()) {
-                                                                Ok(signature) => println!("Rejected {}", signature.to_string().green()),
-                                                                Err(e) => println!("Error: {}", e.to_string().red()),
+                                                                Ok(signature) => println!("Rejected {}", signature.to_string()),
+                                                                Err(e) => println!("Error: {}", e.to_string()),
                                                             }        
                                                         }
                                                     }                                     
                         
                                                 }, 
                                                 None => { 
-                                                    println!("{}", "Error: No available user block".red());
+                                                    println!("{}", "Error: No available user block");
         
                                                 match client.reject_user(
                                                     user.index,
                                                     "Error: No available user block".to_string()) {
-                                                    Ok(signature) => println!("Rejected {}", signature.to_string().green()),
-                                                    Err(e) => println!("Error: {}", e.to_string().red()),
+                                                    Ok(signature) => println!("Rejected {}", signature.to_string()),
+                                                    Err(e) => println!("Error: {}", e.to_string()),
                                                 }                                            
                                             }
                                         }                                                
                                     },
                                     None => {
-                                        eprintln!("Error: Device not found {}", user.device_pk.to_string().red());
+                                        eprintln!("Error: Device not found {}", user.device_pk.to_string());
                                         match client.reject_user(
                                             user.index,
                                             "Error: Device not found".to_string()) {
-                                            Ok(signature) => println!("Rejected {}", signature.to_string().green()),
-                                            Err(e) => println!("Error: {}", e.to_string().red()),
+                                            Ok(signature) => println!("Rejected {}", signature.to_string()),
+                                            Err(e) => println!("Error: {}", e.to_string()),
                                         }                                        
                                     }
                                 }                                                            
                             },
                             // Delete User
                             UserStatus::Deleting | UserStatus::PendingBan => {
-                                print!("Deactivating User {} ", ipv4_to_string(&user.client_ip).green());
+                                print!("Deactivating User {} ", ipv4_to_string(&user.client_ip));
 
                                 if let Some(device_state) = self.devices.get_mut(&user.device_pk) {
-                                    print!("for {} ", device_state.device.code.green());
+                                    print!("for {} ", device_state.device.code);
 
-                                    print!("tunnel_net: {} tunnel_id: {} tunnel_id: {} ", networkv4_to_string(&user.tunnel_net).green(), user.tunnel_id.to_string().green(), ipv4_to_string(&user.dz_ip).green());
+                                    print!("tunnel_net: {} tunnel_id: {} tunnel_id: {} ", networkv4_to_string(&user.tunnel_net), user.tunnel_id.to_string(), ipv4_to_string(&user.dz_ip));
 
                                     if user.tunnel_id != 0 {
                                         self.tunnel_tunnel_ids.unassign(user.tunnel_id);
@@ -316,13 +313,13 @@ impl Activator {
 
                                     if user.status == UserStatus::Deleting {
                                         match client.deactivate_user(user.index, user.owner) {
-                                            Ok(signature) => println!("Deactivated {}", signature.to_string().green()),
-                                            Err(e) => println!("Error: {}", e.to_string().red()),
+                                            Ok(signature) => println!("Deactivated {}", signature.to_string()),
+                                            Err(e) => println!("Error: {}", e.to_string()),
                                         }
                                     } else if user.status == UserStatus::PendingBan {
                                         match client.ban_user(user.index) {
-                                            Ok(signature) => println!("Banned {}", signature.to_string().green()),
-                                            Err(e) => println!("Error: {}", e.to_string().red()),
+                                            Ok(signature) => println!("Banned {}", signature.to_string()),
+                                            Err(e) => println!("Error: {}", e.to_string()),
                                         }
                                     }
                                 }

--- a/activator/src/ipblockallocator.rs
+++ b/activator/src/ipblockallocator.rs
@@ -1,5 +1,4 @@
 use bitvec::prelude::*;
-use colored::Colorize;
 use double_zero_sdk::{networkv4_to_ipnetwork, NetworkV4};
 use ipnetwork::Ipv4Network;
 
@@ -36,7 +35,7 @@ impl IPBlockAllocator {
                 }
             }
             Err(e) => {
-                print!(" {} ", e.red());
+                print!(" {} ", e);
             }
         }
     }
@@ -54,7 +53,7 @@ impl IPBlockAllocator {
                 }
             }
             Err(e) => {
-                print!(" {} ", e.red());
+                print!(" {} ", e);
             }
         }
     }
@@ -94,7 +93,7 @@ impl IPBlockAllocator {
         for (index, assigned) in self.assigned_ips.iter().enumerate() {
             if *assigned {
                 let ip = self.index_to_ip(index);
-                print!("{},", ip.to_string().green());
+                print!("{},", ip.to_string());
             }
         }
     }


### PR DESCRIPTION
Colors are removed from the log because they do not display properly in the service. This happens because the colors are not standard ANSI characters, which can cause formatting issues in the logs.