### PR TITLE
telemetry: add option for redpanda tls

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - "controlplane/**"
+      - "telemetry/**"
       - "smartcontract/sdk/go/**"
       - "go.mod"
       - "go.sum"
@@ -10,6 +11,7 @@ on:
   pull_request:
     paths:
       - "controlplane/**"
+      - "telemetry/**"
       - "smartcontract/sdk/go/**"
       - "go.mod"
       - "go.sum"

--- a/telemetry/enricher/internal/enricher/enricher_test.go
+++ b/telemetry/enricher/internal/enricher/enricher_test.go
@@ -172,6 +172,7 @@ func TestFlowEnrichment(t *testing.T) {
 		WithClickhouseCreds(chUser, chPassword),
 		WithClickhouseTLSEnabled(false),
 		WithRedpandaBroker(rpBroker),
+		WithRedpandaTLSEnabled(false),
 		WithRedpandaCreds(rpUser, rpPassword),
 		WithRedpandaConsumerTopic(rpTopicRaw),
 		WithRedpandaConsumerGroup(rpConsumerGroup),

--- a/telemetry/enricher/internal/enricher/fixtures/enriched_flow.json
+++ b/telemetry/enricher/internal/enricher/fixtures/enriched_flow.json
@@ -61,6 +61,6 @@
     ],
     "ipv6_routing_header_addresses": [],
     "ipv6_routing_header_seg_left": 0,
-    "in_interface": "Switch1/1/2",
-    "out_interface": "Switch1/1/1"
+    "in_ifname": "Switch1/1/2",
+    "out_ifname": "Switch1/1/1"
 }

--- a/telemetry/enricher/internal/enricher/flow.go
+++ b/telemetry/enricher/internal/enricher/flow.go
@@ -124,6 +124,6 @@ type FlowSample struct {
 
 	// New enriched fields should be inserted below this comment.
 	// Fields above are the default fields sent via Goflow.
-	InputInterface  string `json:"in_interface"`
-	OutputInterface string `json:"out_interface"`
+	InputInterface  string `json:"in_ifname"`
+	OutputInterface string `json:"out_ifname"`
 }

--- a/telemetry/enricher/internal/enricher/ifindex.go
+++ b/telemetry/enricher/internal/enricher/ifindex.go
@@ -68,7 +68,6 @@ func (i *IfNameAnnotator) Init(ctx context.Context, sql *sql.DB) error {
 	if err := i.populateCache(ctx); err != nil {
 		return fmt.Errorf("error populating initial ifname cache: %v", err)
 	}
-	log.Printf("cache: %v", i.cache)
 	go func() {
 		ticker := time.NewTicker(1 * time.Minute)
 		for {
@@ -105,7 +104,6 @@ func (i *IfNameAnnotator) Annotate(flow *FlowSample) error {
 
 	if flow.InputIfIndex != 0 {
 		flow.InputInterface = annotate(flow.SamplerAddress.String(), flow.InputIfIndex)
-		log.Printf("input: %s", flow.InputInterface)
 	}
 
 	if flow.OutputIfIndex != 0 {


### PR DESCRIPTION
Redpanda cloud requires TLS to be enabled on the client side. This PR adds an option flag to do so.

This also modifies the {in|out}_interface fields to {in|out}_ifname. 