### PR TITLE
telemetry: add prom metrics to enricher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/twmb/franz-go v1.18.1 // indirect
 	github.com/twmb/franz-go/pkg/kadm v1.15.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
+	github.com/twmb/franz-go/plugin/kprom v1.1.0 // indirect
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/twmb/franz-go/pkg/kadm v1.15.0 h1:Yo3NAPfcsx3Gg9/hdhq4vmwO77TqRRkvpUc
 github.com/twmb/franz-go/pkg/kadm v1.15.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
+github.com/twmb/franz-go/plugin/kprom v1.1.0 h1:grGeIJbm4llUBF8jkDjTb/b8rKllWSXjMwIqeCCcNYQ=
+github.com/twmb/franz-go/plugin/kprom v1.1.0/go.mod h1:cTDrPMSkyrO99LyGx3AtiwF9W6+THHjZrkDE2+TEBIU=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec h1:DGmKwyZwEB8dI7tbLt/I/gQuP559o/0FrAkHKlQM/Ks=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec/go.mod h1:owBmyHYMLkxyrugmfwE/DLJyW8Ro9mkphwuVErQ0iUw=
 github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQdrZk=

--- a/telemetry/enricher/cmd/enricher/main.go
+++ b/telemetry/enricher/cmd/enricher/main.go
@@ -52,6 +52,7 @@ func main() {
 		enricher.WithRedpandaConsumerTopic(*redpandaTopicRaw),
 		enricher.WithRedpandaConsumerGroup(*redpandaConsumerGroup),
 		enricher.WithRedpandaProducerTopic(*redpandaTopicEnriched),
+		enricher.WithRedpandaMetrics(true),
 	}
 	enricher := enricher.NewEnricher(opts...)
 	if err := enricher.Run(ctx); err != nil {


### PR DESCRIPTION
This adds some basic prometheus metrics to the flow enrichment service. Example metrics:
```
# HELP kgo_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
# TYPE kgo_buffered_fetch_records_total gauge
kgo_buffered_fetch_records_total 0
# HELP kgo_buffered_produce_records_total Total number of records buffered within the client ready to be produced
# TYPE kgo_buffered_produce_records_total gauge
kgo_buffered_produce_records_total 0
# HELP kgo_connects_total Total number of connections opened
# TYPE kgo_connects_total counter
kgo_connects_total{node_id="4"} 2
kgo_connects_total{node_id="5"} 2
kgo_connects_total{node_id="seed_0"} 1
# HELP kgo_disconnects_total Total number of connections closed
# TYPE kgo_disconnects_total counter
kgo_disconnects_total{node_id="4"} 1
kgo_disconnects_total{node_id="5"} 1
kgo_disconnects_total{node_id="seed_0"} 1
# HELP kgo_read_bytes_total Total number of bytes read
# TYPE kgo_read_bytes_total counter
kgo_read_bytes_total{node_id="4"} 2798
kgo_read_bytes_total{node_id="5"} 2356
kgo_read_bytes_total{node_id="seed_0"} 947
# HELP kgo_write_bytes_total Total number of bytes written
# TYPE kgo_write_bytes_total counter
kgo_write_bytes_total{node_id="4"} 3013
kgo_write_bytes_total{node_id="5"} 4382
kgo_write_bytes_total{node_id="seed_0"} 307
```