### PR TITLE
client: allow configuration of solana rpc endpoint

### DIFF
--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -18,6 +18,7 @@ var (
 	enableLatencyProbing = flag.Bool("latency-probing", true, "enable latency probing to doublezero nodes")
 	versionFlag          = flag.Bool("version", false, "build version")
 	programId            = flag.String("program-id", "", "override smartcontract program id to monitor")
+	rpcEndpoint          = flag.String("solana-rpc-endpoint", "", "override solana rpc endpoint url")
 
 	commit  = ""
 	version = ""
@@ -45,7 +46,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := runtime.Run(ctx, *sockFile, *enableLatencyProbing, *programId); err != nil {
+	if err := runtime.Run(ctx, *sockFile, *enableLatencyProbing, *programId, *rpcEndpoint); err != nil {
 		log.Fatalf("runtime error: %v", err)
 	}
 }

--- a/client/doublezerod/internal/latency/manager.go
+++ b/client/doublezerod/internal/latency/manager.go
@@ -47,7 +47,7 @@ func UdpPing(ctx context.Context, d dzsdk.Device) LatencyResult {
 	return results
 }
 
-type SmartContractorFunc func(context.Context, string) (*ContractData, error)
+type SmartContractorFunc func(context.Context, string, string) (*ContractData, error)
 
 type DeviceCache struct {
 	Devices []dzsdk.Device
@@ -103,14 +103,14 @@ func NewLatencyManager(s SmartContractorFunc, p ProberFunc) *LatencyManager {
 	}
 }
 
-func (l *LatencyManager) Start(ctx context.Context, programId string) error {
+func (l *LatencyManager) Start(ctx context.Context, programId string, rpcEndpoint string) error {
 
 	// start goroutine for fetching smartcontract devices
 	go func() {
 		fetch := func() {
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			contractData, err := l.SmartContractFunc(ctx, programId)
+			contractData, err := l.SmartContractFunc(ctx, programId, rpcEndpoint)
 			if err != nil {
 				log.Printf("latency: error fetching smart contract data: %v\n", err)
 				return

--- a/client/doublezerod/internal/latency/manager_test.go
+++ b/client/doublezerod/internal/latency/manager_test.go
@@ -56,7 +56,7 @@ func TestLatencyManager(t *testing.T) {
 	}
 
 	sentContractData := make(chan struct{}, 1)
-	mockSmartContractFunc := func(context.Context, string) (*latency.ContractData, error) {
+	mockSmartContractFunc := func(context.Context, string, string) (*latency.ContractData, error) {
 		sentContractData <- struct{}{}
 		return &latency.ContractData{
 			Devices: []dzsdk.Device{
@@ -91,7 +91,7 @@ func TestLatencyManager(t *testing.T) {
 
 	go func() {
 		programId := "9i7v8m3i7W2qPGRonFi8mehN76SXUkDcpgk4tPQhEabc"
-		if err := manager.Start(ctx, programId); err != nil {
+		if err := manager.Start(ctx, programId, ""); err != nil {
 			log.Fatalf("error: %v", err)
 		}
 	}()
@@ -193,7 +193,7 @@ func TestLatencyManager(t *testing.T) {
 }
 
 func TestLatencyUdpPing(t *testing.T) {
-	mockSmartContractFunc := func(context.Context, string) (*latency.ContractData, error) {
+	mockSmartContractFunc := func(context.Context, string, string) (*latency.ContractData, error) {
 		return &latency.ContractData{
 			Devices: []dzsdk.Device{
 				{
@@ -233,7 +233,7 @@ func TestLatencyUdpPing(t *testing.T) {
 	defer cancel()
 	go func() {
 		programId := "9i7v8m3i7W2qPGRonFi8mehN76SXUkDcpgk4tPQhEabc"
-		if err := manager.Start(ctx, programId); err != nil {
+		if err := manager.Start(ctx, programId, ""); err != nil {
 			log.Fatalf("error: %v", err)
 		}
 	}()

--- a/client/doublezerod/internal/latency/smartcontract.go
+++ b/client/doublezerod/internal/latency/smartcontract.go
@@ -16,12 +16,15 @@ type ContractData struct {
 	Users     []dzsdk.User
 }
 
-func FetchContractData(ctx context.Context, programId string) (*ContractData, error) {
+func FetchContractData(ctx context.Context, programId string, rpcEndpoint string) (*ContractData, error) {
+	if rpcEndpoint == "" {
+		rpcEndpoint = rpc.DevNet_RPC
+	}
 	options := []dzsdk.Option{}
 	if programId != "" {
 		options = append(options, dzsdk.WithProgramId(programId))
 	}
-	client := dzsdk.New(rpc.DevNet_RPC, options...)
+	client := dzsdk.New(rpcEndpoint, options...)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := client.Load(ctx); err != nil {

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Run(ctx context.Context, sockFile string, enableLatencyProbing bool, programId string) error {
+func Run(ctx context.Context, sockFile string, enableLatencyProbing bool, programId string, rpcEndpoint string) error {
 	nlr := netlink.Netlink{}
 	bgp, err := bgp.NewBgpServer(net.IPv4(1, 1, 1, 1))
 	if err != nil {
@@ -46,7 +46,7 @@ func Run(ctx context.Context, sockFile string, enableLatencyProbing bool, progra
 	if enableLatencyProbing {
 		latency := latency.NewLatencyManager(latency.FetchContractData, latency.UdpPing)
 		go func() {
-			err := latency.Start(ctx, programId)
+			err := latency.Start(ctx, programId, rpcEndpoint)
 			errCh <- err
 		}()
 		mux.HandleFunc("GET /latency", latency.ServeLatency)

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -47,7 +47,7 @@ func TestRun_EndToEnd(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId)
+		err := runtime.Run(ctx, sockFile, false, programId, "")
 		errChan <- err
 	}()
 
@@ -194,7 +194,7 @@ func TestRun_EndToEnd(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId)
+		err := runtime.Run(ctx, sockFile, false, programId, "")
 		errChan <- err
 	}()
 


### PR DESCRIPTION
We currently hardcode the solana rpc endpoint in the client to use devnet. Unfortunately, this makes attempting to use a local validator as part of testing or solana testnet/mainnet problematic. This PR adds a flag to override the solana rpc endpoint.