### PR TITLE
controller: add flag to override solana rpc endpoint

### DIFF
--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -95,7 +95,7 @@ func NewControllerCommand() *ControllerCommand {
 	c.fs.StringVar(&c.listenAddr, "listen-addr", "localhost", "listening address for controller grpc server")
 	c.fs.StringVar(&c.listenPort, "listen-port", "443", "listening port for controller grpc server")
 	c.fs.StringVar(&c.programId, "program-id", "", "smartcontract program id to monitor")
-
+	c.fs.StringVar(&c.rpcEndpoint, "solana-rpc-endpoint", "", "override solana rpc endpoint (default: devnet)")
 	return c
 }
 
@@ -105,6 +105,7 @@ type ControllerCommand struct {
 	listenAddr  string
 	listenPort  string
 	programId   string
+	rpcEndpoint string
 }
 
 func (c *ControllerCommand) Fs() *flag.FlagSet {
@@ -131,6 +132,10 @@ func (c *ControllerCommand) Run() error {
 	options := []controller.Option{}
 	if c.programId != "" {
 		options = append(options, controller.WithProgramId(c.programId))
+	}
+
+	if c.rpcEndpoint != "" {
+		options = append(options, controller.WithRpcEndpoint(c.rpcEndpoint))
 	}
 
 	lis, err := net.Listen("tcp", net.JoinHostPort(c.listenAddr, c.listenPort))

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -34,9 +34,10 @@ type Controller struct {
 	cache deviceCache
 	mu    sync.RWMutex
 	accountFetcher
-	listener   net.Listener
-	programId  string
-	updateDone chan struct{}
+	listener    net.Listener
+	programId   string
+	rpcEndpoint string
+	updateDone  chan struct{}
 }
 
 type Option func(*Controller)
@@ -66,7 +67,10 @@ func NewController(options ...Option) (*Controller, error) {
 			log.Printf("starting with smartcontract program id %s", controller.programId)
 			options = append(options, dzsdk.WithProgramId(controller.programId))
 		}
-		controller.accountFetcher = dzsdk.New(rpc.DevNet_RPC, options...)
+		if controller.rpcEndpoint == "" {
+			controller.rpcEndpoint = rpc.DevNet_RPC
+		}
+		controller.accountFetcher = dzsdk.New(controller.rpcEndpoint, options...)
 	}
 	return controller, nil
 }
@@ -80,6 +84,12 @@ func WithAccountFetcher(f accountFetcher) Option {
 func WithProgramId(programId string) Option {
 	return func(c *Controller) {
 		c.programId = programId
+	}
+}
+
+func WithRpcEndpoint(rpcEndpoint string) Option {
+	return func(c *Controller) {
+		c.rpcEndpoint = rpcEndpoint
 	}
 }
 


### PR DESCRIPTION
Similar to https://github.com/malbeclabs/doublezero/pull/80, the controller doesn't expose an option to override the solana RPC endpoint, which makes it problematic for using a local validator as a source for onchain data.