### PR TITLE
tests: only build test image in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,10 +11,6 @@ on:
       - "scripts/**"
     branches: [ main ]
 
-permissions:
-    contents: read
-    checks: write
-
 jobs:
   end-to-end:
     name: "end-to-end"
@@ -22,9 +18,18 @@ jobs:
       run:
         working-directory: "e2e/"
     runs-on: ubuntu-24.04-16c-64gb
+    permissions:
+      packages: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Login to docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build
-        run: make all
+        run: make build
       - name: test
         run: make test


### PR DESCRIPTION
This PR stops building the image used to source solana CLI/tools, prior to building the test image. Instead, this is now sourced from our github package registry which saves ~1m on total test runtime.