### PR TITLE
client: add ip rules with kernel proto

### DIFF
--- a/client/doublezerod/internal/netlink/netlink.go
+++ b/client/doublezerod/internal/netlink/netlink.go
@@ -116,6 +116,9 @@ func (n Netlink) RuleAdd(r *IPRule) error {
 	rule.Table = r.Table
 	rule.Src = r.SrcNet
 	rule.Dst = r.DstNet
+	// we mark these rules as kernel protocol to prevent systemd from purging on networkd restarts
+	// see https://github.com/malbeclabs/doublezero/issues/159
+	rule.Protocol = syscall.RTPROT_KERNEL
 	err := nl.RuleAdd(rule)
 	if err != nil && errors.Is(err, syscall.EEXIST) {
 		return ErrRuleExists
@@ -129,6 +132,9 @@ func (n Netlink) RuleDel(r *IPRule) error {
 	rule.Table = r.Table
 	rule.Src = r.SrcNet
 	rule.Dst = r.DstNet
+	// we mark these rules as kernel protocol to prevent systemd from purging on networkd restarts
+	// see https://github.com/malbeclabs/doublezero/issues/159
+	rule.Protocol = syscall.RTPROT_KERNEL
 	return nl.RuleDel(rule)
 }
 


### PR DESCRIPTION
Per https://github.com/malbeclabs/doublezero/issues/159, if a user restarts networking on their host outside of a reboot, systemd will purge all ip rules not marked as kernel protocol, which then breaks traffic steering into doublezero when networking comes back up on the host. In lieu of building something more complex to periodically audit this during runtime, we should mark our rules as such to prevent breakage.