### PR TITLE
removes unset dz info #110

### DIFF
--- a/activator/build.rs
+++ b/activator/build.rs
@@ -3,20 +3,19 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    // Obtén la versión desde una variable de entorno (o usa un valor predeterminado)
+    // Get the version from an environment variable (or use a default value)
     let version = env::var("VERSION").unwrap_or_else(|_| "unknown".to_string());
-    let commit = env::var("COMMIT").unwrap_or_else(|_| "unknown".to_string());
-    let date = env::var("DATE").unwrap_or_else(|_| "unknown".to_string());
-    let os = env::var("OS").unwrap_or_else(|_| "unknown".to_string());
-    let arch = env::var("ARCH").unwrap_or_else(|_| "unknown".to_string());
 
     // Genera un archivo con una constante para la versión
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("version.rs");
     fs::write(
         dest_path,
-        format!(r#"pub const APP_VERSION: &str = "{}";
-pub const APP_LONG_VERSION: &str = "version: {}\ncommit: {}\ndate: {}\nos: {}\narch: {}";"#, version, version, commit, date, os, arch),
+        format!(
+            r#"pub const APP_VERSION: &str = "{}";
+pub const APP_LONG_VERSION: &str = "version: {}\n";"#,
+            version, version
+        ),
     )
     .unwrap();
 }

--- a/client/doublezero/build.rs
+++ b/client/doublezero/build.rs
@@ -3,20 +3,19 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    // Obtén la versión desde una variable de entorno (o usa un valor predeterminado)
+    // Get the version from an environment variable (or use a default value)
     let version = env::var("CLIENT_VERSION").unwrap_or_else(|_| "unknown".to_string());
-    let commit = env::var("COMMIT").unwrap_or_else(|_| "unknown".to_string());
-    let date = env::var("DATE").unwrap_or_else(|_| "unknown".to_string());
-    let os = env::var("OS").unwrap_or_else(|_| "unknown".to_string());
-    let arch = env::var("ARCH").unwrap_or_else(|_| "unknown".to_string());
 
     // Genera un archivo con una constante para la versión
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("version.rs");
     fs::write(
         dest_path,
-        format!(r#"pub const APP_VERSION: &str = "{}";
-pub const APP_LONG_VERSION: &str = "version: {}\ncommit: {}\ndate: {}\nos: {}\narch: {}";"#, version, version, commit, date, os, arch),
+        format!(
+            r#"pub const APP_VERSION: &str = "{}";
+pub const APP_LONG_VERSION: &str = "version: {}\n";"#,
+            version, version
+        ),
     )
     .unwrap();
 }


### PR DESCRIPTION
## What Changed

This addresses https://github.com/malbeclabs/doublezero/issues/110. 

This removes the unset commit, date, os, and arch keys from the activator and the client. Per @packethog, these params were probably never set and aren't currently relevant.  The rust library, [clap](https://docs.rs/clap/latest/clap/), uses `-V` for `version` because `-v` is typically used for `verbose` so it makes sense to keep that as it is.

## Evidence of Testing 
Original:
```
➜  doublezero git:(main) ./target/debug/doublezero -V
DoubleZero unknown

➜  doublezero git:(main) ./target/debug/doublezero --version
DoubleZero version: unknown
commit: unknown
date: unknown
os: unknown
arch: unknown
```

Updated: 
```
➜  doublezero git:(dz_version_number) ./target/debug/doublezero --version
DoubleZero version: unknown

➜  doublezero git:(dz_version_number) ./target/debug/doublezero -V
DoubleZero unknown

```