### PR TITLE
e2e test

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -11,12 +11,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=solana /usr/local/bin /usr/local/bin
 
 RUN apt update && apt install --no-install-recommends -y \
-ca-certificates \
-curl \
-build-essential \
-pkg-config \
-libudev-dev llvm libclang-dev \
-protobuf-compiler libssl-dev git iproute2 iputils-ping tcpdump
+    ca-certificates \
+    curl \
+    build-essential \
+    pkg-config \
+    libudev-dev llvm libclang-dev \
+    protobuf-compiler libssl-dev git iproute2 iputils-ping tcpdump
 
 # install rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -23,7 +23,7 @@ else
 endif
 
 .PHONY: all
-all:
+all: eos
 ifeq ($(ARCH),arm64)
 	docker build -f Dockerfile.solana.arm64 -t $(TAG_PREFIX)/solana-arm64:latest .
 	docker build --build-arg PLATFORM_ARCH=arm64 -f Dockerfile -t $(TAG_PREFIX)/$(TAG):latest ../.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -321,11 +321,6 @@ func TestIBRLWithAllocatedAddress_Disconnect_Output(t *testing.T) {
 		cmd        []string
 	}{
 		{
-			name:       "doublezero_user_list",
-			goldenFile: "fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.txt",
-			cmd:        []string{"doublezero", "user", "list"},
-		},
-		{
 			name:       "doublezero_status",
 			goldenFile: "fixtures/ibrl_with_allocated_addr/doublezero_status_disconnected.txt",
 			cmd:        []string{"doublezero", "status"},

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.txt
@@ -1,9 +1,9 @@
- pubkey                                       | code      | location | exchange | device_type | public_ip      | dz_prefixes       | status    | owner 
- 8scDVeZ8aB1TRTkBqaZgzxuk7WwpARdF1a39wYA7nR3W | ny5-dz01  | ewr      | xewr     | switch      | 64.86.249.80   | 64.86.249.80/29   | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- 3TD6MDfCo2mVeR9a71ukrdXBYVLyWz5cz8RLcNojVpcv | la2-dz01  | lax      | xlax     | switch      | 207.45.216.134 | 207.45.216.136/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- 6Nn23MqDrBETFXXohEvmP4mQJb2LWxBNFqx6Ye2zDUej | frk-dz01  | fra      | xfra     | switch      | 195.219.220.88 | 195.219.220.88/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- EhAqBmYSg2aT2dYwv5zz81mTJGgNe9zGZvLFup1D55bU | sg1-dz01  | sin      | xsin     | switch      | 180.87.102.104 | 180.87.102.104/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- Ejo8G43tLsV4Swp548K6UDX2dLFqmaRN4HKKFnVz9H3p | ams-dz001 | ams      | xams     | switch      | 195.219.138.50 | 195.219.138.56/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- 14LzRsGUMyGYJFHgJkAwPZHKJLnwPK8S1d1v7b3bAkqV | pit-dzd01 | pit      | xpit     | switch      | 204.16.241.243 | 204.16.243.243/32 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- FBUy8tzFWa8LhQmCfXbnWZMg1XUDQfudanoVK5NP4KGP | ld4-dz01  | lhr      | xlhr     | switch      | 195.219.120.72 | 195.219.120.72/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
- Ai18RhhoWwwmLWq6LhUfro9sxLMxfrGuNGc5fuZssh9i | ty2-dz01  | tyo      | xtyo     | switch      | 180.87.154.112 | 180.87.154.112/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ pubkey                                       | code      | location | exchange | device_type | public_ip      | dz_prefixes                        | status    | owner 
+ Ai18RhhoWwwmLWq6LhUfro9sxLMxfrGuNGc5fuZssh9i | ty2-dz01  | tyo      | xtyo     | switch      | 180.87.154.112 | 180.87.154.112/29                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 14LzRsGUMyGYJFHgJkAwPZHKJLnwPK8S1d1v7b3bAkqV | pit-dzd01 | pit      | xpit     | switch      | 204.16.241.243 | 204.16.243.243/32                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 3TD6MDfCo2mVeR9a71ukrdXBYVLyWz5cz8RLcNojVpcv | la2-dz01  | lax      | xlax     | switch      | 207.45.216.134 | 207.45.216.136/30, 200.12.12.12/29 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 6Nn23MqDrBETFXXohEvmP4mQJb2LWxBNFqx6Ye2zDUej | frk-dz01  | fra      | xfra     | switch      | 195.219.220.88 | 195.219.220.88/29                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ Ejo8G43tLsV4Swp548K6UDX2dLFqmaRN4HKKFnVz9H3p | ams-dz001 | ams      | xams     | switch      | 195.219.138.50 | 195.219.138.56/29                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 8scDVeZ8aB1TRTkBqaZgzxuk7WwpARdF1a39wYA7nR3W | ny5-dz01  | ewr      | xewr     | switch      | 64.86.249.80   | 64.86.249.80/29                    | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ EhAqBmYSg2aT2dYwv5zz81mTJGgNe9zGZvLFup1D55bU | sg1-dz01  | sin      | xsin     | switch      | 180.87.102.104 | 180.87.102.104/29                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ FBUy8tzFWa8LhQmCfXbnWZMg1XUDQfudanoVK5NP4KGP | ld4-dz01  | lhr      | xlhr     | switch      | 195.219.120.72 | 195.219.120.72/29                  | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.txt
@@ -1,2 +1,7 @@
- pubkey                                       | user_type           | device   | cyoa_type  | client_ip    | tunnel_id | tunnel_net     | dz_ip        | status    | owner 
- Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW | IBRLWithAllocatedIP | ny5-dz01 | GREOverDIA | 64.86.249.86 | 500       | 169.254.0.0/31 | 64.86.249.81 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ pubkey                                       | user_type           | device   | cyoa_type  | client_ip    | tunnel_id | tunnel_net      | dz_ip        | status    | owner 
+ NR8fpCK7mqeFVJ3mUmhndX2JtRCymZzgQgGj5JNbGp8  | IBRL                | la2-dz01 | GREOverDIA | 1.2.3.4      | 500       | 169.254.0.2/31  | 1.2.3.4      | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 5Rm8dp4dDzR5SE3HtrqGVpqHLaPvvxDEV3EotqPBBUgS | IBRL                | la2-dz01 | GREOverDIA | 5.6.7.8      | 504       | 169.254.0.10/31 | 5.6.7.8      | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ AwGXP4jLSFsjFdsY7zZtjuvXQfyet8F5XoTTUs19HxLa | IBRL                | la2-dz01 | GREOverDIA | 3.4.5.6      | 502       | 169.254.0.6/31  | 3.4.5.6      | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ AA3fFZM1bJbNzCWhPydZrbQpswGkZx4PFhxd2bHaztyG | IBRL                | la2-dz01 | GREOverDIA | 2.3.4.5      | 501       | 169.254.0.4/31  | 2.3.4.5      | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 73cGHjCmZ8Jr5nsViP3GyyEhXD8zQBzo5eRTkY9gxqjj | IBRL                | la2-dz01 | GREOverDIA | 4.5.6.7      | 503       | 169.254.0.8/31  | 4.5.6.7      | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW | IBRLWithAllocatedIP | ny5-dz01 | GREOverDIA | 64.86.249.86 | 500       | 169.254.0.0/31  | 64.86.249.81 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.txt
@@ -1,1 +1,6 @@
- pubkey | user_type | device | cyoa_type | client_ip | tunnel_id | tunnel_net | dz_ip | status | owner 
+ pubkey                                       | user_type | device   | cyoa_type  | client_ip | tunnel_id | tunnel_net      | dz_ip   | status    | owner 
+ NR8fpCK7mqeFVJ3mUmhndX2JtRCymZzgQgGj5JNbGp8  | IBRL      | la2-dz01 | GREOverDIA | 1.2.3.4   | 500       | 169.254.0.2/31  | 1.2.3.4 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 5Rm8dp4dDzR5SE3HtrqGVpqHLaPvvxDEV3EotqPBBUgS | IBRL      | la2-dz01 | GREOverDIA | 5.6.7.8   | 504       | 169.254.0.10/31 | 5.6.7.8 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ AwGXP4jLSFsjFdsY7zZtjuvXQfyet8F5XoTTUs19HxLa | IBRL      | la2-dz01 | GREOverDIA | 3.4.5.6   | 502       | 169.254.0.6/31  | 3.4.5.6 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ AA3fFZM1bJbNzCWhPydZrbQpswGkZx4PFhxd2bHaztyG | IBRL      | la2-dz01 | GREOverDIA | 2.3.4.5   | 501       | 169.254.0.4/31  | 2.3.4.5 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 
+ 73cGHjCmZ8Jr5nsViP3GyyEhXD8zQBzo5eRTkY9gxqjj | IBRL      | la2-dz01 | GREOverDIA | 4.5.6.7   | 503       | 169.254.0.8/31  | 4.5.6.7 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe 

--- a/e2e/start_e2e.sh
+++ b/e2e/start_e2e.sh
@@ -77,6 +77,9 @@ test_ibrl_with_allocated_addr() {
     print_banner "Connecting user tunnel"
     doublezero --keypair $SOLANA_KEYPAIR connect ibrl --client-ip 64.86.249.86  --allocate-addr
 
+    print_banner "Creating multiple users to exhaust the /30 and allocate from the /29, ie use both blocks"
+    create_multiple_users
+
     print_banner "Wait for controller to pickup new user"
     sleep 30
 
@@ -161,7 +164,7 @@ populate_data_onchain() {
 
 
     print_banner "Populate device information onchain - DO NOT SHUFFLE THESE AS THE PUBKEYS WILL CHANGE"
-    doublezero device create --code la2-dz01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "207.45.216.136/29"
+    doublezero device create --code la2-dz01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "207.45.216.136/30,200.12.12.12/29"
     doublezero device create --code ny5-dz01 --location ewr --exchange xewr --public-ip "64.86.249.80" --dz-prefixes "64.86.249.80/29"
     doublezero device create --code ld4-dz01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29"
     doublezero device create --code frk-dz01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29"
@@ -191,6 +194,18 @@ populate_data_onchain() {
     doublezero tunnel create --code "ty2-dz01:la2-dz01" --side-a ty2-dz01 --side-z la2-dz01 --tunnel-type MPLSoGRE --bandwidth "10 Gbps" --mtu 9000 --delay-ms 30 --jitter-ms 10
     print_banner "Tunnel information onchain"
     doublezero tunnel list
+
+}
+
+create_multiple_users() {
+    print_banner "Creating multiple users on a single device"
+    doublezero user create --device la2-dz01 --client-ip 1.2.3.4
+    doublezero user create --device la2-dz01 --client-ip 2.3.4.5
+    doublezero user create --device la2-dz01 --client-ip 3.4.5.6
+    doublezero user create --device la2-dz01 --client-ip 4.5.6.7
+    doublezero user create --device la2-dz01 --client-ip 5.6.7.8
+    print_banner "Multiple users created"
+
 }
 
 err() {


### PR DESCRIPTION
## What Changed

Resolves https://github.com/orgs/malbeclabs/projects/20?pane=issue&itemId=106585236&issue=malbeclabs%7Cdoublezero%7C178

This PR updates the e2e test to add multiple CIDRs to a single user and then validates that once the /30 block is used, the /29 is then allocated.


## Testing Evidence

`la2-dz01` was updated to add an additional `dz-prefix` and change the CIDR range to /30 to make testing and validation of the second prefix easier. 

Create five users to use all the /30 and create a single user on the /29. 

```
doublezero user create --device la2-dz01 --client-ip 1.2.3.4
doublezero user create --device la2-dz01 --client-ip 2.3.4.5
doublezero user create --device la2-dz01 --client-ip 3.4.5.6
doublezero user create --device la2-dz01 --client-ip 4.5.6.7
doublezero user create --device la2-dz01 --client-ip 5.6.7.8
```

Verify that both blocks are used with `doublezero user list`:

```
 pubkey                                       | user_type | device   | cyoa_type  | client_ip | tunnel_id | tunnel_net     | dz_ip          | status    | owner
 J2MUYJeJvTfrHpxMm3tVYkcDhTwgAFFju2veS27WhByX | server    | la2-dz01 | GREOverDIA | 1.2.3.4   | 500       | 169.254.0.0/31 | 207.45.216.137 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
 AA3fFZM1bJbNzCWhPydZrbQpswGkZx4PFhxd2bHaztyG | server    | la2-dz01 | GREOverDIA | 4.5.6.7   | 503       | 169.254.0.6/31 | 200.12.12.9    | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
 Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW | server    | la2-dz01 | GREOverDIA | 2.3.4.5   | 501       | 169.254.0.2/31 | 207.45.216.138 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
 AwGXP4jLSFsjFdsY7zZtjuvXQfyet8F5XoTTUs19HxLa | server    | la2-dz01 | GREOverDIA | 5.6.7.8   | 504       | 169.254.0.8/31 | 200.12.12.10   | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
 NR8fpCK7mqeFVJ3mUmhndX2JtRCymZzgQgGj5JNbGp8  | server    | la2-dz01 | GREOverDIA | 3.4.5.6   | 502       | 169.254.0.4/31 | 207.45.216.139 | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
```