### PR TITLE
#197 - fix typo in vrf1 template

### DIFF
--- a/controlplane/agent/internal/agent/eapi.go
+++ b/controlplane/agent/internal/agent/eapi.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// [{ "vrfs": { "default": { "peerList": [{"peerAddress": "192.168.1.1", "asn": "65432", "linkType": "internal", "routerId": "0.0.0.0", "vrf": "default"}]}}}]
+// [{ "vrfs": { "default": { "peerList": [{"peerAddress": "192.168.1.1", "asn": "65342", "linkType": "internal", "routerId": "0.0.0.0", "vrf": "default"}]}}}]
 type Peer struct {
 	PeerAddress string `json:"peerAddress"`
 }

--- a/controlplane/agent/internal/agent/eapi_test.go
+++ b/controlplane/agent/internal/agent/eapi_test.go
@@ -34,7 +34,7 @@ func (*mockAristaEapiMgr) RunShowCmd(ctx context.Context, req *pb.RunShowCmdRequ
 	var resp []string
 	switch req.Command {
 	case "show ip bgp neighbors":
-		resp = []string{string("{ \"vrfs\": { \"default\": { \"peerList\": [ { \"peerAddress\": \"192.168.1.1\", \"asn\": \"65432\", \"linkType\": \"internal\", \"routerId\": \"0.0.0.0\" }, { \"peerAddress\": \"192.168.1.1\", \"asn\": \"65432\", \"linkType\": \"internal\", \"routerId\": \"0.0.0.0\" } ] } } }")}
+		resp = []string{string("{ \"vrfs\": { \"default\": { \"peerList\": [ { \"peerAddress\": \"192.168.1.1\", \"asn\": \"65342\", \"linkType\": \"internal\", \"routerId\": \"0.0.0.0\" }, { \"peerAddress\": \"192.168.1.1\", \"asn\": \"65342\", \"linkType\": \"internal\", \"routerId\": \"0.0.0.0\" } ] } } }")}
 	case "show configuration sessions":
 		resp = []string{string("{\"sessions\": {\"doublezero-agent-123456789000\": {\"state\": \"pending\", \"completedTime\": 1736543591.7917519, \"commitUser\": \"\", \"description\": \"\", \"instances\": {\"868\": {\"user\": \"root\", \"terminal\": \"vty5\", \"currentTerminal\": false}}}, \"blah1\": {\"state\": \"pending\", \"commitUser\": \"\", \"description\": \"\", \"instances\": {}}}, \"maxSavedSessions\": 1, \"maxOpenSessions\": 5, \"mergeOnCommit\": false, \"saveToStartupConfigOnCommit\": false}")}
 	case "show configuration lock":

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
@@ -46,7 +46,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 2.2.2.2
       no neighbor 169.254.0.13
 !

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
@@ -56,7 +56,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 2.2.2.2
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/controlplane/controller/internal/controller/fixtures/e2e.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.txt
@@ -56,7 +56,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 2.2.2.2
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/controlplane/controller/internal/controller/fixtures/tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/tunnel.txt
@@ -42,7 +42,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 7.7.7.7
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
@@ -42,7 +42,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 7.7.7.7
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -22,7 +22,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id {{ .PublicIP }}
 {{- range .Tunnels }}
 {{- if eq true .Allocated }}
@@ -46,7 +46,7 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 no route-map RM-USER-{{ .Id }}-OUT
 {{- if eq true .Allocated }}
 route-map RM-USER-{{ .Id }}-OUT permit 10
-   match community COMM-ALL_USERS 
+   match community COMM-ALL_USERS
 {{- end }}
 !
 {{- end }}
@@ -56,7 +56,7 @@ no route-map RM-USER-{{ .Id }}-IN
 route-map RM-USER-{{ .Id }}-IN permit 10
    match ip address prefix-list PL-USER-{{ .Id }}
    match as-path length = 1
-   set community 21682:1200 
+   set community 21682:1200
 {{- end }}
 !
 {{- end }}

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.txt
@@ -56,7 +56,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 64.86.249.80
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.txt
@@ -46,7 +46,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 64.86.249.80
 !
 ip community-list COMM-ALL_USERS permit 21682:1200

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.txt
@@ -56,7 +56,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 64.86.249.80
       no neighbor 169.254.0.1
       neighbor 169.254.0.1 remote-as 65000

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.txt
@@ -46,7 +46,7 @@ router bgp 65342
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
-      route-target export vpn-ipv4 65432:1
+      route-target export vpn-ipv4 65342:1
       router-id 64.86.249.80
 !
 ip community-list COMM-ALL_USERS permit 21682:1200


### PR DESCRIPTION
## What Changed

There was an apparent asn typo of `65432` which should be `65342`. 

## Testing Evidence

@packethog and I deployed the latest agent, controller, client to devnet and verified that the ASN was incorrectly set. It was manually changed which then set things correctly. 

Unit and integration tests were updated to use the correct ASN `65342` in the fixtures to make the unit and integration tests pass. 