### PR TITLE
actions: move all remaining actions to dedicated runner

### DIFF
--- a/.github/workflows/release.activator.yml
+++ b/.github/workflows/release.activator.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16c-64gb
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.agent.yml
+++ b/.github/workflows/release.agent.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16c-64gb
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.controller.yml
+++ b/.github/workflows/release.controller.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16c-64gb
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The release for activator took ~10m to build last week so let's move the remaining actions to the dedicated runner for everyone's sanity.