### PR TITLE
#145 - add bgp session status to client

### DIFF
--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -23,11 +23,11 @@ impl StatusArgs {
             Ok(status) => {
                 println!(
                     "Tunnel status: {}\nName: {}\nTunnel src: {}\nTunnel dst: {}\nDoublezero IP: {}",
-                    status.status,
+                    status.doublezero_status.session_status,
                     status.tunnel_name.unwrap_or_default(),
                     status.tunnel_src.unwrap_or_default(),
                     status.tunnel_dst.unwrap_or_default(),
-                    status.doublezero_ip.unwrap_or_default()
+                    status.doublezero_ip.unwrap_or_default(),
                 );
             }
             Err(e) => {

--- a/client/doublezerod/internal/bgp/bgp.go
+++ b/client/doublezerod/internal/bgp/bgp.go
@@ -1,11 +1,13 @@
 package bgp
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/netip"
+	"time"
 
 	"github.com/jwhited/corebgp"
 )
@@ -14,6 +16,51 @@ var (
 	ErrBgpPeerExists    = errors.New("bgp peer already exists")
 	ErrBgpPeerNotExists = errors.New("bgp peer does not exist")
 )
+
+type SessionEvent struct {
+	PeerAddr net.IP
+	Session  Session
+}
+
+type SessionStatus int
+
+const (
+	SessionStatusunknown SessionStatus = iota
+	SessionStatusPending
+	SessionStatusInitializing
+	SessionStatusDown
+	SessionStatusUp
+)
+
+func (s *Session) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		SessionStatus     SessionStatus `json:"session_status"`
+		LastSessionUpdate time.Time     `json:"last_session_update"`
+	}{
+		SessionStatus:     s.SessionStatus,
+		LastSessionUpdate: s.LastSessionUpdate,
+	})
+}
+
+type Session struct {
+	SessionStatus     SessionStatus `json:"session_status"`
+	LastSessionUpdate time.Time     `json:"last_session_update"`
+}
+
+func (s SessionStatus) String() string {
+	return [...]string{
+		"unknown",
+		"pending",
+		"initializing",
+		"down",
+		"up",
+	}[s]
+
+}
+
+func (s SessionStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
 
 type PeerConfig struct {
 	LocalAddress  net.IP
@@ -28,6 +75,8 @@ type BgpServer struct {
 	server          *corebgp.Server
 	addRouteChan    chan NLRI
 	deleteRouteChan chan NLRI
+	peerStatusChan  chan SessionEvent
+	peerStatus      map[string]Session
 }
 
 func NewBgpServer(routerID net.IP) (*BgpServer, error) {
@@ -40,20 +89,28 @@ func NewBgpServer(routerID net.IP) (*BgpServer, error) {
 		server:          srv,
 		addRouteChan:    make(chan NLRI),
 		deleteRouteChan: make(chan NLRI),
+		peerStatusChan:  make(chan SessionEvent),
+		peerStatus:      make(map[string]Session),
 	}, nil
 }
 
 func (b *BgpServer) Serve(lis []net.Listener) error {
+	go func() {
+		for {
+			update := <-b.GetStatusEvent()
+			b.peerStatus[update.PeerAddr.String()] = update.Session
+		}
+	}()
 	return b.server.Serve(lis)
 }
 
-func (b *BgpServer) AddPeer(p *PeerConfig, n []NLRI) error {
+func (b *BgpServer) AddPeer(p *PeerConfig, advertised []NLRI) error {
 	peerOpts := make([]corebgp.PeerOption, 0)
 	peerOpts = append(peerOpts, corebgp.WithLocalAddress(netip.MustParseAddr(p.LocalAddress.String())))
 	if p.Port != 0 {
 		peerOpts = append(peerOpts, corebgp.WithPort(p.Port))
 	}
-	plugin := NewBgpPlugin(b.addRouteChan, b.deleteRouteChan, n, p.RouteTable)
+	plugin := NewBgpPlugin(b.addRouteChan, b.deleteRouteChan, advertised, p.RouteTable, b.peerStatusChan)
 	err := b.server.AddPeer(corebgp.PeerConfig{
 		RemoteAddress: netip.MustParseAddr(p.RemoteAddress.String()),
 		LocalAS:       p.LocalAs,
@@ -82,4 +139,15 @@ func (b *BgpServer) AddRoute() <-chan NLRI {
 
 func (b *BgpServer) WithdrawRoute() <-chan NLRI {
 	return b.deleteRouteChan
+}
+
+func (b *BgpServer) GetStatusEvent() <-chan SessionEvent {
+	return b.peerStatusChan
+}
+
+func (b *BgpServer) GetPeerStatus(ip net.IP) Session {
+	if peerStatus, ok := b.peerStatus[ip.String()]; ok {
+		return peerStatus
+	}
+	return Session{SessionStatus: SessionStatusunknown}
 }

--- a/client/doublezerod/internal/netlink/http.go
+++ b/client/doublezerod/internal/netlink/http.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+
+	"github.com/malbeclabs/doublezero/client/doublezerod/internal/bgp"
 )
 
 type UserType int
@@ -174,11 +176,11 @@ type StatusRequest struct {
 }
 
 type StatusResponse struct {
-	TunnelName   string `json:"tunnel_name"`
-	TunnelSrc    net.IP `json:"tunnel_src"`
-	TunnelDst    net.IP `json:"tunnel_dst"`
-	DoubleZeroIP net.IP `json:"doublezero_ip"`
-	Status       string `json:"status"`
+	TunnelName       string      `json:"tunnel_name"`
+	TunnelSrc        net.IP      `json:"tunnel_src"`
+	TunnelDst        net.IP      `json:"tunnel_dst"`
+	DoubleZeroIP     net.IP      `json:"doublezero_ip"`
+	DoubleZeroStatus bgp.Session `json:"doublezero_status"`
 }
 
 func (n *NetlinkManager) ServeStatus(w http.ResponseWriter, r *http.Request) {
@@ -191,7 +193,7 @@ func (n *NetlinkManager) ServeStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if status == nil {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status": "disconnected"}`))
+		_, _ = w.Write([]byte(`{"doublezero_status": {"session_status": "disconnected"}}`))
 		return
 	}
 	if err = json.NewEncoder(w).Encode(status); err != nil {

--- a/client/doublezerod/internal/netlink/manager.go
+++ b/client/doublezerod/internal/netlink/manager.go
@@ -31,6 +31,7 @@ type BgpReaderWriter interface {
 	DeletePeer(net.IP) error
 	AddRoute() <-chan bgp.NLRI
 	WithdrawRoute() <-chan bgp.NLRI
+	GetPeerStatus(net.IP) bgp.Session
 }
 
 type DbReaderWriter interface {
@@ -102,7 +103,6 @@ func (n *NetlinkManager) provisionIBRL(p ProvisionRequest) error {
 			return fmt.Errorf("error adding peer: %v", err)
 		}
 	}
-
 	return nil
 }
 
@@ -501,11 +501,12 @@ func (n *NetlinkManager) Status() (*StatusResponse, error) {
 		return nil, fmt.Errorf("netlink: saved state is not programmed into client")
 	}
 
+	peerStatus := n.bgp.GetPeerStatus(n.UnicastTunnel.RemoteOverlay)
 	return &StatusResponse{
-		TunnelName:   n.UnicastTunnel.Name,
-		TunnelSrc:    n.UnicastTunnel.LocalUnderlay,
-		TunnelDst:    n.UnicastTunnel.RemoteUnderlay,
-		DoubleZeroIP: n.DoubleZeroAddr,
-		Status:       "connected",
+		TunnelName:       n.UnicastTunnel.Name,
+		TunnelSrc:        n.UnicastTunnel.LocalUnderlay,
+		TunnelDst:        n.UnicastTunnel.RemoteUnderlay,
+		DoubleZeroIP:     n.DoubleZeroAddr,
+		DoubleZeroStatus: peerStatus,
 	}, nil
 }

--- a/client/doublezerod/internal/netlink/manager_test.go
+++ b/client/doublezerod/internal/netlink/manager_test.go
@@ -21,8 +21,9 @@ func (m *MockBgpServer) DeletePeer(ip net.IP) error {
 	m.deletedPeer = ip
 	return nil
 }
-func (m *MockBgpServer) AddRoute() <-chan bgp.NLRI      { return nil }
-func (m *MockBgpServer) WithdrawRoute() <-chan bgp.NLRI { return nil }
+func (m *MockBgpServer) AddRoute() <-chan bgp.NLRI        { return nil }
+func (m *MockBgpServer) WithdrawRoute() <-chan bgp.NLRI   { return nil }
+func (m *MockBgpServer) GetPeerStatus(net.IP) bgp.Session { return bgp.Session{} }
 
 type MockNetlink struct {
 	routes        []*netlink.Route

--- a/e2e/fixtures/ibrl/doublezero_status_connected.txt
+++ b/e2e/fixtures/ibrl/doublezero_status_connected.txt
@@ -2,4 +2,4 @@ Doublezero IP: 64.86.249.86
 Name: doublezero0
 Tunnel dst: 64.86.249.80
 Tunnel src: 64.86.249.86
-Tunnel status: connected
+Tunnel status: up

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.txt
@@ -2,4 +2,4 @@ Doublezero IP: 64.86.249.81
 Name: doublezero0
 Tunnel dst: 64.86.249.80
 Tunnel src: 64.86.249.86
-Tunnel status: connected
+Tunnel status: up


### PR DESCRIPTION
## What Changed

This PR adds bgp session status changes to the doubelzerod and is accessible through the cli with `doublezero status`. The session type is held in memory and changes when the corebgp update handler gets a new message. The handle update conditions are described [here](https://pkg.go.dev/github.com/jwhited/corebgp#Plugin) The session types are:

* unknown
* pending 
* initializing 
* up 
* disconnected 

There's also a timestamp that is updated on session type update. 

E2E test fixtures will be updated in https://github.com/malbeclabs/doublezero/issues/220 to allow for dynamic values and should make the tests less brittle. Adding it in a subsequent PR to keep this PR small and the timestamp isn't used yet.

This also fixes a type `respose` to `response` in the service controller module.

## Evidence of Testing

* e2e tests pass
* manual verification of the cluster locally using the e2e container
