### PR TITLE
tests: add action to validate release pipeline

### DIFF
--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -1,0 +1,70 @@
+name: release pipeline validation
+on:
+  push:
+    paths:
+      - "activator/**"
+      - "client/**"
+      - "controlplane/**"
+      - "telemetry/**"
+      - "smartcontract/**"
+      - "go.mod"
+      - "go.sum"
+      - "!**/**.md"
+      - ".goreleaser.*"
+      - ".github/workflows/release.pipeline.validation.yml"
+    branches: [ main ]
+  pull_request:
+    paths:
+      - "client/**"
+      - "controlplane/**"
+      - "telemetry/**"
+      - "smartcontract/**"
+      - "go.mod"
+      - "go.sum"
+      - "!**/**.md"
+      - ".goreleaser.*"
+      - ".github/workflows/release.pipeline.validation.yml"
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  validate_pipeline:
+    runs-on: ubuntu-24.04-16c-64gb
+    strategy:
+      matrix:
+        release: [
+          activator, 
+          agent,
+          client,
+          controller,
+        ]
+    name: ${{ matrix.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - name: install rust for cli
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install squashfs-tools rpm -y
+      - name: Set env vars
+        run: ./scripts/env.sh >> $GITHUB_ENV
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release --snapshot -f .goreleaser.${{ matrix.release }}.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}


### PR DESCRIPTION
This PR adds a github action to test our release pipelines when dependencies are changed. If either the build stage or packaging stage fails, the check will fail. Publishing and announcing releases are skipped as this only uses snapshot releases.