### PR TITLE
Add status to doublezero export output

### DIFF
--- a/smartcontract/cli/src/export.rs
+++ b/smartcontract/cli/src/export.rs
@@ -85,6 +85,7 @@ struct UserData {
     pub tunnel_id: u16,
     pub tunnel_net: String,
     pub dz_ip: String,
+    pub status: String,
     pub owner: String,
 }
 
@@ -177,6 +178,7 @@ impl ExportArgs {
                             tunnel_id: user.tunnel_id,
                             tunnel_net: networkv4_to_string(&user.tunnel_net),
                             dz_ip: ipv4_to_string(&user.dz_ip),
+                            status: user.status.to_string(),
                             owner: user.owner.to_string(),
                         })
                         .collect(),


### PR DESCRIPTION
Closes #300

I tested this with a local build on chi-dn-bm4.  `status: activated` is as expected in the user tunnel on chi-dn-dzd1

```
ubuntu@chi-dn-bm4:~$ doublezero export --path ~
/home/ubuntu/pit01.yml
/home/ubuntu/chi-dn-dzd3.yml
/home/ubuntu/chi-dn-dzd1.yml
/home/ubuntu/chi-dn-dzd2.yml
/home/ubuntu/chi-dn-dzd4.yml
ubuntu@chi-dn-bm4:~$ cat /home/ubuntu/chi-dn-dzd1.yml
device:
  name: chi-dn-dzd1
  pubkey: BpuXeFfFY3pAYkcpgND7dArFk3La5H6KXndHq9secZoa
  public_ip: 100.0.0.1
  location:
    code: chi
    name: Chicago
    pubkey: 946haj1TRemcrpJFktTLf19NMbpqP9ALCTtJHbmTLRr4
    country: US
    lat: 41.8125316
    lng: -87.9754915
    owner: gwfHPG4suqu1aiXEjCPyW9rZfKnb9zQqdNt4iyqiA1D
  exchange:
    code: xchi
    name: Chicago
    pubkey: 4FWQBCFiHXwjzbFshg7DGJ9yMTTrMcsHv4CpnjrtUteQ
    lat: 41.8125316
    lng: -87.9754915
    owner: gwfHPG4suqu1aiXEjCPyW9rZfKnb9zQqdNt4iyqiA1D
  tunnels: []
  users:
  - pubkey: DFbxP82GprrQSdyRnAkv1riaCb36EWL54dFvTsfu8CMk
    user_type: IBRL
    cyoa_type: GREOverDIA
    client_ip: 137.174.145.145
    tunnel_id: 500
    tunnel_net: 169.254.0.0/31
    dz_ip: 137.174.145.145
    status: activated
    owner: DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan
  owner: gwfHPG4suqu1aiXEjCPyW9rZfKnb9zQqdNt4iyqiA1D
```