### PR TITLE
activator: make activator run as ubuntu

### DIFF
--- a/activator/doublezero-activator.service
+++ b/activator/doublezero-activator.service
@@ -3,6 +3,7 @@ Description=DoubleZero Activator
 After=network.target
 
 [Service]
+User=ubuntu
 PermissionsStartOnly=True
 RuntimeDirectory=doublezero-activator
 RuntimeDirectoryMode=0775


### PR DESCRIPTION
Activator should run as the ubuntu user to inherit the correct config instead of running as root.