### PR TITLE
Refactor: Fixup clippy lints and add idiomatic Rust improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pdb
+.DS_STORE
 **/*.swp
 **/*.rs.bk
 **/coverage.out

--- a/activator/Makefile
+++ b/activator/Makefile
@@ -1,15 +1,15 @@
 PREFIX:=github.com/malbeclabs/doublezero/smartcontract
-BUILD:=`git rev-parse --short HEAD` 
+BUILD:=`git rev-parse --short HEAD`
 LDFLAGS=
 
 .PHONY: test
 test:
-	cargo test --manifest-path Cargo.toml 
+	cargo test --manifest-path Cargo.toml
 
 .PHONY: lint
 lint:
-	cargo clippy --manifest-path Cargo.toml 
+	cargo clippy --manifest-path Cargo.toml
 
 .PHONY: build
 build:
-	cargo build --release -v $(LDFLAGS) --manifest-path Cargo.toml 
+	cargo build --release -v $(LDFLAGS) --manifest-path Cargo.toml

--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -65,7 +65,7 @@ impl Activator {
             "Connected to url: {} ws: {} program_id: {} ",
             client.get_rpc(),
             client.get_ws(),
-            client.get_program_id().to_string()
+            client.get_program_id()
         );
 
         // Wait for the global config to be available
@@ -127,9 +127,9 @@ impl Activator {
 
         println!(
             "devices: {} tunnels: {} users: {}",
-            devices.len().to_string(),
-            tunnels.len().to_string(),
-            users.len().to_string()
+            devices.len(),
+            tunnels.len(),
+            users.len(),
         );
 
         Ok(())
@@ -157,21 +157,20 @@ impl Activator {
                 networkv4_list_to_string(&device.device.dz_prefixes)
             );
 
-            if device.tunnel_ids.assigned.len() == 0 {
-                print!("{},", "-");
+            if device.tunnel_ids.assigned.is_empty() {
+                print!("-,")
             }
-            device.tunnel_ids.assigned.iter().for_each(|tunnel_id| {
-                print!("{},", tunnel_id.to_string());
-            });
+            device
+                .tunnel_ids
+                .assigned
+                .iter()
+                .for_each(|tunnel_id| print!("{},", tunnel_id));
             println!("\x08 ");
         });
 
-        print!(
-            "tunnel_net: {} assigned: ",
-            self.user_tunnel_ips.base_block.to_string()
-        );
-        if self.user_tunnel_ips.assigned_ips.len() == 0 {
-            print!("{},", "-");
+        print!("tunnel_net: {} assigned: ", self.user_tunnel_ips.base_block);
+        if self.user_tunnel_ips.assigned_ips.is_empty() {
+            print!("-,")
         }
         self.user_tunnel_ips.print_assigned_ips();
         println!("\x08 ");
@@ -190,14 +189,14 @@ impl Activator {
             .gets_and_subscribe(move |client, pubkey, data| {
                 match data {
                     AccountData::Device(device) => {
-                        process_device_event(client, pubkey, devices, &device, state_transitions);
+                        process_device_event(client, pubkey, devices, device, state_transitions);
                     }
                     AccountData::Tunnel(tunnel) => {
                         process_tunnel_event(
                             client,
                             tunnel_tunnel_ips,
                             tunnel_tunnel_ids,
-                            &tunnel,
+                            tunnel,
                             state_transitions,
                         );
                     }
@@ -208,7 +207,7 @@ impl Activator {
                             devices,
                             user_tunnel_ips,
                             tunnel_tunnel_ids,
-                            &user,
+                            user,
                             state_transitions,
                         );
                     }
@@ -244,7 +243,7 @@ fn process_device_event(
 
             match res {
                 Ok(signature) => {
-                    println!("Activated {}", signature.to_string());
+                    println!("Activated {}", signature);
 
                     println!(
                         "Add Device: {} public_ip: {} dz_prefixes: {} ",
@@ -257,7 +256,7 @@ fn process_device_event(
                         .entry("device-pending-to-activated")
                         .or_insert(0) += 1;
                 }
-                Err(e) => println!("Error: {}", e.to_string()),
+                Err(e) => println!("Error: {}", e),
             }
         }
         DeviceStatus::Activated => {
@@ -286,7 +285,7 @@ fn process_device_event(
 
             match res {
                 Ok(signature) => {
-                    println!("Deactivated {}", signature.to_string());
+                    println!("Deactivated {}", signature);
                     devices.remove(pubkey);
                     *state_transitions
                         .entry("device-deleting-to-deactivated")
@@ -316,23 +315,23 @@ fn process_tunnel_event(
 
                     let res = ActivateTunnelCommand {
                         index: tunnel.index,
-                        tunnel_id: tunnel_id,
-                        tunnel_net: tunnel_net,
+                        tunnel_id,
+                        tunnel_net,
                     }
                     .execute(client);
 
                     match res {
                         Ok(signature) => {
-                            println!("Activated {}", signature.to_string());
+                            println!("Activated {}", signature);
                             *state_transitions
                                 .entry("tunnel-pending-to-activated")
                                 .or_insert(0) += 1;
                         }
-                        Err(e) => println!("Error: activate_tunnel: {}", e.to_string()),
+                        Err(e) => println!("Error: activate_tunnel: {}", e),
                     }
                 }
                 None => {
-                    println!("{}", "Error: No available tunnel block");
+                    println!("Error: No available tunnel block");
 
                     let res = RejectTunnelCommand {
                         index: tunnel.index,
@@ -342,12 +341,12 @@ fn process_tunnel_event(
 
                     match res {
                         Ok(signature) => {
-                            println!("Rejected {}", signature.to_string());
+                            println!("Rejected {}", signature);
                             *state_transitions
                                 .entry("tunnel-pending-to-rejected")
                                 .or_insert(0) += 1;
                         }
-                        Err(e) => println!("Error: reject_tunnel: {}", e.to_string()),
+                        Err(e) => println!("Error: reject_tunnel: {}", e),
                     }
                 }
             }
@@ -366,12 +365,12 @@ fn process_tunnel_event(
 
             match res {
                 Ok(signature) => {
-                    println!("Deactivated {}", signature.to_string());
+                    println!("Deactivated {}", signature);
                     *state_transitions
                         .entry("tunnel-deleting-to-deactivated")
                         .or_insert(0) += 1;
                 }
-                Err(e) => println!("{}: {}", "Error: deactivate_tunnel:", e.to_string()),
+                Err(e) => println!("Error deactivate_tunnel: {}", e),
             }
         }
         _ => {}
@@ -410,7 +409,7 @@ fn process_user_event(
                         devices.insert(*pubkey, DeviceState::new(&device));
                     }
                     Err(e) => {
-                        println!("Error: {}", e.to_string());
+                        println!("Error: {}", e);
                     }
                 }
             }
@@ -428,12 +427,9 @@ fn process_user_event(
 
                             match user.user_type {
                                 UserType::IBRLWithAllocatedIP | UserType::EdgeFiltering => {
-                                    match device_state.get_next() {
-                                        Some((xtunnel_id, xdz_ip)) => {
-                                            tunnel_id = xtunnel_id;
-                                            dz_ip = xdz_ip;
-                                        }
-                                        None => {}
+                                    if let Some((xtunnel_id, xdz_ip)) = device_state.get_next() {
+                                        tunnel_id = xtunnel_id;
+                                        dz_ip = xdz_ip;
                                     }
                                 }
                                 UserType::IBRL => {
@@ -444,7 +440,7 @@ fn process_user_event(
                             }
 
                             if tunnel_id == 0 {
-                                eprintln!("{}", "Error: No available tunnel block");
+                                eprintln!("Error: No available tunnel block");
 
                                 let res = RejectUserCommand {
                                     index: user.index,
@@ -454,42 +450,42 @@ fn process_user_event(
 
                                 match res {
                                     Ok(signature) => {
-                                        println!("Rejected {}", signature.to_string());
+                                        println!("Rejected {}", signature);
                                         *state_transitions
                                             .entry("user-pending-to-rejected")
                                             .or_insert(0) += 1;
                                     }
-                                    Err(e) => println!("Error: {}", e.to_string()),
+                                    Err(e) => println!("Error: {}", e),
                                 }
                                 return;
                             }
 
                             print!(
                                 "tunnel_id: {} dz_ip: {} ",
-                                tunnel_id.to_string(),
+                                tunnel_id,
                                 ipv4_to_string(&dz_ip)
                             );
 
                             let res = ActivateUserCommand {
                                 index: user.index,
-                                tunnel_id: tunnel_id,
-                                tunnel_net: tunnel_net,
-                                dz_ip: dz_ip,
+                                tunnel_id,
+                                tunnel_net,
+                                dz_ip,
                             }
                             .execute(client);
 
                             match res {
                                 Ok(signature) => {
-                                    println!("Activated   {}", signature.to_string());
+                                    println!("Activated   {}", signature);
                                     *state_transitions
                                         .entry("user-pending-to-activated")
                                         .or_insert(0) += 1;
                                 }
-                                Err(e) => println!("Error: {}", e.to_string()),
+                                Err(e) => println!("Error: {}", e),
                             }
                         }
                         None => {
-                            println!("{}", "Error: No available user block");
+                            println!("Error: No available user block");
 
                             let res = RejectUserCommand {
                                 index: user.index,
@@ -499,18 +495,18 @@ fn process_user_event(
 
                             match res {
                                 Ok(signature) => {
-                                    println!("Rejected {}", signature.to_string());
+                                    println!("Rejected {}", signature);
                                     *state_transitions
                                         .entry("user-pending-to-rejected")
                                         .or_insert(0) += 1;
                                 }
-                                Err(e) => println!("Error: {}", e.to_string()),
+                                Err(e) => println!("Error: {}", e),
                             }
                         }
                     }
                 }
                 None => {
-                    eprintln!("Error: Device not found {}", user.device_pk.to_string());
+                    eprintln!("Error: Device not found {}", user.device_pk);
 
                     let res = RejectUserCommand {
                         index: user.index,
@@ -520,12 +516,12 @@ fn process_user_event(
 
                     match res {
                         Ok(signature) => {
-                            println!("Rejected {}", signature.to_string());
+                            println!("Rejected {}", signature);
                             *state_transitions
                                 .entry("user-pending-to-rejected")
                                 .or_insert(0) += 1;
                         }
-                        Err(e) => println!("Error: {}", e.to_string()),
+                        Err(e) => println!("Error: {}", e),
                     }
                 }
             }
@@ -540,7 +536,7 @@ fn process_user_event(
                 print!(
                     "tunnel_net: {} tunnel_id: {} dz_ip: {} ",
                     networkv4_to_string(&user.tunnel_net),
-                    user.tunnel_id.to_string(),
+                    user.tunnel_id,
                     ipv4_to_string(&user.dz_ip)
                 );
 
@@ -563,24 +559,24 @@ fn process_user_event(
 
                     match res {
                         Ok(signature) => {
-                            println!("Deactivated {}", signature.to_string());
+                            println!("Deactivated {}", signature);
                             *state_transitions
                                 .entry("user-deleting-to-deactivated")
                                 .or_insert(0) += 1;
                         }
-                        Err(e) => println!("Error: {}", e.to_string()),
+                        Err(e) => println!("Error: {}", e),
                     }
                 } else if user.status == UserStatus::PendingBan {
                     let res = BanUserCommand { index: user.index }.execute(client);
 
                     match res {
                         Ok(signature) => {
-                            println!("Banned {}", signature.to_string());
+                            println!("Banned {}", signature);
                             *state_transitions
                                 .entry("user-pending-ban-to-banned")
                                 .or_insert(0) += 1;
                         }
-                        Err(e) => println!("Error: {}", e.to_string()),
+                        Err(e) => println!("Error: {}", e),
                     }
                 }
             }
@@ -594,7 +590,7 @@ fn process_location_event(
     locations: &mut HashMap<Pubkey, Location>,
     location: &Location,
 ) {
-    locations.insert(pubkey.clone(), location.clone());
+    locations.insert(*pubkey, location.clone());
 }
 
 fn process_exchange_event(
@@ -602,7 +598,7 @@ fn process_exchange_event(
     exchanges: &mut HashMap<Pubkey, Exchange>,
     exchange: &Exchange,
 ) {
-    exchanges.insert(pubkey.clone(), exchange.clone());
+    exchanges.insert(*pubkey, exchange.clone());
 }
 
 #[cfg(test)]
@@ -979,7 +975,7 @@ mod tests {
             owner: Pubkey::new_unique(),
             index: 0,
             bump_seed: get_user_bump_seed(&client),
-            user_type: user_type,
+            user_type,
             tenant_pk: Pubkey::new_unique(),
             device_pk: device_pubkey,
             cyoa_type: UserCYOA::GREOverDIA,

--- a/activator/src/activator_metrics.rs
+++ b/activator/src/activator_metrics.rs
@@ -24,8 +24,7 @@ impl ActivatorMetrics {
         exchanges: &HashMap<Pubkey, Exchange>,
         state_transitions: &HashMap<&'static str, usize>,
     ) {
-        let mut metrics: Vec<Metric> = vec![];
-        metrics.reserve(devices.len() + state_transitions.len() + 1);
+        let mut metrics = Vec::with_capacity(devices.len() + state_transitions.len() + 1);
 
         let mut metric = Metric::new("activator_device_count");
         metric.add_field("count", devices.len() as f64);
@@ -43,23 +42,17 @@ impl ActivatorMetrics {
                 .add_field("assigned_ips", assigned as f64)
                 .add_field("total_ips", total_ips as f64);
 
-            match location {
-                Some(location) => {
-                    metric
-                        .add_tag("location", &location.name)
-                        .add_tag("location_code", &location.code)
-                        .add_tag("location_country", &location.country);
-                }
-                None => {}
+            if let Some(location) = location {
+                metric
+                    .add_tag("location", &location.name)
+                    .add_tag("location_code", &location.code)
+                    .add_tag("location_country", &location.country);
             }
 
-            match exchange {
-                Some(exchange) => {
-                    metric
-                        .add_tag("exchange", &exchange.name)
-                        .add_tag("exchange_code", &exchange.code);
-                }
-                None => {}
+            if let Some(exchange) = exchange {
+                metric
+                    .add_tag("exchange", &exchange.name)
+                    .add_tag("exchange_code", &exchange.code);
             }
 
             metrics.push(metric);
@@ -68,7 +61,7 @@ impl ActivatorMetrics {
         for (state_transition, count) in state_transitions.iter() {
             let mut metric = Metric::new("activator_state_transition");
             metric
-                .add_tag("state_transition", *state_transition)
+                .add_tag("state_transition", state_transition)
                 .add_field("count", *count as f64);
             metrics.push(metric);
         }

--- a/activator/src/ipblockallocator.rs
+++ b/activator/src/ipblockallocator.rs
@@ -107,7 +107,7 @@ impl IPBlockAllocator {
         for (index, assigned) in self.assigned_ips.iter().enumerate() {
             if *assigned {
                 let ip = self.index_to_ip(index);
-                print!("{},", ip.to_string());
+                print!("{},", ip)
             }
         }
     }
@@ -120,7 +120,7 @@ impl IPBlockAllocator {
         if base_ip <= ip_as_u32 {
             Ok((ip_as_u32 - base_ip) as usize)
         } else {
-            return Err("IP address is not in the base block");
+            Err("IP address is not in the base block")
         }
     }
 

--- a/activator/src/metrics_service.rs
+++ b/activator/src/metrics_service.rs
@@ -36,5 +36,5 @@ impl Metric {
 pub trait MetricsService: Send + Sync + 'static {
     #[allow(dead_code)]
     fn write_metric(&self, metric: &Metric);
-    fn write_metrics(&self, metrics: &Vec<Metric>);
+    fn write_metrics(&self, metrics: &[Metric]);
 }

--- a/activator/src/utils.rs
+++ b/activator/src/utils.rs
@@ -18,7 +18,7 @@ pub fn get_utc_nanoseconds_since_epoch() -> u128 {
 /// # Arguments
 ///
 /// * `container`: A container that can be converted into an iterator of borrowed
-///     key-value pairs. Examples include [`HashMap`], [`BTreeMap`], and slices of tuples.
+///   key-value pairs. Examples include [`HashMap`], [`BTreeMap`], and slices of tuples.
 ///
 /// # Returns
 ///


### PR DESCRIPTION
Summary
----
This patch introduces several changes to improve code quality and potentially improve performance by adhering more closely to Rust idioms and addressing common clippy lints.

Noteworthy changes:
- Types which implement `Display` do not need a `to_string()` function call. This reduces several unnecessary allocations.
- `<collection>.len() == 0` is replaced with `<collection>.is_empty()`.
- Simplification of single variant match statements with `if let`.
- `Vec::with_capacity` for pre-allocated vectors.
- Field init shorthands.
- Remove unnecessary cloning.
- Minor adjustments to `print!` formatting.
- Fixup trailing whitespaces.
- Dereference `Pubkey` in `HashMap` insertions.