### PR TITLE
client: add support for multiple services in db

### DIFF
--- a/client/doublezerod/internal/netlink/fixtures/doublezerod.edgefiltering.json
+++ b/client/doublezerod/internal/netlink/fixtures/doublezerod.edgefiltering.json
@@ -1,12 +1,14 @@
-{
-    "tunnel_net": "169.254.0.0/31",
-    "doublezero_prefixes": [
-        "7.0.0.0/8"
-    ],
-    "user_type": "EdgeFiltering",
-    "tunnel_src": "1.1.1.1",
-    "tunnel_dst": "2.2.2.2",
-    "doublezero_ip": "7.7.7.7",
-    "bgp_local_asn": 65000,
-    "bgp_remote_asn": 65001
-}
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [
+            "7.0.0.0/8"
+        ],
+        "user_type": "EdgeFiltering",
+        "tunnel_src": "1.1.1.1",
+        "tunnel_dst": "2.2.2.2",
+        "doublezero_ip": "7.7.7.7",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65001
+    }
+]

--- a/client/doublezerod/internal/netlink/fixtures/doublezerod.ibrl.json
+++ b/client/doublezerod/internal/netlink/fixtures/doublezerod.ibrl.json
@@ -1,10 +1,12 @@
-{
-    "tunnel_net": "169.254.0.0/31",
-    "doublezero_prefixes": [],
-    "user_type": "IBRL",
-    "tunnel_src": "1.1.1.1",
-    "tunnel_dst": "2.2.2.2",
-    "doublezero_ip": "1.1.1.1",
-    "bgp_local_asn": 65000,
-    "bgp_remote_asn": 65001
-}
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [],
+        "user_type": "IBRL",
+        "tunnel_src": "1.1.1.1",
+        "tunnel_dst": "2.2.2.2",
+        "doublezero_ip": "1.1.1.1",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65001
+    }
+]

--- a/client/doublezerod/internal/netlink/fixtures/doublezerod.multiservice.json
+++ b/client/doublezerod/internal/netlink/fixtures/doublezerod.multiservice.json
@@ -1,0 +1,22 @@
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [],
+        "user_type": "IBRL",
+        "tunnel_src": "1.1.1.1",
+        "tunnel_dst": "2.2.2.2",
+        "doublezero_ip": "1.1.1.1",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65001
+    },
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [],
+        "user_type": "Multicast",
+        "tunnel_src": "1.1.1.1",
+        "tunnel_dst": "2.2.2.2",
+        "doublezero_ip": "1.1.1.1",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65001
+    }
+]

--- a/client/doublezerod/internal/netlink/fixtures/doublezerod.old.style.json
+++ b/client/doublezerod/internal/netlink/fixtures/doublezerod.old.style.json
@@ -1,0 +1,10 @@
+{
+    "tunnel_net": "169.254.0.0/31",
+    "doublezero_prefixes": [],
+    "user_type": "IBRL",
+    "tunnel_src": "1.1.1.1",
+    "tunnel_dst": "2.2.2.2",
+    "doublezero_ip": "1.1.1.1",
+    "bgp_local_asn": 65000,
+    "bgp_remote_asn": 65001
+}

--- a/client/doublezerod/internal/netlink/http.go
+++ b/client/doublezerod/internal/netlink/http.go
@@ -161,6 +161,7 @@ func (n *NetlinkManager) ServeProvision(w http.ResponseWriter, r *http.Request) 
 	_, _ = w.Write([]byte(`{"status": "ok"}`))
 }
 
+// TODO: we need to take a payload to remove the correct tunnel in a multi-tunnel setup
 func (n *NetlinkManager) ServeRemove(w http.ResponseWriter, r *http.Request) {
 	err := n.Remove()
 	if err != nil {

--- a/client/doublezerod/internal/netlink/http_test.go
+++ b/client/doublezerod/internal/netlink/http_test.go
@@ -166,11 +166,13 @@ func TestHttpStatus(t *testing.T) {
 	})
 
 	t.Run("provisioned_tunnel_status", func(t *testing.T) {
-		db.state = &netlink.ProvisionRequest{
-			TunnelSrc:    net.IP{1, 1, 1, 1},
-			TunnelDst:    net.IP{2, 2, 2, 2},
-			DoubleZeroIP: net.IP{3, 3, 3, 3},
-			UserType:     netlink.UserTypeIBRL,
+		db.state = []*netlink.ProvisionRequest{
+			{
+				TunnelSrc:    net.IP{1, 1, 1, 1},
+				TunnelDst:    net.IP{2, 2, 2, 2},
+				DoubleZeroIP: net.IP{3, 3, 3, 3},
+				UserType:     netlink.UserTypeIBRL,
+			},
 		}
 		provisionBody := `{
 					"tunnel_src": "1.1.1.1",
@@ -213,7 +215,7 @@ func TestHttpStatus(t *testing.T) {
 func TestNetlinkManager_HttpEndpoints(t *testing.T) {
 	m := &MockNetlink{}
 	b := &MockBgpServer{}
-	db := &MockDb{state: &netlink.ProvisionRequest{}}
+	db := &MockDb{state: []*netlink.ProvisionRequest{}}
 	manager := netlink.NewNetlinkManager(m, b, db)
 
 	f, err := os.CreateTemp("/tmp", "doublezero.sock")

--- a/client/doublezerod/internal/netlink/manager.go
+++ b/client/doublezerod/internal/netlink/manager.go
@@ -35,7 +35,7 @@ type BgpReaderWriter interface {
 }
 
 type DbReaderWriter interface {
-	GetState() *ProvisionRequest
+	GetState() []*ProvisionRequest
 	DeleteState() error
 	SaveState(p *ProvisionRequest) error
 }
@@ -462,7 +462,13 @@ func (n *NetlinkManager) Recover() error {
 		return nil
 	}
 	slog.Info("netlink: restoring previous provisioned state")
-	return n.Provision(*state)
+	// TODO: check state to make sure we adhere to our service iteraction rules
+	for _, p := range state {
+		if err := n.Provision(*p); err != nil {
+			return fmt.Errorf("netlink: error while recovering provisioned state: %v", err)
+		}
+	}
+	return nil
 }
 
 func (n *NetlinkManager) Status() (*StatusResponse, error) {

--- a/client/doublezerod/internal/netlink/manager_test.go
+++ b/client/doublezerod/internal/netlink/manager_test.go
@@ -84,10 +84,10 @@ func (m *MockNetlink) RouteByProtocol(protocol int) ([]*routing.Route, error) {
 }
 
 type MockDb struct {
-	state *netlink.ProvisionRequest
+	state []*netlink.ProvisionRequest
 }
 
-func (m *MockDb) GetState() *netlink.ProvisionRequest {
+func (m *MockDb) GetState() []*netlink.ProvisionRequest {
 	return m.state
 }
 
@@ -315,7 +315,7 @@ func TestNetlinkManager_Remove(t *testing.T) {
 		}
 
 		// add non-nil state to skip nil check
-		db := &netlink.Db{State: &netlink.ProvisionRequest{}, Path: stateFile}
+		db := &netlink.Db{State: []*netlink.ProvisionRequest{}, Path: stateFile}
 		m := &MockNetlink{}
 		b := &MockBgpServer{}
 		manager := netlink.NewNetlinkManager(m, b, db)

--- a/client/doublezerod/internal/runtime/fixtures/doublezerod.edgefiltering.json
+++ b/client/doublezerod/internal/runtime/fixtures/doublezerod.edgefiltering.json
@@ -1,12 +1,14 @@
-{
-    "tunnel_net": "169.254.0.0/31",
-    "doublezero_prefixes": [
-        "3.0.0.0/24"
-    ],
-    "user_type": "EdgeFiltering",
-    "tunnel_src": "1.1.1.1",
-    "tunnel_dst": "2.2.2.2",
-    "doublezero_ip": "3.3.3.3",
-    "bgp_local_asn": 65000,
-    "bgp_remote_asn": 65001
-}
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [
+            "3.0.0.0/24"
+        ],
+        "user_type": "EdgeFiltering",
+        "tunnel_src": "1.1.1.1",
+        "tunnel_dst": "2.2.2.2",
+        "doublezero_ip": "3.3.3.3",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65001
+    }
+]

--- a/client/doublezerod/internal/runtime/fixtures/doublezerod.ibrl.json
+++ b/client/doublezerod/internal/runtime/fixtures/doublezerod.ibrl.json
@@ -1,10 +1,12 @@
-{
-    "tunnel_net": "169.254.0.0/31",
-    "doublezero_prefixes": [],
-    "user_type": "IBRL",
-    "tunnel_src": "192.168.1.0",
-    "tunnel_dst": "192.168.1.1",
-    "doublezero_ip": "192.168.1.0",
-    "bgp_local_asn": 65000,
-    "bgp_remote_asn": 65342
-}
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [],
+        "user_type": "IBRL",
+        "tunnel_src": "192.168.1.0",
+        "tunnel_dst": "192.168.1.1",
+        "doublezero_ip": "192.168.1.0",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65342
+    }
+]

--- a/client/doublezerod/internal/runtime/fixtures/doublezerod.ibrl.with.allocated.ip.json
+++ b/client/doublezerod/internal/runtime/fixtures/doublezerod.ibrl.with.allocated.ip.json
@@ -1,10 +1,12 @@
-{
-    "tunnel_net": "169.254.0.0/31",
-    "doublezero_prefixes": [],
-    "user_type": "IBRLWithAllocatedIP",
-    "tunnel_src": "192.168.1.0",
-    "tunnel_dst": "192.168.1.1",
-    "doublezero_ip": "192.168.1.0",
-    "bgp_local_asn": 65000,
-    "bgp_remote_asn": 65342
-}
+[
+    {
+        "tunnel_net": "169.254.0.0/31",
+        "doublezero_prefixes": [],
+        "user_type": "IBRLWithAllocatedIP",
+        "tunnel_src": "192.168.1.0",
+        "tunnel_dst": "192.168.1.1",
+        "doublezero_ip": "192.168.1.0",
+        "bgp_local_asn": 65000,
+        "bgp_remote_asn": 65342
+    }
+]

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -79,13 +79,11 @@ func (p *dummyPlugin) handleUpdate(peer corebgp.PeerConfig, u []byte) *corebgp.N
 func TestEndToEnd_IBRL(t *testing.T) {
 	teardown, err := setupTest(t)
 	rootPath := os.Getenv("XDG_STATE_HOME")
-
+	t.Cleanup(teardown)
 	defer os.RemoveAll(rootPath)
-
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
-	t.Cleanup(teardown)
 
 	// TODO: start corebgp instance in network namespace
 	srv, _ := corebgp.NewServer(netip.MustParseAddr("2.2.2.2"))


### PR DESCRIPTION
We currently save the running state for users after they've provisioned their tunnels. Unfortunately, this was built to assume we lived in a single tunnel world so this PR accommodates saving the state from multiple service instances (i.e. IBRL + multicast). This also handles migrating users from the old style of configuration to the new style, which would need to happen after an upgrade to this release.