### PR TITLE
Feat: Add shell completion support to the doublezero CLI

### DIFF
--- a/client/doublezero/Cargo.lock
+++ b/client/doublezero/Cargo.lock
@@ -804,6 +804,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91d3baa3bcd889d60e6ef28874126a0b384fd225ab83aa6d8a801c519194ce1"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1273,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "console",
  "doublezero_cli",
  "doublezero_sdk",
@@ -1300,7 +1313,6 @@ dependencies = [
  "chrono",
  "clap",
  "console",
- "doublezero-sla-program",
  "doublezero_sdk",
  "eyre",
  "futures",
@@ -2192,6 +2204,15 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -11,6 +11,7 @@ description = "Command line interface to interact with the DZ program."
 
 [dependencies]
 clap = { version = "4.5.38", features = ["derive"] }
+clap_complete = { version = "4", features = [ "unstable-dynamic" ] }
 eyre = "0.6.12"
 solana-program = "2.2.1"
 solana-sdk = "2.2.2"

--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -1,4 +1,5 @@
-use clap::Subcommand;
+use clap::{Args, Subcommand};
+use clap_complete::Shell;
 
 use doublezero_cli::init::InitCliCommand;
 
@@ -63,4 +64,12 @@ pub enum Command {
     Keygen(KeyGenCliCommand),
     #[command(about = "Get logs", hide = false)]
     Log(LogCliCommand),
+    #[command(about = "Generate shell completions", hide = false)]
+    Completion(CompletionCliCommand),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CompletionCliCommand {
+    #[arg(value_enum)]
+    pub shell: Shell,
 }

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -1,4 +1,5 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
 mod cli;
 mod command;
 mod requirements;
@@ -122,6 +123,11 @@ async fn main() -> eyre::Result<()> {
         Command::Export(args) => args.execute(&client, &mut handle),
         Command::Keygen(args) => args.execute(&client, &mut handle),
         Command::Log(args) => args.execute(&dzclient, &mut handle),
+        Command::Completion(args) => {
+            let mut cmd = App::command();
+            generate(args.shell, &mut cmd, "doublezero", &mut std::io::stdout());
+            Ok(())
+        }
     };
 
     match res {


### PR DESCRIPTION
Summary
----
Fix #106

This adds support for generating shell completions for doublezero client CLI.

Notable changes:
- Add `clap_complete` crate as a dependency
- Implement a new `completion` subcommand that generates completions for various shells
- Shell can be one of: bash, zsh, fish, powershell and elvish (all supported by clap_complete)

For example (generating shell completions for zsh):

`doublezero completion zsh > ~/.zsh/completions/_doublezero`

Video:

https://github.com/user-attachments/assets/d8ce4ed2-5a43-409a-8d5a-9c7289d6303e

