### PR TITLE
Fix: Cleanup clippy lints for smartcontracts

### DIFF
--- a/smartcontract/Makefile
+++ b/smartcontract/Makefile
@@ -1,5 +1,5 @@
 PREFIX:=github.com/malbeclabs/doublezero/smartcontract
-BUILD:=`git rev-parse --short HEAD` 
+BUILD:=`git rev-parse --short HEAD`
 LDFLAGS=
 
 .PHONY: test

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -162,7 +162,7 @@ pub struct CliCommandImpl<'a> {
 
 impl CliCommandImpl<'_> {
     pub fn new(client: &DZClient) -> CliCommandImpl {
-        CliCommandImpl { client: client }
+        CliCommandImpl { client }
     }
 }
 

--- a/smartcontract/cli/src/helpers.rs
+++ b/smartcontract/cli/src/helpers.rs
@@ -12,10 +12,7 @@ pub fn parse_pubkey(input: &str) -> Option<Pubkey> {
         return None;
     }
 
-    match Pubkey::from_str(input) {
-        Ok(pk) => Some(pk),
-        Err(_) => None,
-    }
+    Pubkey::from_str(input).ok()
 }
 
 pub fn print_error(e: eyre::Report) {

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -60,10 +60,7 @@ impl DZClient {
         let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
 
         let payer: Option<solana_sdk::signature::Keypair> =
-            match read_keypair_from_file(kaypair.unwrap_or(config.keypair_path)) {
-                Ok(keypair) => Some(keypair),
-                Err(_) => None,
-            };
+            read_keypair_from_file(kaypair.unwrap_or(config.keypair_path)).ok();
 
         let program_id = {
             if program_id.is_none() {
@@ -355,7 +352,7 @@ impl DoubleZeroClient for DZClient {
         let mut list: HashMap<Pubkey, AccountData> = HashMap::new();
         let accounts = self
             .client
-            .get_program_accounts_with_config(&self.get_program_id(), options)?;
+            .get_program_accounts_with_config(self.get_program_id(), options)?;
 
         for (pubkey, account) in accounts {
             assert!(account.data[0] == account_type, "Invalid account type");

--- a/smartcontract/sdk/rs/src/utils.rs
+++ b/smartcontract/sdk/rs/src/utils.rs
@@ -17,11 +17,9 @@ pub fn parse_pubkey(input: &str) -> Option<Pubkey> {
         return None;
     }
 
-    match Pubkey::from_str(input) {
-        Ok(pk) => Some(pk),
-        Err(_) => None,
-    }
+    Pubkey::from_str(input).ok()
 }
+
 /*
 pub fn create_transaction(program_id: Pubkey, instruction: DoubleZeroInstruction, accounts: Vec<AccountMeta>, payer: &Keypair) -> Transaction {
 


### PR DESCRIPTION
Summary
----
Very small PR to cleanup and fix clippy lint warnings under the
smartcontracts workspace.