### PR TITLE
tests: connect dzd container net after start

### DIFF
--- a/e2e/start_e2e.sh
+++ b/e2e/start_e2e.sh
@@ -22,13 +22,13 @@ AGENT_DEVICE=ny5-dz01
 export AGENT_PUBKEY
 
 main() {
-    # WARNING: docker networks are connected unordered to containers in OSX. This can break
+    # WARNING: docker networks are connected unordered to containers. This can break
     #          networking between the e2e container and the device container. The Arista
     #          cEOS container requires at least two networks attached (a management network
-    #          and at least 1 front panel port network i.e. to the e2e container). Docker on OSX
+    #          and at least 1 front panel port network i.e. to the e2e container). Docker
     #          will attach these in a random order which can cause the network facing the e2e container
     #          to be incorrect from the perspective of the device container.
-    print_banner "Check networking to DoubleZero device\n(This can fail randomly on OSX; See comment in this script above.)"
+    print_banner "Check networking to DoubleZero device\n"
     ping -c 3 -q 64.86.249.80
 
     print_banner "Starting local validator w/ smartcontract program"


### PR DESCRIPTION
We occasionally have flakiness in running our e2e tests, which I originally thought was limited to these running on OSX. However, since moving to a bare metal runner, we've seen the same issue on ubuntu, which is non-deterministic network ordering when attaching more than one network to a container. To mitigate this issue, we can attach networks after container start which appears to preserve the desired ordering.

Running 20 iterations of our e2e tests with this patch showed no failures i.e.`ubuntu@chi-dn-bm6:~/$ for i in $(seq 20 $END);do sudo make test;done`