### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/go:1.24-bookworm
+
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "DoubleZero Development",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/rust:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.go",
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    },
+    "remoteUser": "root",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ],
+    "privileged": true,
+    "capAdd": [
+        "NET_ADMIN",
+        "NET_RAW"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ smartcontract/cli/config/*
 .vscode
 
 dist/
-
-.devcontainer/


### PR DESCRIPTION
Adds a minimal [devcontainer](https://containers.dev/) config. If you're on a mac you need to be in one of these or something like it in order to work on the codebase.