### PR TITLE
Config github workflows with go-version-file instead of go-version

### DIFF
--- a/.github/workflows/flow_schema_migrations.yml
+++ b/.github/workflows/flow_schema_migrations.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@latest
       - name: validate
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@latest
       - name: status
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: install goose
         run: go install github.com/pressly/goose/v3/cmd/goose@latest
       - name: migrate

--- a/.github/workflows/release.agent.yml
+++ b/.github/workflows/release.agent.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: Set env vars
         run: ./scripts/env.sh >> $GITHUB_ENV
       - name: install dependencies for rpm packaging

--- a/.github/workflows/release.client.yml
+++ b/.github/workflows/release.client.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: Set env vars
         run: ./scripts/env.sh >> $GITHUB_ENV
       - name: install rust for cli

--- a/.github/workflows/release.controller.yml
+++ b/.github/workflows/release.controller.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: install dependencies for rpm packaging
         run: |
           sudo apt update

--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         release: [
-          activator, 
+          activator,
           agent,
           client,
           controller,
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version-file: go.mod
       - name: install rust for cli
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: install dependencies for rpm packaging


### PR DESCRIPTION
Replaces remaining uses of `go-version: 1.24.x` in github workflow configs with `go-version-file: go.mod`.