### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,1 @@
 FROM mcr.microsoft.com/devcontainers/go:1.24-bookworm
-
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,9 +35,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.64.2
+        uses: golangci/golangci-lint-action@v8
   build:
     name: "build"
     needs: lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,84 +1,91 @@
+version: "2"
 linters:
-
-  disable-all: true
+  default: none
   enable:
     - bidichk
     - errcheck
-    - gofmt
-    - goimports
     - govet
     - ineffassign
     - misspell
     - revive
     - unused
-
-run:
-  timeout: 5m
-
-linters-settings:
-  # bidichk:
-
-  gofmt:
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-
-  # goimports:
-
-  govet:
-    enable:
-      - asmdecl
-      - assign
-      - atomic
-      - bools
-      - buildtag
-      - cgocall
-      - copylocks
-      - deepequalerrors
-      - errorsas
-      - framepointer
-      - httpresponse
-      - ifaceassert
-      - loopclosure
-      - lostcancel
-      - nilfunc
-      - nilness
-      - printf
-      - reflectvaluecompare
-      - shift
-      - sigchanyzer
-      - sortslice
-      - stdmethods
-      - stringintconv
-      - structtag
-      - testinggoroutine
-      - tests
-      - unmarshal
-      - unreachable
-      - unsafeptr
-      - unusedresult
-
-  # misspell:
-
-  revive:
-    enable-all-rules: false
-    ignore-generated-header: true
-    rules:
-      - name: atomic
-      - name: context-keys-type
-      - name: defer
-        arguments: [[
-          # Calling 'recover' at the time a defer is registered (i.e. "defer recover()") has no effect.
-          "immediate-recover",
-          # Calling 'recover' outside of a deferred function has no effect
-          "recover",
-          # Returning values from a deferred function has no effect
-          "return",
-        ]]
-      - name: duplicated-imports
-      - name: errorf
-      - name: string-of-int
-      - name: time-equal
-      - name: unconditional-recursion
-      - name: useless-break
-      - name: waitgroup-by-value
+  settings:
+    govet:
+      enable:
+        - asmdecl
+        - assign
+        - atomic
+        - bools
+        - buildtag
+        - cgocall
+        - copylocks
+        - deepequalerrors
+        - errorsas
+        - framepointer
+        - httpresponse
+        - ifaceassert
+        - loopclosure
+        - lostcancel
+        - nilfunc
+        - nilness
+        - printf
+        - reflectvaluecompare
+        - shift
+        - sigchanyzer
+        - sortslice
+        - stdmethods
+        - stringintconv
+        - structtag
+        - testinggoroutine
+        - tests
+        - unmarshal
+        - unreachable
+        - unsafeptr
+        - unusedresult
+    revive:
+      enable-all-rules: false
+      rules:
+        - name: atomic
+        - name: context-keys-type
+        - name: defer
+          arguments: [[
+            # Calling 'recover' at the time a defer is registered (i.e. "defer recover()") has no effect.
+            "immediate-recover",
+            # Calling 'recover' outside of a deferred function has no effect
+            "recover",
+            # Returning values from a deferred function has no effect
+            "return",
+          ]]
+        - name: duplicated-imports
+        - name: errorf
+        - name: string-of-int
+        - name: time-equal
+        - name: unconditional-recursion
+        - name: useless-break
+        - name: waitgroup-by-value
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Upgrades to golangci-lint v2 from v1. The `.golangci.yaml` was updated using `golangci-lint migrate` per https://golangci-lint.run/product/migration-guide/