### PR TITLE
e2e: add pim/mroute tests

### DIFF
--- a/client/doublezerod/internal/pim/server.go
+++ b/client/doublezerod/internal/pim/server.go
@@ -189,9 +189,8 @@ func sendMsg(buf gopacket.SerializeBuffer, intf *net.Interface, r RawConner) err
 	binary.BigEndian.PutUint16(b[2:4], checksum)
 	if err := r.WriteTo(iph, b, cm); err != nil {
 		return err
-	} else {
-		return err
 	}
+	return nil
 }
 
 func constructGroups(ips []net.IP, joinSourceAddress net.IP, pruneSourceAddress net.IP) []Group {

--- a/e2e/fixtures/doublezero_device_startup_config_base.txt
+++ b/e2e/fixtures/doublezero_device_startup_config_base.txt
@@ -66,7 +66,7 @@ router bgp 65342
 !
 router multicast
    ipv4
-      software-forwarding kernel
+      software-forwarding sfe
    !
    ipv6
       software-forwarding kernel


### PR DESCRIPTION
This adds additional e2e tests for multicast:

Subscriber tests:
- verification we send pim hello messages and a neighbor relationship is formed with the DoubleZero device after tunnel setup
- verification a (*, G) entry on the DoubleZero device is created when we send a pim join message after tunnel setup

Publisher test:
- verification a (S, G) entry is create on the DoubleZero device after tunnel setup

In order for the DoubleZero device container to correctly handle multicast, it needed to be configured to use Berkley Extensible Soft Switch mode (sfe) instead of kernel mode.