### PR TITLE
e2e: make multicast address space reflect prod

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -100,7 +100,7 @@ func (r *ShowIpRoute) GetCmd() string {
 // show ip mroute sparse-mode
 //
 // "groups": {
-//     "224.5.6.0": {
+//     "233.84.178.0": {
 //         "groupSources": {
 //             "0.0.0.0": {
 //                 "sourceAddress": "0.0.0.0",
@@ -1128,22 +1128,22 @@ func TestMulticastPublisher_Connect_Networking(t *testing.T) {
 			t.Fatalf("error fetching routes: %v", err)
 		}
 
-		// Look for multicast route (224.5.6.0/32 for example)
+		// Look for multicast route (233.84.178.0/32 for example)
 		foundMcastRoute := false
 		for _, route := range routes {
-			if route.Dst != nil && route.Dst.IP.Equal(net.ParseIP("224.5.6.0")) {
+			if route.Dst != nil && route.Dst.IP.Equal(net.ParseIP("233.84.178.0")) {
 				foundMcastRoute = true
 				break
 			}
 		}
 		if !foundMcastRoute {
-			t.Fatalf("multicast route 224.5.6.0/32 not found for publisher")
+			t.Fatalf("multicast route 233.84.178.0/32 not found for publisher")
 		}
 	})
 
 	t.Run("check_s_comma_g_is_created", func(t *testing.T) {
 		// Send single ping to simulate multicast traffic
-		cmd := exec.Command("ping", "-c", "1", "-w", "1", "224.5.6.0")
+		cmd := exec.Command("ping", "-c", "1", "-w", "1", "233.84.178.0")
 		_ = cmd.Run()
 
 		mroutes := &ShowIPMroute{}
@@ -1154,7 +1154,7 @@ func TestMulticastPublisher_Connect_Networking(t *testing.T) {
 			t.Fatalf("error fetching neighbors from doublezero device: %v", err)
 		}
 
-		mGroup := "224.5.6.0"
+		mGroup := "233.84.178.0"
 		groups, ok := mroutes.Groups[mGroup]
 		if !ok {
 			t.Fatalf("multicast group %s not found in mroutes", mGroup)
@@ -1162,7 +1162,7 @@ func TestMulticastPublisher_Connect_Networking(t *testing.T) {
 
 		_, ok = groups.GroupSources["64.86.249.81"]
 		if !ok {
-			t.Fatalf("missing S,G for (64.86.249.81, 224.5.6.0)")
+			t.Fatalf("missing S,G for (64.86.249.81, 233.84.178.0)")
 		}
 	})
 
@@ -1265,8 +1265,8 @@ func TestMulticastPublisher_Disconnect_Networking(t *testing.T) {
 
 		// Verify multicast routes are removed
 		for _, route := range routes {
-			if route.Dst != nil && route.Dst.IP.Equal(net.ParseIP("224.5.6.0")) {
-				t.Fatalf("multicast route 224.5.6.0/32 should be removed after disconnect")
+			if route.Dst != nil && route.Dst.IP.Equal(net.ParseIP("233.84.178.0")) {
+				t.Fatalf("multicast route 233.84.178.0/32 should be removed after disconnect")
 			}
 		}
 	})
@@ -1356,16 +1356,16 @@ func TestMulticastSubscriber_Connect_Networking(t *testing.T) {
 			t.Fatalf("error fetching tunnel addresses: %v", err)
 		}
 
-		// Check for multicast group address (e.g., 224.5.6.0/32)
+		// Check for multicast group address (e.g., 233.84.178.0/32)
 		foundMcastAddr := false
 		for _, addr := range addrs {
-			if addr.IP.Equal(net.ParseIP("224.5.6.0")) {
+			if addr.IP.Equal(net.ParseIP("233.84.178.0")) {
 				foundMcastAddr = true
 				break
 			}
 		}
 		if !foundMcastAddr {
-			t.Fatalf("multicast group address 224.5.6.0 not found on tunnel for subscriber")
+			t.Fatalf("multicast group address 233.84.178.0 not found on tunnel for subscriber")
 		}
 	})
 
@@ -1403,7 +1403,7 @@ func TestMulticastSubscriber_Connect_Networking(t *testing.T) {
 				return false, fmt.Errorf("error fetching neighbors from doublezero device: %v", err)
 			}
 
-			mGroup := "224.5.6.0"
+			mGroup := "233.84.178.0"
 			groups, ok := mroutes.Groups[mGroup]
 			if !ok {
 				return false, nil
@@ -1422,7 +1422,7 @@ func TestMulticastSubscriber_Connect_Networking(t *testing.T) {
 
 		err = waitForCondition(t, condition, 30*time.Second)
 		if err != nil {
-			t.Fatalf("PIM join not received for 224.5.6.0: %v", err)
+			t.Fatalf("PIM join not received for 233.84.178.0: %v", err)
 		}
 	})
 

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -210,7 +210,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -184,7 +184,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -210,7 +210,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -184,7 +184,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -218,7 +218,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -184,7 +184,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/multicast_publisher/doublezero_multicast_group_list.txt
+++ b/e2e/fixtures/multicast_publisher/doublezero_multicast_group_list.txt
@@ -1,2 +1,2 @@
  account                                      | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
- 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 224.5.6.0    | 10Gbps        | 1          | 0           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
+ 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 233.84.178.0    | 10Gbps        | 1          | 0           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.txt
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -212,14 +212,14 @@ no ip prefix-list PL-USER-519
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry
-   permit host 224.5.6.0
+   permit host 233.84.178.0
    deny 224.0.0.0/4
 !
 no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.txt
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.txt
@@ -3,7 +3,7 @@ ip multicast-routing
 !
 router pim sparse-mode
    ipv4
-      rp address 10.0.0.0 224.5.6.0/24 override
+      rp address 10.0.0.0 233.84.178.0/24 override
 !
 vrf instance vrf1
 ip routing vrf vrf1
@@ -184,7 +184,7 @@ no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry
    permit ip any 224.0.0.13/32
-   permit ip any 224.5.6.0/24
+   permit ip any 233.84.178.0/24
    deny ip any any
 !
 no ip access-list SEC-USER-SUB-MCAST-IN

--- a/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.txt
+++ b/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.txt
@@ -1,2 +1,2 @@
  account                                      | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
- 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 224.5.6.0    | 10Gbps        | 1          | 1           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
+ 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 233.84.178.0    | 10Gbps        | 1          | 1           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe

--- a/e2e/start_e2e.sh
+++ b/e2e/start_e2e.sh
@@ -137,8 +137,8 @@ start_doublezerod() {
 
 populate_data_onchain() {
     print_banner "Populate global configuration onchain"
-    echo doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 224.5.6.0/24
-    doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 224.5.6.0/24
+    echo doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24
+    doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24
     print_banner "Global configuration onchain"
     doublezero global-config get
 


### PR DESCRIPTION
We said we wanted to use [GLOP multicast space](https://datatracker.ietf.org/doc/html/rfc3180) in production so this changes the e2e tests to reflect this. The second two octets are derived from our 16-bit ASN 21682 per the GLOP spec.