### PR TITLE
 CLI: doublezero multicast group list, incorrect # of publishers

### DIFF
--- a/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.txt
+++ b/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.txt
@@ -1,2 +1,2 @@
  account                                      | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
- 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 233.84.178.0    | 10Gbps        | 1          | 1           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe
+ 52ieY9ydcJsms5rYMdsYtH6SnpMvWT2GcvAa8UydRdgi | mg01 | 233.84.178.0    | 10Gbps        | 0          | 1           | activated | Dc3LFdWwKGJvJcVkXhAr14kh1HS6pN7oCWrvHfQtsHGe

--- a/smartcontract/cli/src/multicastgroup/get.rs
+++ b/smartcontract/cli/src/multicastgroup/get.rs
@@ -26,13 +26,15 @@ impl GetMulticastGroupCliCommand {
 
         // Write the multicast group details first
         writeln!(out,
-        "account: {}\r\ncode: {}\r\nmulticast_ip: {}\r\nmax_bandwidth: {}\r\rpublisher_allowlist: {}\r\nsubscriber_allowlist: {}\r\nstatus: {}\r\nowner: {}\r\n\r\nusers:\r\n",
+        "account: {}\r\ncode: {}\r\nmulticast_ip: {}\r\nmax_bandwidth: {}\r\rpublisher_allowlist: {}\r\nsubscriber_allowlist: {}\r\npublishers: {}\r\nsubscribers: {}\r\nstatus: {}\r\nowner: {}\r\n\r\nusers:\r\n",
         pubkey,
         mgroup.code,
         ipv4_to_string(&mgroup.multicast_ip),
         bandwidth_to_string(&mgroup.max_bandwidth),
         mgroup.pub_allowlist.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
         mgroup.sub_allowlist.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
+        mgroup.publishers.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
+        mgroup.subscribers.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
         mgroup.status,
         mgroup.owner
         )?;
@@ -272,7 +274,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\ncode: test\r\nmulticast_ip: 10.0.0.1\r\nmax_bandwidth: 1Gbps\r\rpublisher_allowlist: \r\nsubscriber_allowlist: \r\nstatus: activated\r\nowner: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\n\r\nusers:\r\n\n account                                   | multicast_mode | device                           | location | cyoa_type  | client_ip   | tunnel_id | tunnel_net  | dz_ip    | status    | owner                                     \n 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 | Tx             | 11111111111111111111111111111111 |          | GREOverDIA | 192.168.1.1 | 12345     | 10.0.0.0/32 | 10.0.0.2 | activated | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 \n");
+        assert_eq!(output_str, "account: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\ncode: test\r\nmulticast_ip: 10.0.0.1\r\nmax_bandwidth: 1Gbps\r\rpublisher_allowlist: \r\nsubscriber_allowlist: \r\npublishers: 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1\r\nsubscribers: \r\nstatus: activated\r\nowner: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\n\r\nusers:\r\n\n account                                   | multicast_mode | device                           | location | cyoa_type  | client_ip   | tunnel_id | tunnel_net  | dz_ip    | status    | owner                                     \n 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 | Tx             | 11111111111111111111111111111111 |          | GREOverDIA | 192.168.1.1 | 12345     | 10.0.0.0/32 | 10.0.0.2 | activated | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 \n");
 
         // Expected success
         let mut output = Vec::new();
@@ -282,6 +284,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\ncode: test\r\nmulticast_ip: 10.0.0.1\r\nmax_bandwidth: 1Gbps\r\rpublisher_allowlist: \r\nsubscriber_allowlist: \r\nstatus: activated\r\nowner: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\n\r\nusers:\r\n\n account                                   | multicast_mode | device                           | location | cyoa_type  | client_ip   | tunnel_id | tunnel_net  | dz_ip    | status    | owner                                     \n 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 | Tx             | 11111111111111111111111111111111 |          | GREOverDIA | 192.168.1.1 | 12345     | 10.0.0.0/32 | 10.0.0.2 | activated | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 \n");
+        assert_eq!(output_str, "account: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\ncode: test\r\nmulticast_ip: 10.0.0.1\r\nmax_bandwidth: 1Gbps\r\rpublisher_allowlist: \r\nsubscriber_allowlist: \r\npublishers: 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1\r\nsubscribers: \r\nstatus: activated\r\nowner: CahibSNzuzo1MZhonHXLw3bJRmZoecDSJRXWdH4WFYJK\r\n\r\nusers:\r\n\n account                                   | multicast_mode | device                           | location | cyoa_type  | client_ip   | tunnel_id | tunnel_net  | dz_ip    | status    | owner                                     \n 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 | Tx             | 11111111111111111111111111111111 |          | GREOverDIA | 192.168.1.1 | 12345     | 10.0.0.0/32 | 10.0.0.2 | activated | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1 \n");
     }
 }

--- a/smartcontract/cli/src/user/get.rs
+++ b/smartcontract/cli/src/user/get.rs
@@ -18,7 +18,7 @@ impl GetUserCliCommand {
         let (pubkey, user) = client.get_user(GetUserCommand { pubkey })?;
 
         writeln!(out,
-                "account: {} user_type: {} device: {} cyoa_type: {} client_ip: {} tunnel_net: {} dz_ip: {} status: {} owner: {}",
+                "account: {}\r\nuser_type: {}\r\ndevice: {}\r\ncyoa_type: {}\r\nclient_ip: {}\r\ntunnel_net: {}\r\ndz_ip: {}\r\npublishers: {}\r\nsuscribers: {}\r\nstatus: {}\r\nowner: {}",
                 pubkey,
                 user.user_type,
                 user.device_pk,
@@ -26,6 +26,8 @@ impl GetUserCliCommand {
                 ipv4_to_string(&user.client_ip),
                 networkv4_to_string(&user.tunnel_net),
                 ipv4_to_string(&user.dz_ip),
+                user.publishers.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
+                user.subscribers.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", "),
                 user.status,
                 user.owner
             )?;
@@ -100,6 +102,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw user_type: IBRL device: 11111111111111111111111111111111 cyoa_type: GREOverDIA client_ip: 10.0.0.1 tunnel_net: 10.2.3.4/24 dz_ip: 10.0.0.2 status: activated owner: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw\n");
+        assert_eq!(output_str, "account: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw\r\nuser_type: IBRL\r\ndevice: 11111111111111111111111111111111\r\ncyoa_type: GREOverDIA\r\nclient_ip: 10.0.0.1\r\ntunnel_net: 10.2.3.4/24\r\ndz_ip: 10.0.0.2\r\npublishers: \r\nsuscribers: \r\nstatus: activated\r\nowner: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw\n");
     }
 }

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -4,7 +4,13 @@ use doublezero_sla_program::{
 };
 use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
-use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use crate::{
+    commands::{
+        globalstate::get::GetGlobalStateCommand,
+        multicastgroup::subscribe::SubscribeMulticastGroupCommand,
+    },
+    DoubleZeroClient,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct DeleteUserCommand {
@@ -17,14 +23,30 @@ impl DeleteUserCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        let (pda_pubkey, bump_seed) = get_user_pda(&client.get_program_id(), self.index);
+        let (user_pubkey, bump_seed) = get_user_pda(&client.get_program_id(), self.index);
+
+        let user = client
+            .get(user_pubkey)
+            .map_err(|_| eyre::eyre!("User not found (index: {})", user_pubkey))?
+            .get_user();
+
+        for mgroup_pk in user.publishers.iter().chain(user.subscribers.iter()) {
+            SubscribeMulticastGroupCommand {
+                group_pk: *mgroup_pk,
+                user_pk: user_pubkey,
+                publisher: false,
+                subscriber: false,
+            }
+            .execute(client)?;
+        }
+
         client.execute_transaction(
             DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
                 index: self.index,
                 bump_seed,
             }),
             vec![
-                AccountMeta::new(pda_pubkey, false),
+                AccountMeta::new(user_pubkey, false),
                 AccountMeta::new(globalstate_pubkey, false),
             ],
         )

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -3,21 +3,22 @@
 clear
 killall solana-test-validator
 killall doublezero-activator
+killall solana
 
 # Build the program
 echo "Build the program"
 cargo build-sbf --manifest-path ../programs/dz-sla-program/Cargo.toml -- -Znext-lockfile-bump
-cp ../programs/dz-sla-program/target/deploy/doublezero_sla_program.so ./target/doublezero_sla_program.so
+cp ../../target/deploy/doublezero_sla_program.so ./target/doublezero_sla_program.so
 
 #Build the activator
 echo "Build the activator"
 cargo build --manifest-path ../../activator/Cargo.toml
-cp ../../activator/target/debug/doublezero-activator ./target/
+cp ../../target/debug/doublezero-activator ./target/
 
 #Build the activator
 echo "Build the client"
 cargo build --manifest-path ../../client/doublezero/Cargo.toml
-cp ../../client/doublezero/target/debug/doublezero ./target/
+cp ../../target/debug/doublezero ./target/
 
 # Configure to connect to localnet
 solana config set --url http://127.0.0.1:8899
@@ -33,6 +34,10 @@ solana-test-validator --reset --bpf-program ./keypair.json ./target/doublezero_s
 # Wait for the solana test cluster to start
 echo "Waiting 15 seconds to start the solana test cluster"
 sleep 15
+
+# start isntruction logger
+echo "Start instruction logger"
+solana logs > ./logs/instruction.log 2>&1 &
 
 # initialice doublezero smart contract
 ./target/doublezero init

--- a/smartcontract/test/stop-test.sh
+++ b/smartcontract/test/stop-test.sh
@@ -2,3 +2,4 @@
 
 killall solana-test-validator
 killall doublezero-activator
+killall solana


### PR DESCRIPTION
Resolved an issue where users disconnected from a multicast group were still being counted as active. The root cause was that the unsubscribe command was not being invoked prior to user deletion. The user deletion logic has been updated to explicitly call unsubscribe and related cleanup steps before removing the user from the system.