### PR TITLE
Fix: bug in process_user_event device insertion

### DIFF
--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -133,9 +133,9 @@ impl Activator {
     }
 
     fn add_device(&mut self, pubkey: &Pubkey, device: &Device) {
-        if !self.devices.contains_key(pubkey) {
-            self.devices.insert(*pubkey, DeviceState::new(device));
-        }
+        self.devices
+            .entry(*pubkey)
+            .or_insert_with(|| DeviceState::new(device));
     }
 
     pub fn run(&mut self) -> eyre::Result<()> {
@@ -200,7 +200,6 @@ impl Activator {
                     AccountData::User(user) => {
                         process_user_event(
                             client,
-                            pubkey,
                             devices,
                             user_tunnel_ips,
                             tunnel_tunnel_ids,

--- a/activator/src/process/multicastgroup.rs
+++ b/activator/src/process/multicastgroup.rs
@@ -6,7 +6,7 @@ use doublezero_sdk::{
     ipv4_to_string, DoubleZeroClient, MulticastGroup, MulticastGroupStatus,
 };
 use solana_sdk::pubkey::Pubkey;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 pub fn process_multicastgroup_event(
     client: &dyn DoubleZeroClient,
@@ -50,10 +50,10 @@ pub fn process_multicastgroup_event(
             }
         }
         MulticastGroupStatus::Activated => {
-            if !multicastgroups.contains_key(pubkey) {
-                println!("Add MulticastGroup: {} ", multicastgroup.code,);
+            if let Entry::Vacant(entry) = multicastgroups.entry(*pubkey) {
+                println!("Add MulticastGroup: {} ", multicastgroup.code);
 
-                multicastgroups.insert(*pubkey, multicastgroup.clone());
+                entry.insert(multicastgroup.clone());
                 multicastgroup_tunnel_ips.assign_block((multicastgroup.multicast_ip, 32));
             }
         }


### PR DESCRIPTION
Fix #479

Summary
----
The `process_user_event` fun was incorrectly using the user's pubkey instead of the device's pubkey when inserting new devices into the devices HashMap. This causes the devices to be indexed by user pubkeys rather than device keys, potentially breaking subsequent device lookups.

This PR:
- Removes the unused user pubkey param entirely from process_user_event
- Fixes device insertion to use the correct key (user.device_pk)

Furthermore:
- Refactors `contains_key -> insert` lookups to use entry api (this is the preferred way of doing this since it's safer and uses a single map lookup)
- Improves error handling with early returns