### PR TITLE
client: Fix persistent spinner show on status command

### DIFF
--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -18,12 +18,16 @@ impl StatusCliCommand {
         check_doublezero(Some(&spinner))?;
 
         match controller.status().await {
-            Err(e) => print_error(e),
+            Err(e) => {
+                spinner.finish_and_clear();
+                print_error(e)
+            }
             Ok(status_responses) => {
                 if !status_responses.is_empty() {
                     let table = Table::new(status_responses)
                         .with(Style::psql().remove_horizontals())
                         .to_string();
+                    spinner.finish_and_clear();
                     println!("{}", table);
                 }
             }


### PR DESCRIPTION
Summary
----
This is very minor but it was annoying me.

Current:
```
ubuntu@chi-dn-bm2:~$ which doublezero
/usr/bin/doublezero
ubuntu@chi-dn-bm2:~$ doublezero status
DoubleZero Service Provisioning
\
 Tunnel status | Last Session Update     | Tunnel Name | Tunnel src      | Tunnel dst | Doublezero IP | User Type
 up            | 2025-06-04 20:13:51 UTC | doublezero1 | 137.174.145.145 | 100.0.0.1  | 10.251.2.1    | Multicast
 ```
 
 With this PR:
 ```
 ubuntu@chi-dn-bm2:~/.bin$ ./doublezero status
DoubleZero Service Provisioning
 Tunnel status | Last Session Update     | Tunnel Name | Tunnel src      | Tunnel dst | Doublezero IP | User Type
 up            | 2025-06-04 20:13:51 UTC | doublezero1 | 137.174.145.145 | 100.0.0.1  | 10.251.2.1    | Multicast
 ```