### PR TITLE
Fix multicast group deletion and improve activator log formatting

### DIFF
--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -147,28 +147,16 @@ impl Activator {
         );
 
         self.devices.iter().for_each(|(_pubkey, device)| {
-            print!(
-                "Device code: {} public_ip: {} dz_prefixes: {} tunnels: ",
+            println!(
+                "Device code: {} public_ip: {} dz_prefixes: {} tunnels: {} tunnel_net: {} assigned: {}",
                 device.device.code,
                 ipv4_to_string(&device.device.public_ip),
-                networkv4_list_to_string(&device.device.dz_prefixes)
+                networkv4_list_to_string(&device.device.dz_prefixes),
+                device.tunnel_ids.display_assigned(),
+                self.user_tunnel_ips.base_block,
+                self.user_tunnel_ips.display_assigned_ips(),
             );
-
-            if device.tunnel_ids.assigned.is_empty() {
-                print!("-,");
-            }
-            device.tunnel_ids.assigned.iter().for_each(|tunnel_id| {
-                print!("{},", tunnel_id);
-            });
-            println!("\x08 ");
         });
-
-        print!("tunnel_net: {} assigned: ", self.user_tunnel_ips.base_block);
-        if self.user_tunnel_ips.assigned_ips.is_empty() {
-            print!("-,");
-        }
-        self.user_tunnel_ips.print_assigned_ips();
-        println!("\x08 ");
 
         // store these so we can move them into the below closure without making the borrow checker mad
         let devices = &mut self.devices;

--- a/activator/src/idallocator.rs
+++ b/activator/src/idallocator.rs
@@ -25,4 +25,12 @@ impl IDAllocator {
         self.assigned.push(id);
         id
     }
+
+    pub fn display_assigned(&self) -> String {
+        self.assigned
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<String>>()
+            .join(",")
+    }
 }

--- a/activator/src/ipblockallocator.rs
+++ b/activator/src/ipblockallocator.rs
@@ -103,13 +103,15 @@ impl IPBlockAllocator {
         None
     }
 
-    pub fn print_assigned_ips(&self) {
+    pub fn display_assigned_ips(&self) -> String {
+        let mut ips = String::new();
         for (index, assigned) in self.assigned_ips.iter().enumerate() {
             if *assigned {
                 let ip = self.index_to_ip(index);
-                print!("{},", ip);
+                ips.push_str(&format!("{},", ip));
             }
         }
+        ips.trim_end_matches(',').to_string()
     }
 
     /// Converts an IP address to an index in the bit vector.

--- a/smartcontract/cli/src/location/delete.rs
+++ b/smartcontract/cli/src/location/delete.rs
@@ -41,6 +41,7 @@ mod tests {
     use doublezero_sdk::Location;
     use doublezero_sdk::LocationStatus;
     use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::Signature;
 
     #[test]
@@ -66,19 +67,20 @@ mod tests {
             lng: 56.78,
             loc_id: 1,
             status: LocationStatus::Activated,
-            owner: pda_pubkey,
+            owner: Pubkey::default(),
         };
 
         client
             .expect_check_requirements()
             .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
             .returning(|_| Ok(()));
+        let location_cloned = location.clone();
         client
             .expect_get_location()
             .with(predicate::eq(GetLocationCommand {
                 pubkey_or_code: pda_pubkey.to_string(),
             }))
-            .returning(move |_| Ok((pda_pubkey, location.clone())));
+            .returning(move |_| Ok((pda_pubkey, location_cloned.clone())));
 
         client
             .expect_delete_location()

--- a/smartcontract/cli/src/multicastgroup/list.rs
+++ b/smartcontract/cli/src/multicastgroup/list.rs
@@ -19,8 +19,6 @@ pub struct ListMulticastGroupCliCommand {
 pub struct MulticastGroupDisplay {
     #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
-    pub owner: Pubkey,
     pub code: String,
     #[serde(serialize_with = "crate::serializer::serialize_ipv4_as_string")]
     #[tabled(display = "doublezero_sla_program::types::ipv4_to_string")]
@@ -35,6 +33,8 @@ pub struct MulticastGroupDisplay {
     #[tabled(display = "crate::util::display_count")]
     pub subscribers: Vec<Pubkey>,
     pub status: MulticastGroupStatus,
+    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    pub owner: Pubkey,
 }
 
 impl ListMulticastGroupCliCommand {
@@ -167,7 +167,7 @@ mod tests {
         assert!(res.is_ok());
 
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, " account                                   | owner                                     | code                | multicast_ip | max_bandwidth | publishers | subscribers | status    \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9 | multicastgroup_code | 1.2.3.4      | 1.23Kbps      | 2          | 1           | activated \n");
+        assert_eq!(output_str, " account                                   | code                | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner                                     \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR | multicastgroup_code | 1.2.3.4      | 1.23Kbps      | 2          | 1           | activated | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9 \n");
 
         let mut output = Vec::new();
         let res = ListMulticastGroupCliCommand {
@@ -178,6 +178,6 @@ mod tests {
         assert!(res.is_ok());
 
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"owner\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"code\":\"multicastgroup_code\",\"multicast_ip\":\"1.2.3.4\",\"max_bandwidth\":\"1.23Kbps\",\"publishers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo2, 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3\",\"subscribers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3\",\"status\":\"Activated\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"code\":\"multicastgroup_code\",\"multicast_ip\":\"1.2.3.4\",\"max_bandwidth\":\"1.23Kbps\",\"publishers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo2, 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3\",\"subscribers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3\",\"status\":\"Activated\",\"owner\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\"}]\n");
     }
 }

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/delete.rs
@@ -1,10 +1,15 @@
+use crate::{
+    commands::{
+        globalstate::get::GetGlobalStateCommand,
+        multicastgroup::subscribe::SubscribeMulticastGroupCommand,
+    },
+    DoubleZeroClient,
+};
 use doublezero_sla_program::{
     instructions::DoubleZeroInstruction, pda::get_multicastgroup_pda,
     processors::multicastgroup::delete::MulticastGroupDeleteArgs,
 };
 use solana_sdk::{instruction::AccountMeta, signature::Signature};
-
-use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct DeleteMulticastGroupCommand {
@@ -17,14 +22,31 @@ impl DeleteMulticastGroupCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        let (pda_pubkey, bump_seed) = get_multicastgroup_pda(&client.get_program_id(), self.index);
+        let (mgroup_pubkey, bump_seed) =
+            get_multicastgroup_pda(&client.get_program_id(), self.index);
+
+        let mgroup = client
+            .get(mgroup_pubkey)
+            .map_err(|_| eyre::eyre!("MulticastGroup not found ({})", mgroup_pubkey))?
+            .get_multicastgroup();
+
+        for user_pk in mgroup.publishers.iter().chain(mgroup.subscribers.iter()) {
+            SubscribeMulticastGroupCommand {
+                group_pk: mgroup_pubkey,
+                user_pk: *user_pk,
+                publisher: false,
+                subscriber: false,
+            }
+            .execute(client)?;
+        }
+
         client.execute_transaction(
             DoubleZeroInstruction::DeleteMulticastGroup(MulticastGroupDeleteArgs {
                 index: self.index,
                 bump_seed,
             }),
             vec![
-                AccountMeta::new(pda_pubkey, false),
+                AccountMeta::new(mgroup_pubkey, false),
                 AccountMeta::new(globalstate_pubkey, false),
             ],
         )
@@ -39,18 +61,45 @@ mod tests {
     };
     use doublezero_sla_program::{
         instructions::DoubleZeroInstruction,
-        pda::{get_globalstate_pda, get_location_pda},
+        pda::{get_globalstate_pda, get_multicastgroup_pda},
         processors::multicastgroup::delete::MulticastGroupDeleteArgs,
+        state::{
+            accountdata::AccountData,
+            accounttype::AccountType,
+            multicastgroup::{MulticastGroup, MulticastGroupStatus},
+        },
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature};
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
-    fn test_commands_location_delete_command() {
+    fn test_commands_multicastgroup_delete_command() {
         let mut client = create_test_client();
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
-        let (pda_pubkey, bump_seed) = get_location_pda(&client.get_program_id(), 1);
+        let (pda_pubkey, bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
+
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 2,
+            bump_seed,
+            tenant_pk: Pubkey::default(),
+            code: "mg01".to_string(),
+            multicast_ip: [0, 0, 0, 0],
+            max_bandwidth: 0,
+            status: MulticastGroupStatus::Activated,
+            pub_allowlist: vec![client.get_payer()],
+            sub_allowlist: vec![client.get_payer()],
+            publishers: vec![],
+            subscribers: vec![],
+            owner: Pubkey::default(),
+        };
+
+        let mgroup_cloned = mgroup.clone();
+        client
+            .expect_get()
+            .with(predicate::eq(pda_pubkey))
+            .returning(move |_| Ok(AccountData::MulticastGroup(mgroup_cloned.clone())));
 
         client
             .expect_execute_transaction()

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -27,7 +27,7 @@ impl DeleteUserCommand {
 
         let user = client
             .get(user_pubkey)
-            .map_err(|_| eyre::eyre!("User not found (index: {})", user_pubkey))?
+            .map_err(|_| eyre::eyre!("User not found ({})", user_pubkey))?
             .get_user();
 
         for mgroup_pk in user.publishers.iter().chain(user.subscribers.iter()) {

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -47,7 +47,7 @@ solana logs > ./logs/instruction.log 2>&1 &
 
 # Build the activator
 echo "Start the activator"
-./target/doublezero-activator --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX >./logs/activator.log 2>&1 &
+./target/doublezero-activator --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX --ws ws://127.0.0.1:8900 >./logs/activator.log 2>&1 &
 
 echo "Add allowlist"
 ./target/doublezero global-config allowlist add --pubkey 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX


### PR DESCRIPTION
The command for deleting multicast groups is being updated to unsubscribe all users from the group before it is deleted. While this may not be a common operation, it helps prevent users from remaining subscribed to a group that no longer exists. As a result, the multicast user will be left without a subscription, so it's necessary to ensure that both the daemon and the controller support this behavior.
The way the activator writes logs is also being modified to remove special characters, ensuring they can be correctly displayed in the service logs.
