### PR TITLE
Remove autojoin, add route manually and ensure prune is sent before tunnel teardown

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,3 +6,7 @@ RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/s
     apt install -y gcc-x86-64-linux-gnu goreleaser-pro && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*
+# Install gotest
+RUN curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && \
+    chmod +x gotest && \
+    mv gotest /usr/local/bin/gotest

--- a/client/doublezerod/internal/manager/http_test.go
+++ b/client/doublezerod/internal/manager/http_test.go
@@ -441,7 +441,7 @@ func (m *MockNetlink) TunnelDelete(n *routing.Tunnel) error {
 	return nil
 }
 
-func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string, _ bool) error {
+func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string) error {
 	m.tunAddrAdded = append(m.tunAddrAdded, ip)
 	return nil
 }

--- a/client/doublezerod/internal/routing/netlink.go
+++ b/client/doublezerod/internal/routing/netlink.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	nl "github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 type Netlink struct{}
@@ -15,7 +14,7 @@ type Netlink struct{}
 type Netlinker interface {
 	TunnelAdd(*Tunnel) error
 	TunnelDelete(*Tunnel) error
-	TunnelAddrAdd(*Tunnel, string, bool) error
+	TunnelAddrAdd(*Tunnel, string) error
 	TunnelUp(*Tunnel) error
 	RouteAdd(*Route) error
 	RouteDelete(*Route) error
@@ -54,7 +53,7 @@ func (n Netlink) TunnelDelete(t *Tunnel) error {
 }
 func (n Netlink) TunnelGet(t *Tunnel) error { return nil }
 
-func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string, autojoin bool) error {
+func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string) error {
 	gre := &nl.Gretun{
 		LinkAttrs: nl.LinkAttrs{
 			Name:      t.Name,
@@ -67,9 +66,7 @@ func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string, autojoin bool) error {
 	if err != nil {
 		return fmt.Errorf("tunnel: error parsing addr: %v", err)
 	}
-	if autojoin {
-		addr.Flags = unix.IFA_F_MCAUTOJOIN
-	}
+
 	err = nl.AddrAdd(gre, addr)
 	if err != nil && errors.Is(err, syscall.EEXIST) {
 		return ErrAddressExists

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	rt "runtime"
-	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -1301,8 +1300,6 @@ func TestMulticastSubscriber(t *testing.T) {
 		if tun.Attrs().MTU != 1476 {
 			t.Fatalf("tunnel mtu should be 1476; got %d", tun.Attrs().MTU)
 		}
-
-		verifyMulticastAddrSet(t, "doublezero1", "239.0.0.1/32")
 	})
 
 	t.Run("verify_state_file_is_created", func(t *testing.T) {
@@ -1805,7 +1802,6 @@ func TestServiceCoexistence(t *testing.T) {
 
 	t.Run("verify_multicast_state", func(t *testing.T) {
 		verifyTunnelIsUp(t, "doublezero1")
-		verifyMulticastAddrSet(t, "doublezero1", "239.0.0.1/32")
 		verifyBgpSessionIsUp(t, httpClient, api.UserTypeMulticast)
 		verifyPimHelloMessageSent(t, pimHelloChan)
 		verifyPimJoinMessageSent(t, pimJoinPruneChan, net.IP([]byte{169, 254, 1, 0}))
@@ -1881,7 +1877,6 @@ func TestServiceCoexistence(t *testing.T) {
 
 	t.Run("verify_multicast_state_after_restart", func(t *testing.T) {
 		verifyTunnelIsUp(t, "doublezero1")
-		verifyMulticastAddrSet(t, "doublezero1", "239.0.0.1/32")
 		verifyBgpSessionIsUp(t, httpClient, api.UserTypeMulticast)
 		verifyPruneMessageSent(t, pimJoinPruneChan, net.IP([]byte{169, 254, 1, 0}))
 		verifyPimHelloMessageSent(t, pimHelloChan)
@@ -2080,29 +2075,6 @@ func verifyTunnelIsUp(t *testing.T, tunName string) {
 		if tun.Attrs().MTU != 1476 {
 			t.Fatalf("tunnel mtu should be 1476; got %d", tun.Attrs().MTU)
 		}
-	})
-}
-
-// verifyMulticastAddrSet checks if the multicast address is set on the tunnel interface
-// with the correct flags. The mAddr argument should be a multicast address in CIDR notation.
-func verifyMulticastAddrSet(t *testing.T, tunName string, mAddr string) {
-	t.Run("verify_multicast_addr_set", func(t *testing.T) {
-		tun, err := nl.LinkByName(tunName)
-		if err != nil {
-			t.Fatalf("error fetching tunnel info: %v", err)
-		}
-		addrs, err := nl.AddrList(tun, nl.FAMILY_V4)
-		if err != nil {
-			t.Fatalf("error fetching tunnel addresses: %v", err)
-		}
-		isMulticastAddrSet := slices.ContainsFunc(addrs, func(addr nl.Addr) bool {
-			return addr.String() == fmt.Sprintf("%s doublezero1", mAddr) && addr.Flags&unix.IFA_F_MCAUTOJOIN == 0x400
-		})
-
-		if !isMulticastAddrSet {
-			t.Fatalf("multicast address %s not found on tunnel doublezero1", mAddr)
-		}
-
 	})
 }
 

--- a/client/doublezerod/internal/services/base.go
+++ b/client/doublezerod/internal/services/base.go
@@ -68,7 +68,7 @@ func createBaseTunnel(nl routing.Netlinker, tun *routing.Tunnel) error {
 		}
 	}
 	slog.Info("tunnel: adding address to tunnel interface", "address", tun.LocalOverlay)
-	err = nl.TunnelAddrAdd(tun, tun.LocalOverlay.String()+"/31", false)
+	err = nl.TunnelAddrAdd(tun, tun.LocalOverlay.String()+"/31")
 	if err != nil {
 		if errors.Is(err, routing.ErrAddressExists) {
 			slog.Error("tunnel: address already present on tunnel")
@@ -90,7 +90,7 @@ func createTunnelWithIP(nl routing.Netlinker, tun *routing.Tunnel, dzIp net.IP) 
 	}
 
 	slog.Info("tunnel: adding dz address to tunnel interface", "dz address", dzIp.String()+"/32")
-	err = nl.TunnelAddrAdd(tun, dzIp.String()+"/32", false)
+	err = nl.TunnelAddrAdd(tun, dzIp.String()+"/32")
 	if err != nil {
 		if errors.Is(err, routing.ErrAddressExists) {
 			slog.Error("tunnel: address already present on tunnel")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1318,26 +1318,27 @@ func TestMulticastSubscriber_Connect_Networking(t *testing.T) {
 		}
 	})
 
-	t.Run("check_multicast_group_addresses", func(t *testing.T) {
-		// For subscribers, multicast group addresses should be configured on the tunnel
-		tun, err := nl.LinkByName("doublezero1")
+	t.Run("check_multicast_static_routes", func(t *testing.T) {
+		routes, err := nl.RouteListFiltered(
+			0,
+			&nl.Route{
+				Table: syscall.RT_TABLE_MAIN,
+			},
+			nl.RT_FILTER_TABLE,
+		)
 		if err != nil {
-			t.Fatalf("error fetching tunnel status: %v", err)
-		}
-		addrs, err := nl.AddrList(tun, nl.FAMILY_V4)
-		if err != nil {
-			t.Fatalf("error fetching tunnel addresses: %v", err)
+			t.Fatalf("error fetching routes: %v", err)
 		}
 
 		// Check for multicast group address (e.g., 233.84.178.0/32)
-		foundMcastAddr := false
-		for _, addr := range addrs {
-			if addr.IP.Equal(net.ParseIP("233.84.178.0")) {
-				foundMcastAddr = true
+		foundMcastRoute := false
+		for _, route := range routes {
+			if route.Dst != nil && route.Dst.IP.Equal(net.ParseIP("233.84.178.0")) {
+				foundMcastRoute = true
 				break
 			}
 		}
-		if !foundMcastAddr {
+		if !foundMcastRoute {
 			t.Fatalf("multicast group address 233.84.178.0 not found on tunnel for subscriber")
 		}
 	})


### PR DESCRIPTION
## Summary of Changes

This PR removes autojoin in favor of manual creating the routes (multicast.go) on the subscriber side. Additionally, this adds a 1 second sleep after the prune message is sent to make sure that the message gets to the subscriber before the tunnel is torn down. 

This PR also adds ancillary changes like adding in `gotest` so tests have nice red and green colors in the devcontainer (we could update GH runner to have nice colors too). 

## Testing Verification

* Test have been updated to reflect the change and now pass
* This was manually verified on devnet using iperf to show that traffic flows from the publisher to the subscriber using iperf to verify traffic is sent and received and the subscriber disconnects and a tcpdump captures the prune message 

![Screenshot 2025-06-05 at 13 56 46](https://github.com/user-attachments/assets/7fee6af2-89c1-4c0d-8cc8-bc29069290ad)
