### PR TITLE
activator: Refactor idallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "doublezero-sla-program",
  "doublezero_sdk",
  "eyre",
+ "indexmap",
  "influxdb2",
  "influxdb2-derive",
  "influxdb2-structmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ http-body-util = "0"
 hyper = "1"
 hyper-util = "0"
 hyperlocal = { version = "0" }
+indexmap = "2"
 indicatif = "0"
 influxdb2 = "0"
 influxdb2-derive = "0"

--- a/activator/Cargo.toml
+++ b/activator/Cargo.toml
@@ -8,6 +8,7 @@ bitvec.workspace = true
 chrono.workspace = true
 clap.workspace = true
 eyre.workspace = true
+indexmap.workspace = true
 influxdb2.workspace = true
 influxdb2-derive.workspace = true
 influxdb2-structmap.workspace = true

--- a/activator/src/idallocator.rs
+++ b/activator/src/idallocator.rs
@@ -1,20 +1,25 @@
+use indexmap::IndexSet;
+
 #[derive(Debug)]
 pub struct IDAllocator {
     pub first: u16,
-    pub assigned: Vec<u16>,
+    pub assigned: IndexSet<u16>,
 }
 
 impl IDAllocator {
     pub fn new(first: u16, assigned: Vec<u16>) -> Self {
-        Self { first, assigned }
+        Self {
+            first,
+            assigned: assigned.into_iter().collect(),
+        }
     }
 
     pub fn assign(&mut self, id: u16) {
-        self.assigned.push(id);
+        self.assigned.insert(id);
     }
 
     pub fn unassign(&mut self, id: u16) {
-        self.assigned.retain(|&x| x != id);
+        self.assigned.shift_remove(&id);
     }
 
     pub fn next_available(&mut self) -> u16 {
@@ -22,7 +27,7 @@ impl IDAllocator {
         while self.assigned.contains(&id) {
             id += 1;
         }
-        self.assigned.push(id);
+        self.assigned.insert(id);
         id
     }
 
@@ -32,5 +37,98 @@ impl IDAllocator {
             .map(|id| id.to_string())
             .collect::<Vec<String>>()
             .join(",")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_allocator() {
+        let allocator = IDAllocator::new(100, vec![101, 103, 105]);
+        assert_eq!(allocator.first, 100);
+        assert_eq!(allocator.display_assigned(), "101,103,105");
+    }
+
+    #[test]
+    fn test_new_with_duplicates() {
+        let allocator = IDAllocator::new(100, vec![101, 103, 101, 105, 103]);
+        assert_eq!(allocator.display_assigned(), "101,103,105");
+    }
+
+    #[test]
+    fn test_assign() {
+        let mut allocator = IDAllocator::new(100, vec![101, 103]);
+        allocator.assign(102);
+        assert_eq!(allocator.display_assigned(), "101,103,102");
+
+        // Assign same id => Doesn't show up
+        allocator.assign(102);
+        assert_eq!(allocator.display_assigned(), "101,103,102");
+    }
+
+    #[test]
+    fn test_unassign() {
+        let mut allocator = IDAllocator::new(100, vec![101, 102, 103]);
+        allocator.unassign(102);
+        assert_eq!(allocator.display_assigned(), "101,103");
+
+        // Should not be able to assign non-existent ID
+        allocator.unassign(999);
+        assert_eq!(allocator.display_assigned(), "101,103");
+    }
+
+    #[test]
+    fn test_next_available_from_first() {
+        let mut allocator = IDAllocator::new(100, vec![101, 102]);
+        let id = allocator.next_available();
+        assert_eq!(id, 100);
+        assert_eq!(allocator.display_assigned(), "101,102,100");
+    }
+
+    #[test]
+    fn test_next_available_fills_gap() {
+        let mut allocator = IDAllocator::new(100, vec![100, 101, 103]);
+        let id = allocator.next_available();
+        assert_eq!(id, 102);
+        assert_eq!(allocator.display_assigned(), "100,101,103,102");
+    }
+
+    #[test]
+    fn test_next_available_after_all_taken() {
+        let mut allocator = IDAllocator::new(100, vec![100, 101, 102]);
+        let id = allocator.next_available();
+        assert_eq!(id, 103);
+        assert_eq!(allocator.display_assigned(), "100,101,102,103");
+    }
+
+    #[test]
+    fn test_reuse_unassigned_id() {
+        let mut allocator = IDAllocator::new(100, vec![100, 101, 102]);
+        allocator.unassign(101);
+        let id = allocator.next_available();
+        assert_eq!(id, 101);
+        assert_eq!(allocator.display_assigned(), "100,102,101");
+    }
+
+    #[test]
+    fn test_empty_allocator() {
+        let mut allocator = IDAllocator::new(200, vec![]);
+        assert_eq!(allocator.display_assigned(), "");
+
+        let id = allocator.next_available();
+        assert_eq!(id, 200);
+        assert_eq!(allocator.display_assigned(), "200");
+    }
+
+    #[test]
+    fn test_insertion_order_preserved() {
+        let mut allocator = IDAllocator::new(1, vec![5, 3, 7, 2]);
+        assert_eq!(allocator.display_assigned(), "5,3,7,2");
+
+        allocator.assign(4);
+        allocator.assign(6);
+        assert_eq!(allocator.display_assigned(), "5,3,7,2,4,6");
     }
 }


### PR DESCRIPTION
Fix #500

Summary
----

This PR:
- Use IndexSet for assigned ID tracking (O(1) instead of O(n) lookups)
- Automatic deduplication on construction
- Maintain insertion order for `display_assigned()`
- Add unit tests
- Maintain backward compat