### PR TITLE
rust: add rust-toolchain.toml with channel=stable

### DIFF
--- a/.github/workflows/release.activator.yml
+++ b/.github/workflows/release.activator.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: Swatinem/rust-cache@v2
-      - name: install rust for cli
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install rust for cli
+        uses: dtolnay/rust-toolchain@stable
       - name: install dependencies for rpm packaging
         run: |
           sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-24.04-16c-64gb
     steps:
       - uses: actions/checkout@v4
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: test
         run: cargo test --workspace --all-features

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
- Add `rust-toolchain.toml` with `channel=stable` to make sure it's used everywhere (dev, CI, e2e, release)
- Updated CI to use `dtolnay/rust-toolchain@stable`