### PR TITLE
Bugfix: dont panic if no mcast group

### DIFF
--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -174,7 +174,6 @@ impl ProvisioningCliCommand {
                 eyre::eyre!("Multicast group not found")
             })?;
 
-
         // Look for user
         let (user_pubkey, user) = self
             .find_or_create_user_and_subscribe(


### PR DESCRIPTION
## Summary of Changes

This PR fixes a bug where if no multicast groups are available, the client  would crash. Now it returns an error instead of panicking. 

## Testing Verification

Using the e2e tests container, tried to create a subscriber and a publisher without an existing multicast group. An error was returned, as expected, instead of a panic.

Subscriber
```
doublezero --keypair $SOLANA_KEYPAIR connect multicast subscriber mg01 --client-ip 64.86.249.86
using keypair: /root/.config/solana/id.json
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 64.86.249.86
🔍  Provisioning User for IP: 64.86.249.86
    Creating an account for the IP: 64.86.249.86
    The Device has been selected: ny5-dz01

Error: Subscriber not allowed

Location:
    smartcontract/sdk/rs/src/commands/user/create_subscribe.rs:50:24
/  Error creating user                                                                                                                                                Error: Error creating user
```

Publisher
```
doublezero --keypair $SOLANA_KEYPAIR connect multicast publisher mg01 --client-ip 64.86.249.86
using keypair: /root/.config/solana/id.json
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 64.86.249.86
🔍  Provisioning User for IP: 64.86.249.86
    Creating an account for the IP: 64.86.249.86
    The Device has been selected: ny5-dz01

Error: Publisher not allowed

Location:
    smartcontract/sdk/rs/src/commands/user/create_subscribe.rs:47:24
/  Error creating user                                                                                                                                                Error: Error creating user

```