### PR TITLE
Fix: rust early error returns

### DIFF
--- a/client/doublezero/src/command/helpers.rs
+++ b/client/doublezero/src/command/helpers.rs
@@ -20,7 +20,7 @@ pub async fn look_for_ip(
                     ip
                 }
                 Err(e) => {
-                    return Err(eyre::eyre!("Error getting public ip. Please provide it using the `--client-ip` argument. ({})", e.to_string()));
+                    eyre::bail!("Error getting public ip. Please provide it using the `--client-ip` argument. ({})", e.to_string());
                 }
             }
         },

--- a/client/doublezero/src/requirements.rs
+++ b/client/doublezero/src/requirements.rs
@@ -12,7 +12,7 @@ pub fn check_doublezero<T: ServiceController>(
             eprintln!("doublezero service is not accessible.");
         }
 
-        return Err(eyre::eyre!("Please start the doublezerod service."));
+        eyre::bail!("Please start the doublezerod service.");
     }
 
     // Check that the doublezerod is accessible
@@ -22,9 +22,7 @@ pub fn check_doublezero<T: ServiceController>(
         } else {
             eprintln!("doublezero service is not accessible.");
         }
-        return Err(eyre::eyre!(
-            "Please check the permissions of the doublezerod service."
-        ));
+        eyre::bail!("Please check the permissions of the doublezerod service.");
     }
 
     Ok(())

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -250,10 +250,7 @@ impl ServiceController for ServiceControllerImpl {
         match client.request(req).await {
             Ok(res) => {
                 if res.status() != 200 {
-                    return Err(eyre!(
-                        "Unable to connect to doublezero daemon: {}",
-                        res.status()
-                    ));
+                    eyre::bail!("Unable to connect to doublezero daemon: {}", res.status());
                 }
 
                 let data = res
@@ -269,7 +266,7 @@ impl ServiceController for ServiceControllerImpl {
                         println!("Data: {:?}", data);
 
                         if data.is_empty() {
-                            return Err(eyre!("No data returned"));
+                            eyre::bail!("No data returned");
                         }
 
                         match serde_json::from_slice::<ErrorResponse>(&data) {

--- a/smartcontract/cli/src/requirements.rs
+++ b/smartcontract/cli/src/requirements.rs
@@ -69,10 +69,10 @@ pub fn check_balance(client: &dyn CliCommand, spinner: Option<&ProgressBar>) -> 
                 } else {
                     eprintln!("Insufficient balance");
                 }
-                return Err(eyre::eyre!(
+                eyre::bail!(
                     "Please transfer some balance to your DoubleZero account [{}].",
                     client.get_payer().to_string()
-                ));
+                );
             }
 
             Ok(())
@@ -106,9 +106,7 @@ pub fn check_allowlist(
         } else {
             eprintln!("Error: You are not in the allowlist");
         }
-        return Err(eyre::eyre!(
-            "Please contact the DoubleZero Foundation to add you to the allowlist."
-        ));
+        eyre::bail!("Please contact the DoubleZero Foundation to add you to the allowlist.");
     }
 
     Ok(())

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -323,7 +323,7 @@ impl DoubleZeroClient for DZClient {
             for log in result.value.logs.unwrap() {
                 println!("{}", log);
             }
-            return Err(eyre!("Error in transaction"));
+            eyre::bail!("Error in transaction");
         }
 
         self.client

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
@@ -19,7 +19,7 @@ impl AddMulticastGroupPubAllowlistCommand {
         .execute(client)?;
 
         if mgroup.pub_allowlist.contains(&self.pubkey) {
-            return Err(eyre::eyre!("Publisher is already in the allowlist"));
+            eyre::bail!("Publisher is already in the allowlist");
         }
 
         client.execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/remove.rs
@@ -20,7 +20,7 @@ impl RemoveMulticastGroupPubAllowlistCommand {
         .execute(client)?;
 
         if !mgroup.pub_allowlist.contains(&self.pubkey) {
-            return Err(eyre::eyre!("Publisher is not in the allowlist"));
+            eyre::bail!("Publisher is not in the allowlist");
         }
 
         client.execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
@@ -20,7 +20,7 @@ impl AddMulticastGroupSubAllowlistCommand {
         .execute(client)?;
 
         if mgroup.sub_allowlist.contains(&self.pubkey) {
-            return Err(eyre::eyre!("Publisher is already in the allowlist"));
+            eyre::bail!("Publisher is already in the allowlist");
         }
 
         client.execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/remove.rs
@@ -20,7 +20,7 @@ impl RemoveMulticastGroupSubAllowlistCommand {
         .execute(client)?;
 
         if !mgroup.sub_allowlist.contains(&self.pubkey) {
-            return Err(eyre::eyre!("Publisher is not in the allowlist"));
+            eyre::bail!("Publisher is not in the allowlist");
         }
 
         client.execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
@@ -33,13 +33,13 @@ impl SubscribeMulticastGroupCommand {
         .map_err(|_err| eyre::eyre!("MulticastGroup not found"))?;
 
         if mgroup.status != MulticastGroupStatus::Activated {
-            return Err(eyre::eyre!("MulticastGroup not active"));
+            eyre::bail!("MulticastGroup not active");
         }
         if self.publisher && !mgroup.pub_allowlist.contains(&client.get_payer()) {
-            return Err(eyre::eyre!("Publisher not allowed"));
+            eyre::bail!("Publisher not allowed");
         }
         if self.subscriber && !mgroup.sub_allowlist.contains(&client.get_payer()) {
-            return Err(eyre::eyre!("Subscriber not allowed"));
+            eyre::bail!("Subscriber not allowed");
         }
 
         let (_, user) = GetUserCommand {
@@ -49,7 +49,7 @@ impl SubscribeMulticastGroupCommand {
         .map_err(|_err| eyre::eyre!("User not found"))?;
 
         if user.status != UserStatus::Activated {
-            return Err(eyre::eyre!("User not active"));
+            eyre::bail!("User not active");
         }
 
         client.execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -41,13 +41,13 @@ impl CreateSubscribeUserCommand {
         .map_err(|_err| eyre::eyre!("MulticastGroup not found"))?;
 
         if mgroup.status != MulticastGroupStatus::Activated {
-            return Err(eyre::eyre!("MulticastGroup not active"));
+            eyre::bail!("MulticastGroup not active");
         }
         if self.publisher && !mgroup.pub_allowlist.contains(&client.get_payer()) {
-            return Err(eyre::eyre!("Publisher not allowed"));
+            eyre::bail!("Publisher not allowed");
         }
         if self.subscriber && !mgroup.sub_allowlist.contains(&client.get_payer()) {
-            return Err(eyre::eyre!("Subscriber not allowed"));
+            eyre::bail!("Subscriber not allowed");
         }
 
         let (pda_pubkey, bump_seed) =


### PR DESCRIPTION
Fix #525 

Summary
----
This PR changes `return Err(eyre!(...))` to be `eyre::bail!(...)`, which is basically equivalent but concise.