### PR TITLE
Refactor: remove unwrap from activator

### DIFF
--- a/activator/src/main.rs
+++ b/activator/src/main.rs
@@ -66,8 +66,7 @@ async fn main() -> eyre::Result<()> {
         args.keypair,
         metrics_service,
     )
-    .await
-    .unwrap();
+    .await?;
 
     println!("Activator started");
 

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -524,7 +524,7 @@ Disconnect and connect again!"#,
 
         spinner.set_message("Getting global-config...");
         let (_, config) = client
-            .get_globalconfig(GetGlobalConfigCommand {})
+            .get_globalconfig(GetGlobalConfigCommand)
             .expect("Unable to get config");
 
         spinner.set_message("Getting user account...");

--- a/smartcontract/cli/src/globalconfig/get.rs
+++ b/smartcontract/cli/src/globalconfig/get.rs
@@ -8,7 +8,7 @@ pub struct GetGlobalConfigCliCommand {}
 
 impl GetGlobalConfigCliCommand {
     pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
-        let (_, config) = client.get_globalconfig(GetGlobalConfigCommand {})?;
+        let (_, config) = client.get_globalconfig(GetGlobalConfigCommand)?;
 
         writeln!(
             out,
@@ -53,7 +53,7 @@ mod tests {
 
         client
             .expect_get_globalconfig()
-            .with(predicate::eq(GetGlobalConfigCommand {}))
+            .with(predicate::eq(GetGlobalConfigCommand))
             .returning(move |_| Ok((pubkey, globalconfig.clone())));
 
         /*****************************************************************************************************/

--- a/smartcontract/sdk/rs/src/commands/globalconfig/get.rs
+++ b/smartcontract/sdk/rs/src/commands/globalconfig/get.rs
@@ -7,8 +7,8 @@ use solana_sdk::pubkey::Pubkey;
 
 use crate::DoubleZeroClient;
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct GetGlobalConfigCommand {}
+#[derive(Default, Debug, PartialEq, Clone)]
+pub struct GetGlobalConfigCommand;
 
 impl GetGlobalConfigCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Pubkey, GlobalConfig)> {


### PR DESCRIPTION
Fix #537

Summary
----
- Convert `GetGlobalConfigCommand` to unit struct.
- Replace `unwrap()` with safer alternatives.
- Use if-let for device lookup.
- Replace `unwrap` with `?` in main.
- Prevent runtime panics.