### PR TITLE
tests: add sudo to go tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=
 
 .PHONY: test
 test:
-	go test ./... -race -v -coverprofile coverage.out
+	go test -exec sudo -race -v ./...
 	$(MAKE) test-e2e
 	cargo test --workspace --all-features
 

--- a/client/doublezerod/Makefile
+++ b/client/doublezerod/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=-ldflags "-X=$(PREFIX)/build.Build=$(BUILD)"
 
 .PHONY: test
 test:
-	go test -race -v -coverprofile coverage.out ./...
+	go test -exec sudo -race -v ./...
 	$(MAKE) test-e2e
 
 .PHONY: test-e2e


### PR DESCRIPTION
We're missing sudo in two makefiles for running go tests and require it since we need CAP_NET_ADMIN/CAP_NET_RAW capabilities in several tests.