### PR TITLE
tests: maintain user env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=
 
 .PHONY: test
 test:
-	go test -exec sudo -race -v ./...
+	go test -exec "sudo -E" -race -v ./...
 	$(MAKE) test-e2e
 	cargo test --workspace --all-features
 

--- a/client/doublezerod/Makefile
+++ b/client/doublezerod/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=-ldflags "-X=$(PREFIX)/build.Build=$(BUILD)"
 
 .PHONY: test
 test:
-	go test -exec sudo -race -v ./...
+	go test -exec "sudo -E" -race -v ./...
 	$(MAKE) test-e2e
 
 .PHONY: test-e2e


### PR DESCRIPTION
It looks like we need to maintain the user env for docker to pull public docker images in go tests if you don't have them locally already. Even though we don't login, docker complains about missing creds which points to not finding the user cred store at `$HOME/.docker/config.json`. This could be an artifact of having build kit enabled in the dev vm but this change fixes it nonetheless.

Before:
```
root ➜ /workspaces/doublezero (fix/cleanup) $ make test
...
#3 [internal] load metadata for docker.io/library/ubuntu:22.04
#3 ERROR: error getting credentials - err: exit status 255, out: ``

#2 [internal] load metadata for docker.io/library/golang:1.24.3-alpine
#2 CANCELED
------
 > [internal] load metadata for docker.io/library/ubuntu:22.04:
------
e2e.dockerfile:6
--------------------
   4 |     RUN go test -c -o /bin/example.test -tags e2e
   5 |     
   6 | >>> FROM ubuntu:22.04
   7 |     RUN apt-get update && \
   8 |         apt-get install -y ca-certificates
--------------------
ERROR: failed to solve: ubuntu:22.04: failed to resolve source metadata for docker.io/library/ubuntu:22.04: error getting credentials - err: exit status 255, out: ``
    runner_test.go:149: failed to setup test runner: failed to build docker image
```

After:
```
root ➜ /workspaces/doublezero (fix/cleanup) $ make test
...
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s