### PR TITLE
Move global config output to tabled

### DIFF
--- a/e2e/start_e2e.sh
+++ b/e2e/start_e2e.sh
@@ -137,7 +137,6 @@ start_doublezerod() {
 
 populate_data_onchain() {
     print_banner "Populate global configuration onchain"
-    echo doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24
     doublezero global-config set --local-asn 65000 --remote-asn 65342 --tunnel-tunnel-block 172.16.0.0/16 --device-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24
     print_banner "Global configuration onchain"
     doublezero global-config get


### PR DESCRIPTION
## Summary of Changes

This PR moves the `global-config get` command to using `tabled` so it matches the rest of the output from the CLI. It updates the key names to be consistent with a space instead of a hyphen or underscore to be consistent with the rest of the commands' output.

## Testing Verification

* smart contract cli test was updated to accurately reflect the new output
* E2E tests output the correct format:

```
 local asn | remote asn | device tunnel block | user tunnel block | multicast group block
 65000     | 65342      | 172.16.0.0/16       | 169.254.0.0/16    | 233.84.178.0/24
```