### PR TITLE
E2E: Tests multiple multicast subscribers/publishers

### DIFF
--- a/e2e/multicast_publisher_test.go
+++ b/e2e/multicast_publisher_test.go
@@ -30,6 +30,12 @@ func TestE2E_Multicast_Publisher(t *testing.T) {
 		dn.WaitForClientTunnelUp(t, client)
 
 		checkMulticastPublisherPostConnect(t, dn, device, client)
+
+		dn.CreateMulticastGroupOnchain(t, client, "mg02")
+
+		output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast publisher mg02 --client-ip " + client.Spec().CYOANetworkIP})
+		require.Error(t, err)
+		require.Contains(t, string(output), "Multicast supports only one subscription at this time")
 	}) {
 		t.Fail()
 		return

--- a/e2e/multicast_subscriber_test.go
+++ b/e2e/multicast_subscriber_test.go
@@ -31,6 +31,12 @@ func TestE2E_Multicast_Subscriber(t *testing.T) {
 		dn.WaitForClientTunnelUp(t, client)
 
 		checkMulticastSubscriberPostConnect(t, dn, device, client)
+
+		dn.CreateMulticastGroupOnchain(t, client, "mg02")
+
+		output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast subscriber mg02 --client-ip " + client.Spec().CYOANetworkIP})
+		require.Error(t, err)
+		require.Contains(t, string(output), "Multicast supports only one subscription at this time")
 	}) {
 		t.Fail()
 		return


### PR DESCRIPTION
Adds tests to make sure a second subscriber or second publisher fail.