### PR TITLE
Activator: remove panic

### DIFF
--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -142,7 +142,7 @@ impl Activator {
             &self.locations,
             &self.exchanges,
             &self.state_transitions,
-        );
+        )?;
 
         self.devices.iter().for_each(|(_pubkey, device)| {
             println!(
@@ -211,7 +211,12 @@ impl Activator {
                     }
                     _ => {}
                 };
-                metrics.record_metrics(devices, locations, exchanges, state_transitions);
+                if let Err(e) =
+                    metrics.record_metrics(devices, locations, exchanges, state_transitions)
+                {
+                    // Just log the error
+                    eprintln!("error on record_metrics: {e}")
+                }
             })?;
         Ok(())
     }

--- a/activator/src/metrics_service.rs
+++ b/activator/src/metrics_service.rs
@@ -34,7 +34,5 @@ impl Metric {
 
 #[automock]
 pub trait MetricsService: Send + Sync + 'static {
-    #[allow(dead_code)]
-    fn write_metric(&self, metric: &Metric);
-    fn write_metrics(&self, metrics: &[Metric]);
+    fn write_metrics(&self, metrics: &[Metric]) -> eyre::Result<()>;
 }

--- a/activator/src/utils.rs
+++ b/activator/src/utils.rs
@@ -1,11 +1,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn get_utc_nanoseconds_since_epoch() -> u128 {
+pub fn get_utc_nanoseconds_since_epoch() -> eyre::Result<u128> {
     match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_nanos(),
-        Err(_) => {
-            panic!("Can't get ns since epoch");
-        }
+        Err(e) => eyre::bail!("Can't get ns since epoch, err: {e}"),
+        Ok(duration) => Ok(duration.as_nanos()),
     }
 }
 


### PR DESCRIPTION
Fix #558

Summary
----
This PR removes `panic!` from activator.

Furthermore:
- Removes dead code related to metrics collection
- Fixes the timestamp helper function to return `eyre::Result`