### PR TITLE
Remove panic! from smartcontract

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -21,6 +21,8 @@ pub enum DoubleZeroError {
     InvalidStatus, // variant 7
     #[error("You are not allowed to execute this action")]
     NotAllowed, // variant 8
+    #[error("Invalid Account Type")]
+    InvalidAccountType, // variant 9
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -35,6 +37,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidDevicePubkey => ProgramError::Custom(6),
             DoubleZeroError::InvalidStatus => ProgramError::Custom(7),
             DoubleZeroError::NotAllowed => ProgramError::Custom(8),
+            DoubleZeroError::InvalidAccountType => ProgramError::Custom(9),
         }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/test.rs
@@ -58,7 +58,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.device_allowlist.len(), 2);
@@ -80,7 +81,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.device_allowlist.len(), 3);
@@ -105,7 +107,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.device_allowlist.len(), 2);
@@ -130,7 +133,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.device_allowlist.len(), 1);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/test.rs
@@ -60,7 +60,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.foundation_allowlist.len(), 2);
@@ -84,7 +85,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.foundation_allowlist.len(), 3);
@@ -109,7 +111,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.foundation_allowlist.len(), 2);
@@ -134,7 +137,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.foundation_allowlist.len(), 1);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/test.rs
@@ -56,7 +56,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.user_allowlist.len(), 2);
@@ -78,7 +79,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.user_allowlist.len(), 3);
@@ -101,7 +103,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.user_allowlist.len(), 2);
@@ -124,7 +127,8 @@ mod device_test {
         let state = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         assert_eq!(state.account_type, AccountType::GlobalState);
         assert_eq!(state.user_allowlist.len(), 1);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -62,7 +62,7 @@ pub fn process_create_device(
         return Err(ProgramError::AccountAlreadyInitialized);
     }
     if globalstate_account.data.borrow().is_empty() {
-        panic!("GlobalState account not initialized");
+        return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get_next(globalstate_account)?;
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
@@ -163,7 +163,8 @@ mod device_test {
         let device = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device.account_type, AccountType::Device);
         assert_eq!(device.code, "la".to_string());
         assert_eq!(device.status, DeviceStatus::Pending);
@@ -191,7 +192,8 @@ mod device_test {
         let device = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device.account_type, AccountType::Device);
         assert_eq!(device.code, "la".to_string());
         assert_eq!(device.status, DeviceStatus::Activated);
@@ -218,7 +220,8 @@ mod device_test {
         let device_la = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.status, DeviceStatus::Suspended);
 
@@ -244,7 +247,8 @@ mod device_test {
         let device = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device.account_type, AccountType::Device);
         assert_eq!(device.status, DeviceStatus::Activated);
 
@@ -274,7 +278,8 @@ mod device_test {
         let device_la = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.code, "la2".to_string());
         assert_eq!(device_la.public_ip, [10, 2, 2, 1]);
@@ -302,7 +307,8 @@ mod device_test {
         let device_la = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.code, "la2".to_string());
         assert_eq!(device_la.public_ip, [10, 2, 2, 1]);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/test.rs
@@ -73,7 +73,8 @@ mod exchange_test {
         let exchange_la = get_account_data(&mut banks_client, exchange_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
         assert_eq!(exchange_la.account_type, AccountType::Exchange);
         assert_eq!(exchange_la.code, "la".to_string());
         assert_eq!(exchange_la.status, ExchangeStatus::Activated);
@@ -100,7 +101,8 @@ mod exchange_test {
         let exchange_la = get_account_data(&mut banks_client, exchange_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
         assert_eq!(exchange_la.account_type, AccountType::Exchange);
         assert_eq!(exchange_la.status, ExchangeStatus::Suspended);
 
@@ -126,7 +128,8 @@ mod exchange_test {
         let exchange = get_account_data(&mut banks_client, exchange_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
         assert_eq!(exchange.account_type, AccountType::Exchange);
         assert_eq!(exchange.status, ExchangeStatus::Activated);
 
@@ -157,7 +160,8 @@ mod exchange_test {
         let exchange_la = get_account_data(&mut banks_client, exchange_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
         assert_eq!(exchange_la.account_type, AccountType::Exchange);
         assert_eq!(exchange_la.code, "la2".to_string());
         assert_eq!(exchange_la.name, "Los Angeles - Los Angeles".to_string());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
@@ -15,6 +15,7 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
     program::invoke_signed,
+    program_error::ProgramError,
     pubkey::Pubkey,
     system_instruction,
     sysvar::{rent::Rent, Sysvar},
@@ -59,7 +60,7 @@ pub fn process_set_globalconfig(
     msg!("process_set_global_config({:?})", value);
 
     if globalstate_account.data.borrow().is_empty() {
-        panic!("GlobalState account not initialized");
+        return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get(globalstate_account)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -62,7 +62,7 @@ pub fn process_create_link(
         return Err(ProgramError::AccountAlreadyInitialized);
     }
     if globalstate_account.data.borrow().is_empty() {
-        panic!("GlobalState account not initialized");
+        return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get_next(globalstate_account)?;
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
@@ -232,7 +232,8 @@ mod tunnel_test {
         let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel_la.account_type, AccountType::Link);
         assert_eq!(tunnel_la.code, "la".to_string());
         assert_eq!(tunnel_la.status, LinkStatus::Pending);
@@ -262,7 +263,8 @@ mod tunnel_test {
         let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel_la.account_type, AccountType::Link);
         assert_eq!(tunnel_la.tunnel_id, 500);
         assert_eq!(tunnel_la.tunnel_net, ([10, 0, 0, 0], 21));
@@ -287,7 +289,8 @@ mod tunnel_test {
         let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel_la.account_type, AccountType::Link);
         assert_eq!(tunnel_la.status, LinkStatus::Suspended);
 
@@ -310,7 +313,8 @@ mod tunnel_test {
         let tunnel = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel.account_type, AccountType::Link);
         assert_eq!(tunnel.status, LinkStatus::Activated);
 
@@ -342,7 +346,8 @@ mod tunnel_test {
         let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel_la.account_type, AccountType::Link);
         assert_eq!(tunnel_la.code, "la2".to_string());
         assert_eq!(tunnel_la.bandwidth, 2000000000);
@@ -373,7 +378,8 @@ mod tunnel_test {
         let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
         assert_eq!(tunnel_la.account_type, AccountType::Link);
         assert_eq!(tunnel_la.code, "la2".to_string());
         assert_eq!(tunnel_la.bandwidth, 2000000000);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/test.rs
@@ -73,7 +73,8 @@ mod location_test {
         let location_la = get_account_data(&mut banks_client, location_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location_la.account_type, AccountType::Location);
         assert_eq!(location_la.code, "la".to_string());
         assert_eq!(location_la.status, LocationStatus::Activated);
@@ -100,7 +101,8 @@ mod location_test {
         let location_la = get_account_data(&mut banks_client, location_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location_la.account_type, AccountType::Location);
         assert_eq!(location_la.status, LocationStatus::Suspended);
 
@@ -126,7 +128,8 @@ mod location_test {
         let location = get_account_data(&mut banks_client, location_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location.account_type, AccountType::Location);
         assert_eq!(location.status, LocationStatus::Activated);
 
@@ -158,7 +161,8 @@ mod location_test {
         let location_la = get_account_data(&mut banks_client, location_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location_la.account_type, AccountType::Location);
         assert_eq!(location_la.code, "la2".to_string());
         assert_eq!(location_la.name, "Los Angeles - Los Angeles".to_string());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/test.rs
@@ -53,7 +53,8 @@ mod device_test {
         let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         let (multicastgroup_pubkey, bump_seed) =
             get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
@@ -80,7 +81,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.code, "test".to_string());
@@ -112,7 +114,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.multicast_ip, [223, 0, 0, 1]);
@@ -143,7 +146,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.pub_allowlist.len(), 1);
@@ -173,7 +177,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.pub_allowlist.len(), 0);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/test.rs
@@ -53,7 +53,8 @@ mod device_test {
         let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_global_state();
+            .get_global_state()
+            .unwrap();
 
         let (multicastgroup_pubkey, bump_seed) =
             get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
@@ -80,7 +81,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.code, "test".to_string());
@@ -112,7 +114,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.multicast_ip, [223, 0, 0, 1]);
@@ -143,7 +146,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.sub_allowlist.len(), 1);
@@ -173,7 +177,8 @@ mod device_test {
         let mgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
 
         assert_eq!(mgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(mgroup.sub_allowlist.len(), 0);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/test.rs
@@ -74,7 +74,8 @@ mod multicastgroup_test {
         let multicastgroup_la = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup_la.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup_la.code, "la".to_string());
         assert_eq!(multicastgroup_la.multicast_ip, [0, 0, 0, 0]);
@@ -106,7 +107,8 @@ mod multicastgroup_test {
         let multicastgroup_la = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup_la.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup_la.code, "la".to_string());
         assert_eq!(multicastgroup_la.multicast_ip, [224, 0, 0, 0]);
@@ -134,7 +136,8 @@ mod multicastgroup_test {
         let multicastgroup_la = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup_la.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup_la.status, MulticastGroupStatus::Suspended);
 
@@ -160,7 +163,8 @@ mod multicastgroup_test {
         let multicastgroup = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup.status, MulticastGroupStatus::Activated);
 
@@ -189,7 +193,8 @@ mod multicastgroup_test {
         let multicastgroup_la = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup_la.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup_la.code, "la2".to_string());
         assert_eq!(multicastgroup_la.status, MulticastGroupStatus::Activated);
@@ -216,7 +221,8 @@ mod multicastgroup_test {
         let multicastgroup_la = get_account_data(&mut banks_client, multicastgroup_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .unwrap();
         assert_eq!(multicastgroup_la.account_type, AccountType::MulticastGroup);
         assert_eq!(multicastgroup_la.code, "la2".to_string());
         assert_eq!(multicastgroup_la.status, MulticastGroupStatus::Deleting);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -66,7 +66,7 @@ pub fn process_create_user(
         return Err(ProgramError::AccountAlreadyInitialized);
     }
     if globalstate_account.data.borrow().is_empty() {
-        panic!("GlobalState account not initialized");
+        return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get_next(globalstate_account)?;
     assert_eq!(
@@ -89,7 +89,7 @@ pub fn process_create_user(
     if device_account.data_is_empty()
         || device_account.data.borrow()[0] != AccountType::Device as u8
     {
-        panic!("Invalid Device Pubkey");
+        return Err(DoubleZeroError::InvalidDevicePubkey.into());
     }
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -68,7 +68,7 @@ pub fn process_create_subscribe_user(
         return Err(ProgramError::AccountAlreadyInitialized);
     }
     if globalstate_account.data.borrow().is_empty() {
-        panic!("GlobalState account not initialized");
+        return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get_next(globalstate_account)?;
     assert_eq!(
@@ -91,7 +91,7 @@ pub fn process_create_subscribe_user(
     if device_account.data_is_empty()
         || device_account.data.borrow()[0] != AccountType::Device as u8
     {
-        panic!("Invalid Device Pubkey");
+        return Err(DoubleZeroError::InvalidDevicePubkey.into());
     }
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
@@ -170,7 +170,8 @@ mod user_test {
         let device_la = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.code, "la".to_string());
         assert_eq!(device_la.status, DeviceStatus::Pending);
@@ -197,7 +198,8 @@ mod user_test {
         let device_la = get_account_data(&mut banks_client, device_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.status, DeviceStatus::Activated);
 
@@ -235,7 +237,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.client_ip, [100, 0, 0, 1]);
         assert_eq!(user.device_pk, device_pubkey);
@@ -267,7 +270,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.tunnel_id, 500);
         assert_eq!(user.tunnel_net, ([10, 1, 2, 3], 21));
@@ -293,7 +297,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.status, UserStatus::Suspended);
 
@@ -316,7 +321,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable to get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.status, UserStatus::Activated);
 
@@ -348,7 +354,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable t get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.client_ip, [10, 2, 3, 4]);
         assert_eq!(user.cyoa_type, UserCYOA::GREOverPrivatePeering);
@@ -376,7 +383,8 @@ mod user_test {
         let user = get_account_data(&mut banks_client, user_pubkey)
             .await
             .expect("Unable t get Account")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user.account_type, AccountType::User);
         assert_eq!(user.client_ip, [10, 2, 3, 4]);
         assert_eq!(user.cyoa_type, UserCYOA::GREOverPrivatePeering);

--- a/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
@@ -1,7 +1,10 @@
-use crate::state::{
-    accounttype::AccountType, device::Device, exchange::Exchange, globalconfig::GlobalConfig,
-    globalstate::GlobalState, link::Link, location::Location, multicastgroup::MulticastGroup,
-    user::User,
+use crate::{
+    error::DoubleZeroError,
+    state::{
+        accounttype::AccountType, device::Device, exchange::Exchange, globalconfig::GlobalConfig,
+        globalstate::GlobalState, link::Link, location::Location, multicastgroup::MulticastGroup,
+        user::User,
+    },
 };
 
 #[derive(Debug, PartialEq)]
@@ -46,67 +49,67 @@ impl AccountData {
         }
     }
 
-    pub fn get_global_state(&self) -> GlobalState {
+    pub fn get_global_state(&self) -> Result<GlobalState, DoubleZeroError> {
         if let AccountData::GlobalState(global_state) = self {
-            global_state.clone()
+            Ok(global_state.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_global_config(&self) -> GlobalConfig {
+    pub fn get_global_config(&self) -> Result<GlobalConfig, DoubleZeroError> {
         if let AccountData::GlobalConfig(global_config) = self {
-            global_config.clone()
+            Ok(global_config.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_location(&self) -> Location {
+    pub fn get_location(&self) -> Result<Location, DoubleZeroError> {
         if let AccountData::Location(location) = self {
-            location.clone()
+            Ok(location.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_exchange(&self) -> Exchange {
+    pub fn get_exchange(&self) -> Result<Exchange, DoubleZeroError> {
         if let AccountData::Exchange(exchange) = self {
-            exchange.clone()
+            Ok(exchange.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_device(&self) -> Device {
+    pub fn get_device(&self) -> Result<Device, DoubleZeroError> {
         if let AccountData::Device(device) = self {
-            device.clone()
+            Ok(device.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_tunnel(&self) -> Link {
+    pub fn get_tunnel(&self) -> Result<Link, DoubleZeroError> {
         if let AccountData::Link(tunnel) = self {
-            tunnel.clone()
+            Ok(tunnel.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_user(&self) -> User {
+    pub fn get_user(&self) -> Result<User, DoubleZeroError> {
         if let AccountData::User(user) = self {
-            user.clone()
+            Ok(user.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 
-    pub fn get_multicastgroup(&self) -> MulticastGroup {
+    pub fn get_multicastgroup(&self) -> Result<MulticastGroup, DoubleZeroError> {
         if let AccountData::MulticastGroup(multicastgroup) = self {
-            multicastgroup.clone()
+            Ok(multicastgroup.clone())
         } else {
-            panic!("Invalid Account Type")
+            Err(DoubleZeroError::InvalidAccountType)
         }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -26,6 +26,7 @@ impl From<u8> for UserType {
             1 => UserType::IBRLWithAllocatedIP,
             2 => UserType::EdgeFiltering,
             3 => UserType::Multicast,
+            // TODO: leaving this as it unwinds a lot of things and doesn't seem worth the effort at this time
             _ => panic!("Unknown UserType"),
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/tests.rs
@@ -119,7 +119,8 @@ pub mod test {
         let location_la = get_account_data(&mut banks_client, location_la_pubkey)
             .await
             .expect("Unable to get Location")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location_la.account_type, AccountType::Location);
         assert_eq!(location_la.code, location_la_code);
         assert_eq!(location_la.status, LocationStatus::Activated);
@@ -165,7 +166,8 @@ pub mod test {
         let location_ny = get_account_data(&mut banks_client, location_ny_pubkey)
             .await
             .expect("Unable to get Location")
-            .get_location();
+            .get_location()
+            .unwrap();
         assert_eq!(location_ny.account_type, AccountType::Location);
         assert_eq!(location_ny.code, location_ny_code);
         println!(
@@ -209,7 +211,8 @@ pub mod test {
         let exchange_la = get_account_data(&mut banks_client, exchange_la_pubkey)
             .await
             .expect("Unable to get Exchange")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
         assert_eq!(exchange_la.account_type, AccountType::Exchange);
         assert_eq!(exchange_la.code, exchange_la_code);
         println!(
@@ -251,7 +254,9 @@ pub mod test {
         let exchange_ny = get_account_data(&mut banks_client, exchange_ny_pubkey)
             .await
             .expect("Unable to get Exchange")
-            .get_exchange();
+            .get_exchange()
+            .unwrap();
+
         assert_eq!(exchange_ny.account_type, AccountType::Exchange);
         assert_eq!(exchange_ny.code, exchange_ny_code);
         println!(
@@ -298,7 +303,8 @@ pub mod test {
         let device_la = get_account_data(&mut banks_client, device_la_pubkey)
             .await
             .expect("Unable to get Device")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.account_type, AccountType::Device);
         assert_eq!(device_la.code, device_la_code);
         println!(
@@ -343,7 +349,8 @@ pub mod test {
         let device_ny = get_account_data(&mut banks_client, device_ny_pubkey)
             .await
             .expect("Unable to get Device")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_ny.account_type, AccountType::Device);
         assert_eq!(device_ny.code, device_ny_code);
         println!(
@@ -370,7 +377,8 @@ pub mod test {
         let device_ny = get_account_data(&mut banks_client, device_ny_pubkey)
             .await
             .expect("Unable to get Device")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_ny.status, DeviceStatus::Activated);
         println!(
             "✅ Device NY activation successfully with index: {}",
@@ -396,7 +404,8 @@ pub mod test {
         let device_la = get_account_data(&mut banks_client, device_la_pubkey)
             .await
             .expect("Unable to get Device")
-            .get_device();
+            .get_device()
+            .unwrap();
         assert_eq!(device_la.status, DeviceStatus::Activated);
         println!(
             "✅ Device LA activation successfully with index: {}",
@@ -445,7 +454,9 @@ pub mod test {
         let tunnel = get_account_data(&mut banks_client, tunnel_la_ny_pubkey)
             .await
             .expect("Unable to get Link")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
+
         assert_eq!(tunnel.account_type, AccountType::Link);
         assert_eq!(tunnel.code, tunnel_la_ny_code);
         assert_eq!(tunnel.status, LinkStatus::Pending);
@@ -481,7 +492,9 @@ pub mod test {
         let tunnel = get_account_data(&mut banks_client, tunnel_la_ny_pubkey)
             .await
             .expect("Unable to get Link")
-            .get_tunnel();
+            .get_tunnel()
+            .unwrap();
+
         assert_eq!(tunnel.account_type, AccountType::Link);
         assert_eq!(tunnel.code, tunnel_la_ny_code);
         assert_eq!(tunnel.status, LinkStatus::Activated);
@@ -525,7 +538,8 @@ pub mod test {
         let user1 = get_account_data(&mut banks_client, user1_pubkey)
             .await
             .expect("Unable to get User")
-            .get_user();
+            .get_user()
+            .unwrap();
         assert_eq!(user1.account_type, AccountType::User);
         assert_eq!(user1.status, UserStatus::Pending);
         println!(
@@ -562,7 +576,9 @@ pub mod test {
         let user1 = get_account_data(&mut banks_client, user1_pubkey)
             .await
             .expect("Unable to get User")
-            .get_user();
+            .get_user()
+            .unwrap();
+
         assert_eq!(user1.account_type, AccountType::User);
         assert_eq!(user1.tunnel_id, 1);
         assert_eq!(user1.tunnel_net, tunnel_net);

--- a/smartcontract/sdk/rs/src/commands/device/list.rs
+++ b/smartcontract/sdk/rs/src/commands/device/list.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use crate::DoubleZeroClient;
-use doublezero_serviceability::state::{
-    accountdata::AccountData, accounttype::AccountType, device::Device,
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    state::{accountdata::AccountData, accounttype::AccountType, device::Device},
 };
 use solana_sdk::pubkey::Pubkey;
 
@@ -11,13 +12,13 @@ pub struct ListDeviceCommand {}
 
 impl ListDeviceCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<HashMap<Pubkey, Device>> {
-        Ok(client
+        client
             .gets(AccountType::Device)?
             .into_iter()
             .map(|(k, v)| match v {
-                AccountData::Device(device) => (k, device),
-                _ => panic!("Invalid Account Type"),
+                AccountData::Device(device) => Ok((k, device)),
+                _ => Err(DoubleZeroError::InvalidAccountType.into()),
             })
-            .collect())
+            .collect()
     }
 }

--- a/smartcontract/sdk/rs/src/commands/link/list.rs
+++ b/smartcontract/sdk/rs/src/commands/link/list.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use crate::DoubleZeroClient;
-use doublezero_serviceability::state::{
-    accountdata::AccountData, accounttype::AccountType, link::Link,
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    state::{accountdata::AccountData, accounttype::AccountType, link::Link},
 };
 use solana_sdk::pubkey::Pubkey;
 
@@ -11,13 +12,13 @@ pub struct ListLinkCommand {}
 
 impl ListLinkCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<HashMap<Pubkey, Link>> {
-        Ok(client
+        client
             .gets(AccountType::Link)?
             .into_iter()
             .map(|(k, v)| match v {
-                AccountData::Link(tunnel) => (k, tunnel),
-                _ => panic!("Invalid Account Type"),
+                AccountData::Link(tunnel) => Ok((k, tunnel)),
+                _ => Err(DoubleZeroError::InvalidAccountType.into()),
             })
-            .collect())
+            .collect()
     }
 }

--- a/smartcontract/sdk/rs/src/commands/location/list.rs
+++ b/smartcontract/sdk/rs/src/commands/location/list.rs
@@ -1,6 +1,7 @@
 use crate::DoubleZeroClient;
-use doublezero_serviceability::state::{
-    accountdata::AccountData, accounttype::AccountType, location::Location,
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    state::{accountdata::AccountData, accounttype::AccountType, location::Location},
 };
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
@@ -13,14 +14,14 @@ impl ListLocationCommand {
         &self,
         client: &dyn DoubleZeroClient,
     ) -> eyre::Result<HashMap<Pubkey, Location>> {
-        Ok(client
+        client
             .gets(AccountType::Location)?
             .into_iter()
             .map(|(k, v)| match v {
-                AccountData::Location(location) => (k, location),
-                _ => panic!("Invalid Account Type"),
+                AccountData::Location(location) => Ok((k, location)),
+                _ => Err(DoubleZeroError::InvalidAccountType.into()),
             })
-            .collect())
+            .collect()
     }
 }
 

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/delete.rs
@@ -28,7 +28,8 @@ impl DeleteMulticastGroupCommand {
         let mgroup = client
             .get(mgroup_pubkey)
             .map_err(|_| eyre::eyre!("MulticastGroup not found ({})", mgroup_pubkey))?
-            .get_multicastgroup();
+            .get_multicastgroup()
+            .map_err(|e| eyre::eyre!(e))?;
 
         for user_pk in mgroup.publishers.iter().chain(mgroup.subscribers.iter()) {
             SubscribeMulticastGroupCommand {

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/list.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/list.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use crate::DoubleZeroClient;
-use doublezero_serviceability::state::{
-    accountdata::AccountData, accounttype::AccountType, multicastgroup::MulticastGroup,
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    state::{accountdata::AccountData, accounttype::AccountType, multicastgroup::MulticastGroup},
 };
 use solana_sdk::pubkey::Pubkey;
 
@@ -14,13 +15,13 @@ impl ListMulticastGroupCommand {
         &self,
         client: &dyn DoubleZeroClient,
     ) -> eyre::Result<HashMap<Pubkey, MulticastGroup>> {
-        Ok(client
+        client
             .gets(AccountType::MulticastGroup)?
             .into_iter()
             .map(|(k, v)| match v {
-                AccountData::MulticastGroup(multicastgroup) => (k, multicastgroup),
-                _ => panic!("Invalid Account Type"),
+                AccountData::MulticastGroup(multicastgroup) => Ok((k, multicastgroup)),
+                _ => Err(DoubleZeroError::InvalidAccountType.into()),
             })
-            .collect())
+            .collect()
     }
 }

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -28,7 +28,8 @@ impl DeleteUserCommand {
         let user = client
             .get(user_pubkey)
             .map_err(|_| eyre::eyre!("User not found ({})", user_pubkey))?
-            .get_user();
+            .get_user()
+            .map_err(|e| eyre::eyre!(e))?;
 
         for mgroup_pk in user.publishers.iter().chain(user.subscribers.iter()) {
             SubscribeMulticastGroupCommand {

--- a/smartcontract/sdk/rs/src/commands/user/list.rs
+++ b/smartcontract/sdk/rs/src/commands/user/list.rs
@@ -1,23 +1,22 @@
-use std::collections::HashMap;
-
 use crate::DoubleZeroClient;
 use doublezero_serviceability::state::{
     accountdata::AccountData, accounttype::AccountType, user::User,
 };
 use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ListUserCommand {}
 
 impl ListUserCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<HashMap<Pubkey, User>> {
-        Ok(client
+        client
             .gets(AccountType::User)?
             .into_iter()
             .map(|(k, v)| match v {
-                AccountData::User(user) => (k, user),
-                _ => panic!("Invalid Account Type"),
+                AccountData::User(user) => Ok((k, user)),
+                _ => eyre::bail!("Invalid Account Type"),
             })
-            .collect())
+            .collect()
     }
 }


### PR DESCRIPTION
## Summary of Changes

This PR removes `panic!` from the smart contract program with one exception that is left as a `TODO`. 

## Testing Verification 

* All tests continue to pass; no functional changes so that is expected