### PR TITLE
controller: log program-id/rpc on start

### DIFF
--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -70,11 +70,13 @@ func NewController(options ...Option) (*Controller, error) {
 			if err != nil {
 				return nil, fmt.Errorf("invalid program id %s: %v", controller.programId, err)
 			}
-			slog.Info("starting with smartcontract", "program-id", controller.programId)
 			options = append(options, dzsdk.WithProgramId(controller.programId))
 		}
 		if controller.rpcEndpoint == "" {
 			controller.rpcEndpoint = dzsdk.URL_DOUBLEZERO
+		}
+		if controller.programId == "" {
+			controller.programId = dzsdk.PROGRAM_ID_TESTNET
 		}
 		controller.accountFetcher = dzsdk.New(controller.rpcEndpoint, options...)
 	}
@@ -282,6 +284,7 @@ func (c *Controller) Run(ctx context.Context) error {
 
 	// start on-chain fetcher
 	go func() {
+		slog.Info("starting fetch of on-chain data", "program-id", c.programId, "rpc-endpoint", c.rpcEndpoint)
 		if err := c.updateStateCache(ctx); err != nil {
 			cacheUpdateErrors.Inc()
 			slog.Error("error fetching accounts", "error", err)


### PR DESCRIPTION
There was an ask to make it more obvious what program-id/rpc endpoint is being used to pull on-chain data in the controller. This does that.

closes #319

```
// default
root ➜ /workspaces/doublezero/controlplane/controller (feature/controller_log_rpc) $ ./bin/controller start
{"time":"2025-06-17T18:59:36.746931052Z","level":"INFO","msg":"starting controller on localhost:443"}
{"time":"2025-06-17T18:59:36.74742676Z","level":"INFO","msg":"starting fetch of on-chain data","program-id":"DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb","rpc-endpoint":"https://doublezerolocalnet.rpcpool.com/f50e62d0-06e7-410e-867e-6873e358ed30"}

// override program-id and rpc endpoint
root ➜ /workspaces/doublezero/controlplane/controller (feature/controller_log_rpc) $ ./bin/controller start -program-id DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Hec -solana-rpc-endpoint https://override.com
{"time":"2025-06-17T19:05:52.758796795Z","level":"INFO","msg":"starting controller on localhost:443"}
{"time":"2025-06-17T19:05:52.759025504Z","level":"INFO","msg":"starting fetch of on-chain data","program-id":"DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Hec","rpc-endpoint":"https://override.com"}
```