### PR TITLE
DZ #592 - standardize commit messge

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+COMMIT_MSG_REGEX="^DZ (#[0-9]* )+- .*$"
+
+
+# Get the commit message file
+COMMIT_MSG_FILE="$1"
+
+# Read the commit message
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+if [[ ! "$COMMIT_MSG" =~ $COMMIT_MSG_REGEX ]]; then
+  echo "ERROR: Commit message does not match the required pattern:"
+  echo "       $COMMIT_MSG_REGEX"
+  echo "Your commit message:"
+  echo "       $COMMIT_MSG"
+  echo "Please fix the commit message and try again."
+  exit 1
+fi
+
+exit 0

--- a/.github/hooks/pre-receive
+++ b/.github/hooks/pre-receive
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+COMMIT_MSG_REGEX="^DZ (#[0-9]* )+- .*$"
+
+
+# Get the commit message file
+COMMIT_MSG_FILE="$1"
+
+# Read the commit message
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+if [[ ! "$COMMIT_MSG" =~ $COMMIT_MSG_REGEX ]]; then
+  echo "ERROR: Commit message does not match the required pattern:"
+  echo "       $COMMIT_MSG_REGEX"
+  echo "Your commit message:"
+  echo "       $COMMIT_MSG"
+  echo "Please fix the commit message and try again."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary of Changes

This PR proposes a commit message of the format `DZ #000 - some msg`. Multiple issues can be linked to a single message like `DZ #000 #000 - msg`. This would only be enforced on `main` and done so through the settings for the repo. If one wants to set up a `commit-msg` hook locally,  each file must be marked as executable with `chmod +x` and then the local git settings need to be updated to reference the hooks with `git config core.hooksPath .github/hooks`. 
 
This PR isn't necessary to enforce the hook since it would be done through GH settings; this is mostly so we have a place of record to discuss and decide on a commit message. 

## Testing Verification
* This commit message passed
* Locally, running with a non-conforming message, the expected error is returned

```
 gc -m 'some msg'
ERROR: Commit message does not match the required pattern:
       ^DZ (#[0-9]* )+- .*$
Your commit message:
       some msg
Please fix the commit message and try again.
```

