### PR TITLE
client: Add json flag to status and latency commands

### DIFF
--- a/client/doublezero/src/command/latency.rs
+++ b/client/doublezero/src/command/latency.rs
@@ -1,9 +1,9 @@
+use crate::command::util;
 use clap::Args;
 use doublezero_cli::doublezerocommand::CliCommand;
 use doublezero_sdk::{commands::device::list::ListDeviceCommand, DeviceStatus};
 use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
-use tabled::{settings::Style, Table};
 
 use crate::{
     requirements::check_doublezero,
@@ -11,7 +11,11 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
-pub struct LatencyCliCommand {}
+pub struct LatencyCliCommand {
+    /// Output as json
+    #[arg(long, default_value = "false")]
+    json: bool,
+}
 
 impl LatencyCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
@@ -32,10 +36,7 @@ impl LatencyCliCommand {
 
         latencies.sort_by(|a, b| a.avg_latency_ns.cmp(&b.avg_latency_ns));
 
-        let table = Table::new(latencies)
-            .with(Style::psql().remove_horizontals())
-            .to_string();
-        println!("{table}");
+        util::show_output(latencies, self.json)?;
 
         Ok(())
     }

--- a/client/doublezero/src/command/mod.rs
+++ b/client/doublezero/src/command/mod.rs
@@ -3,3 +3,4 @@ pub mod disconnect;
 pub mod helpers;
 pub mod latency;
 pub mod status;
+pub mod util;

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -1,4 +1,5 @@
 use crate::{
+    command::util,
     requirements::check_doublezero,
     servicecontroller::{ServiceController, ServiceControllerImpl},
 };
@@ -7,10 +8,13 @@ use doublezero_cli::{
     doublezerocommand::CliCommand,
     helpers::{init_command, print_error},
 };
-use tabled::{settings::Style, Table};
 
 #[derive(Args, Debug)]
-pub struct StatusCliCommand {}
+pub struct StatusCliCommand {
+    /// Output as json
+    #[arg(long, default_value = "false")]
+    json: bool,
+}
 
 impl StatusCliCommand {
     pub async fn execute(self, _client: &dyn CliCommand) -> eyre::Result<()> {
@@ -27,11 +31,8 @@ impl StatusCliCommand {
             }
             Ok(status_responses) => {
                 if !status_responses.is_empty() {
-                    let table = Table::new(status_responses)
-                        .with(Style::psql().remove_horizontals())
-                        .to_string();
                     spinner.finish_and_clear();
-                    println!("{table}");
+                    util::show_output(status_responses, self.json)?
                 }
             }
         }

--- a/client/doublezero/src/command/util.rs
+++ b/client/doublezero/src/command/util.rs
@@ -1,0 +1,17 @@
+use eyre::Result;
+use tabled::{settings::Style, Table, Tabled};
+
+pub fn show_output<T>(data: Vec<T>, is_output_json: bool) -> Result<()>
+where
+    T: serde::Serialize + Tabled,
+{
+    let output = if is_output_json {
+        serde_json::to_string_pretty(&data)?
+    } else {
+        Table::new(data)
+            .with(Style::psql().remove_horizontals())
+            .to_string()
+    };
+    println!("{output}");
+    Ok(())
+}

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -31,7 +31,7 @@ pub struct ProvisioningResponse {
     pub description: Option<String>,
 }
 
-#[derive(Clone, Tabled, Deserialize, Debug)]
+#[derive(Clone, Tabled, Deserialize, Serialize, Debug)]
 pub struct LatencyRecord {
     #[tabled(rename = "pubkey")]
     pub device_pk: String,
@@ -76,7 +76,7 @@ pub struct RemoveResponse {
     pub description: Option<String>,
 }
 
-#[derive(Tabled, Deserialize, Debug)]
+#[derive(Tabled, Serialize, Deserialize, Debug)]
 #[tabled(display(Option, "display::option", ""))]
 pub struct StatusResponse {
     #[tabled(inline)]
@@ -93,7 +93,7 @@ pub struct StatusResponse {
     pub user_type: Option<String>,
 }
 
-#[derive(Tabled, Deserialize, Debug)]
+#[derive(Tabled, Serialize, Deserialize, Debug)]
 pub struct DoubleZeroStatus {
     #[tabled(rename = "Tunnel status")]
     pub session_status: String,


### PR DESCRIPTION
Summary of Changes
----

Fix #595

* Describe what changed in the PR
	- Added `serde::Serialize` to LatencyRecord and StatusResponse
	- Added `json` bool flag to status and latency client cli commands
	- Added `util` module with `show_output` function to handle displaying output
	- Removed extra "DoubleZero Service Provisioning" message since it's redundant and interferes with clean cli output

* Explain why the change is necessary
	- Users need json command output to pipe to other scripts

* Note any metrics that were exposed in this PR
	- None

* Is there supporting documentation or external resources that explain the change?
	-  See Issue #595

* Testing Verification

```bash
ubuntu@chi-dn-bm2:~/.bin$ ./doublezero status
 Tunnel status | Last Session Update     | Tunnel Name | Tunnel src      | Tunnel dst | Doublezero IP   | User Type
 up            | 2025-06-19 21:21:59 UTC | doublezero0 | 137.174.145.145 | 100.0.0.1  | 137.174.145.145 | IBRL
ubuntu@chi-dn-bm2:~/.bin$ ./doublezero status --json
[
  {
    "doublezero_status": {
      "session_status": "up",
      "last_session_update": 1750368119
    },
    "tunnel_name": "doublezero0",
    "tunnel_src": "137.174.145.145",
    "tunnel_dst": "100.0.0.1",
    "doublezero_ip": "137.174.145.145",
    "user_type": "IBRL"
  }
]
ubuntu@chi-dn-bm2:~/.bin$ ./doublezero latency
 pubkey                                       | ip             | min     | max     | avg     | reachable
 ArPeF7rCkr8KWQ53es7vpwUKgznJzeo4QvEp9eLw4DLZ | 204.16.241.243 | 0.00ms  | 0.00ms  | 0.00ms  | false
 BpuXeFfFY3pAYkcpgND7dArFk3La5H6KXndHq9secZoa | 100.0.0.1      | 0.18ms  | 0.23ms  | 0.21ms  | true
 DuckNjhqfqvfVuAsAE7wmDoSRWrNNW8J1KEWGha9eSov | 100.0.0.17     | 10.18ms | 10.24ms | 10.20ms | true
 BHnV5w4kAE5RJdoNzso2aGZ4MTJX18pPdCjUKkS3WQo2 | 100.0.0.33     | 20.16ms | 20.21ms | 20.18ms | true
 B4rUPQQHH3bU2Vfut4aZbkSLetL7EfYGHq6Rmyq6fptj | 100.0.0.49     | 30.19ms | 30.21ms | 30.20ms | true
ubuntu@chi-dn-bm2:~/.bin$ ./doublezero latency --json
[
  {
    "device_pk": "ArPeF7rCkr8KWQ53es7vpwUKgznJzeo4QvEp9eLw4DLZ",
    "device_ip": "204.16.241.243",
    "min_latency_ns": 0,
    "max_latency_ns": 0,
    "avg_latency_ns": 0,
    "reachable": false
  },
  {
    "device_pk": "BpuXeFfFY3pAYkcpgND7dArFk3La5H6KXndHq9secZoa",
    "device_ip": "100.0.0.1",
    "min_latency_ns": 182308,
    "max_latency_ns": 231429,
    "avg_latency_ns": 207199,
    "reachable": true
  },
  {
    "device_pk": "DuckNjhqfqvfVuAsAE7wmDoSRWrNNW8J1KEWGha9eSov",
    "device_ip": "100.0.0.17",
    "min_latency_ns": 10176267,
    "max_latency_ns": 10236975,
    "avg_latency_ns": 10201291,
    "reachable": true
  },
  {
    "device_pk": "BHnV5w4kAE5RJdoNzso2aGZ4MTJX18pPdCjUKkS3WQo2",
    "device_ip": "100.0.0.33",
    "min_latency_ns": 20161377,
    "max_latency_ns": 20205283,
    "avg_latency_ns": 20182538,
    "reachable": true
  },
  {
    "device_pk": "B4rUPQQHH3bU2Vfut4aZbkSLetL7EfYGHq6Rmyq6fptj",
    "device_ip": "100.0.0.49",
    "min_latency_ns": 30190321,
    "max_latency_ns": 30213689,
    "avg_latency_ns": 30198279,
    "reachable": true
  }
]
```
