### PR TITLE
release: ignore daily tag

### DIFF
--- a/.goreleaser.activator.yaml
+++ b/.goreleaser.activator.yaml
@@ -86,3 +86,7 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+
+git:
+  ignore_tags:
+    - activator/daily

--- a/.goreleaser.agent.yaml
+++ b/.goreleaser.agent.yaml
@@ -77,3 +77,7 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+
+git:
+  ignore_tags:
+    - agent/daily

--- a/.goreleaser.client.yaml
+++ b/.goreleaser.client.yaml
@@ -104,3 +104,7 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+
+git:
+  ignore_tags:
+    - client/daily

--- a/.goreleaser.controller.yaml
+++ b/.goreleaser.controller.yaml
@@ -90,3 +90,7 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+
+git:
+  ignore_tags:
+    - controller/daily


### PR DESCRIPTION
## Summary of Changes
* Describe what changed in the PR

This change tells goreleaser to ignore the daily git tag for all components. 

Also, goreleaser does not support globs/regexes on matching these so they need to be explicit: https://github.com/goreleaser/goreleaser/blob/29fac817f0eb700c2cb1e2026494ac5ebea41c83/internal/pipe/git/git.go#L363-L375

* Explain why the change is necessary

goreleaser attempts to compare the latest git tag for a component to a previous tag. Unfortunately, if the  latest tag is not semvar compatible, it will complain and break the release pipeline:

```
  ⨯ release failed after 0s                  error=failed to parse tag 'daily' as semver: Invalid Semantic Version
```

* Note any metrics that were exposed in this PR

N/A

* Is there supporting documentation or external resources that explain the change?

No.

## Testing Verification
* Show evidence of testing the change

In the CI on this PR, the release pipelines ran correctly, ignored the current daily git tag we have and used the correct semvar tags:
```
    • git state                                      commit=d51ec97d26c8b172504cfc844f1a104ab99aceee branch=HEAD current_tag=controller/v0.2.0 previous_tag=controller/v0.1.0 dirty=false
```