### PR TITLE
ci: configure workflows to be available as required checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,14 +1,8 @@
 name: go
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.rs"
     branches: [ main ]
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.rs"
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -2,29 +2,8 @@ name: release pipeline validation
 
 on:
   push:
-    paths:
-      - "activator/**"
-      - "client/**"
-      - "controlplane/**"
-      - "telemetry/**"
-      - "smartcontract/**"
-      - "go.mod"
-      - "go.sum"
-      - "!**/**.md"
-      - ".goreleaser.*"
-      - ".github/workflows/release.*"
     branches: [ main ]
   pull_request:
-    paths:
-      - "client/**"
-      - "controlplane/**"
-      - "telemetry/**"
-      - "smartcontract/**"
-      - "go.mod"
-      - "go.sum"
-      - "!**/**.md"
-      - ".goreleaser.*"
-      - ".github/workflows/release.*"
     branches: [ main ]
 
 permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,14 +1,8 @@
 name: rust
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.go"
     branches: [ main ]
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.go"
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
## Summary of Changes
- Updates rust, go, e2e, and release validation workflows to always run (no `paths` or `paths-ignore` config), which is [needed for them to be available as required checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks)
- Reason: when required checks aren't configured, we can run into cases where auto-merge is selected and it merges into a failing CI (example: https://github.com/malbeclabs/doublezero/pull/617)