### PR TITLE
Multicast group get into table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ smartcontract/cli/config/*
 
 .vscode/*
 .vscode
+.zed
 
 dist/
-
 # Local devnet deployment artifacts.
 dev/.deploy/

--- a/smartcontract/cli/src/device/get.rs
+++ b/smartcontract/cli/src/device/get.rs
@@ -93,7 +93,7 @@ mod tests {
             code: device1_pubkey.to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by pubkey");
+        assert!(res.is_ok(), "I should find an item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: switch\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }

--- a/smartcontract/cli/src/link/get.rs
+++ b/smartcontract/cli/src/link/get.rs
@@ -106,7 +106,7 @@ mod tests {
             code: pda_pubkey.to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by pubkey");
+        assert!(res.is_ok(), "I should find an item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: 45oivwjiumVv8uwsJw8qPjG3EQy9Yn2qAuqLzA5XoE1Q\r\ncode: test\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\ntunnel_type: L3\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nowner: 45oivwjiumVv8uwsJw8qPjG3EQy9Yn2qAuqLzA5XoE1Q\n");
 
@@ -116,7 +116,7 @@ mod tests {
             code: "test".to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by code");
+        assert!(res.is_ok(), "I should find an item by code");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: 45oivwjiumVv8uwsJw8qPjG3EQy9Yn2qAuqLzA5XoE1Q\r\ncode: test\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\ntunnel_type: L3\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nowner: 45oivwjiumVv8uwsJw8qPjG3EQy9Yn2qAuqLzA5XoE1Q\n");
     }

--- a/smartcontract/cli/src/location/get.rs
+++ b/smartcontract/cli/src/location/get.rs
@@ -100,7 +100,7 @@ mod tests {
             code: location1_pubkey.to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by pubkey");
+        assert!(res.is_ok(), "I should find an item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nname: Test Location\r\ncountry: Test Country\r\nlat: 12.34\r\nlng: 56.78\r\nloc_id: 1\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
 
@@ -110,7 +110,7 @@ mod tests {
             code: "test".to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by code");
+        assert!(res.is_ok(), "I should find an item by code");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nname: Test Location\r\ncountry: Test Country\r\nlat: 12.34\r\nlng: 56.78\r\nloc_id: 1\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }

--- a/smartcontract/cli/src/user/get.rs
+++ b/smartcontract/cli/src/user/get.rs
@@ -96,7 +96,7 @@ mod tests {
             pubkey: pda_pubkey.to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok(), "I should find a item by code");
+        assert!(res.is_ok(), "I should find an item by code");
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "account: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw\r\nuser_type: IBRL\r\ndevice: 11111111111111111111111111111111\r\ncyoa_type: GREOverDIA\r\nclient_ip: 10.0.0.1\r\ntunnel_net: 10.2.3.4/24\r\ndz_ip: 10.0.0.2\r\npublishers: \r\nsuscribers: \r\nstatus: activated\r\nowner: CJTXjCEbDDgQoccJgEbNGc63QwWzJtdAoSio36zVXHQw\n");
     }


### PR DESCRIPTION
## Summary of Changes

This PR converts the `multicast group` info into a table using `tabled`. The output is fairly unwieldy but one has to expect that most will use some script to parse the output either in tabular or json form.

 It also corrects a small typo `a` to `an` and adds the `.zed` config directory to `.gitignore`.

## Testing Verification
* Updated the cli `test_cli_multicastgroup_get` test to capture the new output and it passes
* All other tests pass
