### PR TITLE
fix: secrets not inherited

### DIFF
--- a/.github/workflows/release.activator.daily.yml
+++ b/.github/workflows/release.activator.daily.yml
@@ -8,9 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: activator
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.agent.daily.yml
+++ b/.github/workflows/release.agent.daily.yml
@@ -8,9 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: agent
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.all.daily.yml
+++ b/.github/workflows/release.all.daily.yml
@@ -18,9 +18,7 @@ jobs:
         ]
     with:
       component: ${{ matrix.component }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.client.daily.yml
+++ b/.github/workflows/release.client.daily.yml
@@ -8,9 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: client
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.controller.daily.yml
+++ b/.github/workflows/release.controller.daily.yml
@@ -8,9 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: controller
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.daily.yml
+++ b/.github/workflows/release.daily.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set env vars
         run: ./scripts/env.sh >> $GITHUB_ENV
       - name: Install rust for cli
-        uses: dtolnay/rust-toolchain[@stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies for rpm packaging
         run: |
           sudo apt update


### PR DESCRIPTION
## Summary of Changes
* Describe what changed in the PR

Github secrets need to be inherited from parent workflows

* Explain why the change is necessary

When testing the workflow for daily releases locally, ACT seems to behave differently than actual github actions w/r/t secret handling. While the workflow works locally, it fails on the runner:
```
The workflow is not valid. .github/workflows/release.all.daily.yml (Line: 22, Col: 21): Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow. .github/workflows/release.all.daily.yml (Line: 23, Col: 23): Invalid secret, GORELEASER_KEY is not defined in the referenced workflow
```
https://github.com/malbeclabs/doublezero/actions/runs/15826433148

 Even if this worked, I introduced a typo in the shared workflow after testing #596 but before pushing.

* Note any metrics that were exposed in this PR

N/A

* Is there supporting documentation or external resources that explain the change?

No

## Testing Verification
* Show evidence of testing the change

This still passes locally via ACT so not sure what else I can do to test this without using actual github actions: 
```
[release/daily/controller]   ✅  Success - Post Set up Go [2.479861543s]
[release/daily/controller] ⭐ Run Complete job
[release/daily/controller] Cleaning up container for job controller
[release/daily/controller]   ✅  Success - Complete job
[release/daily/controller] 🏁  Job succeeded
```