### PR TITLE
ci: clean up workflow job names for required checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  end-to-end:
-    name: "end-to-end"
+  e2e:
     defaults:
       run:
         working-directory: "e2e/"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  go-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +15,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: make go-build
-  lint:
+  go-lint:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -26,7 +26,7 @@ jobs:
           cache: true
       - uses: golangci/golangci-lint-action@v8
       - run: make go-lint
-  test:
+  go-test:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -36,7 +36,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: make go-test nocontainertest
-  container-test:
+  go-container-test:
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -23,7 +23,7 @@ jobs:
             languages: ["go", "rust"]
           - release: controller
             languages: ["go"]
-    name: ${{ matrix.release }}
+    name: release-validation-${{ matrix.release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  ci:
+  rust-ci:
     runs-on: ubuntu-24.04-16c-64gb
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary of Changes
- The options for PR required checks are based on individual workflow job names, so this PR updates our workflow job names to be more appropriate for that and less ambiguous