### PR TITLE
ci: fix go-build workflow dep

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - run: make go-build
   go-lint:
     runs-on: ubuntu-latest
-    needs: build
+    needs: go-build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -28,7 +28,7 @@ jobs:
       - run: make go-lint
   go-test:
     runs-on: ubuntu-latest
-    needs: build
+    needs: go-build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -38,7 +38,7 @@ jobs:
       - run: make go-test nocontainertest
   go-container-test:
     runs-on: ubuntu-latest
-    needs: build
+    needs: go-build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary of Changes
- The go workflow jobs have a `needs: build` but should be `needs: go-build`, and apparently if a workflow yaml fails to parse in GH CI it doesn't show up in the checks list (https://github.com/malbeclabs/doublezero/actions/runs/15835686207)
- Issue introduced in https://github.com/malbeclabs/doublezero/pull/634