### PR TITLE
Enforce client compatibility based on smart contract version (build warns, major/minor blocks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "chrono",
  "clap",
  "doublezero-serviceability",
+ "doublezero_cli",
  "doublezero_sdk",
  "eyre",
  "indexmap",

--- a/activator/Cargo.toml
+++ b/activator/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 
 # Dependencies from this workspace
 doublezero_sdk.workspace = true
+doublezero_cli.workspace = true
 doublezero-serviceability.workspace = true
 
 [dev-dependencies]

--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     states::devicestate::DeviceState,
 };
+use doublezero_cli::{checkversion::check_version, doublezerocommand::CliCommandImpl};
 use doublezero_sdk::{
     commands::{
         device::list::ListDeviceCommand, exchange::list::ListExchangeCommand,
@@ -17,7 +18,8 @@ use doublezero_sdk::{
         user::list::ListUserCommand,
     },
     ipv4_to_string, networkv4_list_to_string, AccountData, DZClient, Device, DeviceStatus,
-    Exchange, GetGlobalConfigCommand, LinkStatus, Location, MulticastGroup, UserStatus,
+    Exchange, GetGlobalConfigCommand, LinkStatus, Location, MulticastGroup, ProgramVersion,
+    UserStatus,
 };
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashMap, thread, time::Duration};
@@ -59,6 +61,13 @@ impl Activator {
             client.get_ws(),
             client.get_program_id()
         );
+
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+
+        // Check the version of the client against the program version
+        let cli = CliCommandImpl::new(&client);
+        check_version(&cli, &mut handle, ProgramVersion::current())?;
 
         // Wait for the global config to be available
         // This is a workaround for the fact that the global config is not available immediately

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -14,8 +14,8 @@ use crate::cli::{
     location::LocationCommands,
     user::{UserAllowlistCommands, UserCommands},
 };
-use doublezero_cli::doublezerocommand::CliCommandImpl;
-use doublezero_sdk::DZClient;
+use doublezero_cli::{checkversion::check_version, doublezerocommand::CliCommandImpl};
+use doublezero_sdk::{DZClient, ProgramVersion};
 
 #[derive(Parser, Debug)]
 #[command(term_width = 0)]
@@ -54,6 +54,7 @@ async fn main() -> eyre::Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
 
+    check_version(&client, &mut handle, ProgramVersion::current())?;
     let res = match app.command {
         Command::Address(args) => args.execute(&client, &mut handle),
         Command::Balance(args) => args.execute(&client, &mut handle),

--- a/controlplane/doublezero-admin/src/main.rs
+++ b/controlplane/doublezero-admin/src/main.rs
@@ -9,8 +9,8 @@ use cli::{
     location::LocationCommands,
     user::{UserAllowlistCommands, UserCommands},
 };
-use doublezero_cli::doublezerocommand::CliCommandImpl;
-use doublezero_sdk::DZClient;
+use doublezero_cli::{checkversion::check_version, doublezerocommand::CliCommandImpl};
+use doublezero_sdk::{DZClient, ProgramVersion};
 mod cli;
 
 #[derive(Parser, Debug)]
@@ -50,6 +50,7 @@ async fn main() -> eyre::Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
 
+    check_version(&client, &mut handle, ProgramVersion::current())?;
     let res = match app.command {
         Command::Address(args) => args.execute(&client, &mut handle),
         Command::Balance(args) => args.execute(&client, &mut handle),

--- a/smartcontract/cli/src/checkversion.rs
+++ b/smartcontract/cli/src/checkversion.rs
@@ -1,0 +1,109 @@
+use crate::doublezerocommand::CliCommand;
+use doublezero_sdk::{commands::programconfig::get::GetProgramConfigCommand, ProgramVersion};
+use std::io::Write;
+
+pub fn check_version<C: CliCommand, W: Write>(
+    client: &C,
+    out: &mut W,
+    client_version: ProgramVersion,
+) -> eyre::Result<()> {
+    // Check the program configuration version
+    if let Ok((_, pconfig)) = client.get_program_config(GetProgramConfigCommand {}) {
+        // Compare the program version with the client version
+        // If the program version is incompatible, return an error
+        if pconfig.version.error(&client_version) {
+            eyre::bail!("Your client version is no longer up to date. Please update it before continuing to use the client.")
+        }
+        // If the program version is compatible, but the client version is behind, print a warning
+        if pconfig.version.warning(&client_version) {
+            writeln!(out, "A new version of the client is available. We recommend updating to the latest version for the best experience.")?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::doublezerocommand::MockCliCommand;
+    use doublezero_sdk::AccountType;
+    use doublezero_serviceability::state::programconfig::ProgramConfig;
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    use super::*;
+
+    pub fn test_check_version(
+        out: &mut Vec<u8>,
+        contract_version: ProgramVersion,
+        client_version: ProgramVersion,
+    ) -> eyre::Result<()> {
+        let mut client = MockCliCommand::new();
+
+        client
+            .expect_get_program_config()
+            .with(predicate::eq(GetProgramConfigCommand {}))
+            .returning(move |_| {
+                let program_config = ProgramConfig {
+                    account_type: AccountType::ProgramConfig,
+                    bump_seed: 1,
+                    version: contract_version.clone(),
+                };
+                Ok((Pubkey::new_unique(), program_config))
+            });
+
+        check_version(&client, out, client_version)
+    }
+
+    #[test]
+    fn test_check_version_ok() {
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 0, 0),
+            ProgramVersion::new(1, 0, 0),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(output_str, "");
+    }
+
+    #[test]
+    fn test_check_version_minor_ok() {
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 1, 0),
+            ProgramVersion::new(1, 2, 0),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(output_str, "");
+    }
+
+    #[test]
+    fn test_check_version_major_ok() {
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 0, 0),
+            ProgramVersion::new(2, 0, 0),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(output_str, "");
+    }
+
+    #[test]
+    fn test_check_version_build_warning() {
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 2, 10),
+            ProgramVersion::new(1, 2, 0),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(output_str, "A new version of the client is available. We recommend updating to the latest version for the best experience.\n");
+    }
+}

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -58,6 +58,7 @@ use doublezero_sdk::{
             subscribe::SubscribeMulticastGroupCommand,
             update::UpdateMulticastGroupCommand,
         },
+        programconfig::get::GetProgramConfigCommand,
         user::{
             create::CreateUserCommand, create_subscribe::CreateSubscribeUserCommand,
             delete::DeleteUserCommand, get::GetUserCommand, list::ListUserCommand,
@@ -67,6 +68,7 @@ use doublezero_sdk::{
     DZClient, Device, DoubleZeroClient, Exchange, GetGlobalConfigCommand, GlobalConfig, Link,
     Location, MulticastGroup, User,
 };
+use doublezero_serviceability::state::programconfig::ProgramConfig;
 use mockall::automock;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::collections::HashMap;
@@ -74,6 +76,11 @@ use std::collections::HashMap;
 #[automock]
 pub trait CliCommand {
     fn check_requirements(&self, checks: u8) -> eyre::Result<()>;
+
+    fn get_program_config(
+        &self,
+        cmd: GetProgramConfigCommand,
+    ) -> eyre::Result<(Pubkey, ProgramConfig)>;
 
     fn get_program_id(&self) -> Pubkey;
     fn get_payer(&self) -> Pubkey;
@@ -215,6 +222,13 @@ impl CliCommandImpl<'_> {
 impl CliCommand for CliCommandImpl<'_> {
     fn check_requirements(&self, checks: u8) -> eyre::Result<()> {
         crate::requirements::check_requirements(self, None, checks)
+    }
+
+    fn get_program_config(
+        &self,
+        cmd: GetProgramConfigCommand,
+    ) -> eyre::Result<(Pubkey, ProgramConfig)> {
+        cmd.execute(self.client)
     }
 
     fn get_program_id(&self) -> Pubkey {

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod address;
 pub mod allowlist;
 pub mod balance;
+pub mod checkversion;
 pub mod config;
 pub mod device;
 pub mod doublezerocommand;

--- a/smartcontract/programs/doublezero-serviceability/src/accounts.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/accounts.rs
@@ -1,0 +1,88 @@
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    program::invoke_signed,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    system_instruction, system_program,
+    sysvar::{rent::Rent, Sysvar},
+};
+
+pub trait AccountSize {
+    fn size(&self) -> usize;
+}
+pub trait AccountSeed {
+    fn seed(&self, seed: &mut Vec<u8>);
+}
+
+pub fn write_account<'a, D: BorshSerialize + AccountSize + AccountSeed>(
+    account: &AccountInfo<'a>,
+    data: &D,
+    program_id: &Pubkey,
+    payer: &AccountInfo<'a>,
+    system_program: &AccountInfo<'a>,
+) -> ProgramResult {
+    // Size of our index account
+    let required_space = data.size();
+
+    // Calculate minimum balance for rent exemption
+    let rent = Rent::get()?;
+    let required_lamports = rent.minimum_balance(required_space);
+
+    let mut seed: Vec<u8> = Vec::new();
+    data.seed(&mut seed);
+
+    if account.try_borrow_data()?.is_empty() {
+        invoke_signed(
+            &system_instruction::create_account(
+                payer.key,
+                account.key,
+                required_lamports,
+                required_space as u64,
+                program_id,
+            ),
+            &[account.clone(), payer.clone(), system_program.clone()],
+            &[&[seed.as_slice()]],
+        )?;
+    } else {
+        // If the account is already initialized, we need to check if it has enough space
+        if account.data_len() != required_space {
+            account.realloc(required_space, false)?;
+
+            // If the account is not large enough, we need to transfer more lamports
+            if required_space > account.data_len() {
+                let payment = required_lamports - account.lamports();
+
+                invoke_signed(
+                    &system_instruction::transfer(payer.key, account.key, payment),
+                    &[account.clone(), payer.clone(), system_program.clone()],
+                    &[&[seed.as_slice()]],
+                )?;
+            }
+        }
+    }
+
+    let mut account_data = &mut account.data.borrow_mut()[..];
+    data.serialize(&mut account_data).unwrap();
+
+    Ok(())
+}
+
+pub fn account_close(
+    close_account: &AccountInfo,
+    receiving_account: &AccountInfo,
+) -> ProgramResult {
+    // Transfere the rent lamports to the receiving account
+    **receiving_account.lamports.borrow_mut() = receiving_account
+        .lamports()
+        .checked_add(close_account.lamports())
+        .ok_or(ProgramError::InsufficientFunds)?;
+    **close_account.lamports.borrow_mut() = 0;
+
+    // Close the account
+    close_account.realloc(0, false)?;
+    close_account.assign(&system_program::ID);
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/lib.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/lib.rs
@@ -6,11 +6,13 @@ mod entrypoint;
 mod globalstate;
 mod helper;
 
+pub mod accounts;
 pub mod addresses;
 pub mod error;
 pub mod instructions;
 pub mod pda;
 pub mod processors;
+pub mod programversion;
 pub mod seeds;
 pub mod state;
 pub mod tests;

--- a/smartcontract/programs/doublezero-serviceability/src/pda.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/pda.rs
@@ -9,6 +9,10 @@ pub fn get_globalconfig_pda(program_id: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[SEED_PREFIX, SEED_CONFIG], program_id)
 }
 
+pub fn get_program_config_pda(program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[SEED_PREFIX, SEED_PROGRAM_CONFIG], program_id)
+}
+
 pub fn get_location_pda(program_id: &Pubkey, index: u128) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[SEED_PREFIX, SEED_LOCATION, &index.to_le_bytes()],

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/test.rs
@@ -30,6 +30,7 @@ mod device_test {
         let user1 = Pubkey::new_unique();
         let user2 = Pubkey::new_unique();
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
         println!("🟢 1. Global Initialization...");
@@ -38,7 +39,10 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/test.rs
@@ -30,6 +30,7 @@ mod device_test {
         let user1 = Pubkey::new_unique();
         let user2 = Pubkey::new_unique();
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
         println!("🟢 1. Global Initialization...");
@@ -38,7 +39,10 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/test.rs
@@ -28,6 +28,7 @@ mod device_test {
         let user1 = Pubkey::new_unique();
         let user2 = Pubkey::new_unique();
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
         println!("🟢 1. Global Initialization...");
@@ -36,7 +37,10 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
@@ -30,6 +30,7 @@ mod device_test {
         /***********************************************************************************************************************************/
         println!("🟢  Start test_device");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
         println!("🟢 1. Global Initialization...");
@@ -38,7 +39,10 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/test.rs
@@ -25,14 +25,19 @@ mod exchange_test {
         /***********************************************************************************************************************************/
         println!("🟢  Start test_exchange");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
@@ -17,7 +17,7 @@ mod tunnel_test {
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
 
     #[tokio::test]
-    async fn test_tunnel() {
+    async fn test_link() {
         let program_id = Pubkey::new_unique();
         let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
             "doublezero_serviceability",
@@ -28,17 +28,21 @@ mod tunnel_test {
         .await;
 
         /***********************************************************************************************************************************/
-        println!("🟢  Start test_tunnel");
+        println!("🟢  Start test_link");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
-        println!("🟢 1. Global Initizlize...");
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/test.rs
@@ -24,14 +24,20 @@ mod location_test {
 
         /***********************************************************************************************************************************/
         println!("🟢  Start test_location");
+
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/test.rs
@@ -30,18 +30,21 @@ mod device_test {
         .await;
 
         /***********************************************************************************************************************************/
-        println!("🟢  Start user_allowlist_test");
+        println!("🟢 1. Global Initialization...");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
-        /***********************************************************************************************************************************/
         println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/test.rs
@@ -30,18 +30,21 @@ mod device_test {
         .await;
 
         /***********************************************************************************************************************************/
-        println!("🟢  Start user_allowlist_test");
+        println!("🟢 1. Global Initialization...");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
-        /***********************************************************************************************************************************/
         println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/test.rs
@@ -28,14 +28,20 @@ mod multicastgroup_test {
 
         /***********************************************************************************************************************************/
         println!("🟢  Start test_multicastgroup");
+
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
@@ -37,15 +37,19 @@ mod user_test {
         /***********************************************************************************************************************************/
         println!("🟢  Start test_device");
 
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
         let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
-        println!("🟢 1. Global Initialize...");
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/programs/doublezero-serviceability/src/programversion.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/programversion.rs
@@ -1,0 +1,134 @@
+use borsh::BorshSerialize;
+use core::fmt;
+use std::str::FromStr;
+
+#[derive(BorshSerialize, Debug, PartialEq, Clone, Default)]
+pub struct ProgramVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl fmt::Display for ProgramVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl FromStr for ProgramVersion {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err("Invalid version format");
+        }
+
+        let major = parts[0]
+            .parse::<u32>()
+            .map_err(|_| "Invalid major version")?;
+        let minor = parts[1]
+            .parse::<u32>()
+            .map_err(|_| "Invalid minor version")?;
+        let patch = parts[2]
+            .parse::<u32>()
+            .map_err(|_| "Invalid patch version")?;
+
+        Ok(ProgramVersion::new(major, minor, patch))
+    }
+}
+
+impl ProgramVersion {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    pub fn current() -> Self {
+        Self {
+            major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or_default(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or_default(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or_default(),
+        }
+    }
+
+    // Check if the current version is compatible with the required version
+    pub fn warning(&self, client: &ProgramVersion) -> bool {
+        self.major == client.major && self.minor == client.minor && self.patch > client.patch
+    }
+
+    // Check if the current version is incompatible with the required version
+    pub fn error(&self, client: &ProgramVersion) -> bool {
+        self.major > client.major || (self.major == client.major && self.minor > client.minor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_program_version_display() {
+        let version = ProgramVersion::new(1, 2, 3);
+        assert_eq!(version.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_program_version_warning1() {
+        let program = ProgramVersion::new(1, 1, 3);
+        let client = ProgramVersion::new(1, 2, 0);
+        assert!(!program.warning(&client));
+    }
+
+    #[test]
+    fn test_program_version_warning2() {
+        let program = ProgramVersion::new(1, 2, 2);
+        let client = ProgramVersion::new(1, 2, 3);
+        assert!(!program.warning(&client));
+    }
+
+    #[test]
+    fn test_program_version_warning3() {
+        let program = ProgramVersion::new(1, 2, 3);
+        let client = ProgramVersion::new(1, 2, 3);
+        assert!(!program.warning(&client));
+    }
+
+    #[test]
+    fn test_program_version_warning4() {
+        let program = ProgramVersion::new(1, 2, 3);
+        let client = ProgramVersion::new(1, 2, 2);
+        assert!(program.warning(&client));
+    }
+
+    #[test]
+    fn test_program_version_error1() {
+        let program = ProgramVersion::new(1, 2, 3);
+        let client = ProgramVersion::new(1, 3, 0);
+        assert!(!program.error(&client));
+    }
+
+    #[test]
+    fn test_program_version_error2() {
+        let program = ProgramVersion::new(2, 0, 3);
+        let client = ProgramVersion::new(1, 2, 0);
+        assert!(program.error(&client));
+    }
+
+    #[test]
+    fn test_program_version_error3() {
+        let program = ProgramVersion::new(1, 3, 3);
+        let client = ProgramVersion::new(1, 2, 0);
+        assert!(program.error(&client));
+    }
+
+    #[test]
+    fn test_program_version_error4() {
+        let program = ProgramVersion::new(1, 0, 3);
+        let client = ProgramVersion::new(2, 2, 0);
+        assert!(!program.error(&client));
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/src/seeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/seeds.rs
@@ -1,5 +1,6 @@
 pub const SEED_PREFIX: &[u8] = b"doublezero";
 pub const SEED_GLOBALSTATE: &[u8] = b"globalstate";
+pub const SEED_PROGRAM_CONFIG: &[u8] = b"programconfig";
 pub const SEED_CONFIG: &[u8] = b"config";
 pub const SEED_LOCATION: &[u8] = b"location";
 pub const SEED_EXCHANGE: &[u8] = b"exchange";

--- a/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
@@ -3,7 +3,7 @@ use crate::{
     state::{
         accounttype::AccountType, device::Device, exchange::Exchange, globalconfig::GlobalConfig,
         globalstate::GlobalState, link::Link, location::Location, multicastgroup::MulticastGroup,
-        user::User,
+        programconfig::ProgramConfig, user::User,
     },
 };
 
@@ -18,6 +18,7 @@ pub enum AccountData {
     Link(Link),
     User(User),
     MulticastGroup(MulticastGroup),
+    ProgramConfig(ProgramConfig),
 }
 
 impl AccountData {
@@ -32,6 +33,7 @@ impl AccountData {
             AccountData::Link(_) => "Link",
             AccountData::User(_) => "User",
             AccountData::MulticastGroup(_) => "MulticastGroup",
+            AccountData::ProgramConfig(_) => "ProgramConfig",
         }
     }
 
@@ -46,6 +48,7 @@ impl AccountData {
             AccountData::Link(tunnel) => tunnel.to_string(),
             AccountData::User(user) => user.to_string(),
             AccountData::MulticastGroup(multicast_group) => multicast_group.to_string(),
+            AccountData::ProgramConfig(program_config) => program_config.to_string(),
         }
     }
 
@@ -112,6 +115,14 @@ impl AccountData {
             Err(DoubleZeroError::InvalidAccountType)
         }
     }
+
+    pub fn get_program_config(&self) -> Result<ProgramConfig, DoubleZeroError> {
+        if let AccountData::ProgramConfig(program_config) = self {
+            Ok(program_config.clone())
+        } else {
+            Err(DoubleZeroError::InvalidAccountType)
+        }
+    }
 }
 
 impl From<&[u8]> for AccountData {
@@ -126,6 +137,7 @@ impl From<&[u8]> for AccountData {
             AccountType::Link => AccountData::Link(Link::from(bytes)),
             AccountType::User => AccountData::User(User::from(bytes)),
             AccountType::MulticastGroup => AccountData::MulticastGroup(MulticastGroup::from(bytes)),
+            AccountType::ProgramConfig => AccountData::ProgramConfig(ProgramConfig::from(bytes)),
         }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/state/accounttype.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accounttype.rs
@@ -16,6 +16,7 @@ pub enum AccountType {
     Link = 6,
     User = 7,
     MulticastGroup = 8,
+    ProgramConfig = 9,
 }
 
 impl From<u8> for AccountType {
@@ -29,6 +30,7 @@ impl From<u8> for AccountType {
             6 => AccountType::Link,
             7 => AccountType::User,
             8 => AccountType::MulticastGroup,
+            9 => AccountType::ProgramConfig,
             _ => AccountType::None,
         }
     }
@@ -46,14 +48,15 @@ impl fmt::Display for AccountType {
             AccountType::Link => write!(f, "tunnel"),
             AccountType::User => write!(f, "user"),
             AccountType::MulticastGroup => write!(f, "multicastgroup"),
+            AccountType::ProgramConfig => write!(f, "programconfig"),
         }
     }
 }
 
 pub trait AccountTypeInfo {
     fn index(&self) -> u128;
-    fn owner(&self) -> Pubkey;
     fn bump_seed(&self) -> u8;
     fn size(&self) -> usize;
     fn seed(&self) -> &[u8];
+    fn owner(&self) -> Pubkey;
 }

--- a/smartcontract/programs/doublezero-serviceability/src/state/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/mod.rs
@@ -7,4 +7,5 @@ pub mod globalstate;
 pub mod link;
 pub mod location;
 pub mod multicastgroup;
+pub mod programconfig;
 pub mod user;

--- a/smartcontract/programs/doublezero-serviceability/src/state/programconfig.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/programconfig.rs
@@ -1,0 +1,95 @@
+use crate::{
+    accounts::{AccountSeed, AccountSize},
+    bytereader::ByteReader,
+    programversion::ProgramVersion,
+    seeds::{SEED_PREFIX, SEED_PROGRAM_CONFIG},
+    state::accounttype::AccountType,
+};
+use borsh::BorshSerialize;
+use core::fmt;
+use solana_program::{account_info::AccountInfo, program_error::ProgramError};
+
+#[derive(BorshSerialize, Debug, PartialEq, Clone)]
+pub struct ProgramConfig {
+    pub account_type: AccountType, // 1
+    pub bump_seed: u8,             // 1
+    pub version: ProgramVersion,   // 12
+}
+
+impl fmt::Display for ProgramConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "account_type: {}, bump_seed: {}, version: {}",
+            self.account_type, self.bump_seed, self.version,
+        )
+    }
+}
+
+impl AccountSeed for ProgramConfig {
+    fn seed(&self, seed: &mut Vec<u8>) {
+        seed.extend_from_slice(SEED_PREFIX);
+        seed.extend_from_slice(SEED_PROGRAM_CONFIG);
+        seed.extend_from_slice(&[self.bump_seed]);
+    }
+}
+
+impl AccountSize for ProgramConfig {
+    fn size(&self) -> usize {
+        1 // account_type
+            + 1 // bump_seed
+            + 12 // version (major + minor + patch)
+    }
+}
+
+impl From<&[u8]> for ProgramConfig {
+    fn from(data: &[u8]) -> Self {
+        let mut parser = ByteReader::new(data);
+
+        Self {
+            account_type: parser.read_enum(),
+            bump_seed: parser.read_u8(),
+            version: ProgramVersion {
+                major: parser.read_u32(),
+                minor: parser.read_u32(),
+                patch: parser.read_u32(),
+            },
+        }
+    }
+}
+
+impl TryFrom<&AccountInfo<'_>> for ProgramConfig {
+    type Error = ProgramError;
+
+    fn try_from(account: &AccountInfo) -> Result<Self, Self::Error> {
+        let data = account.try_borrow_data()?;
+        Ok(Self::from(&data[..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_location_serialization() {
+        let val = ProgramConfig {
+            account_type: AccountType::GlobalState,
+            bump_seed: 1,
+            version: ProgramVersion {
+                major: 1,
+                minor: 2,
+                patch: 3,
+            },
+        };
+
+        let data = borsh::to_vec(&val).unwrap();
+        let val2 = ProgramConfig::from(&data[..]);
+
+        assert_eq!(val.size(), val2.size());
+        assert_eq!(val.version.major, val2.version.major);
+        assert_eq!(val.version.minor, val2.version.minor);
+        assert_eq!(val.version.patch, val2.version.patch);
+        assert_eq!(data.len(), val.size(), "Invalid Size");
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/src/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/tests.rs
@@ -48,14 +48,19 @@ pub mod test {
         /***********************************************************************************************************************************/
         println!("🟢  Start...");
 
-        let (globalstate_pubkey, _globalstate_bump_seed) = get_globalstate_pda(&program_id);
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+        let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
 
+        println!("🟢 1. Global Initialization...");
         execute_transaction(
             &mut banks_client,
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
             &payer,
         )
         .await;

--- a/smartcontract/sdk/rs/src/commands/globalstate/init.rs
+++ b/smartcontract/sdk/rs/src/commands/globalstate/init.rs
@@ -1,4 +1,7 @@
-use doublezero_serviceability::{instructions::DoubleZeroInstruction, pda::get_globalstate_pda};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_program_config_pda},
+};
 use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
 use crate::DoubleZeroClient;
@@ -8,11 +11,15 @@ pub struct InitGlobalStateCommand {}
 
 impl InitGlobalStateCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (program_config_pubkey, _) = get_program_config_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 
         client.execute_transaction(
             DoubleZeroInstruction::InitGlobalState(),
-            vec![AccountMeta::new(pda_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(pda_pubkey, false),
+            ],
         )
     }
 }

--- a/smartcontract/sdk/rs/src/commands/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod globalstate;
 pub mod link;
 pub mod location;
 pub mod multicastgroup;
+pub mod programconfig;
 pub mod user;

--- a/smartcontract/sdk/rs/src/commands/programconfig/get.rs
+++ b/smartcontract/sdk/rs/src/commands/programconfig/get.rs
@@ -1,0 +1,22 @@
+use doublezero_serviceability::{
+    pda::get_program_config_pda,
+    state::{accountdata::AccountData, programconfig::ProgramConfig},
+};
+use eyre::eyre;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::DoubleZeroClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetProgramConfigCommand {}
+
+impl GetProgramConfigCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Pubkey, ProgramConfig)> {
+        let (pubkey, _) = get_program_config_pda(&client.get_program_id());
+
+        match client.get(pubkey)? {
+            AccountData::ProgramConfig(config) => Ok((pubkey, config)),
+            _ => Err(eyre!("Invalid global state")),
+        }
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/programconfig/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/programconfig/mod.rs
@@ -1,0 +1,1 @@
+pub mod get;

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -11,6 +11,7 @@ pub use crate::config::{
 };
 
 pub use doublezero_serviceability::{
+    programversion::ProgramVersion,
     state::{
         accountdata::AccountData,
         accounttype::AccountType,


### PR DESCRIPTION
## Summary of Changes
The client now verifies the deployed smart contract version before executing commands. If the build version differs, a warning is displayed but execution continues. If either the minor or major version differs, an error is shown and execution is blocked, instructing the user to update the client to a compatible version.

Every time the smart contract version is updated and deployed, the `doublezero init` command must be executed to update the stored version value in the account that tracks supported versions. Clients will reference this value to verify compatibility. Build number changes will trigger a warning, while changes to the minor or major version will render previous clients incompatible.

## Test Verification

- Smart Contract version: 0.2.1 / Client version 0.2.0
```
$ doublezero user list
Warning: A new version of the client is available. We recommend updating to the latest version for the best experience.
...
```

- Smart Contract version: 0.3.0 / Client version 0.2.0
```
$ doublezero user list
Error: Your client version is no longer up to date. Please update it before continuing to use the client.
```

