### PR TITLE
e2e/dev: deploy telemetry program

### DIFF
--- a/e2e/device_agent_telemetry_test.go
+++ b/e2e/device_agent_telemetry_test.go
@@ -182,4 +182,10 @@ func TestE2E_DeviceAgentTelemetry(t *testing.T) {
 			return true
 		}, 10*time.Second, 1*time.Second)
 	}
+
+	// Check that the telemetry program is deployed.
+	log.Info("==> Checking that telemetry program is deployed")
+	isDeployed, err := dn.IsTelemetryProgramDeployed(context.Background())
+	require.NoError(t, err)
+	require.True(t, isDeployed)
 }

--- a/e2e/docker/base.dockerfile
+++ b/e2e/docker/base.dockerfile
@@ -126,11 +126,16 @@ RUN --mount=type=cache,target=/cargo-sbf \
     cd smartcontract/programs/doublezero-serviceability && \
     cargo fetch
 
+RUN --mount=type=cache,target=/cargo-sbf \
+    --mount=type=cache,target=/target-sbf \
+    cd smartcontract/programs/doublezero-telemetry && \
+    cargo fetch
+
 # Set up a binaries directory
 ENV BIN_DIR=/doublezero/bin
 RUN mkdir -p ${BIN_DIR}
 
-# Build the Solana program with build-sbf (rust)
+# Build the Solana programs with build-sbf (rust)
 # Note that we don't use mold here.
 RUN --mount=type=cache,target=/cargo-sbf \
     --mount=type=cache,target=/target-sbf \
@@ -138,6 +143,16 @@ RUN --mount=type=cache,target=/cargo-sbf \
     cd smartcontract/programs/doublezero-serviceability && \
     cargo build-sbf && \
     cp /target-sbf/deploy/doublezero_serviceability.so ${BIN_DIR}/doublezero_serviceability.so
+
+# This serviceability program ID is required by the telemetry program at build-time, and
+# corresponds to the keypair in e2e/data/serviceability-program-keypair.json
+ENV SERVICEABILITY_PROGRAM_ID=7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+RUN --mount=type=cache,target=/cargo-sbf \
+    --mount=type=cache,target=/target-sbf \
+    --mount=type=cache,target=/root/.cache/solana \
+    cd smartcontract/programs/doublezero-telemetry && \
+    cargo build-sbf && \
+    cp /target-sbf/deploy/doublezero_telemetry.so ${BIN_DIR}/doublezero_telemetry.so
 
 
 # -----------------------------------------------------------------------------

--- a/e2e/docker/manager/Dockerfile
+++ b/e2e/docker/manager/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
 
 COPY --from=base /doublezero/bin/doublezero /doublezero/bin/.
 COPY --from=base /doublezero/bin/doublezero_serviceability.so /doublezero/bin/.
+COPY --from=base /doublezero/bin/doublezero_telemetry.so /doublezero/bin/.
 
 COPY --from=base /usr/local/bin/solana /usr/local/bin/.
 COPY --from=base /usr/local/bin/solana-keygen /usr/local/bin/.
@@ -17,6 +18,7 @@ COPY --from=base /usr/local/bin/solana-keygen /usr/local/bin/.
 ENV PATH=/doublezero/bin:$PATH
 
 ENV DZ_SERVICEABILITY_PROGRAM_PATH=/doublezero/bin/doublezero_serviceability.so
+ENV DZ_TELEMETRY_PROGRAM_PATH=/doublezero/bin/doublezero_telemetry.so
 
 ARG DOCKERFILE_DIR
 COPY ${DOCKERFILE_DIR}/scripts/init-config.sh /doublezero/scripts/init-config.sh

--- a/e2e/internal/devnet/cmd/devnet.go
+++ b/e2e/internal/devnet/cmd/devnet.go
@@ -63,12 +63,20 @@ func NewLocalDevnet(log *slog.Logger, deployID string) (*LocalDevnet, error) {
 		return nil, fmt.Errorf("failed to create deploy directory: %w", err)
 	}
 
+	// Use the hardcoded serviceability program keypair for this test, since the telemetry program
+	// is built with it as an expectation, and the initialize instruction will fail if the owner
+	// of the devices/links is not the matching serviceability program ID.
+	serviceabilityProgramKeypairPath := filepath.Join(workspaceDir, "e2e", "data", "serviceability-program-keypair.json")
+
 	dn, err := devnet.New(devnet.DevnetSpec{
 		DeployID:  deployID,
 		DeployDir: deployDir,
 
 		CYOANetwork: devnet.CYOANetworkSpec{
 			CIDRPrefix: subnetCIDRPrefix,
+		},
+		Manager: devnet.ManagerSpec{
+			ServiceabilityProgramKeypairPath: serviceabilityProgramKeypairPath,
 		},
 	}, log, dockerClient, subnetAllocator)
 	if err != nil {

--- a/e2e/internal/devnet/smartcontract_telemetry.go
+++ b/e2e/internal/devnet/smartcontract_telemetry.go
@@ -1,0 +1,83 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/malbeclabs/doublezero/e2e/internal/docker"
+)
+
+func (dn *Devnet) DeployTelemetryProgramIfNotDeployed(ctx context.Context) (bool, error) {
+	log := dn.log.With("programID", dn.Manager.TelemetryProgramID)
+
+	isDeployed, err := dn.IsTelemetryProgramDeployed(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if telemetry program is deployed: %w", err)
+	}
+
+	if isDeployed {
+		log.Info("--> Telemetry program is already deployed")
+		return false, nil
+	}
+
+	log.Info("--> Telemetry program is not deployed, deploying")
+	err = dn.DeployTelemetryProgram(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to deploy telemetry program: %w", err)
+	}
+
+	return true, nil
+}
+
+func (dn *Devnet) DeployTelemetryProgram(ctx context.Context) error {
+	dn.log.Info("==> Deploying telemetry program", "programID", dn.Manager.TelemetryProgramID)
+
+	start := time.Now()
+
+	_, err := dn.Manager.Exec(ctx, []string{"bash", "-c", `
+		set -euo pipefail
+
+		# Fund the manager account with some SOL if the balance is 0.
+		echo "==> Checking manager account balance"
+		solana balance
+		if solana balance | grep -q "^0 SOL$"; then
+			echo "==> Manager account balance is 0 SOL, funding with 1000 SOL"
+			solana airdrop 100 $(solana-keygen pubkey)
+		fi
+		echo
+
+		# Deploy the telemetry program.
+		echo "==> Deploying telemetry program"
+		solana program deploy --program-id ${DZ_TELEMETRY_PROGRAM_KEYPAIR_PATH} ${DZ_TELEMETRY_PROGRAM_PATH}
+
+		# Wait 1 slot to make sure the program is deployed and avoid race condition of follow-on instructions.
+		echo "==> Waiting for telemetry program to be ready"
+		slot_before=$(solana slot)
+		echo "==> Slot before: $slot_before"
+		until [ "$(solana slot)" -gt "$slot_before" ]; do
+			echo "==> Waiting for telemetry program to be ready (slot: $(solana slot))"
+			sleep 0.2
+		done
+		echo "==> Slot after: $(solana slot)"
+	`})
+	if err != nil {
+		return fmt.Errorf("failed to deploy telemetry program: %w", err)
+	}
+
+	dn.log.Info("--> Telemetry program deployed", "duration", time.Since(start), "programID", dn.Manager.TelemetryProgramID)
+	return nil
+}
+
+func (dn *Devnet) IsTelemetryProgramDeployed(ctx context.Context) (bool, error) {
+	output, err := dn.Manager.Exec(ctx, []string{"solana", "program", "show", dn.Manager.TelemetryProgramID}, docker.NoPrintOnError())
+	if err != nil {
+		if strings.Contains(strings.ToLower(string(output)), "unable to find") {
+			return false, nil
+		}
+		fmt.Println("output", string(output))
+		return false, fmt.Errorf("failed to check if telemetry program is deployed: %w", err)
+	}
+	return true, nil
+}


### PR DESCRIPTION
## Summary of Changes
- Updated e2e environment to deploy the telemetry program to the ledger for each test, and also available in the local devnet
- Check that the telemetry program is deployed to the ledger in `TestE2E_DeviceAgentTelemetry`
- NOTE: This is rebased on top of the PR 608 and won't merge until that one is in `main` #608
- Related to https://github.com/malbeclabs/doublezero/issues/533

## Testing Verification
- E2E tests continue to pass
- Local devnet start/stop/destroy continues to function