### PR TITLE
device/telem: re-add samples on retry exhaustion

### DIFF
--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -51,6 +51,11 @@ var (
 func main() {
 	flag.Parse()
 
+	if *probeInterval >= *submissionInterval {
+		fmt.Println("probe-interval must be less than submission-interval")
+		os.Exit(1)
+	}
+
 	if *showVersion {
 		fmt.Println(version)
 		os.Exit(0)


### PR DESCRIPTION
Summary
----
This PR fixes the following issues I noticed with PR#667

1. Configuration validation: ensure `probeInterval` is lower than `submissionInterval`
~~2. Samples Timestamp Fix: Fix timestamp calculation to _actually_ use the earliest sampled timestamp~~
3. Data Loss: Re-add failed samples back to the buffer after max retries
