### PR TITLE
release: deploy dailys to devnet

### DIFF
--- a/.github/workflows/release.daily.yml
+++ b/.github/workflows/release.daily.yml
@@ -6,10 +6,13 @@ on:
       component:
         required: true
         type: string
+      playbook:
+        required: true
+        type: string
 
 jobs:
   release:
-    name: ${{ inputs.component }}
+    name: Build ${{ inputs.component }}
     runs-on: ubuntu-24.04-16c-64gb
     steps:
       - name: Checkout
@@ -30,6 +33,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install squashfs-tools rpm gcc-x86-64-linux-gnu -y
+      - name: Set build date
+        run: echo "BUILD_DATE=$(date -u +%Y%m%d%H%M%S)" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -37,5 +42,31 @@ jobs:
           args: release -f release/.goreleaser.devnet.${{ inputs.component }}.yaml --clean --nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }} 
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}
+  deploy:
+    name: Deploy ${{ inputs.component }} to DevNet
+    runs-on: self-hosted
+    needs: release
+    steps:
+      - uses: actions/checkout@v4
+      - name: checkout ansible playbooks
+        uses: actions/checkout@v4
+        with:
+          repository: "malbeclabs/ansible"
+          path: ansible
+          token: ${{ secrets.GA_ANSIBLE_REPO_RO }}
+      - name: Create ansible vault password file
+        working-directory: ansible
+        run: |
+          cat <<'EOT' > .vault_pass
+          #!/usr/bin/bash
+          echo "${ANSIBLE_VAULT_PASS}"
+          EOT
+          chmod +x .vault_pass
+      - name: Run ansible playbook
+        working-directory: ansible
+        shell: bash -leo pipefail {0}
+        run: ansible-playbook -D --private-key ~/.ssh/id_runner --vault-password-file .vault_pass -i inventory/devnet/hosts.yml ${{ inputs.playbook }}
+        env:
+          ANSIBLE_VAULT_PASS: ${{ secrets.ANSIBLE_VAULT_PASS }}

--- a/.github/workflows/release.devnet.activator.daily.yml
+++ b/.github/workflows/release.devnet.activator.daily.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: activator
+      playbook: playbooks/activators.yml
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.agent.daily.yml
+++ b/.github/workflows/release.devnet.agent.daily.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: agent
+      playbook: playbooks/agents.yml
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -10,14 +10,18 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     strategy:
       matrix:
-        component: [
-          agent,
-          controller,
-          activator,
-          client,
-        ]
+        include:
+          - component: agent
+            playbook: playbooks/agents.yml
+          - component: activator
+            playbook: playbooks/activators.yml
+          - component: controller
+            playbook: playbooks/controllers.yml
+          - component: client
+            playbook: playbooks/validators.yml
     with:
       component: ${{ matrix.component }}
+      playbook: ${{ matrix.playbook }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.client.daily.yml
+++ b/.github/workflows/release.devnet.client.daily.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: client
+      playbook: playbooks/validators.yml
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.controller.daily.yml
+++ b/.github/workflows/release.devnet.controller.daily.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: controller
+      playbook: playbooks/controllers.yml
     secrets: inherit
     permissions:
       contents: write

--- a/release/.goreleaser.base.activator.yaml
+++ b/release/.goreleaser.base.activator.yaml
@@ -87,5 +87,5 @@ git:
 nightly:
   publish_release: true
   keep_single_release: true
-  version_template: '{{ incpatch .Version }}-{{ .ShortCommit }}-daily'
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
   tag_name: 'activator/daily'

--- a/release/.goreleaser.base.agent.yaml
+++ b/release/.goreleaser.base.agent.yaml
@@ -78,5 +78,5 @@ git:
 nightly:
   publish_release: true
   keep_single_release: true
-  version_template: '{{ incpatch .Version }}-{{ .ShortCommit }}-daily'
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
   tag_name: 'agent/daily'

--- a/release/.goreleaser.base.client.yaml
+++ b/release/.goreleaser.base.client.yaml
@@ -105,5 +105,5 @@ git:
 nightly:
   publish_release: true
   keep_single_release: true
-  version_template: '{{ incpatch .Version }}-{{ .ShortCommit }}-daily'
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
   tag_name: 'client/daily'

--- a/release/.goreleaser.base.controller.yaml
+++ b/release/.goreleaser.base.controller.yaml
@@ -91,5 +91,5 @@ git:
 nightly:
   publish_release: true
   keep_single_release: true
-  version_template: '{{ incpatch .Version }}-{{ .ShortCommit }}-daily'
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
   tag_name: 'controller/daily'


### PR DESCRIPTION
## Summary of Changes

This PR adds a deployment job to the already present daily release github action, which will deploy the previously cut daily release to devnet. The smart contract deployment will be handled as a follow up PR. Also included is a change to the version format for these packages as the previous format only included the git hash in the package name which created issues with apt/yum determining the latest release since they compare lexicographically given two releases with the same version number. The new package format includes a timestamp of when the release was built as well as the git hash.

## Testing Verification

This ran successfully across all components (minus smart contract deploy which isn't included):

https://github.com/malbeclabs/doublezero/actions/runs/16013528138