### PR TITLE
ci/docker: change ubuntu mirror

### DIFF
--- a/client/doublezerod/internal/runtime/e2e.dockerfile
+++ b/client/doublezerod/internal/runtime/e2e.dockerfile
@@ -1,3 +1,23 @@
+FROM ubuntu:24.04 AS base
+# Mirrors: https://launchpad.net/ubuntu/+archivemirrors
+ARG ARM64_UBUNTU_MIRROR=https://mirror.mci-1.serverforge.org/ubuntu-ports/
+ARG AMD64_UBUNTU_MIRROR=http://mirror.math.princeton.edu/pub/ubuntu/
+RUN ARCH=$(dpkg --print-architecture) && \
+    CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")" && \
+    UBUNTU_MIRROR=$( \
+    case "$ARCH" in \
+    amd64) echo "${AMD64_UBUNTU_MIRROR}" ;; \
+    arm64) echo "${ARM64_UBUNTU_MIRROR}" ;; \
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac ) && \
+    echo "Using mirror: $UBUNTU_MIRROR for $ARCH ($CODENAME)" && \
+    echo "deb ${UBUNTU_MIRROR} ${CODENAME} main restricted universe multiverse\n\
+    deb ${UBUNTU_MIRROR} ${CODENAME}-updates main restricted universe multiverse\n\
+    deb ${UBUNTU_MIRROR} ${CODENAME}-security main restricted universe multiverse" \
+    > /etc/apt/sources.list && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl ca-certificates
+
 FROM golang:1.24.3-alpine AS builder
 WORKDIR /work
 COPY . .
@@ -6,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go test -c -o /bin/runtime.test -tags e2e .
 
-FROM ubuntu:22.04
+FROM base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates iproute2
 WORKDIR /work

--- a/e2e/docker/base.dockerfile
+++ b/e2e/docker/base.dockerfile
@@ -1,7 +1,28 @@
+FROM ubuntu:24.04 AS base
+# Mirrors: https://launchpad.net/ubuntu/+archivemirrors
+ARG ARM64_UBUNTU_MIRROR=https://mirror.mci-1.serverforge.org/ubuntu-ports/
+ARG AMD64_UBUNTU_MIRROR=http://mirror.math.princeton.edu/pub/ubuntu/
+RUN ARCH=$(dpkg --print-architecture) && \
+    CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")" && \
+    UBUNTU_MIRROR=$( \
+    case "$ARCH" in \
+    amd64) echo "${AMD64_UBUNTU_MIRROR}" ;; \
+    arm64) echo "${ARM64_UBUNTU_MIRROR}" ;; \
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac ) && \
+    echo "Using mirror: $UBUNTU_MIRROR for $ARCH ($CODENAME)" && \
+    echo "deb ${UBUNTU_MIRROR} ${CODENAME} main restricted universe multiverse\n\
+    deb ${UBUNTU_MIRROR} ${CODENAME}-updates main restricted universe multiverse\n\
+    deb ${UBUNTU_MIRROR} ${CODENAME}-security main restricted universe multiverse" \
+    > /etc/apt/sources.list && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl ca-certificates
+
+
 # ----------------------------------------------------------------------------
 # Solana stage with a platform-specific image.
 # ----------------------------------------------------------------------------
-FROM ubuntu:24.04 AS solana
+FROM base AS solana
 
 RUN apt update -qq && \
     apt install --no-install-recommends -y ca-certificates curl bzip2
@@ -27,7 +48,7 @@ ENV PATH="/opt/solana/bin:${PATH}"
 # ----------------------------------------------------------------------------
 # Builder stage for the doublezero components.
 # ----------------------------------------------------------------------------
-FROM ubuntu:24.04 AS builder-base
+FROM base AS builder-base
 
 # Install build dependencies and other utilities
 RUN apt update -qq && \
@@ -188,7 +209,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ----------------------------------------------------------------------------
 # Main stage with only the binaries.
 # ----------------------------------------------------------------------------
-FROM ubuntu:24.04
+FROM base
 
 # Copy binaries from the builder stage.
 COPY --from=solana /opt/solana/bin/solana-test-validator /usr/local/bin/.


### PR DESCRIPTION
## Summary of Changes
- Update docker builds for e2e and container tests to use a different [ubuntu mirror](https://launchpad.net/ubuntu/+archivemirrors), to mitigate the ongoing [canonical outage](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQGKX5yMWdRWwpGHDh0G1l4SLja5_40dmRVWo4ydNOHuGA==)

## Testing Verification
- CI should be 🟢 
