### PR TITLE
e2e: ignore generated IDs in fixture comparisons

### DIFF
--- a/e2e/fixtures/ibrl/doublezero_user_list_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_user_list_user_added.tmpl
@@ -1,2 +1,2 @@
- account                                      | user_type | groups | device   | location | cyoa_type  | client_ip    | dz_ip        | tunnel_id | tunnel_net     | status    | owner
- J2MUYJeJvTfrHpxMm3tVYkcDhTwgAFFju2veS27WhByX | IBRL      |        | ny5-dz01 | New York | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | 500       | 169.254.0.0/31 | activated | {{.ClientPubkeyAddress}}
+ account | user_type | groups | device   | location | cyoa_type  | client_ip    | dz_ip        | tunnel_id | tunnel_net     | status    | owner
+ IGNORED | IBRL      |        | ny5-dz01 | New York | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | 500       | 169.254.0.0/31 | activated | {{.ClientPubkeyAddress}}

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
@@ -1,9 +1,9 @@
- account                                      | code      | location | exchange | device_type | public_ip      | dz_prefixes                        | status    | owner
- 3TD6MDfCo2mVeR9a71ukrdXBYVLyWz5cz8RLcNojVpcv | la2-dz01  | lax      | xlax     | switch      | 207.45.216.134 | 207.45.216.136/30, 200.12.12.12/29 | activated | {{.ManagerPubkey}}
- Ai18RhhoWwwmLWq6LhUfro9sxLMxfrGuNGc5fuZssh9i | ty2-dz01  | tyo      | xtyo     | switch      | 180.87.154.112 | 180.87.154.112/29                  | activated | {{.ManagerPubkey}}
- Ejo8G43tLsV4Swp548K6UDX2dLFqmaRN4HKKFnVz9H3p | ams-dz001 | ams      | xams     | switch      | 195.219.138.50 | 195.219.138.56/29                  | activated | {{.ManagerPubkey}}
- 14LzRsGUMyGYJFHgJkAwPZHKJLnwPK8S1d1v7b3bAkqV | pit-dzd01 | pit      | xpit     | switch      | 204.16.241.243 | 204.16.243.243/32                  | activated | {{.ManagerPubkey}}
- 6Nn23MqDrBETFXXohEvmP4mQJb2LWxBNFqx6Ye2zDUej | frk-dz01  | fra      | xfra     | switch      | 195.219.220.88 | 195.219.220.88/29                  | activated | {{.ManagerPubkey}}
- EhAqBmYSg2aT2dYwv5zz81mTJGgNe9zGZvLFup1D55bU | sg1-dz01  | sin      | xsin     | switch      | 180.87.102.104 | 180.87.102.104/29                  | activated | {{.ManagerPubkey}}
- 8scDVeZ8aB1TRTkBqaZgzxuk7WwpARdF1a39wYA7nR3W | ny5-dz01  | ewr      | xewr     | switch      | {{.DeviceIP}}   | {{.DeviceIP}}/{{.DeviceAllocatablePrefix}}                    | activated | {{.ManagerPubkey}}
- FBUy8tzFWa8LhQmCfXbnWZMg1XUDQfudanoVK5NP4KGP | ld4-dz01  | lhr      | xlhr     | switch      | 195.219.120.72 | 195.219.120.72/29                  | activated | {{.ManagerPubkey}}
+ account | code      | location | exchange | device_type | public_ip      | dz_prefixes                        | status    | owner
+ IGNORED | la2-dz01  | lax      | xlax     | switch      | 207.45.216.134 | 207.45.216.136/30, 200.12.12.12/29 | activated | {{.ManagerPubkey}}
+ IGNORED | ty2-dz01  | tyo      | xtyo     | switch      | 180.87.154.112 | 180.87.154.112/29                  | activated | {{.ManagerPubkey}}
+ IGNORED | ams-dz001 | ams      | xams     | switch      | 195.219.138.50 | 195.219.138.56/29                  | activated | {{.ManagerPubkey}}
+ IGNORED | pit-dzd01 | pit      | xpit     | switch      | 204.16.241.243 | 204.16.243.243/32                  | activated | {{.ManagerPubkey}}
+ IGNORED | frk-dz01  | fra      | xfra     | switch      | 195.219.220.88 | 195.219.220.88/29                  | activated | {{.ManagerPubkey}}
+ IGNORED | sg1-dz01  | sin      | xsin     | switch      | 180.87.102.104 | 180.87.102.104/29                  | activated | {{.ManagerPubkey}}
+ IGNORED | ny5-dz01  | ewr      | xewr     | switch      | {{.DeviceIP}}  | {{.DeviceIP}}/{{.DeviceAllocatablePrefix}} | activated | {{.ManagerPubkey}}
+ IGNORED | ld4-dz01  | lhr      | xlhr     | switch      | 195.219.120.72 | 195.219.120.72/29                  | activated | {{.ManagerPubkey}}

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.tmpl
@@ -1,7 +1,7 @@
- account                                      | user_type           | groups | device   | location    | cyoa_type  | client_ip     | dz_ip         | tunnel_id | tunnel_net      | status    | owner
- Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4       | 1.2.3.4       | 500       | 169.254.0.2/31  | activated | {{.ClientPubkeyAddress}}
- NR8fpCK7mqeFVJ3mUmhndX2JtRCymZzgQgGj5JNbGp8  | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5       | 2.3.4.5       | 501       | 169.254.0.4/31  | activated | {{.ClientPubkeyAddress}}
- AA3fFZM1bJbNzCWhPydZrbQpswGkZx4PFhxd2bHaztyG | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6       | 3.4.5.6       | 502       | 169.254.0.6/31  | activated | {{.ClientPubkeyAddress}}
- AwGXP4jLSFsjFdsY7zZtjuvXQfyet8F5XoTTUs19HxLa | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7       | 4.5.6.7       | 503       | 169.254.0.8/31  | activated | {{.ClientPubkeyAddress}}
- 73cGHjCmZ8Jr5nsViP3GyyEhXD8zQBzo5eRTkY9gxqjj | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8       | 5.6.7.8       | 504       | 169.254.0.10/31 | activated | {{.ClientPubkeyAddress}}
- J2MUYJeJvTfrHpxMm3tVYkcDhTwgAFFju2veS27WhByX | IBRLWithAllocatedIP |        | ny5-dz01 | New York    | GREOverDIA | {{.ClientIP}} | {{.ExpectedAllocatedClientIP}} | 500       | 169.254.0.0/31  | activated | {{.ClientPubkeyAddress}}
+ account | user_type           | groups | device   | location    | cyoa_type  | client_ip     | dz_ip         | tunnel_id | tunnel_net      | status    | owner
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4       | 1.2.3.4       | 500       | 169.254.0.2/31  | activated | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5       | 2.3.4.5       | 501       | 169.254.0.4/31  | activated | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6       | 3.4.5.6       | 502       | 169.254.0.6/31  | activated | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7       | 4.5.6.7       | 503       | 169.254.0.8/31  | activated | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8       | 5.6.7.8       | 504       | 169.254.0.10/31 | activated | {{.ClientPubkeyAddress}}
+ IGNORED | IBRLWithAllocatedIP |        | ny5-dz01 | New York    | GREOverDIA | {{.ClientIP}} | {{.ExpectedAllocatedClientIP}} | 500       | 169.254.0.0/31  | activated | {{.ClientPubkeyAddress}}

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.tmpl
@@ -1,6 +1,6 @@
- account                                      | user_type | groups | device   | location    | cyoa_type  | client_ip | dz_ip   | tunnel_id | tunnel_net      | status      | owner
- Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4   | 1.2.3.4 | 500       | 169.254.0.2/31  | activated   | {{.ClientPubkeyAddress}}
- NR8fpCK7mqeFVJ3mUmhndX2JtRCymZzgQgGj5JNbGp8  | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5   | 2.3.4.5 | 501       | 169.254.0.4/31  | activated   | {{.ClientPubkeyAddress}}
- AA3fFZM1bJbNzCWhPydZrbQpswGkZx4PFhxd2bHaztyG | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6   | 3.4.5.6 | 502       | 169.254.0.6/31  | pending ban | {{.ClientPubkeyAddress}}
- AwGXP4jLSFsjFdsY7zZtjuvXQfyet8F5XoTTUs19HxLa | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7   | 4.5.6.7 | 503       | 169.254.0.8/31  | activated   | {{.ClientPubkeyAddress}}
- 73cGHjCmZ8Jr5nsViP3GyyEhXD8zQBzo5eRTkY9gxqjj | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8   | 5.6.7.8 | 504       | 169.254.0.10/31 | activated   | {{.ClientPubkeyAddress}}
+ account | user_type | groups | device   | location    | cyoa_type  | client_ip | dz_ip   | tunnel_id | tunnel_net      | status      | owner
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4   | 1.2.3.4 | 500       | 169.254.0.2/31  | activated   | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5   | 2.3.4.5 | 501       | 169.254.0.4/31  | activated   | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6   | 3.4.5.6 | 502       | 169.254.0.6/31  | pending ban | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7   | 4.5.6.7 | 503       | 169.254.0.8/31  | activated   | {{.ClientPubkeyAddress}}
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8   | 5.6.7.8 | 504       | 169.254.0.10/31 | activated   | {{.ClientPubkeyAddress}}

--- a/e2e/fixtures/multicast_publisher/doublezero_multicast_group_list.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_multicast_group_list.tmpl
@@ -1,2 +1,2 @@
- account                                      | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
- EYojuw4Tb1J4V9bJt9rCC9MqHSDcLsDiQyFRnNXgbKDD | mg01 | 233.84.178.0 | 10Gbps        | 1          | 0           | activated | {{.ManagerPubkey}}
+ account | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
+ IGNORED | mg01 | 233.84.178.0 | 10Gbps        | 1          | 0           | activated | {{.ManagerPubkey}}

--- a/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_multicast_group_list.tmpl
@@ -1,2 +1,2 @@
- account                                      | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
- EYojuw4Tb1J4V9bJt9rCC9MqHSDcLsDiQyFRnNXgbKDD | mg01 | 233.84.178.0 | 10Gbps        | 0          | 1           | activated | {{.ManagerPubkey}}
+ account | code | multicast_ip | max_bandwidth | publishers | subscribers | status    | owner
+ IGNORED | mg01 | 233.84.178.0 | 10Gbps        | 0          | 1           | activated | {{.ManagerPubkey}}


### PR DESCRIPTION
## Summary of Changes
- Update e2e fixture table diff comparison to ignore generated ID fields
- In support of #655 as requested by @juan-malbeclabs 

## Testing Verification
- CI is 🟢 
