### PR TITLE
e2e: fix running in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,3 +28,11 @@ RUN ARCH=$(uname -m) && \
     cp -r /opt/agave/solana-release/bin/* /opt/solana/bin/ && \
     rm -rf /tmp/agave.tar.bz2
 ENV PATH="/opt/solana/bin:${PATH}"
+
+# Alias to access the DinD container's published ports from inside the container,
+# since localhost does not route through NAT. Used in place of `localhost`.
+ENV DIND_LOCALHOST=host.docker.internal
+
+# Tell Testcontainers to connect to the Docker daemon via host.docker.internal,
+# so sidecar containers like Ryuk can reach the DinD container hosting the daemon.
+ENV TESTCONTAINERS_HOST_OVERRIDE=${DIND_LOCALHOST}

--- a/e2e/internal/devnet/controller.go
+++ b/e2e/internal/devnet/controller.go
@@ -37,9 +37,10 @@ func (s *ControllerSpec) Validate(cyoaNetworkSpec CYOANetworkSpec) error {
 	}
 
 	// Check for required fields.
+	localhost := os.Getenv("DIND_LOCALHOST")
 	if s.ExternalHost == "" {
 		// If the external host is not set, use localhost, assuming the test is running in a docker container.
-		s.ExternalHost = "localhost"
+		s.ExternalHost = localhost
 	}
 
 	return nil

--- a/e2e/internal/devnet/ledger.go
+++ b/e2e/internal/devnet/ledger.go
@@ -47,8 +47,9 @@ func (s *LedgerSpec) Validate() error {
 	}
 
 	// If the external host is not set, use localhost, assuming the test is running in a docker container.
+	localhost := os.Getenv("DIND_LOCALHOST")
 	if s.ExternalHost == "" {
-		s.ExternalHost = "localhost"
+		s.ExternalHost = localhost
 	}
 
 	return nil
@@ -133,7 +134,7 @@ func (l *Ledger) StartIfNotRunning(ctx context.Context) (bool, error) {
 		}
 
 		// Wait for the ledger to be healthy.
-		err = waitForSolanaReady(ctx, l.log, l.ExternalRPCPort)
+		err = waitForSolanaReady(ctx, l.log, l.dn.Spec.Ledger.ExternalHost, l.ExternalRPCPort)
 		if err != nil {
 			return false, fmt.Errorf("failed to wait for ledger to be healthy: %w", err)
 		}
@@ -217,7 +218,7 @@ func (l *Ledger) Start(ctx context.Context) error {
 	}
 
 	// Wait for the ledger to be healthy.
-	err = waitForSolanaReady(ctx, l.log, l.ExternalRPCPort)
+	err = waitForSolanaReady(ctx, l.log, l.dn.Spec.Ledger.ExternalHost, l.ExternalRPCPort)
 	if err != nil {
 		return fmt.Errorf("failed to wait for ledger to be healthy: %w", err)
 	}
@@ -267,14 +268,14 @@ func (l *Ledger) setState(ctx context.Context, containerID string) error {
 	return nil
 }
 
-func waitForSolanaReady(ctx context.Context, log *slog.Logger, rpcPort int) error {
+func waitForSolanaReady(ctx context.Context, log *slog.Logger, rpcHost string, rpcPort int) error {
 	var loggedWait bool
 	timeout := 20 * time.Second
 	var attempts int
 	err := pollUntil(ctx, func() (bool, error) {
 		attempts++
 		reqBody := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"getHealth"}`)
-		req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("http://localhost:%d/", rpcPort), reqBody)
+		req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("http://%s:%d/", rpcHost, rpcPort), reqBody)
 		if err != nil {
 			if !loggedWait && attempts > 1 {
 				log.Debug("--> Waiting for solana to be ready", "rpcPort", rpcPort, "timeout", timeout, "error", err)


### PR DESCRIPTION
## Summary of Changes
- Fixes running e2e tests in the devcontainer
- Updates the devcontainer Dockerfile to set `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal` so that the ryuk (testcontainers reaper/cleanup container) can start up
- Updates e2e devnet to use the `DIND_LOCALHOST` env in place of `localhost`, which is also set to `localhost.docker.internal` in the devcontainer Dockerfile

## Testing Verification
- Confirmed E2E tests are running and passing in the devcontainer
- CI should remain 🟢 
