### PR TITLE
e2e: fix localhost references

### DIFF
--- a/e2e/internal/devnet/controller.go
+++ b/e2e/internal/devnet/controller.go
@@ -38,6 +38,9 @@ func (s *ControllerSpec) Validate(cyoaNetworkSpec CYOANetworkSpec) error {
 
 	// Check for required fields.
 	localhost := os.Getenv("DIND_LOCALHOST")
+	if localhost == "" {
+		localhost = "localhost"
+	}
 	if s.ExternalHost == "" {
 		// If the external host is not set, use localhost, assuming the test is running in a docker container.
 		s.ExternalHost = localhost

--- a/e2e/internal/devnet/ledger.go
+++ b/e2e/internal/devnet/ledger.go
@@ -48,6 +48,9 @@ func (s *LedgerSpec) Validate() error {
 
 	// If the external host is not set, use localhost, assuming the test is running in a docker container.
 	localhost := os.Getenv("DIND_LOCALHOST")
+	if localhost == "" {
+		localhost = "localhost"
+	}
 	if s.ExternalHost == "" {
 		s.ExternalHost = localhost
 	}


### PR DESCRIPTION
## Summary of Changes
- Fixes `localhost` default references in e2e/dev setup
- Follows up on issue introduced in https://github.com/malbeclabs/doublezero/pull/700

## Testing Verification
- E2E tests pass in devcontainer and outside of it
- CI is 🟢 
