### PR TITLE
Jo/702 collecting team suggestions from pr 679

### DIFF
--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -22,63 +22,63 @@ pub enum Command {
     #[command(hide = true)]
     Init(InitCliCommand),
     /// Connect your server to a doublezero device
-    #[command(hide = false)]
+    #[command()]
     Connect(ProvisioningCliCommand),
     /// Get the status of your service
-    #[command(hide = false)]
+    #[command()]
     Status(StatusCliCommand),
     /// Disconnect your server from the doublezero network
-    #[command(hide = false)]
+    #[command()]
     Disconnect(DecommissioningCliCommand),
     /// Get device latencies
-    #[command(hide = false)]
+    #[command()]
     Latency(LatencyCliCommand),
     /// Get your public key
-    #[command(hide = false)]
+    #[command()]
     Address(AddressCliCommand),
     /// Get your balance
-    #[command(hide = false)]
+    #[command()]
     Balance(BalanceCliCommand),
     /// local configuration
-    #[command(hide = false)]
+    #[command()]
     Config(ConfigCliCommand),
     /// Global network configuration
-    #[command(hide = false)]
+    #[command()]
     GlobalConfig(GlobalConfigCliCommand),
     /// Get Account
-    #[command(hide = false)]
+    #[command()]
     Account(GetAccountCliCommand),
     /// Manage locations
-    #[command(hide = false)]
+    #[command()]
     Location(LocationCliCommand),
     /// Manage exchanges
-    #[command(hide = false)]
+    #[command()]
     Exchange(ExchangeCliCommand),
     /// Manage contributors
-    #[command(hide = false)]
+    #[command()]
     Contributor(ContributorCliCommand),
-    #[command(hide = false)]
+    #[command()]
     Device(DeviceCliCommand),
     /// Manage tunnels between devices
-    #[command(hide = false)]
+    #[command()]
     Link(LinkCliCommand),
     /// Manage users
-    #[command(hide = false)]
+    #[command()]
     User(UserCliCommand),
     /// Manage multicast
-    #[command(hide = false)]
+    #[command()]
     Multicast(MulticastCliCommand),
     /// Export all data to files
-    #[command(hide = false)]
+    #[command()]
     Export(ExportCliCommand),
     /// Create a new user identity
-    #[command(hide = false)]
+    #[command()]
     Keygen(KeyGenCliCommand),
     /// Get logs
-    #[command(hide = false)]
+    #[command()]
     Log(LogCliCommand),
     /// Generate shell completions
-    #[command(hide = false)]
+    #[command()]
     Completion(CompletionCliCommand),
 }
 

--- a/client/doublezero/src/cli/config.rs
+++ b/client/doublezero/src/cli/config.rs
@@ -11,9 +11,9 @@ pub struct ConfigCliCommand {
 #[derive(Debug, Subcommand)]
 pub enum ConfigCommands {
     /// Get current config settings
-    #[command(hide = false)]
+    #[command()]
     Get(GetConfigCliCommand),
     /// Set a config setting
-    #[command(hide = false)]
+    #[command()]
     Set(SetConfigCliCommand),
 }

--- a/client/doublezero/src/cli/user.rs
+++ b/client/doublezero/src/cli/user.rs
@@ -43,7 +43,7 @@ pub enum UserCommands {
     #[command(hide = true)]
     Delete(DeleteUserCliCommand),
     /// Manage user allowlist
-    #[command(hide = false)]
+    #[command()]
     Allowlist(UserAllowlistCliCommand),
     /// Request a ban for a user
     #[command(hide = true)]

--- a/controlplane/doublezero-admin/src/cli/command.rs
+++ b/controlplane/doublezero-admin/src/cli/command.rs
@@ -16,51 +16,51 @@ pub enum Command {
     #[command(hide = true)]
     Init(InitCliCommand),
     /// Get your public key
-    #[command(hide = false)]
+    #[command()]
     Address(AddressCliCommand),
     /// Get your balance
-    #[command(hide = false)]
+    #[command()]
     Balance(BalanceCliCommand),
     /// local configuration
-    #[command(hide = false)]
+    #[command()]
     Config(ConfigCliCommand),
     /// Global network configuration
-    #[command(hide = false)]
+    #[command()]
     GlobalConfig(GlobalConfigCliCommand),
     /// Get Account
-    #[command(hide = false)]
+    #[command()]
     Account(GetAccountCliCommand),
     /// Manage locations
-    #[command(hide = false)]
+    #[command()]
     Location(LocationCliCommand),
     /// Manage exchanges
-    #[command(hide = false)]
+    #[command()]
     Exchange(ExchangeCliCommand),
     /// Manage contributors
-    #[command(hide = false)]
+    #[command()]
     Contributor(ContributorCliCommand),
-    #[command(hide = false)]
+    #[command()]
     Device(DeviceCliCommand),
     /// Manage tunnels between devices
-    #[command(hide = false)]
+    #[command()]
     Link(LinkCliCommand),
     /// Manage users
-    #[command(hide = false)]
+    #[command()]
     User(UserCliCommand),
     /// Manage multicast
-    #[command(hide = false)]
+    #[command()]
     Multicast(MulticastCliCommand),
     /// Export all data to files
-    #[command(hide = false)]
+    #[command()]
     Export(ExportCliCommand),
     /// Create a new user identity
-    #[command(hide = false)]
+    #[command()]
     Keygen(KeyGenCliCommand),
     /// Get logs
-    #[command(hide = false)]
+    #[command()]
     Log(LogCliCommand),
     /// Generate shell completions
-    #[command(hide = false)]
+    #[command()]
     Completion(CompletionCliCommand),
 }
 

--- a/controlplane/doublezero-admin/src/cli/config.rs
+++ b/controlplane/doublezero-admin/src/cli/config.rs
@@ -11,9 +11,9 @@ pub struct ConfigCliCommand {
 #[derive(Debug, Subcommand)]
 pub enum ConfigCommands {
     /// Get current config settings
-    #[command(hide = false)]
+    #[command()]
     Get(GetConfigCliCommand),
     /// Set a config setting
-    #[command(hide = false)]
+    #[command()]
     Set(SetConfigCliCommand),
 }

--- a/controlplane/doublezero-admin/src/cli/user.rs
+++ b/controlplane/doublezero-admin/src/cli/user.rs
@@ -43,7 +43,7 @@ pub enum UserCommands {
     #[command(hide = true)]
     Delete(DeleteUserCliCommand),
     /// Manage user allowlist
-    #[command(hide = false)]
+    #[command()]
     Allowlist(UserAllowlistCliCommand),
     /// Request a ban for a user
     #[command(hide = true)]

--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -131,7 +131,6 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
 			set -euo pipefail
 
-			doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
 			doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29"
 			doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29"
 			doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.104/29"

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -162,8 +162,7 @@ func (dn *TestDevnet) Start(t *testing.T) (*devnet.Device, *devnet.Client) {
 	dn.Manager.Exec(ctx, []string{"bash", "-c", `
 		set -euo pipefail
 
-		echo "==> Populate device information onchain - DO NOT SHUFFLE THESE AS THE PUBKEYS WILL CHANGE"
-		doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+		echo "==> Populate device information onchain"
 		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29"
 		doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29"
 		doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.104/29"

--- a/e2e/sdk_telemetry_test.go
+++ b/e2e/sdk_telemetry_test.go
@@ -57,7 +57,6 @@ func TestE2E_SDK_Telemetry(t *testing.T) {
 	dn.Manager.Exec(ctx, []string{"bash", "-c", `
 		set -euo pipefail
 
-		doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
 		doublezero device create --code la2-dz01 --contributor co01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "207.45.216.136/30,200.12.12.12/29" --metrics-publisher ` + la2DeviceAgentPrivateKey.PublicKey().String() + `
 		doublezero device create --code ny5-dz01 --contributor co01 --location ewr --exchange xewr --public-ip "207.45.21.134" --dz-prefixes "200.12.12.12/29" --metrics-publisher ` + ny5DeviceAgentPrivateKey.PublicKey().String() + `
 		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29"

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -22,7 +22,7 @@ pub struct CreateDeviceCliCommand {
     /// Unique device code
     #[arg(long, value_parser = validate_code)]
     pub code: String,
-    /// Location (pubkey or code) associated with the device
+    /// Contributor (pubkey or code) associated with the device
     #[arg(long, value_parser = validate_pubkey_or_code)]
     pub contributor: String,
     /// Location (pubkey or code) associated with the device

--- a/smartcontract/sdk/rs/src/commands/contributor/get.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/get.rs
@@ -80,12 +80,10 @@ mod tests {
             .expect_gets()
             .with(predicate::eq(AccountType::Contributor))
             .returning(move |_| {
-                let mut contributors = HashMap::new();
-                contributors.insert(
+                Ok(HashMap::from([(
                     contributor_pubkey,
                     AccountData::Contributor(contributor2.clone()),
-                );
-                Ok(contributors)
+                )]))
             });
 
         // Search by pubkey


### PR DESCRIPTION
This pull request includes various changes to CLI commands across multiple modules, as well as improvements to contributor validation logic in the smart contract CLI. The most significant updates involve simplifying the `#[command]` attribute usage, adding contributor validation during creation and updates, and refining test data structures.

### CLI Command Attribute Updates:
* Simplified the `#[command]` attribute by removing redundant `hide = false` specifications for commands in `client/doublezero/src/cli/command.rs`, `controlplane/doublezero-admin/src/cli/command.rs`, and related files. This change standardizes the attribute usage across the codebase. [[1]](diffhunk://#diff-8fefb4de46da6cddbb7bf4f57668a326ba05f2487ec3e732e0ee07d59ef9feadL25-R81) [[2]](diffhunk://#diff-0dd26395bade6993c63360e812f7598b5f9ba8ec8a7adf6d2270f884031a4c7aL14-R17) [[3]](diffhunk://#diff-72d2794513bac7084377c16f98600ed7b508369a76928afc5c6d4e74ecebcbbaL19-R63) [[4]](diffhunk://#diff-f1c4b962a66148ec396b430f3b2cdcf36741b47115013ad521c216ce54a1e876L46-R46)

### Contributor Validation Enhancements:
* Added validation to `CreateContributorCliCommand` to prevent duplicate contributor codes by checking existing contributors before creation.
* Enhanced validation in `UpdateContributorCliCommand` to ensure that updated contributor codes do not conflict with existing ones, while also validating the contributor's public key.

### Device CLI Command Update:
* Updated the `CreateDeviceCliCommand` to clarify that the `contributor` argument refers to a contributor (pubkey or code) instead of a location.

### Test Data Structure Refinement:
* Refactored test logic in `smartcontract/sdk/rs/src/commands/contributor/get.rs` to use `HashMap::from` for initializing test data, simplifying the code and improving readability.

### Additional Improvements:
* Introduced `ListContributorCommand` imports in `smartcontract/cli/src/contributor/create.rs` and `smartcontract/cli/src/contributor/update.rs` to support the new validation logic. [[1]](diffhunk://#diff-7a89574ce930f2bedf4951036cef91d95e34445452d75c567dcd5310f6ed053cL7-R9) [[2]](diffhunk://#diff-c6df18fc1f8672fdcca6e0d05f96c519e70bee49239c4b3b95012168c8232db3L8-R8)

## Tests

```
make rust-test
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
```