### PR TITLE
device/telemetry: remove empty account buffer for past epochs

### DIFF
--- a/controlplane/telemetry/internal/telemetry/buffer.go
+++ b/controlplane/telemetry/internal/telemetry/buffer.go
@@ -62,6 +62,19 @@ func (b *AccountsBuffer) Recycle(accountKey AccountKey, samples []Sample) {
 	b.accounts[accountKey].Recycle(samples)
 }
 
+func (b *AccountsBuffer) Remove(key AccountKey) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.accounts, key)
+}
+
+func (b *AccountsBuffer) Has(key AccountKey) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.accounts[key]
+	return ok
+}
+
 func (b *AccountsBuffer) CopyAndReset(key AccountKey) []Sample {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/controlplane/telemetry/internal/telemetry/buffer_test.go
+++ b/controlplane/telemetry/internal/telemetry/buffer_test.go
@@ -83,4 +83,25 @@ func TestAgentTelemetry_Buffer_AccountsBuffer(t *testing.T) {
 		buf.Add(k, newTestSample())
 		require.Len(t, buf.FlushWithoutReset()[k], 1)
 	})
+
+	t.Run("Remove removes account key", func(t *testing.T) {
+		buf := telemetry.NewAccountsBuffer()
+		k := newTestAccountKey()
+		buf.Add(k, newTestSample())
+		buf.Remove(k)
+		require.False(t, buf.Has(k))
+	})
+
+	t.Run("Has returns true if account key exists", func(t *testing.T) {
+		buf := telemetry.NewAccountsBuffer()
+		k := newTestAccountKey()
+		buf.Add(k, newTestSample())
+		require.True(t, buf.Has(k))
+	})
+
+	t.Run("Has returns false if account key does not exist", func(t *testing.T) {
+		buf := telemetry.NewAccountsBuffer()
+		k := newTestAccountKey()
+		require.False(t, buf.Has(k))
+	})
 }

--- a/controlplane/telemetry/internal/telemetry/submitter.go
+++ b/controlplane/telemetry/internal/telemetry/submitter.go
@@ -140,6 +140,12 @@ func (s *Submitter) Tick(ctx context.Context) {
 		if len(tmp) == 0 {
 			log.Debug("No samples to submit, skipping")
 			s.cfg.Buffer.Recycle(accountKey, tmp)
+
+			// If the account is for a past epoch, remove it.
+			if accountKey.Epoch < DeriveEpoch(time.Now().UTC()) {
+				s.cfg.Buffer.Remove(accountKey)
+				log.Debug("Removed account key")
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary of Changes
- When an account buffer is empty and for a past epoch, remove it from the internal accounts structure so that it doesn't continue to be checked for submission on every interval
- Resolves https://github.com/malbeclabs/doublezero/issues/706

## Testing Verification
- Added test coverage to the submitter for this case
- Added test coverage for the new methods on `AccountsBuffer`
