### PR TITLE
docs: add Contributor structure and commands to README files

### DIFF
--- a/smartcontract/cli/README.md
+++ b/smartcontract/cli/README.md
@@ -208,7 +208,7 @@ Below is a list of available CLI commands for each main on-chain structure:
     | --lat        | f64      | Latitude                   |
     | --lng        | f64      | Longitude                  |
 
--### Contributor
+### Contributor
 - `contributor create` — Create a new contributor
     | Argument     | Type     | Description                |
     |--------------|----------|----------------------------|

--- a/smartcontract/programs/doublezero-serviceability/README.md
+++ b/smartcontract/programs/doublezero-serviceability/README.md
@@ -16,7 +16,7 @@ The following Rust structures define the on-chain account types that the smart c
 - **Exchange**: Structure and enums for exchanges, including status.
 - **Contributor**: Structure and enums for contributors, including status.
 - **Device**: Structure and enums for devices, including device type and status.
-- **Link**: Structure and enums for tunnels, including tunnel type and status.
+- **Link**: Structure and enums for links, including tunnel type and status.
 - **User**: Structure and enums for users, including user type.
 - **MulticastGroup**: Structure and enums for multicast groups, including status.
 - **GlobalConfig**: Structure for global configuration parameters, such as ASNs and network blocks.
@@ -59,7 +59,7 @@ classDiagram
         u128 index
         u8 bump_seed
         ContributorStatus status
-        Pubkey ata_owner
+        Pubkey ata_owner_pk
         String code
     }
     class Device {
@@ -225,15 +225,15 @@ stateDiagram-v2
     Deleting --> [*]
 ```
 
-| Field        | Type             | Description        |
-| ------------ | ---------------- | ------------------ |
-| account_type | AccountType      | Type of account    |
-| owner        | Pubkey           | Contributor owner  |
-| index        | u128             | Contributor index  |
-| bump_seed    | u8               | PDA bump seed      |
-| status       | Contributortatus | Contributor status |
-| code         | String           | Location code      |
-| ata_owner    | Pubkey           | ATA identity       |
+| Field        | Type              | Description        |
+| ------------ | ----------------- | ------------------ |
+| account_type | AccountType       | Type of account    |
+| owner        | Pubkey            | Contributor owner  |
+| index        | u128              | Contributor index  |
+| bump_seed    | u8                | PDA bump seed      |
+| status       | ContributorStatus | Contributor status |
+| code         | String            | Contributor code   |
+| ata_owner    | Pubkey            | ATA identity       |
 
 ## Device
 

--- a/smartcontract/sdk/rs/README.md
+++ b/smartcontract/sdk/rs/README.md
@@ -155,7 +155,7 @@ Fetches a location by its public key or code. Returns the location's public key 
 - `pubkey_or_code: String` — Location public key or code
 
 ### DeleteLocationCommand
-Deletes a location by index. Returns the transaction signature.
+Deletes a location. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ### ListLocationCommand
@@ -173,7 +173,7 @@ Lists all locations in the program. Returns a map of location public keys to the
 | loc_id        | u32     | Location ID                |
 
 ### ResumeLocationCommand
-Resumes a previously suspended location by index. Returns the transaction signature.
+Resumes a previously suspended location. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ## Exchange Commands
@@ -202,7 +202,7 @@ Fetches an exchange by its public key or code. Returns the exchange's public key
 - `pubkey_or_code: String` — Exchange public key or code
 
 ### DeleteExchangeCommand
-Deletes an exchange by index. Returns the transaction signature.
+Deletes an exchange. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ### ListExchangeCommand
@@ -246,7 +246,7 @@ Fetches a contributor by its public key or code. Returns the contributor's publi
 - `pubkey_or_code: String` — Contributor public key or code
 
 ### DeleteContributorCommand
-Deletes a contributor by index. Returns the transaction signature.
+Deletes a contributor. Returns the transaction signature.
 
 ### ListContributorCommand
 Lists all contributors in the program. Returns a map of contributor public keys to their on-chain data.
@@ -284,7 +284,7 @@ Fetches a device by its public key or code. Returns the device's public key and 
 - `pubkey_or_code: String` — Device public key or code
 
 ### DeleteDeviceCommand
-Deletes a device by index. Returns the transaction signature.
+Deletes a device. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ### ListDeviceCommand
@@ -307,59 +307,59 @@ Closes the device account, releasing its resources. Returns the transaction sign
 - `owner: Pubkey` — Owner public key
 
 ### RejectDeviceCommand
-Rejects a device by index, providing a reason. Returns the transaction signature.
+Rejects a device, providing a reason. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 - `reason: String` — Rejection reason
 
 ### ResumeDeviceCommand
-Resumes a previously suspended device by index. Returns the transaction signature.
+Resumes a previously suspended device. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
-## Tunnel Commands
+## Link Commands
 
-The following commands allow you to manage Tunnel entities on the DoubleZero protocol. Each command is represented by a struct with the listed arguments.
+The following commands allow you to manage Link entities on the DoubleZero protocol. Each command is represented by a struct with the listed arguments.
 
-### CreateTunnelCommand
-Creates a new tunnel between two endpoints with the specified parameters. Returns the transaction signature and the tunnel's public key on success.
-- `code: String` — Unique tunnel code
+### CreateLinkCommand
+Creates a new link between two endpoints with the specified parameters. Returns the transaction signature and the link's public key on success.
+- `code: String` — Unique link code
 - `side_a_pk: Pubkey` — Public key for side A
 - `side_z_pk: Pubkey` — Public key for side Z
-- `tunnel_type: TunnelTunnelType` — Tunnel type enum
+- `link_type: LinkLinkType` — Link type enum
 - `bandwidth: u64` — Bandwidth in bps
 - `mtu: u32` — MTU size
 - `delay_ns: u64` — Delay in nanoseconds
 - `jitter_ns: u64` — Jitter in nanoseconds
 
-### GetTunnelCommand
-Fetches a tunnel by its public key or code. Returns the tunnel's public key and its on-chain data if found.
-- `pubkey_or_code: String` — Tunnel public key or code
+### GetLinkCommand
+Fetches a link by its public key or code. Returns the link's public key and its on-chain data if found.
+- `pubkey_or_code: String` — Link public key or code
 
-### RejectTunnelCommand
-Rejects a tunnel by index, providing a reason. Returns the transaction signature.
+### RejectLinkCommand
+Rejects a link, providing a reason. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 - `reason: String` — Rejection reason
 
-### ResumeTunnelCommand
-Resumes a previously suspended tunnel by index. Returns the transaction signature.
+### ResumeLinkCommand
+Resumes a previously suspended link. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
-### DeleteTunnelCommand
-Deletes a tunnel by index. Returns the transaction signature.
+### DeleteLinkCommand
+Deletes a link. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
-### ActivateTunnelCommand
-Activates a tunnel, assigning it a tunnel ID and network. Returns the transaction signature.
+### ActivateLinkCommand
+Activates a link, assigning it a link ID and network. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
-- `tunnel_id: u16` — Tunnel ID
-- `tunnel_net: NetworkV4` — Tunnel network (IPv4)
+- `tunnel_id: u16` — Link ID
+- `tunnel_net: NetworkV4` — Link network (IPv4)
 
-### CloseAccountTunnelCommand
-Closes the tunnel account, releasing its resources. Returns the transaction signature.
+### CloseAccountLinkCommand
+Closes the link account, releasing its resources. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 - `owner: Pubkey` — Owner public key
 
-### ListTunnelCommand
-Lists all tunnels in the program. Returns a map of tunnel public keys to their on-chain data.
+### ListLinkCommand
+Lists all links in the program. Returns a map of link public keys to their on-chain data.
 - *(no arguments)*
 
 | Field         | Type              | Description                |
@@ -416,7 +416,7 @@ Fetches a user by its public key or code. Returns the user's public key and its 
 - `pubkey_or_code: String` — User public key or code
 
 ### DeleteUserCommand
-Deletes a user by index. Returns the transaction signature.
+Deletes a user. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ### ListUserCommand
@@ -439,7 +439,7 @@ Suspends a user, disabling their access without deleting the account. Returns th
 - `pubkey: Pubkey` — Pubkey
 
 ### ResumeUserCommand
-Resumes a previously suspended user by index. Returns the transaction signature.
+Resumes a previously suspended user. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 
 ### CloseAccountUserCommand
@@ -448,7 +448,7 @@ Closes the user account, releasing its resources. Returns the transaction signat
 - `owner: Pubkey` — Owner public key
 
 ### RejectUserCommand
-Rejects a user by index, providing a reason. Returns the transaction signature.
+Rejects a user, providing a reason. Returns the transaction signature.
 - `pubkey: Pubkey` — Pubkey
 - `reason: String` — Rejection reason
 


### PR DESCRIPTION
This pull request introduces a new `Contributor` account type to the DoubleZero smart contract system, along with updates to the documentation and CLI commands to support this addition. It also standardizes the use of `pubkey` instead of `index` for identifying entities across various commands. Below is a breakdown of the most important changes:

### Contributor Account Type Additions
* Added a new `Contributor` class to the `classDiagram` in `smartcontract/cli/README.md` and `smartcontract/programs/doublezero-serviceability/README.md`, including fields such as `account_type`, `owner`, `index`, `bump_seed`, `status`, `ata_owner`, and `code`. [[1]](diffhunk://#diff-536b967d913d1ceafe93082565469d970c82270da32515389f0a94a1b1734c65R48-L54) [[2]](diffhunk://#diff-2a9b1ba8f532100dc50c8b2928fa95bf5363e5ab69d5b85b77c94baedf10ea42R17) [[3]](diffhunk://#diff-2a9b1ba8f532100dc50c8b2928fa95bf5363e5ab69d5b85b77c94baedf10ea42R56-L61)
* Updated the `stateDiagram-v2` in `smartcontract/programs/doublezero-serviceability/README.md` to include the lifecycle states for `Contributor` accounts (e.g., `Activated`, `Suspended`, `Deleting`).
* Documented new CLI commands for managing contributors (create, delete, update, get, list) in `smartcontract/cli/README.md` and `smartcontract/sdk/rs/README.md`. [[1]](diffhunk://#diff-536b967d913d1ceafe93082565469d970c82270da32515389f0a94a1b1734c65R211-R240) [[2]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683R229-R260)

### Relationship Updates in Diagrams
* Added a relationship between `Device` and `Contributor` in the `classDiagram`. Devices now reference contributors via `contributor_pk`. [[1]](diffhunk://#diff-536b967d913d1ceafe93082565469d970c82270da32515389f0a94a1b1734c65L85-R97) [[2]](diffhunk://#diff-2a9b1ba8f532100dc50c8b2928fa95bf5363e5ab69d5b85b77c94baedf10ea42R137)

### Standardization of Entity Identifiers
* Replaced the use of `index: u128` with `pubkey: Pubkey` for entity identification in commands across `smartcontract/sdk/rs/README.md`. This change applies to locations, exchanges, devices, tunnels, and users. [[1]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683L160-R159) [[2]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683L194-R193) [[3]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683L245-R276) [[4]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683L308-R358) [[5]](diffhunk://#diff-cd24e16d66ad39ae7a90679b08ca74e473557815ee12bfd080dd403b9aab5683L375-R406)

### Documentation Enhancements
* Updated the `smartcontract/programs/doublezero-serviceability/README.md` to include `Contributor` in the list of account types and provide detailed descriptions of its structure and purpose. [[1]](diffhunk://#diff-2a9b1ba8f532100dc50c8b2928fa95bf5363e5ab69d5b85b77c94baedf10ea42R17) [[2]](diffhunk://#diff-2a9b1ba8f532100dc50c8b2928fa95bf5363e5ab69d5b85b77c94baedf10ea42R213-R237)
* Added detailed descriptions and argument lists for new contributor-related commands in `smartcontract/sdk/rs/README.md`.

These changes collectively enhance the functionality of the DoubleZero system by introducing contributors as a new entity type, improving maintainability through standardized identifiers, and updating documentation for clarity and completeness.