### PR TITLE
Fixes an issue where transactions were not being properly validated by the tests.

### DIFF
--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -318,6 +318,7 @@ impl DoubleZeroClient for DZClient {
             .client
             .simulate_transaction(&transaction)
             .map_err(|e| eyre!(e))?;
+
         if result.value.err.is_some() {
             println!("Program Logs:");
             if let Some(logs) = result.value.logs {

--- a/smartcontract/sdk/rs/src/commands/contributor/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/delete.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::contributor::delete::ContributorDeleteArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_contributor_delete_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -56,8 +55,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/contributor/resume.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/resume.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::contributor::resume::ContributorResumeArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_contributor_resume_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -56,8 +55,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/contributor/suspend.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/suspend.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::contributor::suspend::ContributorSuspendArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_contributor_suspend_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -56,8 +55,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/contributor/update.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/update.rs
@@ -42,9 +42,7 @@ mod tests {
         processors::contributor::update::ContributorUpdateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{
-        instruction::AccountMeta, pubkey::Pubkey, signature::Signature, system_program,
-    };
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
     fn test_commands_contributor_update_command() {
@@ -52,7 +50,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -66,8 +63,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/device/activate.rs
+++ b/smartcontract/sdk/rs/src/commands/device/activate.rs
@@ -38,7 +38,7 @@ mod tests {
         processors::device::activate::DeviceActivateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_device_activate_command() {
@@ -46,7 +46,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_device_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -55,8 +54,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/exchange/create.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/create.rs
@@ -55,7 +55,7 @@ mod tests {
         processors::exchange::create::ExchangeCreateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_exchange_create_command() {
@@ -63,7 +63,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, bump_seed) = get_exchange_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -80,8 +79,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/exchange/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/delete.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::exchange::delete::ExchangeDeleteArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_exchange_delete_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_exchange_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -54,8 +53,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/exchange/resume.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/resume.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::exchange::resume::ExchangeResumeArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_exchange_resume_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_exchange_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -54,8 +53,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/exchange/suspend.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/suspend.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::exchange::suspend::ExchangeSuspendArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_exchange_suspend_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_exchange_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -56,8 +55,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/exchange/update.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/update.rs
@@ -48,7 +48,7 @@ mod tests {
         processors::exchange::update::ExchangeUpdateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_exchange_update_command() {
@@ -56,7 +56,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_exchange_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -71,8 +70,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/location/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/location/delete.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::location::delete::LocationDeleteArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_location_delete_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_location_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -54,8 +53,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/location/resume.rs
+++ b/smartcontract/sdk/rs/src/commands/location/resume.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::location::resume::LocationResumeArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_location_resume_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_location_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -54,8 +53,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/location/suspend.rs
+++ b/smartcontract/sdk/rs/src/commands/location/suspend.rs
@@ -37,7 +37,7 @@ mod tests {
         processors::location::suspend::LocationSuspendArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_location_suspend_command() {
@@ -45,7 +45,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_location_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -56,8 +55,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/location/update.rs
+++ b/smartcontract/sdk/rs/src/commands/location/update.rs
@@ -50,7 +50,7 @@ mod tests {
         processors::location::update::LocationUpdateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature, system_program};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_location_update_command() {
@@ -58,7 +58,6 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_location_pda(&client.get_program_id(), 1);
-        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -74,8 +73,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                    AccountMeta::new(system_program::id(), false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/deactivate.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/deactivate.rs
@@ -48,6 +48,7 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_location_pda(&client.get_program_id(), 1);
+        let payer = client.get_payer();
 
         client
             .expect_execute_transaction()
@@ -57,12 +58,12 @@ mod tests {
                 )),
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
+                    AccountMeta::new(payer, false),
                     AccountMeta::new(globalstate_pubkey, false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));
 
-        let payer = client.get_payer();
         let res = DeactivateMulticastGroupCommand {
             pubkey: pda_pubkey,
             owner: payer,

--- a/smartcontract/sdk/rs/src/tests.rs
+++ b/smartcontract/sdk/rs/src/tests.rs
@@ -4,7 +4,7 @@ pub mod utils {
         state::{accountdata::AccountData, accounttype::AccountType, globalstate::GlobalState},
     };
     use mockall::predicate;
-    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use solana_sdk::pubkey::Pubkey;
     use std::env;
     use tempfile::TempDir;
 
@@ -37,9 +37,6 @@ pub mod utils {
             .expect_get()
             .with(predicate::eq(globalstate_pubkey))
             .returning(move |_| Ok(AccountData::GlobalState(globalstate.clone())));
-        client
-            .expect_execute_transaction()
-            .returning(|_, _| Ok(Signature::new_unique()));
         client
     }
 


### PR DESCRIPTION
This pull request includes changes to clean up test code by removing unused imports and redundant `payer` and `system_program` account metadata in various test modules. Additionally, it updates some test logic for device creation to use consistent indices and variables.

### Test cleanup and simplification:

* Removed unused imports of `system_program` from test modules across multiple files, including `contributor`, `device`, `exchange`, and `location` commands. (`[[1]](diffhunk://#diff-f6b1728290be8899fd7dfddb0c4020634aa2cbc960e299fdd71e6d9c3839500cL40-L48)`, `[[2]](diffhunk://#diff-e5c8a503a88a95f15ba8a5e60bced7c801335c06051dfdb8dbf1d742710a9399L40-L48)`, `[[3]](diffhunk://#diff-e16f3453bf52f7ce33aa77e34173329401b03b2638643ec7b8521c3b5544c206L40-L48)`, `[[4]](diffhunk://#diff-ac2ff973b05ce1442d03e9bac8b269fa75a88202e91a27aa7134456f75cf97ccL45-L55)`, `[[5]](diffhunk://#diff-03526e4152b980297c6838fbfed09c9b41c2090207788c8fb78516a7b9eb39abL41-L49)`, `[[6]](diffhunk://#diff-d0fa7807b37305573edf25b9cce9bb698606a6ae1e224b91efb33ae7f6076e27L75-R81)`, `[[7]](diffhunk://#diff-6abb67a107263da15b44ba1e585b6e616dff91ae2f265540d350cdd9789e0f66L58-L66)`, `[[8]](diffhunk://#diff-a409d87e9a2ad91a53922bbd4ac768c6792a446ec18292c2b54dac1529e4b7dcL40-L48)`, `[[9]](diffhunk://#diff-61cd04c17edd9b61141342fa8a9227569124d135c43d95642fda4656f6bc6c28L40-L48)`, `[[10]](diffhunk://#diff-ddc74d87b504fef814f1564790d3d7f261ffba8150e9d996cb4f3307ee1e5702L40-L48)`, `[[11]](diffhunk://#diff-f3ffba10993bdc59e24263706cbaec2c5cb464cb3d856c75046cf893b7952b10L51-L59)`, `[[12]](diffhunk://#diff-f65b13e8da2fa3dd4cf25009adf0dbf03838ba803dd4100330d4497b6407907dL40-L48)`, `[[13]](diffhunk://#diff-ba860c62b16c2597d402e5c9c8ceecccb7fa24a04a73b66ccdd7d33658489359L40-L48)`)
* Removed `payer` account metadata from test cases where it was no longer required, simplifying the `AccountMeta` definitions. (`[[1]](diffhunk://#diff-f6b1728290be8899fd7dfddb0c4020634aa2cbc960e299fdd71e6d9c3839500cL59-L60)`, `[[2]](diffhunk://#diff-e5c8a503a88a95f15ba8a5e60bced7c801335c06051dfdb8dbf1d742710a9399L59-L60)`, `[[3]](diffhunk://#diff-e16f3453bf52f7ce33aa77e34173329401b03b2638643ec7b8521c3b5544c206L59-L60)`, `[[4]](diffhunk://#diff-ac2ff973b05ce1442d03e9bac8b269fa75a88202e91a27aa7134456f75cf97ccL69-L70)`, `[[5]](diffhunk://#diff-03526e4152b980297c6838fbfed09c9b41c2090207788c8fb78516a7b9eb39abL58-L59)`, `[[6]](diffhunk://#diff-d0fa7807b37305573edf25b9cce9bb698606a6ae1e224b91efb33ae7f6076e27L125-L146)`, `[[7]](diffhunk://#diff-6abb67a107263da15b44ba1e585b6e616dff91ae2f265540d350cdd9789e0f66L83-L84)`, `[[8]](diffhunk://#diff-a409d87e9a2ad91a53922bbd4ac768c6792a446ec18292c2b54dac1529e4b7dcL57-L58)`, `[[9]](diffhunk://#diff-61cd04c17edd9b61141342fa8a9227569124d135c43d95642fda4656f6bc6c28L57-L58)`, `[[10]](diffhunk://#diff-ddc74d87b504fef814f1564790d3d7f261ffba8150e9d996cb4f3307ee1e5702L59-L60)`, `[[11]](diffhunk://#diff-f3ffba10993bdc59e24263706cbaec2c5cb464cb3d856c75046cf893b7952b10L74-L75)`, `[[12]](diffhunk://#diff-f65b13e8da2fa3dd4cf25009adf0dbf03838ba803dd4100330d4497b6407907dL57-L58)`, `Ff949623L54R53`)

### Device creation test updates:

* Updated the device creation test to use consistent indices (`index: 1` instead of `index: 3`) and introduced a new variable `pubmetrics_publisher` for better readability and consistency. (`[[1]](diffhunk://#diff-d0fa7807b37305573edf25b9cce9bb698606a6ae1e224b91efb33ae7f6076e27L125-L146)`, `[[2]](diffhunk://#diff-d0fa7807b37305573edf25b9cce9bb698606a6ae1e224b91efb33ae7f6076e27L159-R159)`)