### PR TITLE
feat: Update device creation logic to validate contributor accounts

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -23,6 +23,8 @@ pub enum DoubleZeroError {
     NotAllowed, // variant 8
     #[error("Invalid Account Type")]
     InvalidAccountType, // variant 9
+    #[error("You are trying to assign a Pubkey that does not correspond to a Contributor")]
+    InvalidContributorPubkey, // variant 10
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -38,6 +40,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidStatus => ProgramError::Custom(7),
             DoubleZeroError::NotAllowed => ProgramError::Custom(8),
             DoubleZeroError::InvalidAccountType => ProgramError::Custom(9),
+            DoubleZeroError::InvalidContributorPubkey => ProgramError::Custom(10),
         }
     }
 }
@@ -54,6 +57,9 @@ impl From<ProgramError> for DoubleZeroError {
                 6 => DoubleZeroError::InvalidDevicePubkey,
                 7 => DoubleZeroError::InvalidStatus,
                 8 => DoubleZeroError::NotAllowed,
+                9 => DoubleZeroError::InvalidAccountType,
+                10 => DoubleZeroError::InvalidContributorPubkey,
+
                 _ => DoubleZeroError::Custom(e),
             },
             _ => DoubleZeroError::Custom(0),

--- a/smartcontract/sdk/rs/src/commands/device/create.rs
+++ b/smartcontract/sdk/rs/src/commands/device/create.rs
@@ -141,6 +141,9 @@ mod tests {
                 })),
                 predicate::eq(vec![
                     AccountMeta::new(device_pubkey, false),
+                    AccountMeta::new(contributor_pubkey, false),
+                    AccountMeta::new(location_pubkey, false),
+                    AccountMeta::new(exchange_pubkey, false),
                     AccountMeta::new(globalstate_pubkey, false),
                     AccountMeta::new(payer, true),
                     AccountMeta::new(system_program::id(), false),

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -88,14 +88,14 @@ echo "Creating contributor"
 
 ### Initialice devices
 echo "Creating devices"
-./target/doublezero device create --code la2-dz01 --contributor test --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "100.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code ny5-dz01 --contributor test --location ewr --exchange xewr --public-ip "64.86.249.80" --dz-prefixes "101.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code ld4-dz01 --contributor test --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "102.0.0.0/29,103.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code frk-dz01 --contributor test --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "104.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code sg1-dz01 --contributor test --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "105.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code ty2-dz01 --contributor test --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "106.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code pit-dzd01 --contributor test --location pit --exchange xpit --public-ip "204.16.241.243" --dz-prefixes "107.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
-./target/doublezero device create --code ams-dz001 --contributor test --location ams --exchange xams --public-ip "195.219.138.50" --dz-prefixes "108.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code la2-dz01 --contributor co01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "100.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code ny5-dz01 --contributor co01 --location ewr --exchange xewr --public-ip "64.86.249.80" --dz-prefixes "101.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "102.0.0.0/29,103.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "104.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "105.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code ty2-dz01 --contributor co01 --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "106.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code pit-dzd01 --contributor co01 --location pit --exchange xpit --public-ip "204.16.241.243" --dz-prefixes "107.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
+./target/doublezero device create --code ams-dz001 --contributor co01 --location ams --exchange xams --public-ip "195.219.138.50" --dz-prefixes "108.0.0.0/16" --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB
 
 ### Initialice links
 echo "Creating links"


### PR DESCRIPTION
This pull request introduces changes to enhance validation logic, improve error handling, and update test and script configurations for the `doublezero-serviceability` program. The most notable changes include the addition of a new error type, refactoring of account validation in the `process_create_device` function, and updates to test and script files to align with the new logic.

### Error Handling Enhancements:
* Added a new error variant `InvalidContributorPubkey` to `DoubleZeroError` to handle invalid contributor public keys. Updated its mapping in `From<DoubleZeroError>` and `From<ProgramError>` implementations. [[1]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R26-R27) [[2]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R43) [[3]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R60-R62)

### Validation Logic Improvements:
* Refactored `process_create_device` to use `try_from` for account deserialization and added stricter validation for contributor, location, and exchange accounts, including checks for their types and ownership.

### Codebase Organization:
* Updated imports in `create.rs` to include specific modules (`account_create`, `get_device_pda`) and additional account types (`Contributor`, `Location`, `Exchange`).

### Test and Script Updates:
* Modified test setup in `create.rs` to include contributor, location, and exchange accounts in the `AccountMeta` list.
* Updated `start-test.sh` to replace the placeholder contributor (`test`) with a specific identifier (`co01`) in device creation commands.