### PR TITLE
e2e: device startup config commit merge

### DIFF
--- a/e2e/internal/devnet/device/startup-config.tmpl
+++ b/e2e/internal/devnet/device/startup-config.tmpl
@@ -5,6 +5,8 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$hb.8VFI7A9D/0zi2$sZady959HlXHgFdWU9r01VDwmbM2CrhDYIXBJzHb3scDP8/t/4ozwxpZbwEgDxbWL.mHYtie0rSO8fRSZ5D0T1
 !
+service configuration session commit merge
+!
 vrf instance vrf1
 ip routing vrf vrf1
 !


### PR DESCRIPTION
## Summary of Changes
- Add `service configuration session commit merge` to device startup-config so that other changes made to the config are not mangled when the controller/agent config is applied
- Fixes flakey e2e test merged with https://github.com/malbeclabs/doublezero/pull/704

## Testing Verification
- All within E2E tests which are 🟢 
