### PR TITLE
devcontainer: fix clippy config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,12 +38,15 @@
                     "--config",
                     "imports_granularity=Crate"
                 ],
-                "rust-analyzer.checkOnSave.command": "clippy",
-                "rust-analyzer.checkOnSave.extraArgs": [
-                    "--",
-                    "-Dclippy::all",
-                    "-Dwarnings"
-                ]
+                "rust-analyzer.checkOnSave": true,
+                "rust-analyzer.check": {
+                    "command": "clippy",
+                    "extraArgs": [
+                        "--",
+                        "-Dclippy::all",
+                        "-Dwarnings"
+                    ]
+                }
             }
         }
     },


### PR DESCRIPTION
## Summary of Changes
- Replaced outdated `rust-analyzer.checkOnSave.*` config with `rust-analyzer.check` in `devcontainer.json`
- Fixes devcontainer warning `invalid config value: /checkOnSave: invalid type: map, expected a boolean;`

## Testing Verification
- Devcontainer build/startup no longer shows this warning