### PR TITLE
agent: expose optional prom metrics

### DIFF
--- a/controlplane/agent/cmd/agent/main.go
+++ b/controlplane/agent/cmd/agent/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,6 +16,7 @@ import (
 	arista "github.com/malbeclabs/doublezero/controlplane/agent/pkg/arista"
 	aristapb "github.com/malbeclabs/doublezero/controlplane/proto/arista/gen/pb-go/arista/EosSdkRpc"
 	pb "github.com/malbeclabs/doublezero/controlplane/proto/controller/gen/pb-go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -25,9 +27,14 @@ var (
 	controllerTimeoutInSeconds = flag.Float64("controller-timeout-in-seconds", 2, "How long to wait for a response from the controller before giving up")
 	maxLockAge                 = flag.Int("max-lock-age-in-seconds", 3600, "If agent detects a config lock that older than the specified age, it will force unlock.")
 	verbose                    = flag.Bool("verbose", false, "Enable verbose logging")
+	showVersion                = flag.Bool("version", false, "Print the version of the doublezero-agent and exit")
+	metricsEnable              = flag.Bool("metrics-enable", false, "Enable prometheus metrics")
+	metricsAddr                = flag.String("metrics-addr", ":8080", "Address to listen on for prometheus metrics")
 
-	version = flag.Bool("version", false, "version info")
-	Build   string
+	// set by LDFLAGS
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func pollControllerAndConfigureDevice(ctx context.Context, dzclient pb.ControllerClient, eapiClient *arista.EAPIClient, pubkey string, verbose *bool, maxLockAge int) error {
@@ -38,12 +45,14 @@ func pollControllerAndConfigureDevice(ctx context.Context, dzclient pb.Controlle
 	neighborIpMap, err = eapiClient.GetBgpNeighbors(ctx)
 	if err != nil {
 		log.Println("pollControllerAndConfigureDevice: eapiClient.GetBgpNeighbors returned error:", err)
+		agent.ErrorsBgpNeighbors.Inc()
 	}
 
 	var configText string
 	configText, err = agent.GetConfigFromServer(ctx, dzclient, pubkey, neighborIpMap, controllerTimeoutInSeconds)
 	if err != nil {
 		log.Printf("pollControllerAndConfigureDevice failed to call agent.GetConfigFromServer: %q", err)
+		agent.ErrorsGetConfig.Inc()
 		return err
 	}
 
@@ -58,6 +67,7 @@ func pollControllerAndConfigureDevice(ctx context.Context, dzclient pb.Controlle
 
 	_, err = eapiClient.AddConfigToDevice(ctx, configText, nil, maxLockAge) // 3rd arg (diffCmd) is only used for testing
 	if err != nil {
+		agent.ErrorsApplyConfig.Inc()
 		return err
 	}
 	return nil
@@ -69,24 +79,30 @@ func main() {
 
 	flag.Parse()
 
-	if Build == "" {
-		Build = "unknown"
-	}
-
-	if *version {
-		fmt.Printf("build: %s\n", Build)
+	if *showVersion {
+		fmt.Printf("version: %s, commit: %s, date: %s\n", version, commit, date)
 		os.Exit(0)
 	}
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile | log.Lmicroseconds)
 
-	log.Printf("Starting doublezero-agent version %s starting\n", Build)
+	log.Printf("Starting doublezero-agent version %s starting\n", version)
 	log.Printf("doublezero-agent pubkey: %s\n", *localDevicePubkey)
 	log.Printf("doublezero-agent controller: %s\n", *controllerAddress)
 	log.Printf("doublezero-agent device: %s\n", *device)
 	log.Printf("doublezero-agent sleep-interval-in-seconds: %f\n", *sleepIntervalInSeconds)
 	log.Printf("doublezero-agent controller-timeout-in-seconds: %f\n", *controllerTimeoutInSeconds)
 	log.Printf("doublezero-agent max-lock-age-in-seconds: %d\n", *maxLockAge)
+
+	if *metricsEnable {
+		agent.BuildInfo.WithLabelValues(version, commit, date).Set(1)
+		go func() {
+			http.Handle("/metrics", promhttp.Handler())
+			if err := http.ListenAndServe(*metricsAddr, nil); err != nil {
+				log.Printf("Failed to start prometheus metrics server: %v", err)
+			}
+		}()
+	}
 
 	dzclient, err := agent.GetDzClient(*controllerAddress)
 	if err != nil {

--- a/controlplane/agent/internal/agent/metrics.go
+++ b/controlplane/agent/internal/agent/metrics.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BuildInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_agent_build_info",
+			Help: "Build information of the agent",
+		},
+		[]string{"version", "commit", "date"},
+	)
+	ErrorsBgpNeighbors = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "doublezero_agent_bgp_neighbors_errors_total",
+			Help: "Number of errors encountered while retrieving BGP neighbors from the device",
+		},
+	)
+	ErrorsGetConfig = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "doublezero_agent_get_config_errors_total",
+			Help: "Number of errors encountered while getting config from the controller",
+		},
+	)
+	ErrorsApplyConfig = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "doublezero_agent_apply_config_errors_total",
+			Help: "Number of errors encountered while applying config to the device",
+		},
+	)
+)

--- a/release/.goreleaser.base.agent.yaml
+++ b/release/.goreleaser.base.agent.yaml
@@ -16,7 +16,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      -X main.Build={{.Env.AGENT_VERSION}}
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
       - linux
     goarch:


### PR DESCRIPTION
## Summary of Changes
This PR adds optional prometheus metrics to the device agent with can be exposed via a `-metrics-enable` flag. The following metrics are exposed:

- `doublezero_agent_build_info` - Build information of the agent (version, commit, date)
- `doublezero_agent_bgp_neighbors_errors_total` - Number of errors encountered while retrieving BGP neighbors from the device
- `doublezero_agent_get_config_errors_total` - Number of errors encountered while getting config from the controller
- `doublezero_agent_apply_config_errors_total` - Number of errors encountered while applying config to the device

The main use case for this is to derive the health of a release to devnet as well as tracking the current build running on each device. But this may also be valuable to contributors who would like to integrate the agent into their existing monitoring stack, assuming they use prometheus.

Also included is an adjustment to the version added to the agent via LDFLAGs as we need this to match the version set by goreleaser in the package so when we build a pre-release of the next version increment, this is reflected in the build (which is then exposed via prometheus). In many cases, the version field was empty if the current commit is not part of a git tag, which is the case when we cut a pre-release.

## Testing Verification

Started the agent outside of a device and watched errors increment. The build info is also correct:
```
ubuntu@chi-dn-bm7:~$ curl -s localhost:8080/metrics | grep doublezero
# HELP doublezero_agent_apply_config_errors_total Number of errors encountered while applying config to the device
# TYPE doublezero_agent_apply_config_errors_total counter
doublezero_agent_apply_config_errors_total 0
# HELP doublezero_agent_bgp_neighbors_errors_total Number of errors encountered while retrieving BGP neighbors from the device
# TYPE doublezero_agent_bgp_neighbors_errors_total counter
doublezero_agent_bgp_neighbors_errors_total 4
# HELP doublezero_agent_build_info Build information of the agent
# TYPE doublezero_agent_build_info gauge
doublezero_agent_build_info{commit="eac3a78a",date="2025-07-10T02:28:12Z",version="0.2.3~git20250710022812.eac3a78a"} 1
# HELP doublezero_agent_get_config_errors_total Number of errors encountered while getting config from the controller
# TYPE doublezero_agent_get_config_errors_total counter
doublezero_agent_get_config_errors_total 4
```
