### PR TITLE
client: expose optional prom metrics

### DIFF
--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -20,7 +20,7 @@ use doublezero_sdk::{DZClient, ProgramVersion};
 #[derive(Parser, Debug)]
 #[command(term_width = 0)]
 #[command(name = "DoubleZero")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
 #[command(about = "DoubleZero client tool", long_about = None)]
 struct App {
     #[command(subcommand)]

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -4,43 +4,52 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
 	solana "github.com/gagliardetto/solana-go"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/runtime"
+	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
 	sockFile             = flag.String("sock-file", "/var/run/doublezerod/doublezerod.sock", "path to doublezerod domain socket")
 	enableLatencyProbing = flag.Bool("latency-probing", true, "enable latency probing to doublezero nodes")
 	versionFlag          = flag.Bool("version", false, "build version")
-	programId            = flag.String("program-id", "", "override smartcontract program id to monitor")
-	rpcEndpoint          = flag.String("solana-rpc-endpoint", "", "override solana rpc endpoint url")
+	programId            = flag.String("program-id", serviceability.SERVICEABILITY_PROGRAM_ID_TESTNET, "override smartcontract program id to monitor")
+	rpcEndpoint          = flag.String("solana-rpc-endpoint", dzsdk.DZ_LEDGER_RPC_URL, "override solana rpc endpoint url")
 	probeInterval        = flag.Int("probe-interval", 30, "latency probe interval in seconds")
 	cacheUpdateInterval  = flag.Int("cache-update-interval", 30, "latency cache update interval in seconds")
 	enableVerboseLogging = flag.Bool("v", false, "enables verbose logging")
+	metricsEnable        = flag.Bool("metrics-enable", false, "Enable prometheus metrics")
+	metricsAddr          = flag.String("metrics-addr", "localhost:0", "Address to listen on for prometheus metrics")
 
-	commit  = ""
-	version = ""
-	date    = ""
+	// set by LDFLAGS
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func main() {
-	opts := &slog.HandlerOptions{}
+	flag.Parse()
 
+	opts := &slog.HandlerOptions{}
 	if *enableVerboseLogging {
 		opts = &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		}
 	}
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, opts))
 	slog.SetDefault(logger)
-
-	flag.Parse()
 
 	if *versionFlag {
 		fmt.Printf("build: %s\n", commit)
@@ -55,6 +64,31 @@ func main() {
 			slog.Error("malformed smartcontract program-id", "error", err)
 			os.Exit(1)
 		}
+	}
+
+	if *metricsEnable {
+		buildInfo := promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_build_info",
+				Help: "Build information of the client",
+			},
+			[]string{"version", "commit", "date"},
+		)
+		buildInfo.WithLabelValues(version, commit, date).Set(1)
+
+		go func() {
+			listener, err := net.Listen("tcp", *metricsAddr)
+			if err != nil {
+				slog.Error("Failed to start prometheus metrics listener", "error", err)
+				os.Exit(1)
+			}
+			http.Handle("/metrics", promhttp.Handler())
+
+			slog.Info("prometheus metrics server started", "address", listener.Addr().String())
+			if err := http.Serve(listener, nil); err != nil {
+				log.Printf("Failed to start prometheus metrics server: %v", err)
+			}
+		}()
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/client/doublezerod/internal/bgp/metrics.go
+++ b/client/doublezerod/internal/bgp/metrics.go
@@ -1,0 +1,20 @@
+package bgp
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	MetricSessionStatus = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "doublezero_session_is_up",
+			Help: "Status of session to doublezero",
+		},
+	)
+	MetricSessionStatusDesc = `
+# HELP doublezero_session_is_up Status of session to doublezero
+# TYPE doublezero_session_is_up gauge
+doublezero_session_is_up %d
+`
+)

--- a/client/doublezerod/internal/bgp/plugin.go
+++ b/client/doublezerod/internal/bgp/plugin.go
@@ -57,6 +57,7 @@ func (p *Plugin) OnOpenMessage(peer corebgp.PeerConfig, routerID netip.Addr, cap
 		PeerAddr: net.ParseIP(peer.RemoteAddress.String()),
 		Session:  Session{SessionStatus: SessionStatusInitializing, LastSessionUpdate: time.Now().Unix()},
 	}
+	MetricSessionStatus.Set(0)
 	return nil
 }
 
@@ -76,6 +77,7 @@ func (p *Plugin) OnEstablished(peer corebgp.PeerConfig, writer corebgp.UpdateMes
 		PeerAddr: net.ParseIP(peer.RemoteAddress.String()),
 		Session:  Session{SessionStatus: SessionStatusUp, LastSessionUpdate: time.Now().Unix()},
 	}
+	MetricSessionStatus.Set(1)
 	return p.handleUpdate
 }
 
@@ -100,6 +102,7 @@ func (p *Plugin) OnClose(peer corebgp.PeerConfig) {
 			}
 		}
 	}
+	MetricSessionStatus.Set(0)
 }
 
 func (p *Plugin) handleUpdate(peer corebgp.PeerConfig, u []byte) *corebgp.Notification {

--- a/client/doublezerod/internal/latency/smartcontract.go
+++ b/client/doublezerod/internal/latency/smartcontract.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
@@ -19,9 +18,6 @@ type ContractData struct {
 }
 
 func FetchContractData(ctx context.Context, programId string, rpcEndpoint string) (*ContractData, error) {
-	if rpcEndpoint == "" {
-		rpcEndpoint = dzsdk.DZ_LEDGER_RPC_URL
-	}
 	programID, err := solana.PublicKeyFromBase58(programId)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/release/.goreleaser.base.client.yaml
+++ b/release/.goreleaser.base.client.yaml
@@ -14,6 +14,8 @@ builds:
     binary: doublezerod
     env:
       - CGO_ENABLED=0
+    ldflags:
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
       - linux
     goarch:
@@ -30,6 +32,7 @@ builds:
       - --release
     env:
       - RUSTFLAGS=-C linker=x86_64-linux-gnu-gcc
+      - BUILD_VERSION={{.Version}}
 
 archives:
   - id: doublezero_archive


### PR DESCRIPTION
## Summary of Changes
This adds optional prometheus metrics to the doublezero client which can be enabled by setting the `enable-metrics` flag. Only two metrics are exposed:

- `doublezero_build_info`: contains the current build information of doublezerod
- `doublezero_session_is_up`: if the session to doublezero is up, a one is reported, else a zero

The doublezero CLI has also been fixed to report the correct build version when a daily release is built. Previously, the `CARGO_PKG_VERSION` env var was used which caused the last release version to always be reported. We know check to see if `BUILD_VERSION` is set, which is the version set by goreleaser, and if not, fall back to `CARGO_PKG_VERSION`

Also, this contains a fix similar to #749, where #657 broke setting default program-ids and rpc urls if not passed by the caller. This was causing the client to fail to fetch doublezero devices for latency measurement as the program-id was nil.

## Testing Verification

1. Metrics from the /metrics endpoint of the client:
```
# HELP doublezero_build_info Build information of the agent
# TYPE doublezero_build_info gauge
doublezero_build_info{commit="99df11f4",date="2025-07-10T21:59:37Z",version="0.2.3~git20250710215937.99df11f4"} 1
# HELP doublezero_session_is_up Status of session to doublezero
# TYPE doublezero_session_is_up gauge
doublezero_session_is_up 0
```
There are two unit tests to verify `doublezero_session_is_up` is set to 0 when the session is down and 1 when the session is up. These both pass.


2. cli/daemon build versions now match; previously the cli would report v0.2.2:
```
root ➜ /workspaces/doublezero (feature/client_metrics) $ ./dist/doublezero-cli_aarch64-unknown-linux-gnu/doublezero -V
DoubleZero 0.2.3~git20250710215937.99df11f4

root ➜ /workspaces/doublezero (feature/client_metrics) $ ./dist/doublezerod_linux_arm64_v8.0/doublezerod -version
build: 99df11f4
version: 0.2.3~git20250710215937.99df11f4
date: 2025-07-10T21:59:37Z
```

3. The daemon actually works now. On main, when started, it's unable to fetch devices onchain:
```
root ➜ /workspaces/doublezero (main) $ ./doublezerod 
{"time":"2025-07-11T02:43:08.600795719Z","level":"INFO","msg":"network: starting network manager"}
{"time":"2025-07-11T02:43:08.601269094Z","level":"INFO","msg":"bgp: starting bgp fsm"}
{"time":"2025-07-11T02:43:08.601859177Z","level":"INFO","msg":"http: starting api manager"}
{"time":"2025-07-11T02:43:08.60190051Z","level":"ERROR","msg":"latency: error fetching smart contract data","error":"decode: zero length string"}
```

With this PR, it starts normally and latency data is now being reported:
```
oot ➜ /workspaces/doublezero (feature/client_metrics) $ ./dist/doublezerod_linux_arm64_v8.0/doublezerod 
{"time":"2025-07-11T02:45:43.839308929Z","level":"INFO","msg":"network: starting network manager"}
{"time":"2025-07-11T02:45:43.839788596Z","level":"INFO","msg":"bgp: starting bgp fsm"}
{"time":"2025-07-11T02:45:43.839912846Z","level":"INFO","msg":"http: starting api manager"}


root ➜ /workspaces/doublezero (feature/client_metrics) $ ./dist/doublezero-cli_aarch64-unknown-linux-gnu/doublezero latency
 pubkey                                       | ip             | min      | max      | avg      | reachable 
 6E1fuqbDBG5ejhYEGKHNkWG5mSTczjy4R77XCKEdUtpb | 64.86.249.22   | 23.96ms  | 24.70ms  | 24.21ms  | true      
 CT8mP6RUoRcAB67HjKV9am7SBTCpxaJEwfQrSjVLdZfD | 207.45.216.134 | 86.88ms  | 88.23ms  | 87.78ms  | true      
 Cpt3doj17dCF6bEhvc7VeAuZbXLD88a1EboTyE8uj6ZL | 195.219.120.66 | 102.04ms | 103.94ms | 102.75ms | true      
 4Wr7PQr5kyqCNJo3RKa8675K7ZtQ6fBUeorcexgp49Zp | 195.219.138.50 | 103.68ms | 105.83ms | 104.94ms | true      
 29ghthsKeH2ZCUmN2sUvhJtpEXn2ZxqAuq4sZFBFZmEs | 195.219.220.58 | 104.04ms | 113.96ms | 107.50ms | true      
 hWffRFpLrsZoF5r9qJS6AL2D9TEmSvPUBEbDrLc111Y  | 195.12.227.250 | 111.09ms | 112.62ms | 111.98ms | true      
 8jyamHfu3rumSEJt9YhtYw3J4a7aKeiztdqux17irGSj | 195.12.228.250 | 119.24ms | 127.37ms | 124.23ms | true      
 5tqXoiQtZmuL6CjhgAC6vA49JRUsgB9Gsqh4fNjEhftU | 180.87.154.78  | 197.97ms | 198.57ms | 198.27ms | true      
 D3ZjDiLzvrGi5NJGzmM7b3YZg6e2DrUcBCQznJr3KfC8 | 180.87.102.98  | 256.76ms | 256.76ms | 256.76ms | true
```