### PR TITLE
device/telemetry: render control plane ACL via controller with UDP probe rule

### DIFF
--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 !
 default interface Tunnel501

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/controlplane/controller/internal/controller/fixtures/e2e.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-MCAST-500

--- a/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-MCAST-500

--- a/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-MCAST-500

--- a/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
@@ -10,6 +10,42 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -60,8 +60,9 @@ type Tunnel struct {
 }
 
 type templateData struct {
-	Device              *Device
-	UnknownBgpPeers     []net.IP
-	MulticastGroupBlock string
-	NoHardware          bool
+	Device                   *Device
+	UnknownBgpPeers          []net.IP
+	MulticastGroupBlock      string
+	NoHardware               bool
+	TelemetryTWAMPListenPort int
 }

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -19,7 +19,8 @@ func TestRenderConfig(t *testing.T) {
 			Name:        "render_unicast_tunnels_successfully",
 			Description: "render config for a set of unicast tunnels",
 			Data: templateData{
-				MulticastGroupBlock: "239.0.0.0/24",
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
 				Device: &Device{
 					PublicIP: net.IP{7, 7, 7, 7},
 					Tunnels: []*Tunnel{
@@ -60,7 +61,8 @@ func TestRenderConfig(t *testing.T) {
 			Name:        "render_peer_removal_successfully",
 			Description: "render config for removal of unknown peers successfully",
 			Data: templateData{
-				MulticastGroupBlock: "239.0.0.0/24",
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
 				Device: &Device{
 					PublicIP: net.IP{7, 7, 7, 7},
 					Tunnels: []*Tunnel{
@@ -103,7 +105,8 @@ func TestRenderConfig(t *testing.T) {
 			Name:        "render_multicast_tunnel_successfully",
 			Description: "render config for a multicast tunnel",
 			Data: templateData{
-				MulticastGroupBlock: "239.0.0.0/24",
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
 				Device: &Device{
 					PublicIP: net.IP{7, 7, 7, 7},
 					Tunnels: []*Tunnel{
@@ -177,7 +180,8 @@ func TestRenderConfig(t *testing.T) {
 			Name:        "render_mixed_tunnels_successfully",
 			Description: "render config for a mix of unicast and multicast tunnels",
 			Data: templateData{
-				MulticastGroupBlock: "239.0.0.0/24",
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
 				Device: &Device{
 					PublicIP: net.IP{7, 7, 7, 7},
 					Tunnels: []*Tunnel{
@@ -262,8 +266,9 @@ func TestRenderConfig(t *testing.T) {
 			Name:        "render_nohardware_tunnels_successfully",
 			Description: "render config for a mix of unicast and multicast tunnels with no hardware option",
 			Data: templateData{
-				NoHardware:          true,
-				MulticastGroupBlock: "239.0.0.0/24",
+				NoHardware:               true,
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
 				Device: &Device{
 					PublicIP: net.IP{7, 7, 7, 7},
 					Tunnels: []*Tunnel{

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	pb "github.com/malbeclabs/doublezero/controlplane/proto/controller/gen/pb-go"
+	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/mr-tron/base58"
@@ -368,10 +369,11 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 	multicastGroupBlock := formatCIDR(&c.cache.Config.MulticastGroupBlock)
 
 	data := templateData{
-		MulticastGroupBlock: multicastGroupBlock,
-		Device:              device,
-		UnknownBgpPeers:     unknownPeers,
-		NoHardware:          c.noHardware,
+		MulticastGroupBlock:      multicastGroupBlock,
+		Device:                   device,
+		UnknownBgpPeers:          unknownPeers,
+		NoHardware:               c.noHardware,
+		TelemetryTWAMPListenPort: telemetryconfig.TWAMPListenPort,
 	}
 
 	config, err := renderConfig(data)

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -12,6 +12,42 @@ ip routing vrf vrf1
 hardware access-list update default-result permit
 !
 {{- end }}
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP {{ .TelemetryTWAMPListenPort }})
+   290 permit udp any any eq {{ .TelemetryTWAMPListenPort }}
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 {{- range .Device.Tunnels }}
 default interface Tunnel{{ .Id }}
 {{- if eq true .Allocated }}

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/netns"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/netutil"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/telemetry"
+	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	sdktelemetry "github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 	twamplight "github.com/malbeclabs/doublezero/tools/twamp/pkg/light"
@@ -23,7 +24,7 @@ import (
 const (
 	defaultProbeInterval         = 10 * time.Second
 	defaultSubmissionInterval    = 60 * time.Second
-	defaultTWAMPListenPort       = telemetry.DefaultTWAMPListenPort
+	defaultTWAMPListenPort       = telemetryconfig.TWAMPListenPort
 	defaultTWAMPReflectorTimeout = 1 * time.Second
 	defaultPeersRefreshInterval  = 10 * time.Second
 	defaultTWAMPSenderTimeout    = 1 * time.Second

--- a/controlplane/telemetry/internal/telemetry/config.go
+++ b/controlplane/telemetry/internal/telemetry/config.go
@@ -8,10 +8,6 @@ import (
 	twamplight "github.com/malbeclabs/doublezero/tools/twamp/pkg/light"
 )
 
-const (
-	DefaultTWAMPListenPort = uint16(862)
-)
-
 type Config struct {
 	// TWAMPReflector is the reflector for TWAMP probes.
 	TWAMPReflector *twamplight.Reflector

--- a/controlplane/telemetry/pkg/config/constants.go
+++ b/controlplane/telemetry/pkg/config/constants.go
@@ -1,0 +1,6 @@
+package config
+
+const (
+	// TWAMPListenPort is the port on which devices listen for TWAMP probes.
+	TWAMPListenPort = 862
+)

--- a/e2e/docker/device/start-config-agent.sh
+++ b/e2e/docker/device/start-config-agent.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -n "$1" ] && [[ "$1" != "-"* ]]; then
+  export DZ_MANAGEMENT_NAMESPACE="$1"
+  shift
+fi
+
 # If DZ_MANAGEMENT_NAMESPACE is set, wait for it to appear.
 if [ -n "$DZ_MANAGEMENT_NAMESPACE" ]; then
   for i in {1..20}; do

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 !
 default interface Tunnel501

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-UCAST-500

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 !
 default interface Tunnel501

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-MCAST-500

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 !
 default interface Tunnel501

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 interface Tunnel500
    description USER-MCAST-500

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,42 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
 default interface Tunnel500
 !
 default interface Tunnel501

--- a/e2e/internal/devnet/device.go
+++ b/e2e/internal/devnet/device.go
@@ -29,9 +29,6 @@ import (
 //go:embed device/startup-config.tmpl
 var deviceStartupConfigTemplate string
 
-//go:embed device/rc.eos.tmpl
-var deviceRCEOS string
-
 const (
 	internalEAPIHTTPPort = 80
 )
@@ -363,23 +360,6 @@ func (d *Device) Start(ctx context.Context) error {
 	}
 	if spec.Telemetry.Verbose {
 		telemetryCommandArgs = append(telemetryCommandArgs, "-verbose")
-	}
-
-	// Render the device rc.eos script.
-	var rcEosContents bytes.Buffer
-	rcEOSTemplate := template.Must(template.New("rc.eos").Parse(deviceRCEOS))
-	err = rcEOSTemplate.Execute(&rcEosContents, map[string]any{
-		"TelemetryEnabled":         spec.Telemetry.Enabled,
-		"TelemetryTWAMPListenPort": strconv.Itoa(int(spec.Telemetry.TWAMPListenPort)),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to execute template: %w", err)
-	}
-	containerRCEOSPath := "/mnt/flash/rc.eos"
-	d.log.Info("==> Writing device /mnt/flash/rc.eos script", "path", containerRCEOSPath)
-	err = container.CopyToContainer(ctx, rcEosContents.Bytes(), containerRCEOSPath, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write device rc.eos script: %w", err)
 	}
 
 	// Render the device config from go template.

--- a/e2e/internal/devnet/device/rc.eos.tmpl
+++ b/e2e/internal/devnet/device/rc.eos.tmpl
@@ -1,4 +1,0 @@
-#!/bin/bash
-{{- if .TelemetryEnabled }}
-iptables -I INPUT -p udp --dport {{.TelemetryTWAMPListenPort}} -j ACCEPT
-{{- end }}

--- a/e2e/internal/devnet/device/startup-config.tmpl
+++ b/e2e/internal/devnet/device/startup-config.tmpl
@@ -18,7 +18,7 @@ ip name-server vrf management 8.8.8.8
 !
 {{- end }}
 daemon doublezero-agent
-   exec /mnt/flash/start-config-agent.sh {{.AgentCommandArgs}}
+   exec /mnt/flash/start-config-agent.sh {{.ManagementNS}} {{.AgentCommandArgs}}
    no shutdown
 !
 {{- if .TelemetryEnabled }}
@@ -44,7 +44,7 @@ management api http-commands
 !
 management api eos-sdk-rpc
    transport grpc foo
-      localhost loopback {{- if .ManagementNS }}vrf management{{- end }}
+      localhost loopback {{ if .ManagementNS }}vrf management{{ end }}
       service all
       no disabled
 !


### PR DESCRIPTION
## Summary of Changes
- Update controller to render control plane ACL based on `default-control-plane-acl` with telemetry UDP probe rule added
- Added `controlplane/telemetry/pkg/config/constants.go` to expose the shared `TWAMPListenPort` for the controller to use
- Remove iptables hack in e2e that was previously used to expose the TWAMP port
- Fix management namespace issue in e2e config agent startup where `vrf management` wasn't being included in the `eos-sdk-rpc` entry
- Resolves https://github.com/malbeclabs/doublezero/issues/752

## Testing Verification
- Updated controller and e2e test fixtures to include expectation of control plane ACL
