### PR TITLE
device/telemetry: fix duplicate sender instances in collector

### DIFF
--- a/controlplane/telemetry/internal/telemetry/collector.go
+++ b/controlplane/telemetry/internal/telemetry/collector.go
@@ -23,7 +23,7 @@ type Collector struct {
 	pinger    *Pinger
 	submitter *Submitter
 
-	senders   map[Peer]*senderEntry
+	senders   map[string]*senderEntry
 	sendersMu sync.Mutex
 
 	buffer *AccountsBuffer
@@ -41,7 +41,7 @@ func New(log *slog.Logger, cfg Config) (*Collector, error) {
 		cfg:       cfg,
 		peers:     cfg.PeerDiscovery,
 		reflector: cfg.TWAMPReflector,
-		senders:   make(map[Peer]*senderEntry),
+		senders:   make(map[string]*senderEntry),
 		buffer:    buffer,
 	}
 
@@ -196,7 +196,7 @@ func (c *Collector) getOrCreateSender(ctx context.Context, peer *Peer) twampligh
 	c.sendersMu.Lock()
 	defer c.sendersMu.Unlock()
 
-	entry, ok := c.senders[*peer]
+	entry, ok := c.senders[peer.String()]
 	if ok {
 		entry.lastUsed = time.Now()
 		return entry.sender
@@ -209,7 +209,7 @@ func (c *Collector) getOrCreateSender(ctx context.Context, peer *Peer) twampligh
 		c.log.Error("Failed to create sender", "error", err)
 		return nil
 	}
-	c.senders[*peer] = &senderEntry{sender: sender, lastUsed: time.Now()}
+	c.senders[peer.String()] = &senderEntry{sender: sender, lastUsed: time.Now()}
 	return sender
 }
 


### PR DESCRIPTION
## Summary of Changes

In the logs we're seeing batches of `Evicting idle sender" every minute:
```
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc0001119c0 TWAMPPort:862}"
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc0000de3c0 TWAMPPort:862}"
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/submitter.go:144 msg="Submitting samples" account=5JcwAoBnsuwng78a21LQXh9LaQ6CLRapEkjXUxQw3chd-5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS-6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ-10140 count=6
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc000474440 TWAMPPort:862}"
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc000484340 TWAMPPort:862}"
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc000474400 TWAMPPort:862}"
time=2025-07-11T17:47:19.956Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc000111980 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc0004cd000 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:6aYy3mh5zF1fWvoLipXHWnGojFjn3chcvbeXKRJx5hiZ DevicePK:5z5NQTAEwHzARf2f7f1NbVZSq6djHa3ocYfUr2gCtrDS Tunnel:0xc0004741c0 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc0004ccfc0 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc000484200 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc000474180 TWAMPPort:862}"
time=2025-07-11T17:47:19.957Z level=DEBUG source=/home/runner/work/doublezero/doublezero/controlplane/telemetry/internal/telemetry/collector.go:224 msg="Evicting idle sender" peer="{LinkPK:4CEJN5dMT2fBf5bfWv6muqqGbJiLRQYBjMYwqgbGs3Xb DevicePK:B9xjyQCvhVJSAZW9xN2gnE9s7tyQ1ExxJ3jURnWTfFTX Tunnel:0xc0000de380 TWAMPPort:862}"
```

While this does not affect functionality, it does result in a new sender being created for every probe, which is very wasteful of fds.

This is a regression introduced in https://github.com/malbeclabs/doublezero/pull/710 - where the key of the senders map was changed to being the `Peer` struct instance instead of string, but this results in unique key for every sender.

## Testing Verification
- Added test coverage for sender deduplication to avoid future regression on it
