### PR TITLE
controller: add "no" command before control plane ACL definition

### DIFF
--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/e2e.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
@@ -10,6 +10,7 @@ ip routing vrf vrf1
 !
 hardware access-list update default-result permit
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -12,6 +12,7 @@ ip routing vrf vrf1
 hardware access-list update default-result permit
 !
 {{- end }}
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
@@ -8,6 +8,7 @@ router pim sparse-mode
 vrf instance vrf1
 ip routing vrf vrf1
 !
+no ip access-list MAIN-CONTROL-PLANE-ACL
 ip access-list MAIN-CONTROL-PLANE-ACL
    counters per-entry
    10 permit icmp any any


### PR DESCRIPTION
## Summary of Changes
- Add `no ip access-list MAIN-CONTROL-PLANE-ACL` before ACL definition so that if a contributor adds lines to the ACL, they will be removed by the agent.

## Testing Verification
- Updated fixtures to match expectation
