### PR TITLE
activator: add shutdown signal listening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,7 @@ dependencies = [
  "doublezero_sdk",
  "env_logger 0.9.3",
  "eyre",
+ "futures",
  "indexmap",
  "influxdb2",
  "influxdb2-derive",

--- a/activator/Cargo.toml
+++ b/activator/Cargo.toml
@@ -8,6 +8,7 @@ bitvec.workspace = true
 chrono.workspace = true
 clap.workspace = true
 eyre.workspace = true
+futures.workspace = true
 indexmap.workspace = true
 influxdb2.workspace = true
 influxdb2-derive.workspace = true

--- a/smartcontract/cli/src/subscribe.rs
+++ b/smartcontract/cli/src/subscribe.rs
@@ -1,6 +1,9 @@
 use clap::Args;
 use doublezero_sdk::DZClient;
-use std::io::Write;
+use std::{
+    io::Write,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 #[derive(Args, Debug)]
 pub struct SubscribeCliCommand;
@@ -9,11 +12,14 @@ impl SubscribeCliCommand {
     pub fn execute<W: Write>(self, client: &DZClient, out: &mut W) -> eyre::Result<()> {
         println!("Waiting for events...");
 
-        client.subscribe(|_, pubkey, account| {
-            if let Err(e) = writeln!(out, "{pubkey} -> {account:?}") {
-                eprintln!("Failed to write output: {e}");
-            }
-        })?;
+        client.subscribe(
+            |_, pubkey, account| {
+                if let Err(e) = writeln!(out, "{pubkey} -> {account:?}") {
+                    eprintln!("Failed to write output: {e}");
+                }
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary of Changes
* Wrap the activator's rust processes in a biased tokio select that awaits a shutdown synchronization primitive, deferring to the shutdown future in the scheduler in the event an exit signal is sent from the server's host OS and then gracefully cancels the activator sync subscriber handler and metrics submitter processes.
* For a long running server process, we should listen for and handle exit signals propagated from the host OS to gracefully shut down the application processes and prevent it from hanging and/or requiring the host systemd from having to force-kill the process on timeout when it's attempting to shut down for any reason.

## Testing Verification
* I'm unclear if there's a proper way to test this change in the e2e suite but in theory we can ensure the exit signals from the test runner are propagated to the activator server process by wrapping the test dockerfile's invocation of the entrypoint.sh script in a call to `tini`

addresses https://github.com/malbeclabs/doublezero/issues/831