### PR TITLE
device/telemetry: data cli fix aggregate over multiple epochs and N recent samples per group

### DIFF
--- a/controlplane/telemetry/cmd/telemetry-data/main.go
+++ b/controlplane/telemetry/cmd/telemetry-data/main.go
@@ -267,7 +267,9 @@ func buildSummaries(ctx context.Context, log *slog.Logger, rpcEndpoint, servicea
 		}
 
 		if recentSamples > 0 {
-			samples = samples[len(samples)-int(recentSamples):]
+			if int(recentSamples) <= len(samples) {
+				samples = samples[len(samples)-int(recentSamples):]
+			}
 		}
 
 		successSamples := make([]uint32, 0, len(samples))


### PR DESCRIPTION
## Summary of Changes
- Fix aggregation over multiple epochs
- Support including just the recent N samples in aggregation
- Follow-up on https://github.com/malbeclabs/doublezero/pull/793 and related to https://github.com/malbeclabs/doublezero/issues/675

## Testing Verification
```
Epoch: 10141 (last 1500 samples)
Telemetry Program: C9xqH76NSm11pBS6maNnY163tWHT8Govww47uyEmSnoG
Serviceability Program: GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah
* RTT aggregates are in microseconds (µs)
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
|   Origin    |   Target    |          Link           | RTT Mean | Median | Jitter | MAD  | P95 | P99 | Min | Max | Success | Loss | Loss |
|             |             |                         |   (µs)   |  (µs)  |  (µs)  |      |     |     |     |     |   (#)   | (#)  | (%)  |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
| chi-dn-dzd1 | chi-dn-dzd2 | chi-dn-dzd1:chi-dn-dzd2 |      178 |    178 |   27.0 | 18.0 | 221 | 240 | 102 | 362 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
|             | chi-dn-dzd3 | chi-dn-dzd1:chi-dn-dzd3 |      176 |    177 |   26.7 | 19.0 | 218 | 235 | 106 | 285 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
| chi-dn-dzd2 | chi-dn-dzd1 | chi-dn-dzd1:chi-dn-dzd2 |      182 |    182 |   25.8 | 18.0 | 220 | 236 | 112 | 268 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
|             | chi-dn-dzd4 | chi-dn-dzd2:chi-dn-dzd4 |      143 |    138 |   26.2 | 16.0 | 195 | 209 |  96 | 222 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
| chi-dn-dzd3 | chi-dn-dzd1 | chi-dn-dzd1:chi-dn-dzd3 |      189 |    190 |   24.7 | 17.0 | 229 | 248 | 118 | 343 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
|             | chi-dn-dzd4 | chi-dn-dzd3:chi-dn-dzd4 |      190 |    191 |   28.1 | 19.0 | 230 | 254 | 114 | 391 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
| chi-dn-dzd4 | chi-dn-dzd2 | chi-dn-dzd2:chi-dn-dzd4 |      146 |    144 |   19.6 | 11.0 | 179 | 199 |  97 | 288 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
|             | chi-dn-dzd3 | chi-dn-dzd3:chi-dn-dzd4 |      164 |    163 |   22.8 | 14.0 | 198 | 220 | 103 | 429 |    1500 |    0 | 0.0% |
+-------------+-------------+-------------------------+----------+--------+--------+------+-----+-----+-----+-----+---------+------+------+
```
