### PR TITLE
sdk/go: update testnet telemetry program id const

### DIFF
--- a/smartcontract/sdk/go/telemetry/constants.go
+++ b/smartcontract/sdk/go/telemetry/constants.go
@@ -28,10 +28,8 @@ const (
 // Telemetry Program IDs
 const (
 	// TELEMETRY_PROGRAM_ID_TESTNET is the telemetry program ID for testnet
-	// TODO: placeholder
 	TELEMETRY_PROGRAM_ID_TESTNET = "3KogTMmVxc5eUHtjZnwm136H5P8tvPwVu4ufbGPvM7p1"
 	// TELEMETRY_PROGRAM_ID_DEVNET is the telemetry program ID for devnet
-	// TODO: placeholder
 	TELEMETRY_PROGRAM_ID_DEVNET = "C9xqH76NSm11pBS6maNnY163tWHT8Govww47uyEmSnoG"
 )
 


### PR DESCRIPTION
## Summary of Changes
- Update Telemetry Program ID in Go SDK to match testnet deployment
- Resolves https://github.com/malbeclabs/doublezero/issues/814