### PR TITLE
sc/serviceability: device update by allowlist account or device owner

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
@@ -15,7 +15,7 @@ mod device_test {
     use device::activate::DeviceActivateArgs;
     use globalconfig::set::SetGlobalConfigArgs;
     use solana_program_test::*;
-    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+    use solana_sdk::{hash::Hash, instruction::AccountMeta, pubkey::Pubkey, signature::Keypair};
 
     #[tokio::test]
     async fn test_device() {
@@ -366,5 +366,256 @@ mod device_test {
 
         println!("✅ Device deleted successfully");
         println!("🟢🟢🟢  End test_device  🟢🟢🟢");
+    }
+
+    #[tokio::test]
+    async fn test_device_update_metrics_publisher_by_foundation_allowlist_account() {
+        let (
+            mut banks_client,
+            payer,
+            program_id,
+            _globalstate_pubkey,
+            location_pubkey,
+            exchange_pubkey,
+            contributor_pubkey,
+        ) = setup_program_with_location_and_exchange().await;
+
+        let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+
+        // Create device
+        let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+        let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+        assert_eq!(globalstate_account.account_index, 3);
+        let (device_pubkey, bump_seed) =
+            get_device_pda(&program_id, globalstate_account.account_index + 1);
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+                index: globalstate_account.account_index + 1,
+                bump_seed,
+                code: "la".to_string(),
+                device_type: DeviceType::Switch,
+                contributor_pk: contributor_pubkey,
+                location_pk: location_pubkey,
+                exchange_pk: exchange_pubkey,
+                public_ip: [10, 0, 0, 1].into(),
+                dz_prefixes: "10.1.0.0/23".parse().unwrap(),
+                metrics_publisher_pk: Pubkey::default(),
+            }),
+            vec![
+                AccountMeta::new(device_pubkey, false),
+                AccountMeta::new(contributor_pubkey, false),
+                AccountMeta::new(location_pubkey, false),
+                AccountMeta::new(exchange_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+        let device = get_account_data(&mut banks_client, device_pubkey)
+            .await
+            .unwrap()
+            .get_device()
+            .unwrap();
+        assert_eq!(device.account_type, AccountType::Device);
+        assert_eq!(device.code, "la".to_string());
+        assert_eq!(device.status, DeviceStatus::Pending);
+
+        // Update device metrics publisher by foundation allowlist account (payer)
+        let metrics_publisher_pk = Pubkey::new_unique();
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+                code: None,
+                device_type: None,
+                contributor_pk: None,
+                public_ip: None,
+                dz_prefixes: None,
+                metrics_publisher_pk: Some(metrics_publisher_pk),
+            }),
+            vec![
+                AccountMeta::new(device_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+        let device = get_account_data(&mut banks_client, device_pubkey)
+            .await
+            .unwrap()
+            .get_device()
+            .unwrap();
+        assert_eq!(device.account_type, AccountType::Device);
+        assert_eq!(device.code, "la".to_string());
+        assert_eq!(device.public_ip.to_string(), "10.0.0.1");
+        assert_eq!(device.metrics_publisher_pk, metrics_publisher_pk);
+    }
+
+    async fn setup_program_with_location_and_exchange(
+    ) -> (BanksClient, Keypair, Pubkey, Pubkey, Pubkey, Pubkey, Pubkey) {
+        let program_id = Pubkey::new_unique();
+        let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
+            "doublezero_serviceability",
+            program_id,
+            processor!(process_instruction),
+        )
+        .start()
+        .await;
+
+        // Start with a fresh program
+        let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+        let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::InitGlobalState(),
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+
+        // Initialize GlobalConfig
+        let (config_pubkey, _) = get_globalconfig_pda(&program_id);
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+                local_asn: 65000,
+                remote_asn: 65001,
+                device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+                user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+                multicastgroup_block: "224.0.0.0/4".parse().unwrap(),
+            }),
+            vec![
+                AccountMeta::new(config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+
+        // Create Location
+        let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+        assert_eq!(globalstate_account.account_index, 0);
+
+        let (location_pubkey, bump_seed) =
+            get_location_pda(&program_id, globalstate_account.account_index + 1);
+
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::CreateLocation(location::create::LocationCreateArgs {
+                index: globalstate_account.account_index + 1,
+                bump_seed,
+                code: "la".to_string(),
+                name: "Los Angeles".to_string(),
+                country: "us".to_string(),
+                lat: 1.234,
+                lng: 4.567,
+                loc_id: 0,
+            }),
+            vec![
+                AccountMeta::new(location_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+
+        // Create Exchange
+        let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+        assert_eq!(globalstate_account.account_index, 1);
+
+        let (exchange_pubkey, bump_seed) =
+            get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::CreateExchange(exchange::create::ExchangeCreateArgs {
+                index: globalstate_account.account_index + 1,
+                bump_seed,
+                code: "la".to_string(),
+                name: "Los Angeles".to_string(),
+                lat: 1.234,
+                lng: 4.567,
+                loc_id: 0,
+            }),
+            vec![
+                AccountMeta::new(exchange_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+
+        // Create Contributor
+        let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+        let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+        assert_eq!(globalstate_account.account_index, 2);
+
+        let (contributor_pubkey, bump_seed) =
+            get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+
+        execute_transaction(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+                index: globalstate_account.account_index + 1,
+                bump_seed,
+                code: "cont".to_string(),
+                ata_owner_pk: Pubkey::default(),
+            }),
+            vec![
+                AccountMeta::new(contributor_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+            &payer,
+        )
+        .await;
+
+        let contributor = get_account_data(&mut banks_client, contributor_pubkey)
+            .await
+            .expect("Unable to get Account")
+            .get_contributor()
+            .unwrap();
+        assert_eq!(contributor.account_type, AccountType::Contributor);
+        assert_eq!(contributor.code, "cont".to_string());
+        assert_eq!(contributor.status, ContributorStatus::Activated);
+
+        (
+            banks_client,
+            payer,
+            program_id,
+            globalstate_pubkey,
+            location_pubkey,
+            exchange_pubkey,
+            contributor_pubkey,
+        )
+    }
+
+    async fn wait_for_new_blockhash(banks_client: &mut BanksClient) -> Hash {
+        let current_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+        let mut new_blockhash = current_blockhash;
+        while new_blockhash == current_blockhash {
+            new_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+
+        new_blockhash
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
@@ -69,11 +69,6 @@ pub fn process_update_device(
     );
     // Check if the account is writable
     assert!(device_account.is_writable, "PDA Account is not writable");
-    // Parse the global state account & check if the payer is in the allowlist
-    let globalstate = globalstate_get(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
 
     let mut device: Device = Device::try_from(device_account)?;
     assert_eq!(
@@ -82,8 +77,13 @@ pub fn process_update_device(
         "Invalid Device Account Type"
     );
 
-    if device.owner != *payer_account.key {
-        return Err(solana_program::program_error::ProgramError::Custom(0));
+    let globalstate = globalstate_get(globalstate_account)?;
+
+    // Check if the payer is in the foundation allowlist or the owner of the device
+    if !globalstate.foundation_allowlist.contains(payer_account.key)
+        && device.owner != *payer_account.key
+    {
+        return Err(DoubleZeroError::NotAllowed.into());
     }
 
     if let Some(code) = &value.code {


### PR DESCRIPTION
## Summary of Changes
- Updates device update in serviceability program to require only that the signer is in the foundation allowlist or the device owner, but not necessarily both. Currently it requires that the signer matches both of these conditions.
- Fixes https://github.com/malbeclabs/doublezero/issues/849
- Discovered during https://github.com/malbeclabs/doublezero/issues/815

## Testing Verification
- Added test coverage for this update
