### PR TITLE
device/telemetry: data cli support some accounts not found

### DIFF
--- a/controlplane/telemetry/cmd/telemetry-data/main.go
+++ b/controlplane/telemetry/cmd/telemetry-data/main.go
@@ -231,7 +231,7 @@ func buildSummaries(ctx context.Context, log *slog.Logger, rpcEndpoint, servicea
 
 				account, err := tel.GetDeviceLatencySamples(ctx, q.origin.PubKey, q.target.PubKey, linkPK, q.epoch)
 				if err != nil {
-					errChan <- fmt.Errorf("failed to get device latency samples: %w", err)
+					log.Warn("Failed to get device latency samples", "error", err, "origin", q.origin.Code, "target", q.target.Code, "link", link.Code, "epoch", q.epoch)
 					return
 				}
 


### PR DESCRIPTION
## Summary of Changes
- Update internal telemetry data CLI to not fail if some accounts are not found yet, which is the case in testnet right now. Rather than fail, just show a warning.
- Related to https://github.com/malbeclabs/doublezero/issues/815

## Testing Verification

```console
$ go run controlplane/telemetry/cmd/telemetry-data/main.go --telemetry-program-id 3KogTMmVxc5eUHtjZnwm136H5P8tvPwVu4ufbGPvM7p1 --serviceability-program-id DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb

9:29AM WRN Failed to get device latency samples error="account not found" origin=prg-dz-001-x target=fra-dz-001-x link=fra-dz-001-x:prg-dz-001-x epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=fra-dz-001-x target=prg-dz-001-x link=fra-dz-001-x:prg-dz-001-x epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=ams-dz001 target=lon-dz001 link=ams-dz001:lon-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=lon-dz001 target=ams-dz001 link=ams-dz001:lon-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=sin-dz001 target=lon-dz001 link=lon-dz001:sin-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=lon-dz001 target=sin-dz001 link=lon-dz001:sin-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=sin-dz001 target=tyo-dz001 link=sin-dz001:tyo-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=tyo-dz001 target=sin-dz001 link=sin-dz001:tyo-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=lon-dz001 target=nyc-dz001 link=nyc-dz001:lon-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=fra-dz001 target=lon-dz001 link=lon-dz001:fra-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=lon-dz001 target=fra-dz001 link=lon-dz001:fra-dz001 epoch=10143
9:29AM WRN Failed to get device latency samples error="account not found" origin=tyo-dz001 target=lax-dz001 link=tyo-dz001:lax-dz001 epoch=10143
Epoch: 10143
Telemetry Program: 3KogTMmVxc5eUHtjZnwm136H5P8tvPwVu4ufbGPvM7p1
Serviceability Program: DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb
* RTT aggregates are in microseconds (µs)
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
|  Origin   |  Target   |        Link         | RTT Mean | Median | Jitter | MAD | P95 | P99 | Min | Max | Success | Loss | Loss |
|           |           |                     |   (µs)   |  (µs)  |  (µs)  |     |     |     |     |     |   (#)   | (#)  | (%)  |
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
| lax-dz001 | nyc-dz001 | lax-dz001:nyc-dz001 |        0 |      0 |    0.0 | 0.0 |   0 |   0 |   0 |   0 |       0 |   90 | 0.0% |
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
|           | tyo-dz001 | tyo-dz001:lax-dz001 |        0 |      0 |    0.0 | 0.0 |   0 |   0 |   0 |   0 |       0 |   88 | 0.0% |
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
| nyc-dz001 | lax-dz001 | lax-dz001:nyc-dz001 |        0 |      0 |    0.0 | 0.0 |   0 |   0 |   0 |   0 |       0 |  144 | 0.0% |
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
|           | lon-dz001 | nyc-dz001:lon-dz001 |        0 |      0 |    0.0 | 0.0 |   0 |   0 |   0 |   0 |       0 |  148 | 0.0% |
+-----------+-----------+---------------------+----------+--------+--------+-----+-----+-----+-----+-----+---------+------+------+
```
