### PR TITLE
funder: prometheus metrics

### DIFF
--- a/controlplane/funder/internal/funder/config.go
+++ b/controlplane/funder/internal/funder/config.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	defaultWaitForBalanceTimeout      = 20 * time.Second
+	defaultWaitForBalanceTimeout      = 60 * time.Second
 	defaultWaitForBalancePollInterval = 1 * time.Second
 )
 
@@ -38,6 +38,14 @@ type Config struct {
 	Interval                   time.Duration
 	WaitForBalanceTimeout      time.Duration
 	WaitForBalancePollInterval time.Duration
+}
+
+func (c *Config) MinBalanceLamports() uint64 {
+	return uint64(c.MinBalanceSOL * float64(solana.LAMPORTS_PER_SOL))
+}
+
+func (c *Config) TopUpLamports() uint64 {
+	return uint64(c.TopUpSOL * float64(solana.LAMPORTS_PER_SOL))
 }
 
 func (c *Config) Validate() error {

--- a/controlplane/funder/internal/metrics/metrics.go
+++ b/controlplane/funder/internal/metrics/metrics.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Metrics names.
+	MetricNameBuildInfo               = "doublezero_funder_build_info"
+	MetricNameErrors                  = "doublezero_funder_errors_total"
+	MetricNameFunderAccountBalanceSOL = "doublezero_funder_account_balance_sol"
+
+	// Labels.
+	LabelVersion       = "version"
+	LabelCommit        = "commit"
+	LabelDate          = "date"
+	LabelErrorType     = "error_type"
+	LabelFunderAccount = "funder_account"
+
+	// Error types.
+	ErrorTypeLoadServiceabilityState           = "load_serviceability_state"
+	ErrorTypeGetFunderAccountBalance           = "get_funder_account_balance"
+	ErrorTypeFunderAccountBalanceBelowMinimum  = "funder_account_balance_below_minimum"
+	ErrorTypeGetMetricsPublisherAccountBalance = "get_metrics_publisher_account_balance"
+	ErrorTypeTransferFundsToMetricsPublisher   = "transfer_funds_to_metrics_publisher"
+	ErrorTypeWaitForMetricsPublisherBalance    = "wait_for_metrics_publisher_balance"
+)
+
+var (
+	BuildInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameBuildInfo,
+			Help: "Build information of the funder agent",
+		},
+		[]string{LabelVersion, LabelCommit, LabelDate},
+	)
+
+	Errors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameErrors,
+			Help: "Number of errors encountered",
+		},
+		[]string{LabelErrorType},
+	)
+
+	FunderAccountBalanceSOL = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameFunderAccountBalanceSOL,
+			Help: "The balance of the funder account in SOL",
+		},
+		[]string{LabelFunderAccount},
+	)
+)


### PR DESCRIPTION
## Summary of Changes
- Expose prometheus `/metrics` endpoint on funder
- Emit the following metrics:
  - `doublezero_funder_build_info` - Build information of the agent (version, commit, date)
  - `doublezero_funder_errors_total` - Number of errors (counter) with labels of error_type for distinguishing
  - `doublezero_funder_account_balance_sol` - Funder account balance in SOL (gauge) for alerting when funds are low
- Resolves https://github.com/malbeclabs/doublezero/issues/856
- Related to https://github.com/malbeclabs/doublezero/issues/742

## Testing Verification
- Update funder e2e test to check errors and balance metrics
