### PR TITLE
client: deflake bgp test

### DIFF
--- a/client/doublezerod/internal/bgp/bgp_test.go
+++ b/client/doublezerod/internal/bgp/bgp_test.go
@@ -169,13 +169,19 @@ func TestBgpServer(t *testing.T) {
 	}
 
 	waitForPeerStatus := func(s bgp.SessionStatus) bool {
-		deadline := time.Now().Add(5 * time.Second)
+		deadline := time.Now().Add(30 * time.Second)
+		start := time.Now()
 		for time.Now().Before(deadline) {
 			status := b.GetPeerStatus(net.IP{127, 0, 0, 1})
 			if status.SessionStatus == s {
 				return true
 			}
-			time.Sleep(200 * time.Millisecond)
+			if time.Since(start) > 10*time.Second {
+				t.Logf("Waiting for peer status %v, got %v", s, status)
+				time.Sleep(3 * time.Second)
+			} else {
+				time.Sleep(500 * time.Millisecond)
+			}
 		}
 		return false
 	}


### PR DESCRIPTION
## Summary of Changes
- Deflake `TestBgpServer/validate_peer_status_is_pending` in the client package by increasing wait for peer status timeout
- Fixes https://github.com/malbeclabs/doublezero/issues/628

## Testing Verification
- I ran this in a loop for a couple hours in the background, and no longer hit the flake