### PR TITLE
ensure systemd restarts critical processes by default

### DIFF
--- a/activator/doublezero-activator.service
+++ b/activator/doublezero-activator.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=DoubleZero Activator
 After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 User=ubuntu
@@ -8,6 +10,9 @@ PermissionsStartOnly=True
 RuntimeDirectory=doublezero-activator
 RuntimeDirectoryMode=0775
 ExecStart=/usr/local/bin/doublezero-activator
+PIDFile=/var/run/doublezero-activator
+Restart=always
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target

--- a/controlplane/controller/cmd/controller/doublezero-controller.service
+++ b/controlplane/controller/cmd/controller/doublezero-controller.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=DoubleZero controller
 After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 ExecStart=/usr/local/bin/doublezero-controller start -listen-addr 0.0.0.0 -listen-port 7000
+PIDFile=/var/run/doublezero-controller
+Restart=always
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary of Changes
* Adds default configuration to the systemd settings for two critical server processes to ensure they perform a reasonable number of automatic restarts in the event of a crash
* An un-noticed outage of the activator affected a demo after the service attempted to restart, failed, and did not retry
* fixes https://github.com/malbeclabs/doublezero/issues/865

## Testing Verification
* Kill the PID of the process in question and it restarts within the specified time

Also ensures predictable creation of a pid file for the processes and defines a threshold by which they should _stop_ retrying in the event of some catastrophic missing precondition or disruption