### PR TITLE
Remove ata-owner parameter from contributor commands and related documentation

### DIFF
--- a/client/doublezero/dz-testnet.sh
+++ b/client/doublezero/dz-testnet.sh
@@ -30,7 +30,7 @@ cargo build
 ./target/debug/doublezero exchange create --code xam --name "Amsterdam" --lat 52.30085793004002 --lng 4.942241140085309
 
 ### Contributors
-./target/doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+./target/doublezero contributor create --code co01
 
 ### Devices
 ./target/debug/doublezero device create --code la2-dz01 --contributor co01 --location la --exchange xla --public-ip "207.45.216.136" --dz-prefix "207.45.216.136/29"

--- a/e2e/internal/devnet/smartcontract_init.go
+++ b/e2e/internal/devnet/smartcontract_init.go
@@ -119,7 +119,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 		doublezero exchange list
 
 		echo "==> Populating contributor information onchain"
-		doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+		doublezero contributor create --code co01
 
 		echo "--> Smart contract initialized"
 

--- a/smartcontract/README.md
+++ b/smartcontract/README.md
@@ -155,7 +155,7 @@ The Latency Smart Contract functions as the on-chain registry for all network la
 To start contributing to DoubleZero, a contributor account must be registered. This is done using the DoubleZero CLI, where a code and the pubkey of the identity that will receive the rewards (ATA account) must be provided. The code is a short, space-free name used to identify the contributor. It doesn't need to reference the actual company—it can be something like a color or a flower name, for example. The ATA Owner is the pubkey that will be used to transfer the tokens generated from rewards.
 
 ```bash
-$ doublezero contributor create --code flower_power --ata-owner Do1iXv6tNMHRzF1yYHBcLNfNngCK6Yyr9izpLZc1rrwW
+$ doublezero contributor create --code flower_power
 Signature: 2gpYMUZ5U8r8SxfRNvBN6i4LAawG3yHg5dQ3jDdUZriPv2rqDEJTe6EqTxt8SKurkeKdrHfTLdXdyaEdYg1SGWbU
 ```
 

--- a/smartcontract/cli/README.md
+++ b/smartcontract/cli/README.md
@@ -213,7 +213,6 @@ Below is a list of available CLI commands for each main on-chain structure:
     | Argument     | Type     | Description                |
     |--------------|----------|----------------------------|
     | --code       | String   | Unique contributor code    |
-    | --ata-owner  | Pubkey   | ATA owner public key       |
 - `contributor delete` — Delete a contributor
     | Argument   | Type   | Description                 |
     |------------|--------|-----------------------------|
@@ -236,7 +235,6 @@ Below is a list of available CLI commands for each main on-chain structure:
     |--------------|----------|----------------------------|
     | --pubkey     | Pubkey   | Contributor public key     |
     | --code       | String   | New contributor code       |
-    | --ata-owner  | Pubkey   | New ATA owner public key   |
 
 ### Device
 - `device create` — Create a new device

--- a/smartcontract/cli/src/contributor/delete.rs
+++ b/smartcontract/cli/src/contributor/delete.rs
@@ -63,7 +63,7 @@ mod tests {
             index: 1,
             bump_seed: 255,
             code: "test".to_string(),
-            ata_owner_pk: Pubkey::default(),
+
             status: ContributorStatus::Activated,
             owner: Pubkey::default(),
         };

--- a/smartcontract/cli/src/contributor/get.rs
+++ b/smartcontract/cli/src/contributor/get.rs
@@ -18,12 +18,8 @@ impl GetContributorCliCommand {
 
         writeln!(
             out,
-            "account: {},\r\ncode: {}\r\nata_owner_pk: {}\r\nstatus: {}\r\nowner: {}",
-            pubkey,
-            contributor.code,
-            contributor.ata_owner_pk,
-            contributor.status,
-            contributor.owner
+            "account: {},\r\ncode: {}\r\nstatus: {}\r\nowner: {}",
+            pubkey, contributor.code, contributor.status, contributor.owner
         )?;
 
         Ok(())
@@ -52,7 +48,7 @@ mod tests {
             index: 1,
             bump_seed: 255,
             code: "test".to_string(),
-            ata_owner_pk: Pubkey::default(),
+
             status: ContributorStatus::Activated,
             owner: contributor1_pubkey,
         };
@@ -96,7 +92,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nata_owner_pk: 11111111111111111111111111111111\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
 
         // Expected success
         let mut output = Vec::new();
@@ -106,6 +102,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nata_owner_pk: 11111111111111111111111111111111\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }
 }

--- a/smartcontract/cli/src/contributor/list.rs
+++ b/smartcontract/cli/src/contributor/list.rs
@@ -21,7 +21,6 @@ pub struct ContributorDisplay {
     #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
-    pub ata_owner: String,
     pub status: ContributorStatus,
     #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
@@ -40,7 +39,6 @@ impl ListContributorCliCommand {
             .map(|(pubkey, tunnel)| ContributorDisplay {
                 account: pubkey,
                 code: tunnel.code,
-                ata_owner: tunnel.ata_owner_pk.to_string(),
                 status: tunnel.status,
                 owner: tunnel.owner,
             })
@@ -83,7 +81,7 @@ mod tests {
             index: 1,
             bump_seed: 255,
             code: "some code".to_string(),
-            ata_owner_pk: Pubkey::default(),
+
             status: Activated,
             owner: contributor1_pubkey,
         };
@@ -99,7 +97,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, " account                                   | code      | ata_owner                        | status    | owner                                     \n 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo | some code | 11111111111111111111111111111111 | activated | 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo \n");
+        assert_eq!(output_str, " account                                   | code      | status    | owner                                     \n 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo | some code | activated | 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo \n");
 
         let mut output = Vec::new();
         let res = ListContributorCliCommand {
@@ -110,6 +108,6 @@ mod tests {
         assert!(res.is_ok());
 
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\",\"code\":\"some code\",\"ata_owner\":\"11111111111111111111111111111111\",\"status\":\"Activated\",\"owner\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\",\"code\":\"some code\",\"status\":\"Activated\",\"owner\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\"}]\n");
     }
 }

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -194,7 +194,7 @@ mod tests {
             index: 1,
             bump_seed: 255,
             code: "test".to_string(),
-            ata_owner_pk: Pubkey::default(),
+
             status: ContributorStatus::Activated,
             owner: contributor_pk,
         };

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -813,14 +813,12 @@ mod tests {
                 index: 123,
                 bump_seed: 255,
                 code: "test".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             "CreateContributor",
         );
         test_instruction(
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: Some("test".to_string()),
-                ata_owner_pk: Some(Pubkey::default()),
             }),
             "UpdateContributor",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
@@ -21,7 +21,6 @@ use solana_program::msg;
 pub struct ContributorCreateArgs {
     pub index: u128,
     pub bump_seed: u8,
-    pub ata_owner_pk: Pubkey,
     pub code: String,
 }
 
@@ -29,8 +28,8 @@ impl fmt::Debug for ContributorCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "index: {}, bump_seed: {}, code: {}, ata_owner_pk: {}",
-            self.index, self.bump_seed, self.code, self.ata_owner_pk
+            "index: {}, bump_seed: {}, code: {}",
+            self.index, self.bump_seed, self.code
         )
     }
 }
@@ -86,7 +85,6 @@ pub fn process_create_contributor(
         index: globalstate.account_index,
         bump_seed,
         code: value.code.clone(),
-        ata_owner_pk: value.ata_owner_pk,
         status: ContributorStatus::Activated,
     };
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/test.rs
@@ -62,7 +62,6 @@ mod contributor_test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "la".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),
@@ -138,7 +137,6 @@ mod contributor_test {
             program_id,
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: Some("la2".to_string()),
-                ata_owner_pk: Some(Pubkey::default()),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
@@ -13,16 +13,11 @@ use std::fmt;
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct ContributorUpdateArgs {
     pub code: Option<String>,
-    pub ata_owner_pk: Option<Pubkey>,
 }
 
 impl fmt::Debug for ContributorUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "code: {:?}, ata_owner_pk: {:?}",
-            self.code, self.ata_owner_pk
-        )
+        write!(f, "code: {:?}", self.code)
     }
 }
 
@@ -70,9 +65,6 @@ pub fn process_update_contributor(
 
     if let Some(ref code) = value.code {
         contributor.code = code.clone();
-    }
-    if let Some(ref ata_owner_pk) = value.ata_owner_pk {
-        contributor.ata_owner_pk = *ata_owner_pk;
     }
 
     account_write(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
@@ -145,7 +145,6 @@ mod device_test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "cont".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),
@@ -577,7 +576,6 @@ mod device_test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "cont".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
@@ -148,7 +148,6 @@ mod tunnel_test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "cont".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
@@ -154,7 +154,6 @@ mod user_test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "cont".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/src/state/contributor.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/contributor.rs
@@ -71,7 +71,6 @@ pub struct Contributor {
     pub owner: Pubkey,             // 32
     pub index: u128,               // 16
     pub bump_seed: u8,             // 1
-    pub ata_owner_pk: Pubkey,      // 32
     pub status: ContributorStatus, // 1
     pub code: String,              // 4 + len
 }
@@ -80,8 +79,8 @@ impl fmt::Display for Contributor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "account_type: {}, owner: {}, index: {}, bump_seed: {}, ata_owner_pk: {}, code: {}",
-            self.account_type, self.owner, self.index, self.bump_seed, self.ata_owner_pk, self.code
+            "account_type: {}, owner: {}, index: {}, bump_seed: {}, code: {}",
+            self.account_type, self.owner, self.index, self.bump_seed, self.code
         )
     }
 }
@@ -91,7 +90,7 @@ impl AccountTypeInfo for Contributor {
         SEED_CONTRIBUTOR
     }
     fn size(&self) -> usize {
-        1 + 32 + 16 + 1 + 32 + 1 + 4 + self.code.len()
+        1 + 32 + 16 + 1 + 1 + 4 + self.code.len()
     }
     fn bump_seed(&self) -> u8 {
         self.bump_seed
@@ -113,7 +112,6 @@ impl From<&[u8]> for Contributor {
             owner: parser.read_pubkey(),
             index: parser.read_u128(),
             bump_seed: parser.read_u8(),
-            ata_owner_pk: parser.read_pubkey(),
             status: parser.read_enum(),
             code: parser.read_string(),
         }
@@ -140,7 +138,6 @@ mod tests {
             owner: Pubkey::default(),
             index: 123,
             bump_seed: 1,
-            ata_owner_pk: Pubkey::default(),
             status: ContributorStatus::Activated,
             code: "test".to_string(),
         };
@@ -153,7 +150,6 @@ mod tests {
         assert_eq!(val.code, val2.code);
         assert_eq!(val.index, val2.index);
         assert_eq!(val.bump_seed, val2.bump_seed);
-        assert_eq!(val.ata_owner_pk, val2.ata_owner_pk);
         assert_eq!(val.status, val2.status);
         assert_eq!(val.account_type, val2.account_type);
         assert_eq!(data.len(), val.size(), "Invalid Size");

--- a/smartcontract/programs/doublezero-serviceability/src/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/tests.rs
@@ -287,7 +287,6 @@ pub mod test {
                 index: globalstate_account.account_index + 1,
                 bump_seed,
                 code: "cont".to_string(),
-                ata_owner_pk: Pubkey::default(),
             }),
             vec![
                 AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
@@ -714,7 +714,6 @@ impl ServiceabilityProgramHelper {
                 index,
                 bump_seed,
                 code,
-                ata_owner_pk: Pubkey::default(), // Default ATA owner
             }),
             vec![
                 AccountMeta::new(contributor_pk, false),

--- a/smartcontract/sdk/rs/src/commands/contributor/create.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/create.rs
@@ -8,7 +8,6 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 #[derive(Debug, PartialEq, Clone)]
 pub struct CreateContributorCommand {
     pub code: String,
-    pub ata_owner_pk: Pubkey,
 }
 
 impl CreateContributorCommand {
@@ -25,7 +24,6 @@ impl CreateContributorCommand {
                     index: globalstate.account_index + 1,
                     bump_seed,
                     code: self.code.clone(),
-                    ata_owner_pk: self.ata_owner_pk,
                 }),
                 vec![
                     AccountMeta::new(pda_pubkey, false),
@@ -48,7 +46,7 @@ mod tests {
         processors::contributor::create::ContributorCreateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_contributor_create_command() {
@@ -65,7 +63,6 @@ mod tests {
                         index: 1,
                         bump_seed,
                         code: "test".to_string(),
-                        ata_owner_pk: Pubkey::default(),
                     },
                 )),
                 predicate::eq(vec![
@@ -77,7 +74,6 @@ mod tests {
 
         let res = CreateContributorCommand {
             code: "test".to_string(),
-            ata_owner_pk: Pubkey::default(),
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/contributor/get.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/get.rs
@@ -64,7 +64,7 @@ mod tests {
             index: 1,
             bump_seed: 2,
             code: "contributor_code".to_string(),
-            ata_owner_pk: Pubkey::new_unique(),
+
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
         };

--- a/smartcontract/sdk/rs/src/commands/contributor/list.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/list.rs
@@ -50,7 +50,6 @@ mod tests {
             index: 1,
             bump_seed: 2,
             code: "contributor1_code".to_string(),
-            ata_owner_pk: Pubkey::new_unique(),
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
         };
@@ -61,7 +60,7 @@ mod tests {
             index: 1,
             bump_seed: 2,
             code: "contributor2_code".to_string(),
-            ata_owner_pk: Pubkey::new_unique(),
+
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
         };

--- a/smartcontract/sdk/rs/src/commands/contributor/update.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/update.rs
@@ -8,7 +8,6 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 pub struct UpdateContributorCommand {
     pub pubkey: Pubkey,
     pub code: Option<String>,
-    pub ata_owner: Option<Pubkey>,
 }
 
 impl UpdateContributorCommand {
@@ -20,7 +19,6 @@ impl UpdateContributorCommand {
         client.execute_transaction(
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: self.code.to_owned(),
-                ata_owner_pk: self.ata_owner,
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -42,7 +40,7 @@ mod tests {
         processors::contributor::update::ContributorUpdateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
     fn test_commands_contributor_update_command() {
@@ -57,7 +55,6 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::UpdateContributor(
                     ContributorUpdateArgs {
                         code: Some("test".to_string()),
-                        ata_owner_pk: Some(Pubkey::default()),
                     },
                 )),
                 predicate::eq(vec![
@@ -70,7 +67,6 @@ mod tests {
         let res = UpdateContributorCommand {
             pubkey: pda_pubkey,
             code: Some("test".to_string()),
-            ata_owner: Some(Pubkey::default()),
         }
         .execute(&client);
 

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -84,7 +84,7 @@ echo "Update exchanges"
 
 ### Initialice controbutor
 echo "Creating contributor"
-./target/doublezero contributor create --code co01 --ata-owner 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+./target/doublezero contributor create --code co01
 
 ### Initialice devices
 echo "Creating devices"


### PR DESCRIPTION
This pull request removes the `--ata-owner` argument and related functionality from the contributor commands in the DoubleZero CLI and backend. The changes simplify the contributor creation, update, and management processes by eliminating the need to specify or validate an ATA owner public key. Below is a summary of the most important changes grouped by theme.

### CLI and Command Updates
- Removed the `--ata-owner` argument from the `contributor create` and `contributor update` commands, along with its associated validations and logic in the CLI (`smartcontract/cli/src/contributor/create.rs`, `smartcontract/cli/src/contributor/update.rs`). [[1]](diffhunk://#diff-7a89574ce930f2bedf4951036cef91d95e34445452d75c567dcd5310f6ed053cL4-L20) [[2]](diffhunk://#diff-c6df18fc1f8672fdcca6e0d05f96c519e70bee49239c4b3b95012168c8232db3L21-L23)
- Updated the `contributor list` and `contributor get` commands to exclude the `ata_owner` field from their outputs and internal logic (`smartcontract/cli/src/contributor/list.rs`, `smartcontract/cli/src/contributor/get.rs`). [[1]](diffhunk://#diff-a294a6c4404d5212aebcfd6a01297343558d593d85d5d81f03b3c3bdfc663481L24) [[2]](diffhunk://#diff-3d2590d979d5299d39c0c48fcb65601b07c1e6ebd1a7c4b0f01f970f40115f7eL21-R22)

### Documentation Updates
- Updated CLI documentation to remove references to the `--ata-owner` argument in the contributor commands (`smartcontract/cli/README.md`). [[1]](diffhunk://#diff-536b967d913d1ceafe93082565469d970c82270da32515389f0a94a1b1734c65L216) [[2]](diffhunk://#diff-536b967d913d1ceafe93082565469d970c82270da32515389f0a94a1b1734c65L239)
- Adjusted the main smart contract README to reflect the removal of the `--ata-owner` argument in example commands and descriptions (`smartcontract/README.md`).

### Backend Logic and Tests
- Removed the `ata_owner_pk` field from the contributor-related structs, commands, and tests in the backend (`smartcontract/cli/src/contributor/create.rs`, `smartcontract/cli/src/contributor/update.rs`). [[1]](diffhunk://#diff-7a89574ce930f2bedf4951036cef91d95e34445452d75c567dcd5310f6ed053cL36-L41) [[2]](diffhunk://#diff-c6df18fc1f8672fdcca6e0d05f96c519e70bee49239c4b3b95012168c8232db3L51-L67)
- Updated tests across various modules to align with the removal of the `ata_owner_pk` field and related logic (`smartcontract/cli/src/contributor/create.rs`, `smartcontract/cli/src/contributor/update.rs`, `smartcontract/cli/src/contributor/list.rs`). [[1]](diffhunk://#diff-7a89574ce930f2bedf4951036cef91d95e34445452d75c567dcd5310f6ed053cL87-R79) [[2]](diffhunk://#diff-c6df18fc1f8672fdcca6e0d05f96c519e70bee49239c4b3b95012168c8232db3L111-R94) [[3]](diffhunk://#diff-a294a6c4404d5212aebcfd6a01297343558d593d85d5d81f03b3c3bdfc663481L86-R84)

### Program-Level Changes
- Removed `ata_owner_pk` references from program-level instruction handling for contributor creation and updates (`smartcontract/programs/doublezero-serviceability/src/instructions.rs`).

### Shell Script Updates
- Updated testnet initialization scripts to remove the `--ata-owner` argument from the `contributor create` command (`client/doublezero/dz-testnet.sh`, `e2e/internal/devnet/smartcontract_init.go`). [[1]](diffhunk://#diff-c67c426aed36e8b3effa130565b47876dd37c1dc98bf20efd203ebddd3ce41d9L33-R33) [[2]](diffhunk://#diff-b2b355699dc974cae32c03422bd3d0837bb3870fd70dd84aa76313b2d6f18edfL122-R122)