### PR TITLE
device/telemetry: lower batch size to be within transaction size limit

### DIFF
--- a/controlplane/telemetry/internal/telemetry/submitter_test.go
+++ b/controlplane/telemetry/internal/telemetry/submitter_test.go
@@ -424,8 +424,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 
-		require.Equal(t, 3, calls, "expected 3 submission calls for 5500 samples with max 2560 per call")
-		assert.Equal(t, []int{sdktelemetry.MaxSamplesPerBatch, sdktelemetry.MaxSamplesPerBatch, 380}, samplesPerCall, "each call should contain at most 2560 samples")
+		require.Equal(t, 23, calls, "expected 23 submission calls for 5500 samples with max 245 per call")
+		for i := range 22 {
+			assert.Equal(t, sdktelemetry.MaxSamplesPerBatch, samplesPerCall[i])
+		}
+		assert.Equal(t, 110, samplesPerCall[22], "last call should contain 110 samples")
 	})
 
 	t.Run("negative_rtts_are_submitted_as_one", func(t *testing.T) {

--- a/smartcontract/sdk/go/telemetry/constants.go
+++ b/smartcontract/sdk/go/telemetry/constants.go
@@ -13,13 +13,14 @@ const (
 	// when the given PDA does not exist.
 	InstructionErrorAccountDoesNotExist = 1011
 
-	// SolanaMaxPermittedDataIncrease is the maximum number of bytes a program may add to an
-	// account during a single realloc.
-	// This is the samples batch size limit in bytes.
-	SolanaMaxPermittedDataIncrease = 10_240
-
 	// MaxSamplesPerBatch is the maximum number of samples that can be written in a single batch.
-	MaxSamplesPerBatch = SolanaMaxPermittedDataIncrease / 4
+	//
+	// Messages transmitted to Solana validators must not exceed the IPv6 MTU size to ensure fast
+	// and reliable network transmission of cluster info over UDP. Solana's networking stack uses a
+	// conservative MTU size of 1280 bytes which, after accounting for headers, leaves 1232 bytes
+	// for packet data like serialized transactions.
+	// https://docs.anza.xyz/proposals/versioned-transactions#problem
+	MaxSamplesPerBatch = 245 // 980 bytes
 
 	// MaxSamples is the maximum number of samples that can be written to a single account.
 	MaxSamples = 35_000


### PR DESCRIPTION
## Summary of Changes
- Update the device telemetry samples submission batch size to be 245 (980 bytes) so that it's within the Solana transaction size limit
- After some testing, it looks like we can include at most 245 samples in our transactions. This makes sense because https://docs.anza.xyz/proposals/versioned-transactions#problem

   > Messages transmitted to Solana validators must not exceed the IPv6 MTU size to ensure fast and reliable network transmission of cluster info over UDP. Solana's networking stack uses a conservative MTU size of 1280 bytes which, after accounting for headers, leaves 1232 bytes for packet data like serialized transactions.
- Fixes https://github.com/malbeclabs/doublezero/issues/876

## Testing Verification
- Added e2e test coverage for Go SDK submitting samples at the batch limit and 1 over the batch limit
