### PR TITLE
Refactor contributor, device, link, and user creation arguments to remove unnecessary fields

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -500,11 +500,8 @@ mod tests {
             DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
                 code: "test".to_string(),
                 public_ip: [1, 2, 3, 4].into(),
-                contributor_pk: Pubkey::new_unique(),
                 device_type: DeviceType::Switch,
                 dz_prefixes: "1.2.3.4/1".parse().unwrap(),
-                location_pk: Pubkey::new_unique(),
-                exchange_pk: Pubkey::new_unique(),
                 metrics_publisher_pk: Pubkey::new_unique(),
                 bgp_asn: 100,
                 dia_bgp_asn: 200,
@@ -551,9 +548,6 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CreateLink(LinkCreateArgs {
                 code: "test".to_string(),
-                contributor_pk: Pubkey::new_unique(),
-                side_a_pk: Pubkey::new_unique(),
-                side_z_pk: Pubkey::new_unique(),
                 link_type: LinkLinkType::L3,
                 bandwidth: 100,
                 mtu: 1500,
@@ -598,7 +592,6 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CreateUser(UserCreateArgs {
                 user_type: UserType::IBRL,
-                device_pk: Pubkey::new_unique(),
                 cyoa_type: UserCYOA::GREOverDIA,
                 client_ip: [1, 2, 3, 4].into(),
             }),
@@ -804,7 +797,6 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
                 user_type: UserType::IBRL,
-                device_pk: Pubkey::new_unique(),
                 cyoa_type: UserCYOA::GREOverDIA,
                 client_ip: [1, 2, 3, 4].into(),
                 publisher: false,
@@ -814,8 +806,6 @@ mod tests {
         );
         test_instruction(
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: 123,
-                bump_seed: 255,
                 code: "test".to_string(),
             }),
             "CreateContributor",

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/test.rs
@@ -51,7 +51,7 @@ mod contributor_test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 0);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -59,8 +59,6 @@ mod contributor_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "la".to_string(),
             }),
             vec![

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -24,9 +24,6 @@ use solana_program::{
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct DeviceCreateArgs {
     pub code: String,
-    pub contributor_pk: Pubkey,
-    pub location_pk: Pubkey,
-    pub exchange_pk: Pubkey,
     pub device_type: DeviceType,
     pub public_ip: std::net::Ipv4Addr,
     pub dz_prefixes: NetworkV4List,
@@ -43,14 +40,10 @@ impl fmt::Debug for DeviceCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "code: {}, contributor_pk: {}, location_pk: {}, \
-exchange_pk: {}, device_type: {:?}, public_ip: {}, dz_prefixes: {}, \
+            "code: {}, device_type: {:?}, public_ip: {}, dz_prefixes: {}, \
 metrics_publisher_pk: {}, bgp_asn: {}, dia_bgp_asn: {}, mgmt_vrf: {}, \
 dns_servers: {:?}, ntp_servers: {:?}, interfaces: {:?}",
             self.code,
-            self.contributor_pk,
-            self.location_pk,
-            self.exchange_pk,
             self.device_type,
             self.public_ip,
             self.dz_prefixes,
@@ -141,9 +134,9 @@ pub fn process_create_device(
         index: globalstate.account_index,
         bump_seed,
         code: value.code.clone(),
-        contributor_pk: value.contributor_pk,
-        location_pk: value.location_pk,
-        exchange_pk: value.exchange_pk,
+        contributor_pk: *contributor_account.key,
+        location_pk: *location_account.key,
+        exchange_pk: *exchange_account.key,
         device_type: value.device_type,
         public_ip: value.public_ip,
         dz_prefixes: value.dz_prefixes.clone(),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/test.rs
@@ -130,7 +130,7 @@ mod device_test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 2);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -138,8 +138,6 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "cont".to_string(),
             }),
             vec![
@@ -177,9 +175,6 @@ mod device_test {
             DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
                 code: "la".to_string(),
                 device_type: DeviceType::Switch,
-                contributor_pk: contributor_pubkey,
-                location_pk: location_pubkey,
-                exchange_pk: exchange_pubkey,
                 public_ip: [10, 0, 0, 1].into(),
                 dz_prefixes: "10.1.0.0/23".parse().unwrap(),
                 metrics_publisher_pk: Pubkey::default(),
@@ -398,9 +393,6 @@ mod device_test {
             DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
                 code: "la".to_string(),
                 device_type: DeviceType::Switch,
-                contributor_pk: contributor_pubkey,
-                location_pk: location_pubkey,
-                exchange_pk: exchange_pubkey,
                 public_ip: [10, 0, 0, 1].into(),
                 dz_prefixes: "10.1.0.0/23".parse().unwrap(),
                 metrics_publisher_pk: Pubkey::default(),
@@ -575,7 +567,7 @@ mod device_test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 2);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -583,8 +575,6 @@ mod device_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "cont".to_string(),
             }),
             vec![

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -21,9 +21,6 @@ use solana_program::{
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct LinkCreateArgs {
     pub code: String,
-    pub contributor_pk: Pubkey,
-    pub side_a_pk: Pubkey,
-    pub side_z_pk: Pubkey,
     pub link_type: LinkLinkType,
     pub bandwidth: u64,
     pub mtu: u32,
@@ -37,8 +34,8 @@ impl fmt::Debug for LinkCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "code: {}, side_a_pk: {}, side_z_pk: {}, link_type: {:?}, bandwidth: {}, mtu: {}, delay_ns: {}, jitter_ns: {}, side_a_iface_name: {}, side_z_iface_name: {}",
-            self.code, self.side_a_pk, self.side_z_pk, self.link_type, self.bandwidth, self.mtu, self.delay_ns, self.jitter_ns, self.side_a_iface_name, self.side_z_iface_name
+            "code: {}, link_type: {:?}, bandwidth: {}, mtu: {}, delay_ns: {}, jitter_ns: {}, side_a_iface_name: {}, side_z_iface_name: {}",
+            self.code, self.link_type, self.bandwidth, self.mtu, self.delay_ns, self.jitter_ns, self.side_a_iface_name, self.side_z_iface_name
         )
     }
 }
@@ -139,9 +136,9 @@ pub fn process_create_link(
         index: globalstate.account_index,
         bump_seed,
         code: value.code.clone(),
-        contributor_pk: value.contributor_pk,
-        side_a_pk: value.side_a_pk,
-        side_z_pk: value.side_z_pk,
+        contributor_pk: *contributor_account.key,
+        side_a_pk: *side_a_account.key,
+        side_z_pk: *side_z_account.key,
         link_type: value.link_type,
         bandwidth: value.bandwidth,
         mtu: value.mtu,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/test.rs
@@ -136,7 +136,7 @@ mod tunnel_test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 2);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -144,8 +144,6 @@ mod tunnel_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "cont".to_string(),
             }),
             vec![
@@ -182,9 +180,6 @@ mod tunnel_test {
             DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
                 code: "A".to_string(),
                 device_type: DeviceType::Switch,
-                contributor_pk: contributor_pubkey,
-                location_pk: location_pubkey,
-                exchange_pk: exchange_pubkey,
                 public_ip: [10, 0, 0, 1].into(),
                 dz_prefixes: "10.1.0.0/24".parse().unwrap(),
                 metrics_publisher_pk: Pubkey::default(),
@@ -226,9 +221,6 @@ mod tunnel_test {
             DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
                 code: "Z".to_string(),
                 device_type: DeviceType::Switch,
-                contributor_pk: contributor_pubkey,
-                location_pk: location_pubkey,
-                exchange_pk: exchange_pubkey,
                 public_ip: [11, 0, 0, 1].into(),
                 dz_prefixes: "11.1.0.0/23".parse().unwrap(),
                 metrics_publisher_pk: Pubkey::default(),
@@ -273,9 +265,6 @@ mod tunnel_test {
             DoubleZeroInstruction::CreateLink(LinkCreateArgs {
                 code: "la".to_string(),
                 link_type: LinkLinkType::L3,
-                contributor_pk: contributor_pubkey,
-                side_a_pk: device_a_pubkey,
-                side_z_pk: device_z_pubkey,
                 bandwidth: 100000000,
                 mtu: 9000,
                 delay_ns: 150000,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -23,7 +23,6 @@ use solana_program::{
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct UserCreateArgs {
     pub user_type: UserType,
-    pub device_pk: Pubkey,
     pub cyoa_type: UserCYOA,
     pub client_ip: std::net::Ipv4Addr,
 }
@@ -32,8 +31,8 @@ impl fmt::Debug for UserCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "user_type: {}, device_pk: {}, cyoa_type: {}, client_ip: {}",
-            self.user_type, self.device_pk, self.cyoa_type, &self.client_ip,
+            "user_type: {}, cyoa_type: {}, client_ip: {}",
+            self.user_type, self.cyoa_type, &self.client_ip,
         )
     }
 }
@@ -99,7 +98,7 @@ pub fn process_create_user(
         index: globalstate.account_index,
         tenant_pk: Pubkey::default(),
         user_type: value.user_type,
-        device_pk: value.device_pk,
+        device_pk: *device_account.key,
         cyoa_type: value.cyoa_type,
         client_ip: value.client_ip,
         dz_ip: std::net::Ipv4Addr::UNSPECIFIED,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -25,7 +25,6 @@ use solana_program::{
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct UserCreateSubscribeArgs {
     pub user_type: UserType,
-    pub device_pk: Pubkey,
     pub cyoa_type: UserCYOA,
     pub client_ip: std::net::Ipv4Addr,
     pub publisher: bool,
@@ -36,8 +35,8 @@ impl fmt::Debug for UserCreateSubscribeArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "user_type: {}, device_pk: {}, cyoa_type: {}, client_ip: {}",
-            self.user_type, self.device_pk, self.cyoa_type, &self.client_ip,
+            "user_type: {}, cyoa_type: {}, client_ip: {}",
+            self.user_type, self.cyoa_type, &self.client_ip,
         )
     }
 }
@@ -105,7 +104,7 @@ pub fn process_create_subscribe_user(
         index: globalstate.account_index,
         tenant_pk: Pubkey::default(),
         user_type: value.user_type,
-        device_pk: value.device_pk,
+        device_pk: *device_account.key,
         cyoa_type: value.cyoa_type,
         client_ip: value.client_ip,
         dz_ip: std::net::Ipv4Addr::UNSPECIFIED,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/tests.rs
@@ -139,7 +139,7 @@ mod user_test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 2);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -147,8 +147,6 @@ mod user_test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "cont".to_string(),
             }),
             vec![
@@ -187,9 +185,6 @@ mod user_test {
             DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
                 code: "la".to_string(),
                 device_type: DeviceType::Switch,
-                contributor_pk: contributor_pubkey,
-                location_pk: location_pubkey,
-                exchange_pk: exchange_pubkey,
                 public_ip: [10, 0, 0, 1].into(),
                 dz_prefixes: "10.1.0.0/23".parse().unwrap(),
                 metrics_publisher_pk: Pubkey::default(),
@@ -260,7 +255,6 @@ mod user_test {
             DoubleZeroInstruction::CreateUser(UserCreateArgs {
                 client_ip: [100, 0, 0, 1].into(),
                 user_type: UserType::IBRL,
-                device_pk: device_pubkey,
                 cyoa_type: UserCYOA::GREOverDIA,
             }),
             vec![

--- a/smartcontract/programs/doublezero-serviceability/src/tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/tests.rs
@@ -268,7 +268,7 @@ pub mod test {
         let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
         assert_eq!(globalstate_account.account_index, 4);
 
-        let (contributor_pubkey, bump_seed) =
+        let (contributor_pubkey, _) =
             get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
         execute_transaction(
@@ -276,8 +276,6 @@ pub mod test {
             recent_blockhash,
             program_id,
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                index: globalstate_account.account_index + 1,
-                bump_seed,
                 code: "cont".to_string(),
             }),
             vec![
@@ -309,9 +307,6 @@ pub mod test {
             get_device_pda(&program_id, globalstate_account.account_index + 1);
         let device_la: DeviceCreateArgs = DeviceCreateArgs {
             code: device_la_code.clone(),
-            contributor_pk: contributor_pubkey,
-            location_pk: location_la_pubkey,
-            exchange_pk: exchange_la_pubkey,
             device_type: DeviceType::Switch,
             public_ip: [1, 0, 0, 1].into(),
             dz_prefixes: NetworkV4List::default(),
@@ -367,9 +362,6 @@ pub mod test {
             get_device_pda(&program_id, globalstate_account.account_index + 1);
         let device_ny: DeviceCreateArgs = DeviceCreateArgs {
             code: device_ny_code.clone(),
-            contributor_pk: contributor_pubkey,
-            location_pk: location_ny_pubkey,
-            exchange_pk: exchange_ny_pubkey,
             device_type: DeviceType::Switch,
             public_ip: [1, 0, 0, 2].into(),
             dz_prefixes: vec!["10.1.0.1/24".parse().unwrap()].into(),
@@ -473,9 +465,6 @@ pub mod test {
             get_link_pda(&program_id, globalstate_account.account_index + 1);
         let tunnel_la_ny: LinkCreateArgs = LinkCreateArgs {
             code: tunnel_la_ny_code.clone(),
-            contributor_pk: contributor_pubkey,
-            side_a_pk: device_la_pubkey,
-            side_z_pk: device_ny_pubkey,
             link_type: LinkLinkType::L3,
             bandwidth: 100,
             mtu: 1900,
@@ -560,7 +549,6 @@ pub mod test {
         let (user1_pubkey, _) = get_user_pda(&program_id, globalstate_account.account_index + 1);
         let user1: UserCreateArgs = UserCreateArgs {
             user_type: UserType::IBRL,
-            device_pk: device_la_pubkey,
             cyoa_type: UserCYOA::GREOverDIA,
             client_ip: user_ip,
         };

--- a/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
@@ -633,42 +633,46 @@ async fn test_initialize_device_latency_samples_fail_origin_device_not_activated
     // Origin device: not activated
     let origin_device_pk = ledger
         .serviceability
-        .create_device(DeviceCreateArgs {
-            code: "OriginDevice".to_string(),
+        .create_device(
+            DeviceCreateArgs {
+                code: "OriginDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [1, 2, 3, 4].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [1, 2, 3, 4].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     // Target device: activated
     let target_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "TargetDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "TargetDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [5, 6, 7, 8].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [5, 6, 7, 8].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
@@ -678,9 +682,6 @@ async fn test_initialize_device_latency_samples_fail_origin_device_not_activated
         .create_and_activate_link(
             LinkCreateArgs {
                 code: "LINK1".to_string(),
-                contributor_pk,
-                side_a_pk: origin_device_pk,
-                side_z_pk: target_device_pk,
                 link_type: LinkLinkType::L3,
                 bandwidth: 1000,
                 mtu: 1500,
@@ -689,6 +690,9 @@ async fn test_initialize_device_latency_samples_fail_origin_device_not_activated
                 side_a_iface_name: "eth0".to_string(),
                 side_z_iface_name: "eth1".to_string(),
             },
+            contributor_pk,
+            origin_device_pk,
+            target_device_pk,
             1,
             "10.1.1.0/30".parse().unwrap(),
         )
@@ -754,42 +758,46 @@ async fn test_initialize_device_latency_samples_fail_target_device_not_activated
     // Origin device: activated
     let origin_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "OriginDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "OriginDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [1, 2, 3, 4].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [1, 2, 3, 4].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     // Target device: not activated
     let target_device_pk = ledger
         .serviceability
-        .create_device(DeviceCreateArgs {
-            code: "TargetDevice".to_string(),
+        .create_device(
+            DeviceCreateArgs {
+                code: "TargetDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [5, 6, 7, 8].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [5, 6, 7, 8].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
@@ -799,9 +807,6 @@ async fn test_initialize_device_latency_samples_fail_target_device_not_activated
         .create_and_activate_link(
             LinkCreateArgs {
                 code: "LINK1".to_string(),
-                contributor_pk,
-                side_a_pk: origin_device_pk,
-                side_z_pk: target_device_pk,
                 link_type: LinkLinkType::L3,
                 bandwidth: 1000,
                 mtu: 1500,
@@ -810,6 +815,9 @@ async fn test_initialize_device_latency_samples_fail_target_device_not_activated
                 side_a_iface_name: "eth0".to_string(),
                 side_z_iface_name: "eth1".to_string(),
             },
+            contributor_pk,
+            origin_device_pk,
+            target_device_pk,
             1,
             "10.1.1.0/30".parse().unwrap(),
         )
@@ -874,60 +882,66 @@ async fn test_initialize_device_latency_samples_fail_link_not_activated() {
 
     let origin_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "OriginDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "OriginDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [1, 2, 3, 4].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [1, 2, 3, 4].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     let target_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "TargetDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "TargetDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [5, 6, 7, 8].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [5, 6, 7, 8].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     // Create link but do not activate
     let link_pk = ledger
         .serviceability
-        .create_link(LinkCreateArgs {
-            code: "LINK1".to_string(),
+        .create_link(
+            LinkCreateArgs {
+                code: "LINK1".to_string(),
+                link_type: LinkLinkType::L3,
+                bandwidth: 1000,
+                mtu: 1500,
+                delay_ns: 10,
+                jitter_ns: 1,
+                side_a_iface_name: "eth0".to_string(),
+                side_z_iface_name: "eth1".to_string(),
+            },
             contributor_pk,
-            side_a_pk: origin_device_pk,
-            side_z_pk: target_device_pk,
-            link_type: LinkLinkType::L3,
-            bandwidth: 1000,
-            mtu: 1500,
-            delay_ns: 10,
-            jitter_ns: 1,
-            side_a_iface_name: "eth0".to_string(),
-            side_z_iface_name: "eth1".to_string(),
-        })
+            origin_device_pk,
+            target_device_pk,
+        )
         .await
         .unwrap();
 
@@ -989,82 +1003,90 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
     // Origin device and target device: activated
     let origin_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "OriginDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "OriginDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [1, 1, 1, 1].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [1, 1, 1, 1].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     let target_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "TargetDevice".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "TargetDevice".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [2, 2, 2, 2].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [2, 2, 2, 2].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     // Other devices for the link
     let device_x_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "DeviceX".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "DeviceX".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [3, 3, 3, 3].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [3, 3, 3, 3].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     let device_y_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "DeviceY".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "DeviceY".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [4, 4, 4, 4].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [4, 4, 4, 4].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
@@ -1074,9 +1096,6 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
         .create_and_activate_link(
             LinkCreateArgs {
                 code: "LINK1".to_string(),
-                contributor_pk,
-                side_a_pk: device_x_pk,
-                side_z_pk: device_y_pk,
                 link_type: LinkLinkType::L2,
                 bandwidth: 1000,
                 mtu: 1500,
@@ -1085,6 +1104,9 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
                 side_a_iface_name: "eth0".to_string(),
                 side_z_iface_name: "eth1".to_string(),
             },
+            contributor_pk,
+            device_x_pk,
+            device_y_pk,
             1,
             "10.1.1.0/30".parse().unwrap(),
         )
@@ -1149,41 +1171,45 @@ async fn test_initialize_device_latency_samples_succeeds_with_reversed_link_side
 
     let origin_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "OriginDevice".into(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "OriginDevice".into(),
+                device_type: DeviceType::Switch,
+                public_ip: [10, 0, 0, 1].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [10, 0, 0, 1].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     let target_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "TargetDevice".into(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "TargetDevice".into(),
+                device_type: DeviceType::Switch,
+                public_ip: [10, 0, 0, 2].into(),
+                metrics_publisher_pk: agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [10, 0, 0, 2].into(),
-            metrics_publisher_pk: agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
@@ -1193,9 +1219,6 @@ async fn test_initialize_device_latency_samples_succeeds_with_reversed_link_side
         .create_and_activate_link(
             LinkCreateArgs {
                 code: "LINK1".into(),
-                contributor_pk,
-                side_a_pk: target_device_pk,
-                side_z_pk: origin_device_pk,
                 link_type: LinkLinkType::L2,
                 bandwidth: 1000,
                 mtu: 1500,
@@ -1204,6 +1227,9 @@ async fn test_initialize_device_latency_samples_succeeds_with_reversed_link_side
                 side_a_iface_name: "eth1".to_string(),
                 side_z_iface_name: "eth0".to_string(),
             },
+            contributor_pk,
+            target_device_pk,
+            origin_device_pk,
             1,
             "192.168.0.0/24".parse().unwrap(),
         )
@@ -1405,42 +1431,46 @@ async fn test_initialize_device_latency_samples_fail_agent_not_owner_of_origin_d
     // Origin device: activated, owned by owner_agent
     let origin_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "A".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "A".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [1, 1, 1, 1].into(),
+                metrics_publisher_pk: owner_agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth0".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [1, 1, 1, 1].into(),
-            metrics_publisher_pk: owner_agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth0".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
     // Target device: also valid
     let target_device_pk = ledger
         .serviceability
-        .create_and_activate_device(DeviceCreateArgs {
-            code: "Z".to_string(),
+        .create_and_activate_device(
+            DeviceCreateArgs {
+                code: "Z".to_string(),
+                device_type: DeviceType::Switch,
+                public_ip: [2, 2, 2, 2].into(),
+                metrics_publisher_pk: unauthorized_agent.pubkey(),
+                interfaces: vec![Interface {
+                    version: CURRENT_INTERFACE_VERSION,
+                    name: "eth1".to_string(),
+                    ..Interface::default()
+                }],
+                ..DeviceCreateArgs::default()
+            },
             contributor_pk,
             location_pk,
             exchange_pk,
-            device_type: DeviceType::Switch,
-            public_ip: [2, 2, 2, 2].into(),
-            metrics_publisher_pk: unauthorized_agent.pubkey(),
-            interfaces: vec![Interface {
-                version: CURRENT_INTERFACE_VERSION,
-                name: "eth1".to_string(),
-                ..Interface::default()
-            }],
-            ..DeviceCreateArgs::default()
-        })
+        )
         .await
         .unwrap();
 
@@ -1454,12 +1484,12 @@ async fn test_initialize_device_latency_samples_fail_agent_not_owner_of_origin_d
                 mtu: 1500,
                 delay_ns: 10,
                 jitter_ns: 1,
-                contributor_pk,
-                side_a_pk: origin_device_pk,
-                side_z_pk: target_device_pk,
                 side_a_iface_name: "eth0".to_string(),
                 side_z_iface_name: "eth1".to_string(),
             },
+            contributor_pk,
+            origin_device_pk,
+            target_device_pk,
             1,
             "10.0.0.0/24".parse().unwrap(),
         )

--- a/smartcontract/sdk/rs/src/commands/contributor/create.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/create.rs
@@ -16,13 +16,11 @@ impl CreateContributorCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        let (pda_pubkey, bump_seed) =
+        let (pda_pubkey, _) =
             get_contributor_pda(&client.get_program_id(), globalstate.account_index + 1);
         client
             .execute_transaction(
                 DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-                    index: globalstate.account_index + 1,
-                    bump_seed,
                     code: self.code.clone(),
                 }),
                 vec![
@@ -53,15 +51,13 @@ mod tests {
         let mut client = create_test_client();
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
-        let (pda_pubkey, bump_seed) = get_contributor_pda(&client.get_program_id(), 1);
+        let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
 
         client
             .expect_execute_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CreateContributor(
                     ContributorCreateArgs {
-                        index: 1,
-                        bump_seed,
                         code: "test".to_string(),
                     },
                 )),

--- a/smartcontract/sdk/rs/src/commands/device/create.rs
+++ b/smartcontract/sdk/rs/src/commands/device/create.rs
@@ -36,9 +36,6 @@ impl CreateDeviceCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
                     code: self.code.clone(),
-                    contributor_pk: self.contributor_pk,
-                    location_pk: self.location_pk,
-                    exchange_pk: self.exchange_pk,
                     device_type: self.device_type,
                     public_ip: self.public_ip,
                     dz_prefixes: self.dz_prefixes.clone(),
@@ -137,9 +134,6 @@ mod tests {
             .with(
                 predicate::eq(DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
                     code: "test-device".to_string(),
-                    contributor_pk: contributor_pubkey,
-                    location_pk: location_pubkey,
-                    exchange_pk: exchange_pubkey,
                     device_type: DeviceType::Switch,
                     public_ip: [10, 0, 0, 1].into(),
                     dz_prefixes: "10.0.0.0/8".parse().unwrap(),

--- a/smartcontract/sdk/rs/src/commands/link/create.rs
+++ b/smartcontract/sdk/rs/src/commands/link/create.rs
@@ -32,9 +32,6 @@ impl CreateLinkCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateLink(LinkCreateArgs {
                     code: self.code.to_string(),
-                    contributor_pk: self.contributor_pk,
-                    side_a_pk: self.side_a_pk,
-                    side_z_pk: self.side_z_pk,
                     link_type: self.link_type,
                     bandwidth: self.bandwidth,
                     mtu: self.mtu,

--- a/smartcontract/sdk/rs/src/commands/user/create.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create.rs
@@ -28,7 +28,6 @@ impl CreateUserCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateUser(UserCreateArgs {
                     user_type: self.user_type,
-                    device_pk: self.device_pk,
                     cyoa_type: self.cyoa_type,
                     client_ip: self.client_ip,
                 }),

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -55,7 +55,6 @@ impl CreateSubscribeUserCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
                     user_type: self.user_type,
-                    device_pk: self.device_pk,
                     cyoa_type: self.cyoa_type,
                     client_ip: self.client_ip,
                     publisher: self.publisher,


### PR DESCRIPTION
This pull request simplifies the `doublezero-serviceability` program by removing redundant fields from several instruction argument structs and their associated logic. The changes streamline the codebase, reduce complexity, and improve maintainability while preserving functionality.

### Removal of Redundant Fields from Instruction Argument Structs:

* **Contributor Creation:**
  - Removed `index` and `bump_seed` fields from `ContributorCreateArgs` and their associated logic in `process_create_contributor` and related tests. [[1]](diffhunk://#diff-8c4976fb9f1d9a53e9f9a6172903c3f336c7ca526c4c13e94700b9576a3a7e58L22-R27) [[2]](diffhunk://#diff-8c4976fb9f1d9a53e9f9a6172903c3f336c7ca526c4c13e94700b9576a3a7e58L64-R69) [[3]](diffhunk://#diff-7ebaf0e4b1b0c148b17e7bf065c4f72ba1103cf62087997c4f67589d073ad0e2L54-L63)

* **Device Creation:**
  - Removed `contributor_pk`, `location_pk`, and `exchange_pk` fields from `DeviceCreateArgs` and their associated logic in `process_create_device` and related tests. [[1]](diffhunk://#diff-70e71946643fcb7040a5e4d9fec55f137a1c085bfea9f040b685a55d94a5c546L27-L29) [[2]](diffhunk://#diff-70e71946643fcb7040a5e4d9fec55f137a1c085bfea9f040b685a55d94a5c546L40-R42) [[3]](diffhunk://#diff-70e71946643fcb7040a5e4d9fec55f137a1c085bfea9f040b685a55d94a5c546L122-R125) [[4]](diffhunk://#diff-729b951745f8d8fed8f6d16bb69fa5dbdf89c1fbee1cd1f595b0270b1012a46eL133-L142) [[5]](diffhunk://#diff-729b951745f8d8fed8f6d16bb69fa5dbdf89c1fbee1cd1f595b0270b1012a46eL180-L182) [[6]](diffhunk://#diff-729b951745f8d8fed8f6d16bb69fa5dbdf89c1fbee1cd1f595b0270b1012a46eL389-L391)

* **Link Creation:**
  - Removed `contributor_pk`, `side_a_pk`, and `side_z_pk` fields from `LinkCreateArgs` and their associated logic in `process_create_link` and related tests. [[1]](diffhunk://#diff-c8e1ea3d4a083f2e5d37bdf2de32bcfd71ce7ff4fd4e3367fb38d115de8b0f73L24-L26) [[2]](diffhunk://#diff-c8e1ea3d4a083f2e5d37bdf2de32bcfd71ce7ff4fd4e3367fb38d115de8b0f73L38-R36) [[3]](diffhunk://#diff-c8e1ea3d4a083f2e5d37bdf2de32bcfd71ce7ff4fd4e3367fb38d115de8b0f73L122-R121) [[4]](diffhunk://#diff-efc8d9b72ebf10579b24ec6e12db4077bfe429472d6cb3a4fadd7f739543f9aeL136-L145) [[5]](diffhunk://#diff-efc8d9b72ebf10579b24ec6e12db4077bfe429472d6cb3a4fadd7f739543f9aeL182-L184) [[6]](diffhunk://#diff-efc8d9b72ebf10579b24ec6e12db4077bfe429472d6cb3a4fadd7f739543f9aeL216-L218) [[7]](diffhunk://#diff-efc8d9b72ebf10579b24ec6e12db4077bfe429472d6cb3a4fadd7f739543f9aeL253-L255)

* **User Creation:**
  - Removed `device_pk` field from `UserCreateArgs` and `UserCreateSubscribeArgs` and their associated logic in `process_create_user`, `process_create_subscribe_user`, and related tests. [[1]](diffhunk://#diff-50a1438f8af41564d2206a2bc66f4efbd8d410b02b1273d63634342dc8ba321eL26) [[2]](diffhunk://#diff-50a1438f8af41564d2206a2bc66f4efbd8d410b02b1273d63634342dc8ba321eL35-R35) [[3]](diffhunk://#diff-50a1438f8af41564d2206a2bc66f4efbd8d410b02b1273d63634342dc8ba321eL102-R101) [[4]](diffhunk://#diff-cddaff613b96778de97f99ba3220571784cbb1d1d3533c475f24ad47af738624L28) [[5]](diffhunk://#diff-cddaff613b96778de97f99ba3220571784cbb1d1d3533c475f24ad47af738624L39-R39) [[6]](diffhunk://#diff-cddaff613b96778de97f99ba3220571784cbb1d1d3533c475f24ad47af738624L108-R107)

### Updates to Test Cases:
- Adjusted test cases to reflect the removal of redundant fields, ensuring tests align with the updated instruction argument structs and logic. [[1]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL503-L507) [[2]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL542-L544) [[3]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL587) [[4]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL793) [[5]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL803-L804)

These changes collectively simplify the program by reducing unnecessary dependencies on certain fields, making the code cleaner and easier to work with.
