### PR TITLE
funder: enable metrics in testnet

### DIFF
--- a/controlplane/funder/cmd/funder/doublezero-funder.service
+++ b/controlplane/funder/cmd/funder/doublezero-funder.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
-ExecStart=/usr/local/bin/doublezero-funder -env testnet -keypair /etc/doublezero/funder-keypair.json
+ExecStart=/usr/local/bin/doublezero-funder -env testnet -keypair /etc/doublezero/funder-keypair.json -metrics-enable
 Restart=always
 RestartSec=15
 


### PR DESCRIPTION
## Summary of Changes
- Update funder serviced config to enable metrics by default in testnet
- Related to https://github.com/malbeclabs/doublezero/issues/894 

## Testing Verification
- Installed snapshot on devnet and testnet nodes and ran ansible deploy playbook
