### PR TITLE
funder: fix playbook reference in release workflow

### DIFF
--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -18,7 +18,7 @@ jobs:
           - component: controller
             playbook: playbooks/controllers.yml
           - component: funder
-            playbook: playbooks/funder.yml
+            playbook: playbooks/funders.yml
           - component: client
             playbook: playbooks/validators.yml
           - component: device-telemetry-agent

--- a/.github/workflows/release.devnet.funder.yml
+++ b/.github/workflows/release.devnet.funder.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ./.github/workflows/release.daily.yml
     with:
       component: funder
-      playbook: playbooks/funder.yml
+      playbook: playbooks/funders.yml
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary of Changes
- Update playbook reference in release workflow to be `funders.yml` instead of `funder.yml`
- Fixes https://github.com/malbeclabs/doublezero/actions/runs/16472917911/job/46566788069

## Testing Verification
- N/A
