### PR TITLE
payments-tracker: skip failing tests

### DIFF
--- a/smartcontract/doublezero-payment-tracker/src/rewards.rs
+++ b/smartcontract/doublezero-payment-tracker/src/rewards.rs
@@ -188,6 +188,7 @@ mod tests {
 
     #[tokio::test]
     // TODO: can we mock the JITO api
+    #[ignore]
     async fn jito_rewards() {
         let pubkey = "CvSb7wdQAFpHuSpTYTJnX5SYH4hCfQ9VuGnqrKaKwycB";
         let validator_ids: &[String] = &[String::from(pubkey)];
@@ -202,6 +203,7 @@ mod tests {
 
     #[tokio::test]
     // TODO:  use the mock solana calls once these three PRs are done
+    #[ignore]
     async fn get_inflation_rewards_for_validators() {
         let pubkey = "6WgdYhhGE53WrZ7ywJA15hBVkw7CRbQ8yDBBTwmBtAHN";
         let validator_ids: &[String] = &[String::from(pubkey)];


### PR DESCRIPTION
## Summary of Changes
- Update payments tracker rewards tests to be temporarily skipped to unblock CI and PR merges
- These tests are failing consistently in CI: https://github.com/malbeclabs/doublezero/actions/runs/16474126374/job/46570960271
- This code is not in production yet, and was merged with the intention to continue to iterate on it

## Testing Verification
- CI should be 🟢 again
