### PR TITLE
activator: standardize build info

### DIFF
--- a/activator/src/main.rs
+++ b/activator/src/main.rs
@@ -24,7 +24,7 @@ mod utils;
 #[derive(Parser, Debug)]
 #[command(term_width = 0)]
 #[command(name = "DoubleZero Activator")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
 #[command(about = "DoubleZero")]
 struct AppArgs {
     #[arg(long)]
@@ -147,8 +147,19 @@ fn init_logger(log_level: &str) {
 }
 
 fn export_build_info() {
+    let version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let build_commit = option_env!("BUILD_COMMIT").unwrap_or("unknown");
+    let build_date = option_env!("DATE").unwrap_or("unknown");
     let pkg_version = env!("CARGO_PKG_VERSION");
     let program_version = ProgramVersion::current().to_string();
 
-    metrics::gauge!("doublezero_activator_build_info", "pkg_version" => pkg_version, "program_version" => program_version).set(1);
+    metrics::gauge!(
+        "doublezero_activator_build_info",
+        "version" => version,
+        "commit" => build_commit,
+        "date" => build_date,
+        "pkg_version" => pkg_version,
+        "program_version" => program_version
+    )
+    .set(1);
 }

--- a/release/.goreleaser.base.activator.yaml
+++ b/release/.goreleaser.base.activator.yaml
@@ -21,6 +21,9 @@ builds:
       - x86_64-unknown-linux-gnu
     env:
       - RUSTFLAGS=-C linker=x86_64-linux-gnu-gcc
+      - BUILD_VERSION={{.Version}}
+      - BUILD_COMMIT={{.ShortCommit}}
+      - DATE={{.Date}}
 
 archives:
   - id: activator_archive


### PR DESCRIPTION
## Summary of Changes
Activator build info needs some tweaks to accommodate daily builds and additional labels on it's build info metric to match other services, namely `version`, `commit` and `date`.

The version flag reports the `CARGO_PKG_VERSION` which is incorrect when we produce a daily build as we use the next semvar bump. The below version should be reported as a 0.2.3 pre-release build instead of 0.2.2:
```
$ ./target/release/doublezero-activator --version
DoubleZero Activator 0.2.2
```
We now use a `BUILD_VERSION` env var to control the build version and if it isn't set, fall back to `CARGO_PKG_VERSION`.

## Testing Verification
```
$ ./doublezero-activator --version
DoubleZero Activator 0.2.3~git20250723194352.a043e809
```
```
$ curl localhost:9000/metrics
...
# TYPE doublezero_activator_build_info gauge
doublezero_activator_build_info{version="0.2.3~git20250723194352.a043e809",commit="a043e809",date="2025-07-23T19:43:53Z",pkg_version="0.2.2",program_version="0.2.2"} 1
```
