### PR TITLE
Improvement in `connect` command (cleanup and simplification)

### DIFF
--- a/client/doublezero/src/command/disconnect.rs
+++ b/client/doublezero/src/command/disconnect.rs
@@ -40,7 +40,7 @@ pub struct DecommissioningCliCommand {
 
 impl DecommissioningCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
-        let spinner = init_command();
+        let spinner = init_command(4);
         let controller = ServiceControllerImpl::new(None);
 
         // Check that have your id.json
@@ -56,6 +56,7 @@ impl DecommissioningCliCommand {
         // Get public IP
         let (client_ip, _) = look_for_ip(&self.client_ip, &spinner).await?;
 
+        spinner.inc(1);
         spinner.set_message("deleting user account...");
 
         let users = client.list_user(ListUserCommand)?;
@@ -77,6 +78,7 @@ impl DecommissioningCliCommand {
                 None => {}
             }
 
+            spinner.inc(1);
             println!("🔍  Deleting User Account for: {pubkey}");
             let res = client.delete_user(DeleteUserCommand { pubkey: *pubkey });
             match res {
@@ -95,7 +97,8 @@ impl DecommissioningCliCommand {
                 .await;
         }
 
-        spinner.finish_with_message("🔍  Deprovisioning Complete");
+        spinner.println("✅  Deprovisioning Complete");
+        spinner.finish_and_clear();
 
         Ok(())
     }

--- a/client/doublezero/src/command/helpers.rs
+++ b/client/doublezero/src/command/helpers.rs
@@ -12,15 +12,15 @@ pub async fn look_for_ip(
             ip
         }
         None => &{
-            spinner.set_message("Searching for Public IP...");
+            spinner.set_message("Discovering your public IP...");
 
             match get_public_ipv4() {
                 Ok(ip) => {
-                    spinner.println(format!("Public IP: {ip} (If you want to specify a particular address, use the argument --client-ip x.x.x.x)"));
+                    spinner.println(format!("Public IP detected: {ip} - If you want to use a different IP, you can specify it with `--client-ip x.x.x.x`"));
                     ip
                 }
                 Err(e) => {
-                    eyre::bail!("Error getting public ip. Please provide it using the `--client-ip` argument. ({})", e.to_string());
+                    eyre::bail!("Could not detect your public IP. Please provide the `--client-ip` argument. ({})", e.to_string());
                 }
             }
         },

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -4,10 +4,7 @@ use crate::{
     servicecontroller::{ServiceController, ServiceControllerImpl},
 };
 use clap::Args;
-use doublezero_cli::{
-    doublezerocommand::CliCommand,
-    helpers::{init_command, print_error},
-};
+use doublezero_cli::{doublezerocommand::CliCommand, helpers::print_error};
 
 #[derive(Args, Debug)]
 pub struct StatusCliCommand {
@@ -18,20 +15,15 @@ pub struct StatusCliCommand {
 
 impl StatusCliCommand {
     pub async fn execute(self, _client: &dyn CliCommand) -> eyre::Result<()> {
-        let spinner = init_command();
         let controller = ServiceControllerImpl::new(None);
 
         // Check requirements
-        check_doublezero(&controller, Some(&spinner))?;
+        check_doublezero(&controller, None)?;
 
         match controller.status().await {
-            Err(e) => {
-                spinner.finish_and_clear();
-                print_error(e)
-            }
+            Err(e) => print_error(e),
             Ok(status_responses) => {
                 if !status_responses.is_empty() {
-                    spinner.finish_and_clear();
                     util::show_output(status_responses, self.json)?
                 }
             }

--- a/smartcontract/cli/src/helpers.rs
+++ b/smartcontract/cli/src/helpers.rs
@@ -58,13 +58,14 @@ pub fn get_public_ipv4() -> Result<String, Box<dyn std::error::Error>> {
     Err("Failed to extract the IP from the response".into())
 }
 
-pub fn init_command() -> ProgressBar {
-    let spinner = ProgressBar::new_spinner();
+pub fn init_command(len: u64) -> ProgressBar {
+    let spinner = ProgressBar::new(len);
 
     spinner.set_style(
         ProgressStyle::default_spinner()
-            .template("{spinner:.green}  {msg}")
+            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} {msg}")
             .expect("Failed to set template")
+            .progress_chars("#>-")
             .tick_strings(&["-", "\\", "|", "/"]),
     );
     spinner.enable_steady_tick(Duration::from_millis(100));


### PR DESCRIPTION
This pull request refactors the `ProvisioningCliCommand` and `DecommissioningCliCommand` implementations in the `client/doublezero/src/command` module to improve clarity, error handling, and user feedback. Key changes include modifying the `ProgressBar` usage to pass it by reference, enhancing status messages for better user experience, and adding incremental progress updates. Additionally, minor adjustments were made to the test cases for improved readability.

The output has been improved to better reflect the process and ensure that spinner artifacts are cleared from the screen after each task completes.

**Connect IBRL**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
    User account created
    Connected to device: device1 
    The user has been successfully activated
    Service provisioned with status: success
✅  User Provisioned
```
**Connect IBRL with allocate**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
    User account created
    Connected to device: device1 
    The user has been successfully activated
    Service provisioned with status: success
✅  User Provisioned
```
**Connect Multicast Producer**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
    Creating an account for the IP: 1.2.3.4
    The Device has been selected: device1 
    The user has been successfully activated
    Service provisioned with status: success
✅  User Provisioned
```
**Connect Multicast Subscribe**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
    Creating an account for the IP: 1.2.3.4
    The Device has been selected: device1 
    The user has been successfully activated
    Service provisioned with status: success
✅  User Provisioned
```
**Adding a second subscriber fails**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
❌ Multicast user already exists for IP: 1.2.3.4
Multicast supports only one subscription at this time.
Disconnect and connect again!
```
**Adding an IBRL tunnel with an existing multicast fails**
```
DoubleZero Service Provisioning
🔗  Start Provisioning User...
    Using Public IP: 1.2.3.4
🔍  Provisioning User for IP: 1.2.3.4
❌  User with IP 1.2.3.4 already exists with type Multicast. Expected type IBRL. Only one tunnel currently supported.
```

### Improvements to `ProvisioningCliCommand`:

* Changed the `ProgressBar` parameter to be passed by reference instead of by value across all methods for better efficiency. (`[[1]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L116-R115)`, `[[2]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L141-L167)`, `[[3]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L177-R190)`, `[[4]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L231-R227)`)
* Enhanced user feedback by replacing `finish_with_message` calls with `println` for clearer and more consistent status updates, such as error messages and provisioning progress. (`[[1]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184R371-R380)`, `[[2]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L424-R422)`, `[[3]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L434-R436)`, `[[4]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L587-R588)`)
* Improved progress tracking by replacing static prefixes with `spinner.inc()` calls to increment progress dynamically. (`[[1]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L325-R342)`, `[[2]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L453-R450)`, `[[3]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L523-R520)`, `[[4]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L544-R539)`)
* Adjusted error handling to use `eyre::bail!` for early exits, improving readability and consistency. (`[[1]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L127-R136)`, `[[2]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L424-R422)`, `[[3]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L434-R436)`)

### Enhancements to `DecommissioningCliCommand`:

* Updated the `init_command` function to accept a progress step count and added `spinner.inc()` calls to reflect progress during user account deletion. (`[[1]](diffhunk://#diff-e7bdc8c360ff41068fa2fb556325b1d4cc09fcd9409873454a26b6c3e4260b18L43-R43)`, `[[2]](diffhunk://#diff-e7bdc8c360ff41068fa2fb556325b1d4cc09fcd9409873454a26b6c3e4260b18R59)`, `[[3]](diffhunk://#diff-e7bdc8c360ff41068fa2fb556325b1d4cc09fcd9409873454a26b6c3e4260b18R81)`)
* Improved status messages during decommissioning to provide clearer feedback to the user. (`[[1]](diffhunk://#diff-e7bdc8c360ff41068fa2fb556325b1d4cc09fcd9409873454a26b6c3e4260b18R59)`, `[[2]](diffhunk://#diff-e7bdc8c360ff41068fa2fb556325b1d4cc09fcd9409873454a26b6c3e4260b18R81)`)








