### PR TITLE
rust: use workspace version in sub-crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
+version = "0.3.0"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"
@@ -22,7 +23,6 @@ description = "Malbec Labs DoubleZero"
 homepage = "https://github.com/malbeclabs/doublezero"
 license = "Apache-2.0"
 repository = "https://github.com/malbeclabs/doublezero"
-version = "0.3.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/activator/Cargo.toml
+++ b/activator/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "doublezero-activator"
-version = "0.3.0"
-edition = "2021"
+
+# Workspace inherited keys
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 bitvec.workspace = true

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "doublezero"
-version = "0.3.0"
 
 description = "Command line interface to interact with the DZ program."
 
 # Workspace inherited keys
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/controlplane/doublezero-admin/Cargo.toml
+++ b/controlplane/doublezero-admin/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "doublezero-admin"
-version = "0.3.0"
 description = "Command line interface to interact with the DZ program."
 
 # Workspace inherited keys
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/smartcontract/cli/Cargo.toml
+++ b/smartcontract/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "doublezero_cli"
-version = "0.3.0"
 
 # Workspace inherited keys
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/smartcontract/programs/doublezero-serviceability/Cargo.toml
+++ b/smartcontract/programs/doublezero-serviceability/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "doublezero-serviceability"
-version = "0.3.0"
 
 # Workspace inherited keys
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/smartcontract/sdk/rs/Cargo.toml
+++ b/smartcontract/sdk/rs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "doublezero_sdk"
-version = "0.3.0"
 
 # Workspace inherited keys
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary of Changes
- Update all the sub-crates to use `version.workspace = true` instead of inlining versions across them all

## Testing Verification
- N/A
