### PR TITLE
remove allow(deprecated)

### DIFF
--- a/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
+++ b/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use core::fmt;
-#[allow(deprecated)] //TOOD: not sure why this is being triggered
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
@@ -205,7 +204,6 @@ fn realloc_samples_account_if_needed(
         }
 
         // Resize the account to accommodate the expanded data.
-        #[allow(deprecated)] //TOOD: not sure why this is being triggered
         samples_account
             .realloc(new_len, false)
             .expect("Unable to realloc the account");

--- a/smartcontract/sdk/rs/src/config.rs
+++ b/smartcontract/sdk/rs/src/config.rs
@@ -169,7 +169,6 @@ pub fn get_doublezero_pubkey() -> eyre::Result<Keypair> {
         Err(_) => eyre::bail!("Unable to read configured keypair_path"),
         Ok(key_content) => {
             let key_bytes: Vec<u8> = serde_json::from_str(&key_content)?;
-            #[allow(deprecated)] //TOOD: not sure why this is being triggered
             let key = Keypair::from_bytes(&key_bytes)?;
             Ok(key)
         }

--- a/smartcontract/sdk/rs/src/utils.rs
+++ b/smartcontract/sdk/rs/src/utils.rs
@@ -4,7 +4,6 @@ use std::{error::Error, fs, str::FromStr};
 pub fn read_keypair_from_file(file: String) -> eyre::Result<Keypair, Box<dyn Error>> {
     let file_content = fs::read_to_string(file)?;
     let secret_key_bytes: Vec<u8> = serde_json::from_str(&file_content)?;
-    #[allow(deprecated)] //TOOD: not sure why this is being triggered
     let keypair = Keypair::from_bytes(&secret_key_bytes)?;
 
     Ok(keypair)


### PR DESCRIPTION
## Summary of Changes
Forgot to remove `#[allow(deprecated)]` in #939.

## Testing Verification
`make rust-lint` will work.
