### PR TITLE
e2e: deflake metrics checks with wait for ready

### DIFF
--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -254,12 +254,12 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 
 	// Fetch metrics from both devices.
 	la2MetricsClient := dn.Devices["la2-dz01"].GetTelemetryMetricsClient()
+	require.NoError(t, la2MetricsClient.WaitForReady(t.Context(), 3*time.Second))
 	err = la2MetricsClient.Fetch(t.Context())
 	require.NoError(t, err)
-	require.NoError(t, err)
 	ny5MetricsClient := dn.Devices["ny5-dz01"].GetTelemetryMetricsClient()
+	require.NoError(t, ny5MetricsClient.WaitForReady(t.Context(), 3*time.Second))
 	err = ny5MetricsClient.Fetch(t.Context())
-	require.NoError(t, err)
 	require.NoError(t, err)
 
 	// Get the post-reachability "tunnel not found" metric for the la2 device, so we can check that it doesn't increase from here at the end.

--- a/e2e/funder_test.go
+++ b/e2e/funder_test.go
@@ -63,6 +63,7 @@ func TestE2E_Funder(t *testing.T) {
 	// Check that the errors metric only contains "funder_account_balance_below_minimum" errors,
 	// which occur on startup while waiting for the manager/funder account to be funded.
 	metricsClient := dn.Funder.GetMetricsClient()
+	require.NoError(t, metricsClient.WaitForReady(ctx, 3*time.Second))
 	require.NoError(t, metricsClient.Fetch(ctx))
 	errors := metricsClient.GetCounterValues("doublezero_funder_errors_total")
 	require.NotNil(t, errors)

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/malbeclabs/doublezero/e2e/internal/docker"
 	"github.com/malbeclabs/doublezero/e2e/internal/netutil"
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 	"github.com/malbeclabs/doublezero/e2e/internal/solana"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -245,7 +246,7 @@ func (c *Client) setState(ctx context.Context, containerID string) error {
 	var attempts int
 	timeout := 10 * time.Second
 	var container dockercontainer.InspectResponse
-	err = pollUntil(ctx, func() (bool, error) {
+	err = poll.Until(ctx, func() (bool, error) {
 		attempts++
 		var err error
 		container, err = c.dn.dockerClient.ContainerInspect(ctx, containerID)

--- a/e2e/internal/devnet/device.go
+++ b/e2e/internal/devnet/device.go
@@ -22,6 +22,7 @@ import (
 	"github.com/malbeclabs/doublezero/e2e/internal/docker"
 	"github.com/malbeclabs/doublezero/e2e/internal/logging"
 	"github.com/malbeclabs/doublezero/e2e/internal/netutil"
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 	"github.com/malbeclabs/doublezero/e2e/internal/prometheus"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -446,7 +447,7 @@ func (d *Device) setState(ctx context.Context, containerID string) error {
 	timeout := 10 * time.Second
 	var attempts int
 	var container dockercontainer.InspectResponse
-	err = pollUntil(ctx, func() (bool, error) {
+	err = poll.Until(ctx, func() (bool, error) {
 		attempts++
 		var err error
 		container, err = d.dn.dockerClient.ContainerInspect(ctx, containerID)

--- a/e2e/internal/devnet/ledger.go
+++ b/e2e/internal/devnet/ledger.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/e2e/internal/logging"
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 	"github.com/testcontainers/testcontainers-go"
@@ -244,7 +245,7 @@ func waitForSolanaReady(ctx context.Context, log *slog.Logger, rpcHost string, r
 	var loggedWait bool
 	timeout := 20 * time.Second
 	var attempts int
-	err := pollUntil(ctx, func() (bool, error) {
+	err := poll.Until(ctx, func() (bool, error) {
 		attempts++
 		reqBody := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"getHealth"}`)
 		req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("http://%s:%d/", rpcHost, rpcPort), reqBody)

--- a/e2e/internal/devnet/smartcontract_init.go
+++ b/e2e/internal/devnet/smartcontract_init.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/malbeclabs/doublezero/e2e/internal/docker"
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 )
 
 // IsSmartContractInitialized checks if the smart contract is initialized by checking for the presence
@@ -134,7 +135,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 	}
 
 	// Wait for the global config to be populated.
-	err = pollUntil(ctx, func() (bool, error) {
+	err = poll.Until(ctx, func() (bool, error) {
 		data, err := client.GetProgramData(ctx)
 		if err != nil {
 			return false, fmt.Errorf("failed to load serviceability program client: %w", err)

--- a/e2e/internal/poll/until.go
+++ b/e2e/internal/poll/until.go
@@ -1,0 +1,31 @@
+package poll
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func Until(ctx context.Context, condition func() (bool, error), timeout, interval time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		ok, err := condition()
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("polling cancelled or timed out: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/e2e/internal/prometheus/metrics.go
+++ b/e2e/internal/prometheus/metrics.go
@@ -3,7 +3,9 @@ package prometheus
 import (
 	"context"
 	"net/http"
+	"time"
 
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 	prom "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
@@ -28,6 +30,13 @@ func NewMetricsClient(url string) *MetricsClient {
 		url:      url,
 		families: make(map[string]*prom.MetricFamily),
 	}
+}
+
+func (m *MetricsClient) WaitForReady(ctx context.Context, timeout time.Duration) error {
+	return poll.Until(ctx, func() (bool, error) {
+		err := m.Fetch(ctx)
+		return err == nil, err
+	}, timeout, 500*time.Millisecond)
 }
 
 func (m *MetricsClient) Fetch(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.37.2
 	github.com/alitto/pond/v2 v2.5.0
 	github.com/aristanetworks/goeapi v1.0.1-0.20250411124937-7090068b8735
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/docker v28.3.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/gagliardetto/binary v0.8.0
@@ -61,6 +60,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect


### PR DESCRIPTION
## Summary of Changes
- Update e2e tests that query `/metrics` with a wait for ready mechanism to deflake an intermittent failure that happens when the query races the prom server being ready
- Fixes https://github.com/malbeclabs/doublezero/issues/952
- We've seen this happen in CI a couple times, and I was able to reproduce locally by running the tests in a loop for a few hours until I hit it: https://github.com/malbeclabs/doublezero/actions/runs/16531345151/job/46757224771
- Extract the `pollUntil` method into a package as `poll.Until`

## Testing Verification
- Ran test in a loop for hours in the background without error
