### PR TITLE
e2e: multicast monitor

### DIFF
--- a/e2e/cmd/mmonitor/main.go
+++ b/e2e/cmd/mmonitor/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/malbeclabs/doublezero/e2e/internal/netutil"
+)
+
+type groupPortPairs []string
+
+func (g *groupPortPairs) String() string {
+	return strings.Join(*g, ", ")
+}
+
+func (g *groupPortPairs) Set(value string) error {
+	*g = append(*g, value)
+	return nil
+}
+
+var (
+	groups groupPortPairs
+	ifName = flag.String("interface", "doublezero1", "Network interface to use for multicast")
+)
+
+func main() {
+	flag.Var(&groups, "group", "Multicast group and port to join in group:port format. Can be specified multiple times.")
+	flag.Parse()
+
+	if len(groups) == 0 {
+		log.Fatal("Please specify at least one multicast group using -group <ip:port>")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+
+	listener := netutil.NewMulticastListener()
+	for _, group := range groups {
+		host, port, err := net.SplitHostPort(group)
+		if err != nil {
+			log.Fatalf("Invalid group format: %s, expected <ip:port>", group)
+		}
+		groupIP := net.ParseIP(host)
+		if groupIP == nil {
+			log.Fatalf("Invalid group IP address: %s", host)
+		}
+
+		log.Printf("Joining multicast group %s:%s on interface %s", groupIP, port, *ifName)
+		if err := listener.JoinGroup(ctx, groupIP, port, *ifName); err != nil {
+			log.Fatalf("Failed to join multicast group %s: %v", group, err)
+		}
+	}
+
+	<-ctx.Done()
+	log.Println("Shutting down...")
+	stop()
+	listener.Stop()
+}

--- a/e2e/internal/netutil/multicast.go
+++ b/e2e/internal/netutil/multicast.go
@@ -1,0 +1,121 @@
+package netutil
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"syscall"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/sys/unix"
+)
+
+const maxUdpPayload = 1500
+
+// MulticastListener is a simple multicast monitoring utility that allows
+// joining multicast groups and recording per-group statistics.
+type MulticastListener struct {
+	mu           sync.RWMutex
+	packetCounts map[string]uint64
+	wg           sync.WaitGroup
+}
+
+func NewMulticastListener() *MulticastListener {
+	return &MulticastListener{
+		packetCounts: make(map[string]uint64),
+	}
+}
+
+func (m *MulticastListener) GetStatistics(group net.IP) uint64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.packetCounts[group.String()]
+}
+
+func (m *MulticastListener) JoinGroup(ctx context.Context, group net.IP, port string, ifName string) error {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("failed to get network interfaces: %v", err)
+	}
+
+	var i *net.Interface
+	for _, iface := range ifaces {
+		if iface.Name == ifName {
+			i = &iface
+			break
+		}
+	}
+	if i == nil {
+		return fmt.Errorf("interface %s not found", ifName)
+	}
+
+	// We need to set the IP_MULTICAST_ALL option to 0 to prevent the kernel from
+	// sending multicast packets from all system-wide subscribed groups to all multicast
+	// listening sockets. See https://man7.org/linux/man-pages/man7/ip.7.html.
+	var lc net.ListenConfig
+	lc.Control = func(network, address string, c syscall.RawConn) error {
+		var opErr error
+		err := c.Control(func(fd uintptr) {
+			opErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_MULTICAST_ALL, 0)
+			if opErr != nil {
+				return
+			}
+		})
+		if err != nil {
+			return err
+		}
+		return opErr
+	}
+
+	addr := net.JoinHostPort(group.String(), port)
+	c, err := lc.ListenPacket(ctx, "udp4", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %v", addr, err)
+	}
+	p := ipv4.NewPacketConn(c)
+
+	if err := p.JoinGroup(i, &net.UDPAddr{IP: group}); err != nil {
+		p.Close()
+		return fmt.Errorf("failed to join multicast group %s: %v", group, err)
+	}
+	if err := p.SetControlMessage(ipv4.FlagDst, true); err != nil {
+		p.Close()
+		return fmt.Errorf("failed to set control message: %v", err)
+	}
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		<-ctx.Done()
+		p.Close()
+	}()
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		buf := make([]byte, maxUdpPayload)
+		for {
+			n, cm, src, err := p.ReadFrom(buf)
+			if err != nil {
+				if ctx.Err() != nil {
+					log.Printf("Shutting down multicast listener for group %s on %s.", group.String(), ifName)
+					return
+				}
+				log.Printf("Failed to read from connection for group %s on %s: %v", group.String(), ifName, err)
+				return
+			}
+			m.mu.Lock()
+			m.packetCounts[cm.Dst.String()]++
+			count := m.packetCounts[cm.Dst.String()]
+			m.mu.Unlock()
+			log.Printf("Received %d bytes for group %s from src %s (total: %d)", n, cm.Dst, src, count)
+		}
+	}()
+	return nil
+}
+
+func (m *MulticastListener) Stop() {
+	m.wg.Wait()
+}


### PR DESCRIPTION
## Summary of Changes
This adds a small multicast listening service that allows for subscribing to multiple multicast groups and simply counts received packets per group. We need to validate multicast publishing/subscribing in devnet for QA purposes so this is some initial validation plumbing.

## Testing Verification

Start listening server:
```
root ➜ .../doublezero/e2e/cmd/mmonitor (feature/mmonitor) $ go run main.go -group 239.0.0.1:12345 -group 239.0.0.2:12345  -interface eth0
2025/07/29 02:14:50 Joining multicast group 239.0.0.1:12345 on interface eth0
2025/07/29 02:14:50 Joining multicast group 239.0.0.2:12345 on interface eth0
```
Send packets to each group:
```
root@b81cfc77f3fa:/# nc -u 239.0.0.1 12345
asdasdasd
asd
...
root@b81cfc77f3fa:/# nc -u 239.0.0.2 12345
asd
asdasdasd
```

Per-group counters count them:
```
2025/07/29 02:14:57 Received 10 bytes for group 239.0.0.1 from src 172.16.0.5:58101 (total: 1)
2025/07/29 02:14:59 Received 4 bytes for group 239.0.0.1 from src 172.16.0.5:58101 (total: 2)
2025/07/29 02:15:09 Received 4 bytes for group 239.0.0.2 from src 172.16.0.5:55182 (total: 1)
2025/07/29 02:15:13 Received 10 bytes for group 239.0.0.2 from src 172.16.0.5:55182 (total: 2)
^C2025/07/29 02:15:16 Shutting down...
2025/07/29 02:15:16 Shutting down multicast listener for group 239.0.0.2 on eth0.
2025/07/29 02:15:16 Shutting down multicast listener for group 239.0.0.1 on eth0.
```