### PR TITLE
e2e: add build linux constraint to multicast tool

### DIFF
--- a/e2e/internal/netutil/multicast.go
+++ b/e2e/internal/netutil/multicast.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package netutil
 
 import (


### PR DESCRIPTION
## Summary of Changes
- Add `go:build linux` constraint to multicast tool so we can still run e2e tests on mac outside of the devcontainer. Otherwise this happens:
   ```
   # github.com/malbeclabs/doublezero/e2e/internal/netutil
   internal/netutil/multicast.go:61:62: undefined: unix.IP_MULTICAST_ALL
   FAIL	github.com/malbeclabs/doublezero/e2e [build failed]
   ```

## Testing Verification
- E2E tests run on mac outside of devcontainer
