### PR TITLE
internet-latency: env-specific serviceability locations

### DIFF
--- a/controlplane/internet-latency-collector/internal/collector/location.go
+++ b/controlplane/internet-latency-collector/internal/collector/location.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"sort"
 
-	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
@@ -104,22 +103,12 @@ func CalculateDistanceToLocation(sourceLat, sourceLng float64, targetLocation Lo
 	return DistanceResult{Distance: distance, Valid: true}
 }
 
-func GetLocations(ctx context.Context, logger *slog.Logger) []LocationMatch {
+type ServiceabilityClient interface {
+	GetProgramData(ctx context.Context) (*serviceability.ProgramData, error)
+}
 
-	rpcEndpoint := dzsdk.DZ_LEDGER_RPC_URL
-	programId := serviceability.SERVICEABILITY_PROGRAM_ID_TESTNET
-
-	options := []dzsdk.Option{
-		dzsdk.WithServiceabilityProgramID(programId),
-	}
-
-	client, err := dzsdk.New(logger, rpcEndpoint, options...)
-	if err != nil {
-		logger.Error("Error creating SDK client", slog.String("error", err.Error()))
-		return []LocationMatch{}
-	}
-
-	data, err := client.Serviceability.GetProgramData(ctx)
+func GetLocations(ctx context.Context, logger *slog.Logger, serviceabilityClient ServiceabilityClient) []LocationMatch {
+	data, err := serviceabilityClient.GetProgramData(ctx)
 	if err != nil {
 		logger.Error("Error loading program data", slog.String("error", err.Error()))
 		return []LocationMatch{}

--- a/controlplane/internet-latency-collector/internal/collector/location_test.go
+++ b/controlplane/internet-latency-collector/internal/collector/location_test.go
@@ -740,7 +740,7 @@ func TestInternetLatency_Location_GetLocations(t *testing.T) {
 	// we can only test that it doesn't panic and returns a slice
 	t.Run("Returns locations array without panic", func(t *testing.T) {
 		ctx := t.Context()
-		locations := GetLocations(ctx, log)
+		locations := GetLocations(ctx, log, &mockServiceabilityClient{})
 
 		// Should return a slice (may be empty depending on blockchain state)
 		require.NotNil(t, locations, "GetLocations() should return non-nil slice")

--- a/controlplane/internet-latency-collector/internal/collector/main_test.go
+++ b/controlplane/internet-latency-collector/internal/collector/main_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"flag"
 	"log/slog"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lmittmann/tint"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
 var (
@@ -33,4 +35,15 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+type mockServiceabilityClient struct {
+	GetProgramDataFunc func(ctx context.Context) (*serviceability.ProgramData, error)
+}
+
+func (m *mockServiceabilityClient) GetProgramData(ctx context.Context) (*serviceability.ProgramData, error) {
+	if m.GetProgramDataFunc == nil {
+		return &serviceability.ProgramData{}, nil
+	}
+	return m.GetProgramDataFunc(ctx)
 }

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -54,9 +54,10 @@ type MeasurementInfo struct {
 }
 
 type Collector struct {
-	client   clientInterface
-	log      *slog.Logger
-	exporter exporter.Exporter
+	client           clientInterface
+	log              *slog.Logger
+	exporter         exporter.Exporter
+	getLocationsFunc func(ctx context.Context) []collector.LocationMatch
 }
 
 type MeasurementSpec struct {
@@ -68,11 +69,12 @@ type MeasurementSpec struct {
 	TargetProbe        Probe
 }
 
-func NewCollector(logger *slog.Logger, exporter exporter.Exporter) *Collector {
+func NewCollector(logger *slog.Logger, exporter exporter.Exporter, getLocationsFunc func(ctx context.Context) []collector.LocationMatch) *Collector {
 	return &Collector{
-		client:   NewClient(logger),
-		log:      logger,
-		exporter: exporter,
+		client:           NewClient(logger),
+		log:              logger,
+		exporter:         exporter,
+		getLocationsFunc: getLocationsFunc,
 	}
 }
 
@@ -482,7 +484,7 @@ func (c *Collector) exportSingleMeasurementResults(ctx context.Context, measurem
 func (c *Collector) RunRipeAtlasMeasurementCreation(ctx context.Context, dryRun bool, probesPerLocation int, outputDir string, stateDir string) error {
 	c.log.Info("Running RIPE Atlas measurement creation")
 
-	locations := collector.GetLocations(ctx, c.log)
+	locations := c.getLocationsFunc(ctx)
 	if len(locations) == 0 {
 		c.log.Warn("No locations found for RIPE Atlas measurements")
 		return collector.ErrNoDevicesFound

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
@@ -232,7 +232,9 @@ func TestInternetLatency_RIPEAtlas_NewCollector(t *testing.T) {
 
 	log := logger.With("test", t.Name())
 
-	c := NewCollector(log, nil)
+	c := NewCollector(log, nil, func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	})
 
 	require.NotNil(t, c, "NewCollector should return a non-nil collector")
 	require.NotNil(t, c.client, "Client should be initialized")
@@ -243,7 +245,9 @@ func TestInternetLatency_RIPEAtlas_ParseLatencyFromResult(t *testing.T) {
 
 	log := logger.With("test", t.Name())
 
-	c := NewCollector(log, nil)
+	c := NewCollector(log, nil, func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	})
 
 	// Valid ping result
 	timestamp := time.Unix(1609459200, 0).UTC()
@@ -577,7 +581,9 @@ func TestInternetLatency_RIPEAtlas_ListAtlasProbes_NoDevices(t *testing.T) {
 
 	log := logger.With("test", t.Name())
 
-	c := NewCollector(log, nil)
+	c := NewCollector(log, nil, func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	})
 
 	err := c.ListAtlasProbes(t.Context(), []collector.LocationMatch{})
 
@@ -589,7 +595,9 @@ func TestInternetLatency_RIPEAtlas_GenerateWantedMeasurements_Deterministic(t *t
 
 	log := logger.With("test", t.Name())
 
-	c := NewCollector(log, nil)
+	c := NewCollector(log, nil, func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	})
 
 	// Create test locations with probes in non-alphabetical order
 	locations := []LocationProbeMatch{
@@ -724,7 +732,9 @@ func TestInternetLatency_RIPEAtlas_RunRipeAtlasMeasurementCreation(t *testing.T)
 		},
 	}
 
-	c := &Collector{client: mockClient, log: log}
+	c := &Collector{client: mockClient, log: log, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	}}
 
 	// Use a context with timeout
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
@@ -781,7 +791,9 @@ func TestInternetLatency_RIPEAtlas_ConfigureMeasurements_CreateNew(t *testing.T)
 		},
 	}
 
-	c := &Collector{client: mockClient, log: log}
+	c := &Collector{client: mockClient, log: log, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	}}
 
 	// Locations with probes that should trigger measurement creation
 	locationMatches := []LocationProbeMatch{
@@ -897,7 +909,9 @@ func TestInternetLatency_RIPEAtlas_ConfigureMeasurements_RemoveUnwanted(t *testi
 
 	e, err := exporter.NewCSVExporter(log, "ripe_atlas_measurements", outputDir)
 	require.NoError(t, err)
-	c := &Collector{client: mockClient, log: log, exporter: e}
+	c := &Collector{client: mockClient, log: log, exporter: e, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	}}
 
 	// Empty location matches means all existing measurements should be removed
 	err = c.configureMeasurements(t.Context(), []LocationProbeMatch{}, false, 1, outputDir, stateDir)
@@ -935,7 +949,9 @@ func TestInternetLatency_RIPEAtlas_Run_ErrorHandling(t *testing.T) {
 
 		e, err := exporter.NewCSVExporter(log, "ripe_atlas_measurements", t.TempDir())
 		require.NoError(t, err)
-		c := &Collector{client: mockClient, log: log, exporter: e}
+		c := &Collector{client: mockClient, log: log, exporter: e, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+			return []collector.LocationMatch{}
+		}}
 
 		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
@@ -958,7 +974,9 @@ func TestInternetLatency_RIPEAtlas_Run_ErrorHandling(t *testing.T) {
 
 		e, err := exporter.NewCSVExporter(log, "ripe_atlas_measurements", t.TempDir())
 		require.NoError(t, err)
-		c := &Collector{client: mockClient, log: log, exporter: e}
+		c := &Collector{client: mockClient, log: log, exporter: e, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+			return []collector.LocationMatch{}
+		}}
 
 		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
@@ -1048,7 +1066,9 @@ func TestInternetLatency_RIPEAtlas_Run(t *testing.T) {
 
 	e, err := exporter.NewCSVExporter(log, "ripe_atlas_measurements", outputDir)
 	require.NoError(t, err)
-	c := &Collector{client: mockClient, log: log, exporter: e}
+	c := &Collector{client: mockClient, log: log, exporter: e, getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+		return []collector.LocationMatch{}
+	}}
 
 	// Use different intervals to verify both run independently
 	measurementInterval := 50 * time.Millisecond


### PR DESCRIPTION
## Summary of Changes
- Update internet latency collector to get locations from serviceability based on devnet vs testnet env, where previously it was always getting locations from the testnet serviceability program
- Add `env` flag to `main.go` that makes use of `config.NetworkConfigForEnv` similar to other components
- Related to https://github.com/malbeclabs/doublezero/issues/836 and https://github.com/malbeclabs/doublezero/issues/972

## Testing Verification
- Updated existing test coverage to match the changes
