### PR TITLE
feat(contributor): add owner field to Create and Update Contributor commands

### DIFF
--- a/e2e/internal/devnet/smartcontract_init.go
+++ b/e2e/internal/devnet/smartcontract_init.go
@@ -120,7 +120,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 		doublezero exchange list
 
 		echo "==> Populating contributor information onchain"
-		doublezero contributor create --code co01
+		doublezero contributor create --code co01 --owner me
 
 		echo "--> Smart contract initialized"
 

--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -31,6 +31,8 @@ pub enum DoubleZeroError {
     InvalidInterfaceName, // variant 12
     #[error("Reference Count is not zero")]
     ReferenceCountNotZero, // variant 13
+    #[error("Invalid Contributor")]
+    InvalidContributor, // variant 14
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -50,6 +52,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidInterfaceVersion => ProgramError::Custom(11),
             DoubleZeroError::InvalidInterfaceName => ProgramError::Custom(12),
             DoubleZeroError::ReferenceCountNotZero => ProgramError::Custom(13),
+            DoubleZeroError::InvalidContributor => ProgramError::Custom(14),
         }
     }
 }
@@ -71,6 +74,7 @@ impl From<ProgramError> for DoubleZeroError {
                 11 => DoubleZeroError::InvalidInterfaceVersion,
                 12 => DoubleZeroError::InvalidInterfaceName,
                 13 => DoubleZeroError::ReferenceCountNotZero,
+                14 => DoubleZeroError::InvalidContributor,
 
                 _ => DoubleZeroError::Custom(e),
             },

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -807,12 +807,14 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
                 code: "test".to_string(),
+                owner: Pubkey::new_unique(),
             }),
             "CreateContributor",
         );
         test_instruction(
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: Some("test".to_string()),
+                owner: Some(Pubkey::new_unique()),
             }),
             "UpdateContributor",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
@@ -20,11 +20,12 @@ use solana_program::msg;
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct ContributorCreateArgs {
     pub code: String,
+    pub owner: Pubkey,
 }
 
 impl fmt::Debug for ContributorCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "code: {}", self.code)
+        write!(f, "code: {}, owner: {}", self.code, self.owner)
     }
 }
 
@@ -75,7 +76,7 @@ pub fn process_create_contributor(
 
     let contributor = Contributor {
         account_type: AccountType::Contributor,
-        owner: *payer_account.key,
+        owner: value.owner,
         index: globalstate.account_index,
         reference_count: 0,
         bump_seed,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
@@ -13,11 +13,12 @@ use std::fmt;
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
 pub struct ContributorUpdateArgs {
     pub code: Option<String>,
+    pub owner: Option<Pubkey>,
 }
 
 impl fmt::Debug for ContributorUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "code: {:?}", self.code)
+        write!(f, "code: {:?}, owner: {:?}", self.code, self.owner)
     }
 }
 
@@ -65,6 +66,9 @@ pub fn process_update_contributor(
 
     if let Some(ref code) = value.code {
         contributor.code = code.clone();
+    }
+    if let Some(ref owner) = value.owner {
+        contributor.owner = *owner;
     }
 
     account_write(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -109,22 +109,15 @@ pub fn process_create_device(
         "Invalid Device PubKey"
     );
     let mut contributor = Contributor::try_from(contributor_account)?;
-    if contributor.account_type != AccountType::Contributor {
-        return Err(DoubleZeroError::InvalidContributorPubkey.into());
-    }
+    assert_eq!(contributor.account_type, AccountType::Contributor);
     if contributor.owner != *payer_account.key {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
     let mut location = Location::try_from(location_account)?;
-    if location.account_type != AccountType::Location {
-        return Err(DoubleZeroError::InvalidLocationPubkey.into());
-    }
-
+    assert_eq!(location.account_type, AccountType::Location);
     let mut exchange = Exchange::try_from(exchange_account)?;
-    if exchange.account_type != AccountType::Exchange {
-        return Err(DoubleZeroError::InvalidExchangePubkey.into());
-    }
+    assert_eq!(exchange.account_type, AccountType::Exchange);
 
     contributor.reference_count += 1;
     location.reference_count += 1;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -81,7 +81,6 @@ pub fn process_create_link(
         return Err(ProgramError::UninitializedAccount);
     }
     let globalstate = globalstate_get_next(globalstate_account)?;
-
     if !globalstate.device_allowlist.contains(payer_account.key) {
         return Err(DoubleZeroError::NotAllowed.into());
     }
@@ -94,10 +93,21 @@ pub fn process_create_link(
 
     let mut contributor = Contributor::try_from(contributor_account)?;
     assert_eq!(contributor.account_type, AccountType::Contributor);
+    if contributor.owner != *payer_account.key {
+        return Err(DoubleZeroError::InvalidOwnerPubkey.into());
+    }
+
     let mut side_a_dev = Device::try_from(side_a_account)?;
     assert_eq!(side_a_dev.account_type, AccountType::Device);
+    if side_a_dev.contributor_pk != *contributor_account.key {
+        return Err(DoubleZeroError::InvalidContributor.into());
+    }
+
     let mut side_z_dev = Device::try_from(side_z_account)?;
     assert_eq!(side_z_dev.account_type, AccountType::Device);
+    if side_z_dev.contributor_pk != *contributor_account.key {
+        return Err(DoubleZeroError::InvalidContributor.into());
+    }
 
     if !side_a_dev
         .interfaces

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -60,6 +60,7 @@ async fn test_contributor() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "la".to_string(),
+            owner: Pubkey::new_unique(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
@@ -135,6 +136,7 @@ async fn test_contributor() {
         program_id,
         DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
             code: Some("la2".to_string()),
+            owner: Some(Pubkey::new_unique()),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -12,7 +12,9 @@ use doublezero_serviceability::{
 };
 use globalconfig::set::SetGlobalConfigArgs;
 use solana_program_test::*;
-use solana_sdk::{hash::Hash, instruction::AccountMeta, pubkey::Pubkey, signature::Keypair};
+use solana_sdk::{
+    hash::Hash, instruction::AccountMeta, pubkey::Pubkey, signature::Keypair, signer::Signer,
+};
 
 mod test_helpers;
 use test_helpers::*;
@@ -137,6 +139,7 @@ async fn test_device() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
+            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
@@ -620,6 +623,7 @@ async fn setup_program_with_location_and_exchange(
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
+            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
@@ -265,6 +265,7 @@ async fn test_doublezero_program() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
+            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/link_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_test.rs
@@ -17,7 +17,7 @@ use doublezero_serviceability::{
 use globalconfig::set::SetGlobalConfigArgs;
 use link::closeaccount::LinkCloseAccountArgs;
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
 
 mod test_helpers;
 use test_helpers::*;
@@ -143,6 +143,7 @@ async fn test_link() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
+            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -16,7 +16,7 @@ use doublezero_serviceability::{
 };
 use globalconfig::set::SetGlobalConfigArgs;
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
 use user::closeaccount::UserCloseAccountArgs;
 
 mod test_helpers;
@@ -143,6 +143,7 @@ async fn test_user() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
+            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),

--- a/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
@@ -596,6 +596,13 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_owner() {
 #[tokio::test]
 async fn test_initialize_device_latency_samples_fail_origin_device_not_activated() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     let location_pk = ledger
         .serviceability
@@ -622,7 +629,7 @@ async fn test_initialize_device_latency_samples_fail_origin_device_not_activated
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
 
@@ -721,6 +728,13 @@ async fn test_initialize_device_latency_samples_fail_origin_device_not_activated
 #[tokio::test]
 async fn test_initialize_device_latency_samples_fail_target_device_not_activated() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     let location_pk = ledger
         .serviceability
@@ -753,7 +767,7 @@ async fn test_initialize_device_latency_samples_fail_target_device_not_activated
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
 
@@ -846,6 +860,13 @@ async fn test_initialize_device_latency_samples_fail_target_device_not_activated
 #[tokio::test]
 async fn test_initialize_device_latency_samples_fail_link_not_activated() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     let location_pk = ledger
         .serviceability
@@ -878,7 +899,7 @@ async fn test_initialize_device_latency_samples_fail_link_not_activated() {
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
 
@@ -967,6 +988,13 @@ async fn test_initialize_device_latency_samples_fail_link_not_activated() {
 #[tokio::test]
 async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     let location_pk = ledger
         .serviceability
@@ -999,7 +1027,7 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
     // Origin device and target device: activated
@@ -1135,6 +1163,13 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_devices() {
 #[tokio::test]
 async fn test_initialize_device_latency_samples_succeeds_with_reversed_link_sides() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     let location_pk = ledger
         .serviceability
@@ -1167,7 +1202,7 @@ async fn test_initialize_device_latency_samples_succeeds_with_reversed_link_side
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
 
@@ -1386,6 +1421,13 @@ async fn test_initialize_device_latency_samples_fail_same_origin_device_and_targ
 #[tokio::test]
 async fn test_initialize_device_latency_samples_fail_agent_not_owner_of_origin_device() {
     let mut ledger = LedgerHelper::new().await.unwrap();
+    let payer = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
 
     // Create agent that owns origin device
     let owner_agent = Keypair::new();
@@ -1426,7 +1468,7 @@ async fn test_initialize_device_latency_samples_fail_agent_not_owner_of_origin_d
 
     let contributor_pk = ledger
         .serviceability
-        .create_contributor("CONTRIB".to_string())
+        .create_contributor("CONTRIB".to_string(), payer)
         .await
         .unwrap();
 

--- a/smartcontract/sdk/rs/src/commands/contributor/create.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/create.rs
@@ -8,6 +8,7 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 #[derive(Debug, PartialEq, Clone)]
 pub struct CreateContributorCommand {
     pub code: String,
+    pub owner: Pubkey,
 }
 
 impl CreateContributorCommand {
@@ -22,6 +23,7 @@ impl CreateContributorCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
                     code: self.code.clone(),
+                    owner: self.owner,
                 }),
                 vec![
                     AccountMeta::new(pda_pubkey, false),
@@ -44,7 +46,7 @@ mod tests {
         processors::contributor::create::ContributorCreateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature};
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
     fn test_commands_contributor_create_command() {
@@ -59,6 +61,7 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::CreateContributor(
                     ContributorCreateArgs {
                         code: "test".to_string(),
+                        owner: Pubkey::default(),
                     },
                 )),
                 predicate::eq(vec![
@@ -70,6 +73,7 @@ mod tests {
 
         let res = CreateContributorCommand {
             code: "test".to_string(),
+            owner: Pubkey::default(),
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/contributor/update.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/update.rs
@@ -8,6 +8,7 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 pub struct UpdateContributorCommand {
     pub pubkey: Pubkey,
     pub code: Option<String>,
+    pub owner: Option<Pubkey>,
 }
 
 impl UpdateContributorCommand {
@@ -19,6 +20,7 @@ impl UpdateContributorCommand {
         client.execute_transaction(
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: self.code.to_owned(),
+                owner: self.owner.to_owned(),
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -40,7 +42,7 @@ mod tests {
         processors::contributor::update::ContributorUpdateArgs,
     };
     use mockall::predicate;
-    use solana_sdk::{instruction::AccountMeta, signature::Signature};
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
     fn test_commands_contributor_update_command() {
@@ -55,6 +57,7 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::UpdateContributor(
                     ContributorUpdateArgs {
                         code: Some("test".to_string()),
+                        owner: Some(Pubkey::default()),
                     },
                 )),
                 predicate::eq(vec![
@@ -67,6 +70,7 @@ mod tests {
         let res = UpdateContributorCommand {
             pubkey: pda_pubkey,
             code: Some("test".to_string()),
+            owner: Some(Pubkey::default()),
         }
         .execute(&client);
 


### PR DESCRIPTION
## Summary of Changes
- The owner parameter is added to the contributor creation instruction.
- The SDK and CLI are updated accordingly.
- Validation checks are added to ensure that both the device and the link belong to the same contributor.

## Testing Verification
* Show evidence of testing the change
