### PR TITLE
sdk/go: device telemetry samples v0-v1 compatibility

### DIFF
--- a/smartcontract/sdk/go/telemetry/state.go
+++ b/smartcontract/sdk/go/telemetry/state.go
@@ -17,6 +17,27 @@ const (
 	AccountTypeInternetLatencySamples
 )
 
+type DeviceLatencySamplesHeaderOnlyAccountType struct {
+	AccountType AccountType // 1
+}
+
+func (d *DeviceLatencySamplesHeaderOnlyAccountType) Serialize(w io.Writer) error {
+	enc := bin.NewBorshEncoder(w)
+	if err := enc.Encode(d.AccountType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DeviceLatencySamplesHeaderOnlyAccountType) Deserialize(data []byte) error {
+	dec := bin.NewBorshDecoder(data)
+	if err := dec.Decode(&d.AccountType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type DeviceLatencySamplesHeader struct {
 	// Used to distinguish this account type during deserialization
 	AccountType AccountType // 1

--- a/smartcontract/sdk/go/telemetry/state_v0.go
+++ b/smartcontract/sdk/go/telemetry/state_v0.go
@@ -1,0 +1,108 @@
+package telemetry
+
+import (
+	"fmt"
+	"io"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+type DeviceLatencySamplesHeaderV0 struct {
+	// Used to distinguish this account type during deserialization
+	AccountType AccountType // 1
+
+	// Required for recreating the PDA (seed authority)
+	BumpSeed uint8 // 1
+
+	// Epoch number in which samples were collected
+	Epoch uint64 // 8
+
+	// Agent authorized to write RTT samples (must match signer)
+	OriginDeviceAgentPK solana.PublicKey // 32
+
+	// Device initiating sampling
+	OriginDevicePK solana.PublicKey // 32
+
+	// Destination device in RTT path
+	TargetDevicePK solana.PublicKey // 32
+
+	// Cached location of origin device for query/UI optimization
+	OriginDeviceLocationPK solana.PublicKey // 32
+
+	// Cached location of target device
+	TargetDeviceLocationPK solana.PublicKey // 32
+
+	// Link over which the RTT samples were taken
+	LinkPK solana.PublicKey // 32
+
+	// Sampling interval configured by the agent (in microseconds)
+	SamplingIntervalMicroseconds uint64 // 8
+
+	// Timestamp of the first written sample (µs since UNIX epoch).
+	// Set on the first write, remains unchanged after.
+	StartTimestampMicroseconds uint64 // 8
+
+	// Tracks how many samples have been appended.
+	NextSampleIndex uint32 // 4
+
+	// Reserved for future use.
+	Unused [128]uint8 // 128
+}
+
+type DeviceLatencySamplesV0 struct {
+	DeviceLatencySamplesHeaderV0
+	Samples []uint32 // 4 + n*4 (RTT values in microseconds)
+}
+
+func (d *DeviceLatencySamplesV0) Serialize(w io.Writer) error {
+	enc := bin.NewBorshEncoder(w)
+	if err := enc.Encode(d.DeviceLatencySamplesHeaderV0); err != nil {
+		return err
+	}
+	for _, sample := range d.Samples {
+		if err := enc.Encode(sample); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DeviceLatencySamplesV0) Deserialize(data []byte) error {
+	dec := bin.NewBorshDecoder(data)
+	if err := dec.Decode(&d.DeviceLatencySamplesHeaderV0); err != nil {
+		return err
+	}
+
+	if d.DeviceLatencySamplesHeaderV0.NextSampleIndex > MaxDeviceLatencySamplesPerAccount {
+		return fmt.Errorf("next sample index %d exceeds max allowed samples %d", d.DeviceLatencySamplesHeaderV0.NextSampleIndex, MaxDeviceLatencySamplesPerAccount)
+	}
+
+	d.Samples = make([]uint32, d.DeviceLatencySamplesHeaderV0.NextSampleIndex)
+	for i := 0; i < int(d.DeviceLatencySamplesHeaderV0.NextSampleIndex); i++ {
+		if err := dec.Decode(&d.Samples[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DeviceLatencySamplesV0) ToV1() *DeviceLatencySamples {
+	return &DeviceLatencySamples{
+		DeviceLatencySamplesHeader: DeviceLatencySamplesHeader{
+			AccountType:                  AccountTypeDeviceLatencySamples,
+			Epoch:                        d.DeviceLatencySamplesHeaderV0.Epoch,
+			OriginDeviceAgentPK:          d.DeviceLatencySamplesHeaderV0.OriginDeviceAgentPK,
+			OriginDevicePK:               d.DeviceLatencySamplesHeaderV0.OriginDevicePK,
+			TargetDevicePK:               d.DeviceLatencySamplesHeaderV0.TargetDevicePK,
+			OriginDeviceLocationPK:       d.DeviceLatencySamplesHeaderV0.OriginDeviceLocationPK,
+			TargetDeviceLocationPK:       d.DeviceLatencySamplesHeaderV0.TargetDeviceLocationPK,
+			LinkPK:                       d.DeviceLatencySamplesHeaderV0.LinkPK,
+			SamplingIntervalMicroseconds: d.DeviceLatencySamplesHeaderV0.SamplingIntervalMicroseconds,
+			StartTimestampMicroseconds:   d.DeviceLatencySamplesHeaderV0.StartTimestampMicroseconds,
+			NextSampleIndex:              d.DeviceLatencySamplesHeaderV0.NextSampleIndex,
+			Unused:                       d.DeviceLatencySamplesHeaderV0.Unused,
+		},
+		Samples: d.Samples,
+	}
+}

--- a/smartcontract/sdk/go/telemetry/state_v0_test.go
+++ b/smartcontract/sdk/go/telemetry/state_v0_test.go
@@ -1,0 +1,153 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDK_Telemetry_State_DeviceLatencySamplesV0(t *testing.T) {
+	t.Run("round-trip serialize/deserialize with samples", func(t *testing.T) {
+		origin := solana.NewWallet().PublicKey()
+		target := solana.NewWallet().PublicKey()
+		loc1 := solana.NewWallet().PublicKey()
+		loc2 := solana.NewWallet().PublicKey()
+		link := solana.NewWallet().PublicKey()
+
+		original := &DeviceLatencySamplesV0{
+			DeviceLatencySamplesHeaderV0: DeviceLatencySamplesHeaderV0{
+				AccountType:                  AccountTypeDeviceLatencySamplesV0,
+				Epoch:                        42,
+				OriginDeviceAgentPK:          origin,
+				OriginDevicePK:               origin,
+				TargetDevicePK:               target,
+				OriginDeviceLocationPK:       loc1,
+				TargetDeviceLocationPK:       loc2,
+				LinkPK:                       link,
+				SamplingIntervalMicroseconds: 250_000,
+				StartTimestampMicroseconds:   1_625_000_000,
+				NextSampleIndex:              5,
+				Unused:                       [128]byte{88},
+			},
+			Samples: []uint32{100, 200, 300, 400, 500},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, original.Serialize(&buf))
+
+		var decoded DeviceLatencySamplesV0
+		require.NoError(t, decoded.Deserialize(buf.Bytes()))
+
+		require.Equal(t, original.DeviceLatencySamplesHeaderV0, decoded.DeviceLatencySamplesHeaderV0)
+		require.Equal(t, original.Samples, decoded.Samples)
+	})
+
+	t.Run("round-trip with empty sample list", func(t *testing.T) {
+		header := DeviceLatencySamplesHeaderV0{
+			AccountType:                  AccountTypeDeviceLatencySamplesV0,
+			SamplingIntervalMicroseconds: 100_000,
+			NextSampleIndex:              0,
+		}
+		original := &DeviceLatencySamplesV0{
+			DeviceLatencySamplesHeaderV0: header,
+			Samples:                      []uint32{},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, original.Serialize(&buf))
+
+		var decoded DeviceLatencySamplesV0
+		require.NoError(t, decoded.Deserialize(buf.Bytes()))
+
+		require.Equal(t, original.DeviceLatencySamplesHeaderV0, decoded.DeviceLatencySamplesHeaderV0)
+		require.Empty(t, decoded.Samples)
+	})
+
+	t.Run("sample byte layout is little-endian", func(t *testing.T) {
+		sample := &DeviceLatencySamplesV0{
+			DeviceLatencySamplesHeaderV0: DeviceLatencySamplesHeaderV0{
+				AccountType:     AccountTypeDeviceLatencySamplesV0,
+				NextSampleIndex: 3,
+			},
+			Samples: []uint32{0x11223344, 0x55667788, 0x99aabbcc},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, sample.Serialize(&buf))
+		b := buf.Bytes()
+
+		expected := []byte{
+			0x44, 0x33, 0x22, 0x11,
+			0x88, 0x77, 0x66, 0x55,
+			0xcc, 0xbb, 0xaa, 0x99,
+		}
+		require.GreaterOrEqual(t, len(b), len(expected))
+		require.Equal(t, expected, b[len(b)-len(expected):])
+	})
+
+	t.Run("rejects deserialization with NextSampleIndex over MaxDeviceLatencySamplesPerAccount", func(t *testing.T) {
+		header := DeviceLatencySamplesHeaderV0{
+			AccountType:                  AccountTypeDeviceLatencySamplesV0,
+			SamplingIntervalMicroseconds: 100_000,
+			NextSampleIndex:              MaxDeviceLatencySamplesPerAccount + 1,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, binary.Write(&buf, binary.LittleEndian, header))
+
+		// Add dummy data to simulate the start of the samples section.
+		// It won't be read since it should fail before then.
+		_, _ = buf.Write(make([]byte, 4)) // one sample's worth of padding
+
+		var decoded DeviceLatencySamplesV0
+		err := decoded.Deserialize(buf.Bytes())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max allowed samples")
+	})
+
+	t.Run("ToV1 conversion", func(t *testing.T) {
+		origin := solana.NewWallet().PublicKey()
+		target := solana.NewWallet().PublicKey()
+		loc1 := solana.NewWallet().PublicKey()
+		loc2 := solana.NewWallet().PublicKey()
+		link := solana.NewWallet().PublicKey()
+
+		v0 := &DeviceLatencySamplesV0{
+			DeviceLatencySamplesHeaderV0: DeviceLatencySamplesHeaderV0{
+				AccountType:                  AccountTypeDeviceLatencySamplesV0,
+				BumpSeed:                     7,
+				Epoch:                        12345,
+				OriginDeviceAgentPK:          origin,
+				OriginDevicePK:               origin,
+				TargetDevicePK:               target,
+				OriginDeviceLocationPK:       loc1,
+				TargetDeviceLocationPK:       loc2,
+				LinkPK:                       link,
+				SamplingIntervalMicroseconds: 1_000_000,
+				StartTimestampMicroseconds:   2_000_000,
+				NextSampleIndex:              3,
+				Unused:                       [128]byte{0x42},
+			},
+			Samples: []uint32{111, 222, 333},
+		}
+
+		v1 := v0.ToV1()
+
+		require.Equal(t, AccountTypeDeviceLatencySamples, v1.AccountType)
+		require.Equal(t, v0.Epoch, v1.Epoch)
+		require.Equal(t, v0.OriginDeviceAgentPK, v1.OriginDeviceAgentPK)
+		require.Equal(t, v0.OriginDevicePK, v1.OriginDevicePK)
+		require.Equal(t, v0.TargetDevicePK, v1.TargetDevicePK)
+		require.Equal(t, v0.OriginDeviceLocationPK, v1.OriginDeviceLocationPK)
+		require.Equal(t, v0.TargetDeviceLocationPK, v1.TargetDeviceLocationPK)
+		require.Equal(t, v0.LinkPK, v1.LinkPK)
+		require.Equal(t, v0.SamplingIntervalMicroseconds, v1.SamplingIntervalMicroseconds)
+		require.Equal(t, v0.StartTimestampMicroseconds, v1.StartTimestampMicroseconds)
+		require.Equal(t, v0.NextSampleIndex, v1.NextSampleIndex)
+		require.Equal(t, v0.Unused, v1.Unused)
+		require.Equal(t, v0.Samples, v1.Samples)
+	})
+}


### PR DESCRIPTION
## Summary of Changes
- Update device telemetry samples in Go SDK to support reading v0 and v1 samples depending on the discriminator 
- This allows consumers of the telemetry data to read/understand both versions ([dashboard](https://doublezero.grafana.net/d/9dc316d2-68cb-4dda-a114-0d188bd62a2f/doublezero-telemetry-device-circuit-latencies))

## Testing Verification
- Add test coverage for the v0-v1 conversion when that case occurs
- Duplicated existing test coverage for the previous version of the state
