### PR TITLE
feat(multicastgroup): replace deactivate command with close account functionality

### DIFF
--- a/activator/src/process/multicastgroup.rs
+++ b/activator/src/process/multicastgroup.rs
@@ -1,7 +1,7 @@
 use crate::ipblockallocator::IPBlockAllocator;
 use doublezero_sdk::{
     commands::multicastgroup::{
-        activate::ActivateMulticastGroupCommand, deactivate::DeactivateMulticastGroupCommand,
+        activate::ActivateMulticastGroupCommand, closeaccount::CloseAccountMulticastGroupCommand,
     },
     DoubleZeroClient, MulticastGroup, MulticastGroupStatus,
 };
@@ -82,7 +82,7 @@ pub fn process_multicastgroup_event(
             )
             .unwrap();
 
-            let res = DeactivateMulticastGroupCommand {
+            let res = CloseAccountMulticastGroupCommand {
                 pubkey: *pubkey,
                 owner: multicastgroup.owner,
             }
@@ -90,10 +90,7 @@ pub fn process_multicastgroup_event(
 
             match res {
                 Ok(signature) => {
-                    write!(&mut log_msg, " Deactivated {signature}",).unwrap();
-
-                    multicastgroup_tunnel_ips
-                        .unassign_block(Ipv4Network::new(multicastgroup.multicast_ip, 32)?);
+                    write!(&mut log_msg, " CloseAccount {signature}",).unwrap();
 
                     multicastgroups.remove(pubkey);
                     *state_transitions

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -55,8 +55,8 @@ use doublezero_sdk::{
                     remove::RemoveMulticastGroupSubAllowlistCommand,
                 },
             },
+            closeaccount::CloseAccountMulticastGroupCommand,
             create::CreateMulticastGroupCommand,
-            deactivate::DeactivateMulticastGroupCommand,
             delete::DeleteMulticastGroupCommand,
             get::GetMulticastGroupCommand,
             list::ListMulticastGroupCommand,
@@ -197,7 +197,7 @@ pub trait CliCommand {
     fn reject_multicastgroup(&self, cmd: RejectMulticastGroupCommand) -> eyre::Result<Signature>;
     fn deactivate_multicastgroup(
         &self,
-        cmd: DeactivateMulticastGroupCommand,
+        cmd: CloseAccountMulticastGroupCommand,
     ) -> eyre::Result<Signature>;
     fn subscribe_multicastgroup(
         &self,
@@ -488,7 +488,7 @@ impl CliCommand for CliCommandImpl<'_> {
     }
     fn deactivate_multicastgroup(
         &self,
-        cmd: DeactivateMulticastGroupCommand,
+        cmd: CloseAccountMulticastGroupCommand,
     ) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }

--- a/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
@@ -53,8 +53,8 @@ use crate::{
                     remove::process_remove_multicast_sub_allowlist,
                 },
             },
+            closeaccount::process_closeaccount_multicastgroup,
             create::process_create_multicastgroup,
-            deactivate::process_deactivate_multicastgroup,
             delete::process_delete_multicastgroup,
             reactivate::process_reactivate_multicastgroup,
             reject::process_reject_multicastgroup,
@@ -243,8 +243,8 @@ pub fn process_instruction(
         DoubleZeroInstruction::UpdateMulticastGroup(value) => {
             process_update_multicastgroup(program_id, accounts, &value)?
         }
-        DoubleZeroInstruction::DeactivateMulticastGroup(value) => {
-            process_deactivate_multicastgroup(program_id, accounts, &value)?
+        DoubleZeroInstruction::CloseAccountMulticastGroup(value) => {
+            process_closeaccount_multicastgroup(program_id, accounts, &value)?
         }
         DoubleZeroInstruction::AddMulticastGroupPubAllowlist(value) => {
             process_add_multicastgroup_pub_allowlist(program_id, accounts, &value)?

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -41,8 +41,8 @@ use crate::processors::{
                 remove::RemoveMulticastGroupSubAllowlistArgs,
             },
         },
+        closeaccount::MulticastGroupCloseAccountArgs,
         create::MulticastGroupCreateArgs,
-        deactivate::MulticastGroupDeactivateArgs,
         delete::MulticastGroupDeleteArgs,
         reactivate::MulticastGroupReactivateArgs,
         reject::MulticastGroupRejectArgs,
@@ -124,7 +124,7 @@ pub enum DoubleZeroInstruction {
     SuspendMulticastGroup(MulticastGroupSuspendArgs), // variant 50
     ReactivateMulticastGroup(MulticastGroupReactivateArgs), // variant 51
     DeleteMulticastGroup(MulticastGroupDeleteArgs), // variant 52
-    DeactivateMulticastGroup(MulticastGroupDeactivateArgs), // variant 53
+    CloseAccountMulticastGroup(MulticastGroupCloseAccountArgs), // variant 53
 
     AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs), // variant 54
     RemoveMulticastGroupPubAllowlist(RemoveMulticastGroupPubAllowlistArgs), // variant 55
@@ -212,7 +212,7 @@ impl DoubleZeroInstruction {
             50 => Ok(Self::SuspendMulticastGroup(from_slice::<MulticastGroupSuspendArgs>(rest).unwrap())),
             51 => Ok(Self::ReactivateMulticastGroup(from_slice::<MulticastGroupReactivateArgs>(rest).unwrap())),
             52 => Ok(Self::DeleteMulticastGroup(from_slice::<MulticastGroupDeleteArgs>(rest).unwrap())),
-            53 => Ok(Self::DeactivateMulticastGroup(from_slice::<MulticastGroupDeactivateArgs>(rest).unwrap())),
+            53 => Ok(Self::CloseAccountMulticastGroup(from_slice::<MulticastGroupCloseAccountArgs>(rest).unwrap())),
 
             54 => Ok(Self::AddMulticastGroupPubAllowlist(from_slice::<AddMulticastGroupPubAllowlistArgs>(rest).unwrap())),
             55 => Ok(Self::RemoveMulticastGroupPubAllowlist(from_slice::<RemoveMulticastGroupPubAllowlistArgs>(rest).unwrap())),
@@ -294,7 +294,7 @@ impl DoubleZeroInstruction {
             Self::ReactivateMulticastGroup(_) => "ReactivateMulticastGroup".to_string(), // variant 50
             Self::DeleteMulticastGroup(_) => "DeleteMulticastGroup".to_string(), // variant 51
             Self::UpdateMulticastGroup(_) => "UpdateMulticastGroup".to_string(), // variant 52
-            Self::DeactivateMulticastGroup(_) => "DeactivateMulticastGroup".to_string(), // variant 53
+            Self::CloseAccountMulticastGroup(_) => "CloseAccountMulticastGroup".to_string(), // variant 53
 
             Self::AddMulticastGroupPubAllowlist(_) => "AddMulticastGroupPubAllowlist".to_string(), // variant 54
             Self::RemoveMulticastGroupPubAllowlist(_) => {
@@ -379,7 +379,7 @@ impl DoubleZeroInstruction {
             Self::ReactivateMulticastGroup(args) => format!("{args:?}"), // variant 50
             Self::DeleteMulticastGroup(args) => format!("{args:?}"), // variant 51
             Self::UpdateMulticastGroup(args) => format!("{args:?}"), // variant 52
-            Self::DeactivateMulticastGroup(args) => format!("{args:?}"), // variant 53
+            Self::CloseAccountMulticastGroup(args) => format!("{args:?}"), // variant 53
             Self::SubscribeMulticastGroup(args) => format!("{args:?}"), // variant 54
             Self::AddMulticastGroupPubAllowlist(args) => format!("{args:?}"), // variant 55
             Self::RemoveMulticastGroupPubAllowlist(args) => format!("{args:?}"), // variant 56
@@ -743,8 +743,8 @@ mod tests {
         );
 
         test_instruction(
-            DoubleZeroInstruction::DeactivateMulticastGroup(MulticastGroupDeactivateArgs {}),
-            "DeactivateMulticastGroup",
+            DoubleZeroInstruction::CloseAccountMulticastGroup(MulticastGroupCloseAccountArgs {}),
+            "CloseAccountMulticastGroup",
         );
 
         test_instruction(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/closeaccount.rs
@@ -16,18 +16,18 @@ use solana_program::{
 use std::fmt;
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone)]
-pub struct MulticastGroupDeactivateArgs {}
+pub struct MulticastGroupCloseAccountArgs {}
 
-impl fmt::Debug for MulticastGroupDeactivateArgs {
+impl fmt::Debug for MulticastGroupCloseAccountArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "")
     }
 }
 
-pub fn process_deactivate_multicastgroup(
+pub fn process_closeaccount_multicastgroup(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    _value: &MulticastGroupDeactivateArgs,
+    _value: &MulticastGroupCloseAccountArgs,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
@@ -38,7 +38,7 @@ pub fn process_deactivate_multicastgroup(
     let system_program = next_account_info(accounts_iter)?;
 
     #[cfg(test)]
-    msg!("process_deactivate_multicastgroup({:?})", _value);
+    msg!("process_closeaccount_multicastgroup({:?})", _value);
 
     // Check the owner of the accounts
     assert_eq!(
@@ -84,7 +84,7 @@ pub fn process_deactivate_multicastgroup(
     account_close(multicastgroup_account, owner_account)?;
 
     #[cfg(test)]
-    msg!("Deactivated: MulticastGroup closed");
+    msg!("Closed account: MulticastGroup closed");
 
     Ok(())
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/mod.rs
@@ -1,7 +1,7 @@
 pub mod activate;
 pub mod allowlist;
+pub mod closeaccount;
 pub mod create;
-pub mod deactivate;
 pub mod delete;
 pub mod reactivate;
 pub mod reject;

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
@@ -3,8 +3,8 @@ use doublezero_serviceability::{
     instructions::*,
     pda::*,
     processors::multicastgroup::{
-        activate::MulticastGroupActivateArgs, create::*, deactivate::MulticastGroupDeactivateArgs,
-        delete::*, reactivate::*, suspend::*, update::*,
+        activate::MulticastGroupActivateArgs, closeaccount::MulticastGroupCloseAccountArgs,
+        create::*, delete::*, reactivate::*, suspend::*, update::*,
     },
     state::{accounttype::AccountType, multicastgroup::*},
 };
@@ -229,7 +229,7 @@ async fn test_multicastgroup() {
         &mut banks_client,
         recent_blockhash,
         program_id,
-        DoubleZeroInstruction::DeactivateMulticastGroup(MulticastGroupDeactivateArgs {}),
+        DoubleZeroInstruction::CloseAccountMulticastGroup(MulticastGroupCloseAccountArgs {}),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(multicastgroup.owner, false),

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/closeaccount.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/closeaccount.rs
@@ -1,24 +1,24 @@
 use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
-    processors::multicastgroup::deactivate::MulticastGroupDeactivateArgs,
+    processors::multicastgroup::closeaccount::MulticastGroupCloseAccountArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct DeactivateMulticastGroupCommand {
+pub struct CloseAccountMulticastGroupCommand {
     pub pubkey: Pubkey,
     pub owner: Pubkey,
 }
 
-impl DeactivateMulticastGroupCommand {
+impl CloseAccountMulticastGroupCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
         client.execute_transaction(
-            DoubleZeroInstruction::DeactivateMulticastGroup(MulticastGroupDeactivateArgs {}),
+            DoubleZeroInstruction::CloseAccountMulticastGroup(MulticastGroupCloseAccountArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),
                 AccountMeta::new(self.owner, false),
@@ -31,13 +31,13 @@ impl DeactivateMulticastGroupCommand {
 #[cfg(test)]
 mod tests {
     use crate::{
-        commands::multicastgroup::deactivate::DeactivateMulticastGroupCommand,
+        commands::multicastgroup::closeaccount::CloseAccountMulticastGroupCommand,
         tests::utils::create_test_client, DoubleZeroClient,
     };
     use doublezero_serviceability::{
         instructions::DoubleZeroInstruction,
         pda::{get_globalstate_pda, get_location_pda},
-        processors::multicastgroup::deactivate::MulticastGroupDeactivateArgs,
+        processors::multicastgroup::closeaccount::MulticastGroupCloseAccountArgs,
     };
     use mockall::predicate;
     use solana_sdk::{instruction::AccountMeta, signature::Signature};
@@ -53,8 +53,8 @@ mod tests {
         client
             .expect_execute_transaction()
             .with(
-                predicate::eq(DoubleZeroInstruction::DeactivateMulticastGroup(
-                    MulticastGroupDeactivateArgs {},
+                predicate::eq(DoubleZeroInstruction::CloseAccountMulticastGroup(
+                    MulticastGroupCloseAccountArgs {},
                 )),
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
@@ -64,7 +64,7 @@ mod tests {
             )
             .returning(|_, _| Ok(Signature::new_unique()));
 
-        let res = DeactivateMulticastGroupCommand {
+        let res = CloseAccountMulticastGroupCommand {
             pubkey: pda_pubkey,
             owner: payer,
         }

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/mod.rs
@@ -1,7 +1,7 @@
 pub mod activate;
 pub mod allowlist;
+pub mod closeaccount;
 pub mod create;
-pub mod deactivate;
 pub mod delete;
 pub mod get;
 pub mod list;


### PR DESCRIPTION
This pull request introduces a significant change by renaming and refactoring the "DeactivateMulticastGroup" functionality to "CloseAccountMulticastGroup" across the codebase. The updates ensure consistency in naming, improve clarity, and implement the new behavior for closing multicast group accounts. Below is a summary of the most important changes grouped by theme:

### Core Functionality Refactor
* Replaced `DeactivateMulticastGroupCommand` with `CloseAccountMulticastGroupCommand` in `activator/src/process/multicastgroup.rs` and updated the corresponding logic for processing multicast group events. (`[[1]](diffhunk://#diff-99283986d997d61d1c2b3bab783231dcc50435103090d2bf2910f112a0b17cc8L4-R4)`, `[[2]](diffhunk://#diff-99283986d997d61d1c2b3bab783231dcc50435103090d2bf2910f112a0b17cc8L88-R96)`)
* Renamed the file `deactivate.rs` to `closeaccount.rs` and updated its structure and methods to reflect the new "CloseAccount" functionality. (`[[1]](diffhunk://#diff-1a202eb0895a5fdf26a1ae85d0f221428a93467fd890e2cd4d594dc7f2f3be6fL19-R30)`, `[[2]](diffhunk://#diff-1a202eb0895a5fdf26a1ae85d0f221428a93467fd890e2cd4d594dc7f2f3be6fL41-R41)`, `[[3]](diffhunk://#diff-1a202eb0895a5fdf26a1ae85d0f221428a93467fd890e2cd4d594dc7f2f3be6fL87-R87)`, `[[4]](diffhunk://#diff-fa1365450b33eb8d394e9693bb853d70fb7e84d1e3f5d866e578b96c946be431L4-R21)`, `[[5]](diffhunk://#diff-fa1365450b33eb8d394e9693bb853d70fb7e84d1e3f5d866e578b96c946be431L34-R40)`, `[[6]](diffhunk://#diff-fa1365450b33eb8d394e9693bb853d70fb7e84d1e3f5d866e578b96c946be431L56-R57)`, `[[7]](diffhunk://#diff-fa1365450b33eb8d394e9693bb853d70fb7e84d1e3f5d866e578b96c946be431L67-R67)`)

### Instruction and Processor Updates
* Updated the `DoubleZeroInstruction` enum to replace the `DeactivateMulticastGroup` variant with `CloseAccountMulticastGroup` and adjusted all related methods and test cases. (`[[1]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL127-R127)`, `[[2]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL215-R215)`, `[[3]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL297-R297)`, `[[4]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL382-R382)`, `[[5]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL754-R755)`)
* Modified the `process_instruction` function in `entrypoint.rs` to handle the new `CloseAccountMulticastGroup` instruction. (`[smartcontract/programs/doublezero-serviceability/src/entrypoint.rsL246-R247](diffhunk://#diff-c992aa851133119f782befb3b467fcb9b2d4e35084dc0f0a303989e1be9f8cb3L246-R247)`)

### CLI and SDK Adjustments
* Updated the `CliCommand` trait and its implementation to use `CloseAccountMulticastGroupCommand` instead of `DeactivateMulticastGroupCommand`. (`[[1]](diffhunk://#diff-430587015023e7ac3057101cd2e2553b6b773181e0c6aec15c42b22d01dd132eL200-R200)`, `[[2]](diffhunk://#diff-430587015023e7ac3057101cd2e2553b6b773181e0c6aec15c42b22d01dd132eL491-R491)`)
* Adjusted the SDK to include the new `CloseAccountMulticastGroupCommand` and removed references to the old `DeactivateMulticastGroupCommand`. (`[[1]](diffhunk://#diff-430587015023e7ac3057101cd2e2553b6b773181e0c6aec15c42b22d01dd132eR58-L59)`, `[[2]](diffhunk://#diff-192bc1c0fc8ef981328cb5c53b2ddec85a2189e44f82a306de2093440f806e81L4-R4)`)

### Tests and State Updates
* Refactored test cases to align with the new "CloseAccount" functionality, ensuring proper validation of the updated behavior. (`[[1]](diffhunk://#diff-a03b663621cd3a0186c79e9d7369c64f29470048fdb5705252bc03d482706ccbL6-R7)`, `[[2]](diffhunk://#diff-a03b663621cd3a0186c79e9d7369c64f29470048fdb5705252bc03d482706ccbL232-R232)`)
* Minor cleanup in `state/exchange.rs` to remove unnecessary whitespace. (`[smartcontract/programs/doublezero-serviceability/src/state/exchange.rsR50](diffhunk://#diff-88bede2ff36b0ef0a175dca34fdabc29a15f9ecf7b68bcde7d11a0439986930aR50)`)

## Testing Verification
* Show evidence of testing the change
