### PR TITLE
device/telemetry: data cli and api use epoch from ledger

### DIFF
--- a/controlplane/telemetry/cmd/data-api/main.go
+++ b/controlplane/telemetry/cmd/data-api/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/malbeclabs/doublezero/config"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data"
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/epoch"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 )
@@ -79,9 +80,15 @@ func newProvider(log *slog.Logger, env string) (data.Provider, error) {
 
 	rpcClient := solanarpc.New(networkConfig.LedgerRPCURL)
 
+	epochFinder, err := epoch.NewFinder(log, rpcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create epoch finder: %w", err)
+	}
+
 	return data.NewProvider(&data.ProviderConfig{
 		Logger:               log,
 		ServiceabilityClient: serviceability.New(rpcClient, networkConfig.ServiceabilityProgramID),
 		TelemetryClient:      telemetry.New(log, rpcClient, nil, networkConfig.TelemetryProgramID),
+		EpochFinder:          epochFinder,
 	})
 }

--- a/controlplane/telemetry/cmd/data-cli/main.go
+++ b/controlplane/telemetry/cmd/data-cli/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/malbeclabs/doublezero/config"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data"
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/epoch"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 )
@@ -123,10 +124,16 @@ func newProvider(log *slog.Logger, env string) (data.Provider, error) {
 
 	rpcClient := solanarpc.New(networkConfig.LedgerRPCURL)
 
+	epochFinder, err := epoch.NewFinder(log, rpcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create epoch finder: %w", err)
+	}
+
 	return data.NewProvider(&data.ProviderConfig{
 		Logger:               log,
 		ServiceabilityClient: serviceability.New(rpcClient, networkConfig.ServiceabilityProgramID),
 		TelemetryClient:      telemetry.New(log, rpcClient, nil, networkConfig.TelemetryProgramID),
+		EpochFinder:          epochFinder,
 	})
 }
 

--- a/controlplane/telemetry/internal/data/circuits_test.go
+++ b/controlplane/telemetry/internal/data/circuits_test.go
@@ -47,7 +47,12 @@ func TestTelemetry_Data_Provider_GetCircuits(t *testing.T) {
 			Logger:               logger,
 			ServiceabilityClient: client,
 			TelemetryClient:      &mockTelemetryClient{},
-			CircuitsCacheTTL:     1 * time.Minute,
+			EpochFinder: &mockEpochFinder{
+				ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+					return 1, nil
+				},
+			},
+			CircuitsCacheTTL: 1 * time.Minute,
 		})
 		require.NoError(t, err)
 
@@ -89,7 +94,12 @@ func TestTelemetry_Data_Provider_GetCircuits(t *testing.T) {
 			Logger:               logger,
 			ServiceabilityClient: client,
 			TelemetryClient:      &mockTelemetryClient{},
-			CircuitsCacheTTL:     1 * time.Minute,
+			EpochFinder: &mockEpochFinder{
+				ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+					return 1, nil
+				},
+			},
+			CircuitsCacheTTL: 1 * time.Minute,
 		})
 		require.NoError(t, err)
 		circuits, err := provider.GetCircuits(t.Context())
@@ -109,7 +119,12 @@ func TestTelemetry_Data_Provider_GetCircuits(t *testing.T) {
 			Logger:               logger,
 			ServiceabilityClient: client,
 			TelemetryClient:      &mockTelemetryClient{},
-			CircuitsCacheTTL:     1 * time.Minute,
+			EpochFinder: &mockEpochFinder{
+				ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+					return 1, nil
+				},
+			},
+			CircuitsCacheTTL: 1 * time.Minute,
 		})
 		require.NoError(t, err)
 		_, err = provider.GetCircuits(t.Context())
@@ -154,7 +169,12 @@ func TestTelemetry_Data_Provider_GetCircuits(t *testing.T) {
 			Logger:               logger,
 			ServiceabilityClient: client,
 			TelemetryClient:      &mockTelemetryClient{},
-			CircuitsCacheTTL:     1 * time.Minute,
+			EpochFinder: &mockEpochFinder{
+				ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+					return 1, nil
+				},
+			},
+			CircuitsCacheTTL: 1 * time.Minute,
 		})
 		require.NoError(t, err)
 
@@ -181,7 +201,12 @@ func TestTelemetry_Data_Provider_GetCircuits(t *testing.T) {
 					}, nil
 				},
 			},
-			TelemetryClient:  &mockTelemetryClient{},
+			TelemetryClient: &mockTelemetryClient{},
+			EpochFinder: &mockEpochFinder{
+				ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+					return 1, nil
+				},
+			},
 			CircuitsCacheTTL: 0, // Disable cache so every call invokes Load()
 		})
 		require.NoError(t, err)

--- a/controlplane/telemetry/internal/data/epoch.go
+++ b/controlplane/telemetry/internal/data/epoch.go
@@ -1,7 +1,0 @@
-package data
-
-import "time"
-
-func DeriveEpoch(now time.Time) uint64 {
-	return uint64(now.Unix() / (60 * 60 * 24 * 2))
-}

--- a/controlplane/telemetry/internal/data/latencies.go
+++ b/controlplane/telemetry/internal/data/latencies.go
@@ -76,7 +76,10 @@ func (p *provider) GetCircuitLatenciesForEpoch(ctx context.Context, circuitCode 
 	samples := enrichSamplesWithTimestamps(account.Samples, account.StartTimestampMicroseconds, account.SamplingIntervalMicroseconds)
 
 	// If the epoch is sufficiently in the past, cache for much longer.
-	currentEpoch := DeriveEpoch(time.Now())
+	currentEpoch, err := p.cfg.EpochFinder.ApproximateAtTime(ctx, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current epoch: %w", err)
+	}
 	ttl := p.cfg.CurrentEpochLatenciesCacheTTL
 	if epoch < currentEpoch-1 {
 		ttl = p.cfg.HistoricEpochLatenciesCacheTTL
@@ -87,8 +90,14 @@ func (p *provider) GetCircuitLatenciesForEpoch(ctx context.Context, circuitCode 
 }
 
 func (p *provider) GetCircuitLatencies(ctx context.Context, circuitCode string, from, to time.Time) ([]CircuitLatencySample, error) {
-	startEpoch := DeriveEpoch(from)
-	endEpoch := DeriveEpoch(to)
+	startEpoch, err := p.cfg.EpochFinder.ApproximateAtTime(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get start epoch: %w", err)
+	}
+	endEpoch, err := p.cfg.EpochFinder.ApproximateAtTime(ctx, to)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get end epoch: %w", err)
+	}
 
 	var latencies []CircuitLatencySample
 

--- a/controlplane/telemetry/internal/data/latencies_test.go
+++ b/controlplane/telemetry/internal/data/latencies_test.go
@@ -38,7 +38,7 @@ func TestTelemetry_Data_Provider_GetCircuitLatencies(t *testing.T) {
 		}, defaultCircuit())
 
 		ctx := context.Background()
-		epoch := data.DeriveEpoch(time.Now())
+		epoch := uint64(1)
 
 		first, err := provider.GetCircuitLatenciesForEpoch(ctx, "A → B (L1)", epoch)
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestTelemetry_Data_Provider_GetCircuitLatencies(t *testing.T) {
 			return nil, telemetry.ErrAccountNotFound
 		}, defaultCircuit())
 
-		epoch := data.DeriveEpoch(time.Now())
+		epoch := uint64(1)
 		latencies, err := provider.GetCircuitLatenciesForEpoch(context.Background(), "A → B (L1)", epoch)
 		assert.ErrorIs(t, err, telemetry.ErrAccountNotFound)
 		assert.Empty(t, latencies)
@@ -240,6 +240,11 @@ func newTestProvider(
 		TelemetryClient: &mockTelemetryClient{
 			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error) {
 				return getFunc(epoch)
+			},
+		},
+		EpochFinder: &mockEpochFinder{
+			ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+				return 1, nil
 			},
 		},
 		CircuitsCacheTTL:               time.Minute,

--- a/controlplane/telemetry/internal/data/main_test.go
+++ b/controlplane/telemetry/internal/data/main_test.go
@@ -77,3 +77,11 @@ func (m *mockProvider) GetCircuitLatencies(ctx context.Context, circuit string, 
 func (m *mockProvider) GetCircuitLatenciesForEpoch(ctx context.Context, circuit string, epoch uint64) ([]data.CircuitLatencySample, error) {
 	return m.GetCircuitLatenciesForEpochFunc(ctx, circuit, epoch)
 }
+
+type mockEpochFinder struct {
+	ApproximateAtTimeFunc func(ctx context.Context, target time.Time) (uint64, error)
+}
+
+func (m *mockEpochFinder) ApproximateAtTime(ctx context.Context, target time.Time) (uint64, error) {
+	return m.ApproximateAtTimeFunc(ctx, target)
+}

--- a/controlplane/telemetry/internal/data/provider.go
+++ b/controlplane/telemetry/internal/data/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alitto/pond/v2"
 	"github.com/gagliardetto/solana-go"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/epoch"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
 )
@@ -49,6 +50,7 @@ type ProviderConfig struct {
 	Logger               *slog.Logger
 	ServiceabilityClient ServiceabilityClient
 	TelemetryClient      TelemetryClient
+	EpochFinder          epoch.Finder
 
 	CircuitsCacheTTL               time.Duration
 	HistoricEpochLatenciesCacheTTL time.Duration
@@ -65,6 +67,9 @@ func (c *ProviderConfig) Validate() error {
 	}
 	if c.TelemetryClient == nil {
 		return errors.New("telemetry client is required")
+	}
+	if c.EpochFinder == nil {
+		return errors.New("epoch finder is required")
 	}
 	if c.CircuitsCacheTTL == 0 {
 		c.CircuitsCacheTTL = defaultCircuitsCacheTTL

--- a/controlplane/telemetry/pkg/epoch/finder.go
+++ b/controlplane/telemetry/pkg/epoch/finder.go
@@ -140,7 +140,7 @@ func (e *epochFinder) getSlotWithRetry(ctx context.Context) (uint64, error) {
 		return slot, nil
 	}, backoff.WithBackOff(backoff.NewExponentialBackOff()))
 	if err != nil {
-		return 0, fmt.Errorf("failed to get current epoch: %w", err)
+		return 0, fmt.Errorf("failed to get current slot: %w", err)
 	}
 	return slot, nil
 }


### PR DESCRIPTION
## Summary of Changes
- Update telemetry data API/CLI to use ledger epoch to match https://github.com/malbeclabs/doublezero/pull/1004 
- Resolves https://github.com/malbeclabs/doublezero/issues/1019
- Adds `EpochFinder` that's used to derive ledger epoch from timestamp, with some caching since it makes a few RPC calls, and is shared between this code and the internet telemetry collector in https://github.com/malbeclabs/doublezero/pull/1013

## Testing Verification
- Updates existing test coverage to match the changes
- This has already been deployed with the Grafana dashboard using it
