### PR TITLE
cli: keygen outfile flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
  "doublezero-serviceability",
  "doublezero_cli",
  "doublezero_sdk",
- "env_logger 0.9.3",
+ "env_logger 0.11.8",
  "eyre",
  "futures",
  "indexmap",
@@ -1704,6 +1704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "solana-account-decoder",
  "solana-client",
  "solana-program",
@@ -4758,6 +4759,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c789ec87f4687d022a2405cf46e0cd6284889f1839de292cadeb6c6019506f2"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.4",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64f9e531ce97c88b4778aad0ceee079216071cffec6ac9b904277f8f92e7fe3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0"
+serial_test = "0"
 solana-account-decoder = "2.2.7"
 solana-client = "2.2.7"
 solana-program = "2.2.1"

--- a/smartcontract/cli/src/keygen.rs
+++ b/smartcontract/cli/src/keygen.rs
@@ -2,18 +2,21 @@ use crate::doublezerocommand::CliCommand;
 use clap::Args;
 use doublezero_sdk::create_new_pubkey_user;
 use solana_sdk::signer::Signer;
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
 
 #[derive(Args, Debug)]
 pub struct KeyGenCliCommand {
     /// Force keypair generation
     #[arg(short, default_value = "false")]
     force: bool,
+    /// Path to generated file
+    #[arg(short, long)]
+    outfile: Option<PathBuf>,
 }
 
 impl KeyGenCliCommand {
     pub fn execute<W: Write>(self, _client: &dyn CliCommand, out: &mut W) -> eyre::Result<()> {
-        match create_new_pubkey_user(self.force) {
+        match create_new_pubkey_user(self.force, self.outfile) {
             Ok(keypair) => {
                 writeln!(out, "Pubkey: {}", keypair.pubkey())?;
             }

--- a/smartcontract/sdk/rs/Cargo.toml
+++ b/smartcontract/sdk/rs/Cargo.toml
@@ -25,6 +25,7 @@ mockall.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+serial_test.workspace = true
 solana-account-decoder.workspace = true
 solana-client.workspace = true
 solana-program.workspace = true

--- a/smartcontract/sdk/rs/src/tests.rs
+++ b/smartcontract/sdk/rs/src/tests.rs
@@ -48,7 +48,7 @@ pub mod utils {
             ..Default::default()
         };
         write_doublezero_config(&client_cfg)?;
-        create_new_pubkey_user(false)?;
+        create_new_pubkey_user(false, None)?;
         Ok(tmpdir)
     }
 }


### PR DESCRIPTION
## Summary of Changes
- Add `--outfile` (`-o`) flag to `keygen` CLI command so that users and contributors can use it to generate keys to a specific file without needing something like `solana-keygen`
- Resolves https://github.com/malbeclabs/doublezero/issues/1024
- Related to https://github.com/malbeclabs/doublezero/issues/925

## Testing Verification
- Adds test coverage for new functionality and backfills coverage for some existing functionality
