### PR TITLE
release: qa agent build workflow

### DIFF
--- a/.github/workflows/release.qa.agent.yml
+++ b/.github/workflows/release.qa.agent.yml
@@ -1,0 +1,39 @@
+name: releaser.qa.agent
+
+on:
+  push:
+    tags:
+      - "qaagent/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Set env vars
+        run: ./scripts/env.sh >> $GITHUB_ENV
+      - name: install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install squashfs-tools rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.devnet.qa.agent.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -168,7 +168,7 @@ func (q *QAAgent) ConnectUnicast(ctx context.Context, req *pb.ConnectUnicastRequ
 		return status[0].DoubleZeroStatus.State == "up", nil
 	}
 
-	err = poll.Until(ctx, condition, 20*time.Second, 1*time.Second)
+	err = poll.Until(ctx, condition, 30*time.Second, 1*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("failed while polling for session status: %v", err)
 	}


### PR DESCRIPTION
## Summary of Changes
This adds a github action to handle a package release for QA agent to devnet.

This also fixes a flake I found that seems to only happen when running under systemd.

## Testing Verification
This action is used elsewhere apart from the differing goreleaser file and the goreleaser file build correctly as the service is running on chi-dn-bm2:
```
root ➜ /workspaces/doublezero (feature/qa) $ goreleaser release -f release/.goreleaser.devnet.qa.agent.yaml --clean --snapshot
...
  • building binaries
    • building                                       binary=dist/doublezero-qaagent_linux_amd64_v1/doublezero-qaagent
  • archives
    • archiving                                      name=dist/doublezero-qaagent_0.0.0-SNAPSHOT-73ffcb90_linux_amd64.tar.gz
  • linux packages
    • creating                                       package=doublezero-qaagent format=deb arch=amd64v1 file=dist/doublezero-qaagent_0.0.0-SNAPSHOT-73ffcb90_linux_amd64.deb
  • calculating checksums
  • storing artifacts metadata
  • release succeeded after 3s
  • thanks for using GoReleaser Pro!
  ```
