### PR TITLE
release: fix dependency tree and deflake

### DIFF
--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -35,6 +35,9 @@ jobs:
     secrets: inherit
   qa:
     uses: ./.github/workflows/qa.yml
+    needs:
+      - release
+      - smartcontract
   notify:
     name: Post failure to slack
     runs-on: ubuntu-24.04-16c-64gb

--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -97,7 +97,7 @@ func (q *QAAgent) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResult
 		return nil, fmt.Errorf("ping failed: %v", err)
 	}
 	stats := pinger.Statistics()
-
+	q.log.Info("Ping statistics", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv)
 	return &pb.PingResult{PacketsSent: uint32(stats.PacketsSent), PacketsReceived: uint32(stats.PacketsRecv)}, nil
 }
 

--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -99,7 +99,7 @@ func TestConnectivityUnicast(t *testing.T) {
 
 			for _, peer := range peers {
 				t.Run("to_"+peer, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+					ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 					defer cancel()
 					pingReq := &pb.PingRequest{
 						TargetIp:    peer,


### PR DESCRIPTION
## Summary of Changes
This PR fixes the dependency tree for the daily deploy to make sure all components are released prior to running QA tests. This also fixes flakiness when running inside the runner as the 10s context timeout for ping results can be tripped due to the RPC call initiation/1 second delay between ping packets and the RPC reply.

## Testing Verification

https://github.com/malbeclabs/doublezero/actions/runs/16694719770
