### PR TITLE
rust: stop using cargo.toml version (set to 0.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "bitvec",
  "chrono",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1611,14 +1611,14 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "doublezero-record"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.0.0"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Update the `Cargo.toml` version to `0.0.0` with the intention to signal that we are no longer using this for versioning
- We don't publish any of these crates; we just release deb/rpm packages via cloudsmith and that has it's own versioning
- If we ever want to publish crates from this repo, we can introduce cargo toml versioning for those then, but right now it seems like an unnecessary step in our release checklist

## Testing Verification
- N/A
