### PR TITLE
smartcontract: clean up `account_close`

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/accounts.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/accounts.rs
@@ -4,9 +4,8 @@ use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
     program::invoke_signed,
-    program_error::ProgramError,
     pubkey::Pubkey,
-    system_instruction, system_program,
+    system_instruction,
     sysvar::{rent::Rent, Sysvar},
 };
 
@@ -64,24 +63,6 @@ pub fn write_account<'a, D: BorshSerialize + AccountSize + AccountSeed>(
 
     let mut account_data = &mut account.data.borrow_mut()[..];
     data.serialize(&mut account_data).unwrap();
-
-    Ok(())
-}
-
-pub fn account_close(
-    close_account: &AccountInfo,
-    receiving_account: &AccountInfo,
-) -> ProgramResult {
-    // Transfere the rent lamports to the receiving account
-    **receiving_account.lamports.borrow_mut() = receiving_account
-        .lamports()
-        .checked_add(close_account.lamports())
-        .ok_or(ProgramError::InsufficientFunds)?;
-    **close_account.lamports.borrow_mut() = 0;
-
-    // Close the account
-    close_account.realloc(0, false)?;
-    close_account.assign(&system_program::ID);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary of Changes
- Make lamport borrows safer using `try_borrow_mut_lamports`
- Remove unnecessary allocate and assign
- Remove unnecessary `checked_add` call (and erroneous program error)
- Remove duplicate `account_close` implementation

## Testing Verification
- Tests pass
