### PR TITLE
fix: The assignment of the used block is being moved

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
@@ -95,7 +95,6 @@ pub fn process_closeaccount_device(
     location.reference_count = location.reference_count.saturating_sub(1);
     exchange.reference_count = exchange.reference_count.saturating_sub(1);
 
-    account_close(device_account, owner_account)?;
     account_write(
         contributor_account,
         &contributor,
@@ -104,6 +103,7 @@ pub fn process_closeaccount_device(
     )?;
     account_write(location_account, &location, payer_account, system_program)?;
     account_write(exchange_account, &exchange, payer_account, system_program)?;
+    account_close(device_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: Device closed");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
@@ -97,7 +97,6 @@ pub fn process_closeaccount_link(
     side_a_dev.reference_count = side_a_dev.reference_count.saturating_sub(1);
     side_z_dev.reference_count = side_z_dev.reference_count.saturating_sub(1);
 
-    account_close(link_account, owner_account)?;
     account_write(
         contributor_account,
         &contributor,
@@ -106,6 +105,7 @@ pub fn process_closeaccount_link(
     )?;
     account_write(side_a_account, &side_a_dev, payer_account, system_program)?;
     account_write(side_z_account, &side_z_dev, payer_account, system_program)?;
+    account_close(link_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: Link closed");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -78,8 +78,8 @@ pub fn process_closeaccount_user(
 
     device.reference_count = device.reference_count.saturating_sub(1);
 
-    account_close(user_account, owner_account)?;
     account_write(device_account, &device, payer_account, system_program)?;
+    account_close(user_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: User closed");

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -89,7 +89,7 @@ echo "Update exchanges"
 
 ### Initialice controbutor
 echo "Creating contributor"
-./target/doublezero contributor create --code co01
+./target/doublezero contributor create --code co01 --owner me
 
 ### Initialice devices
 echo "Creating devices"


### PR DESCRIPTION
This pull request refactors terminology and improves functionality in the `Activator` implementation. The most significant changes include renaming variables for clarity, updating logging messages, and adding a new operation to assign tunnel IP blocks to users.

Fixes https://github.com/malbeclabs/doublezero/issues/1057

### Terminology updates:
* Renamed the `tunnels` variable to `links` throughout the `init` method to align with updated terminology. This includes updating the logging message to reflect the new term. (`activator/src/activator.rs`, [[1]](diffhunk://#diff-6cc6afdb257ea4da2ae7f2a6a8af0beb30cef3c66e2f97925c51438eb3cee38cL113-R118) [[2]](diffhunk://#diff-6cc6afdb257ea4da2ae7f2a6a8af0beb30cef3c66e2f97925c51438eb3cee38cL148-R159)

### Functional improvements:
* Added a new operation to assign tunnel IP blocks to users by iterating over the `users` collection and calling `self.user_tunnel_ips.assign_block` for each user's tunnel network. (`activator/src/activator.rs`, [activator/src/activator.rsR133-R136](diffhunk://#diff-6cc6afdb257ea4da2ae7f2a6a8af0beb30cef3c66e2f97925c51438eb3cee38cR133-R136))