### PR TITLE
refactor: streamline tunnel and user event processing by moving unassignment logic

### DIFF
--- a/activator/src/process/link.rs
+++ b/activator/src/process/link.rs
@@ -82,9 +82,6 @@ pub fn process_tunnel_event(
             )
             .unwrap();
 
-            link_ids.unassign(link.tunnel_id);
-            link_ips.unassign_block(link.tunnel_net.into());
-
             let res = CloseAccountLinkCommand {
                 pubkey: *pubkey,
                 owner: link.owner,
@@ -94,6 +91,9 @@ pub fn process_tunnel_event(
             match res {
                 Ok(signature) => {
                     write!(&mut log_msg, " Deactivated {signature}").unwrap();
+
+                    link_ids.unassign(link.tunnel_id);
+                    link_ips.unassign_block(link.tunnel_net.into());
 
                     *state_transitions
                         .entry("tunnel-deleting-to-deactivated")

--- a/activator/src/process/multicastgroup.rs
+++ b/activator/src/process/multicastgroup.rs
@@ -82,9 +82,6 @@ pub fn process_multicastgroup_event(
             )
             .unwrap();
 
-            multicastgroup_tunnel_ips
-                .unassign_block(Ipv4Network::new(multicastgroup.multicast_ip, 32)?);
-
             let res = DeactivateMulticastGroupCommand {
                 pubkey: *pubkey,
                 owner: multicastgroup.owner,
@@ -94,6 +91,9 @@ pub fn process_multicastgroup_event(
             match res {
                 Ok(signature) => {
                     write!(&mut log_msg, " Deactivated {signature}",).unwrap();
+
+                    multicastgroup_tunnel_ips
+                        .unassign_block(Ipv4Network::new(multicastgroup.multicast_ip, 32)?);
 
                     multicastgroups.remove(pubkey);
                     *state_transitions

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -315,22 +315,22 @@ pub fn process_user_event(
                 )
                 .unwrap();
 
-                if user.tunnel_id != 0 {
-                    link_ids.unassign(user.tunnel_id);
-                }
-                if user.tunnel_net != NetworkV4::default() {
-                    user_tunnel_ips.unassign_block(user.tunnel_net.into());
-                }
-                if user.dz_ip != Ipv4Addr::UNSPECIFIED {
-                    device_state.release(user.dz_ip, user.tunnel_id).unwrap();
-                }
-
                 if user.status == UserStatus::Deleting {
                     let res = CloseAccountUserCommand { pubkey: *pubkey }.execute(client);
 
                     match res {
                         Ok(signature) => {
                             write!(&mut log_msg, " Deactivated {signature}").unwrap();
+
+                            if user.tunnel_id != 0 {
+                                link_ids.unassign(user.tunnel_id);
+                            }
+                            if user.tunnel_net != NetworkV4::default() {
+                                user_tunnel_ips.unassign_block(user.tunnel_net.into());
+                            }
+                            if user.dz_ip != Ipv4Addr::UNSPECIFIED {
+                                device_state.release(user.dz_ip, user.tunnel_id).unwrap();
+                            }
 
                             *state_transitions
                                 .entry("user-deleting-to-deactivated")
@@ -344,6 +344,16 @@ pub fn process_user_event(
                     match res {
                         Ok(signature) => {
                             write!(&mut log_msg, " Banned {signature}").unwrap();
+
+                            if user.tunnel_id != 0 {
+                                link_ids.unassign(user.tunnel_id);
+                            }
+                            if user.tunnel_net != NetworkV4::default() {
+                                user_tunnel_ips.unassign_block(user.tunnel_net.into());
+                            }
+                            if user.dz_ip != Ipv4Addr::UNSPECIFIED {
+                                device_state.release(user.dz_ip, user.tunnel_id).unwrap();
+                            }
 
                             *state_transitions
                                 .entry("user-pending-ban-to-banned")


### PR DESCRIPTION
This pull request refactors the unassignment logic for various resources (e.g., tunnel IDs, IP blocks) to ensure that cleanup operations are performed only after successful state transitions. The changes improve the reliability and clarity of resource deallocation across different event-processing functions.

### Refactoring of unassignment logic:

* **`process_tunnel_event` (`activator/src/process/link.rs`)**:
  - Moved the unassignment of `link_ids` and `link_ips` to occur after a successful state transition to "tunnel-deleting-to-deactivated." This ensures cleanup happens only if the state transition is completed. [[1]](diffhunk://#diff-d9c91ea17e4fe3e26302887a60fd0596f950bcc4949005b71ae4fbf2acfc5ebbL85-L87) [[2]](diffhunk://#diff-d9c91ea17e4fe3e26302887a60fd0596f950bcc4949005b71ae4fbf2acfc5ebbR95-R97)

* **`process_multicastgroup_event` (`activator/src/process/multicastgroup.rs`)**:
  - Adjusted the unassignment of `multicastgroup_tunnel_ips` to take place after the state transition to "multicastgroup-deleting-to-deactivated," improving consistency and reliability in cleanup. [[1]](diffhunk://#diff-99283986d997d61d1c2b3bab783231dcc50435103090d2bf2910f112a0b17cc8L85-L87) [[2]](diffhunk://#diff-99283986d997d61d1c2b3bab783231dcc50435103090d2bf2910f112a0b17cc8R95-R97)

* **`process_user_event` (`activator/src/process/user.rs`)**:
  - Refactored the unassignment of `tunnel_id`, `tunnel_net`, and `dz_ip` to occur conditionally based on the user's status (e.g., deleting or banned). This ensures proper resource cleanup only when specific state transitions (e.g., "user-deleting-to-deactivated" or "user-pending-ban-to-banned") are successful. [[1]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR318-R324) [[2]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dL328-L334) [[3]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR348-R357)
