### PR TITLE
smartcontract: Move common custom serializer to doublezero-sdk

### DIFF
--- a/smartcontract/cli/src/contributor/list.rs
+++ b/smartcontract/cli/src/contributor/list.rs
@@ -1,6 +1,8 @@
 use crate::doublezerocommand::CliCommand;
 use clap::Args;
-use doublezero_sdk::{commands::contributor::list::ListContributorCommand, *};
+use doublezero_sdk::{
+    commands::contributor::list::ListContributorCommand, serializer, Contributor, ContributorStatus,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -18,11 +20,11 @@ pub struct ListContributorCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct ContributorDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     pub status: ContributorStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -5,7 +5,7 @@ use doublezero_sdk::{
         contributor::list::ListContributorCommand, device::list::ListDeviceCommand,
         exchange::list::ListExchangeCommand, location::list::ListLocationCommand,
     },
-    *,
+    serializer, Device, DeviceStatus, DeviceType, NetworkV4List,
 };
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
@@ -24,12 +24,12 @@ pub struct ListDeviceCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct DeviceDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     #[tabled(skip)]
     pub bump_seed: u8,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(skip)]
     pub location_pk: Pubkey,
     #[tabled(rename = "contributor")]
@@ -38,7 +38,7 @@ pub struct DeviceDisplay {
     pub location_code: String,
     #[tabled(skip)]
     pub location_name: String,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(skip)]
     pub exchange_pk: Pubkey,
     #[tabled(rename = "exchange")]
@@ -48,7 +48,7 @@ pub struct DeviceDisplay {
     pub device_type: DeviceType,
     pub public_ip: Ipv4Addr,
     #[tabled(display = "doublezero_serviceability::types::NetworkV4List::to_string")]
-    #[serde(serialize_with = "crate::serializer::serialize_networkv4list_as_string")]
+    #[serde(serialize_with = "serializer::serialize_networkv4list_as_string")]
     pub dz_prefixes: NetworkV4List,
     pub status: DeviceStatus,
     pub bgp_asn: u32,
@@ -58,7 +58,7 @@ pub struct DeviceDisplay {
     pub dns_servers: Vec<Ipv4Addr>,
     #[tabled(display = "stringify_vec")]
     pub ntp_servers: Vec<Ipv4Addr>,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/exchange/list.rs
+++ b/smartcontract/cli/src/exchange/list.rs
@@ -1,6 +1,8 @@
 use crate::doublezerocommand::CliCommand;
 use clap::Args;
-use doublezero_sdk::{commands::exchange::list::ListExchangeCommand, *};
+use doublezero_sdk::{
+    commands::exchange::list::ListExchangeCommand, serializer, Exchange, ExchangeStatus,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -18,7 +20,7 @@ pub struct ListExchangeCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct ExchangeDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     pub name: String,
@@ -26,7 +28,7 @@ pub struct ExchangeDisplay {
     pub lng: f64,
     pub loc_id: u32,
     pub status: ExchangeStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -19,7 +19,6 @@ pub mod location;
 pub mod logcommand;
 pub mod multicastgroup;
 pub mod requirements;
-pub mod serializer;
 pub mod subscribe;
 pub mod tests;
 pub mod user;

--- a/smartcontract/cli/src/link/list.rs
+++ b/smartcontract/cli/src/link/list.rs
@@ -5,7 +5,7 @@ use doublezero_sdk::{
         contributor::list::ListContributorCommand, device::list::ListDeviceCommand,
         link::list::ListLinkCommand,
     },
-    *,
+    serializer, Link, LinkLinkType, LinkStatus, NetworkV4,
 };
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
@@ -24,18 +24,18 @@ pub struct ListLinkCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct LinkDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     #[tabled(rename = "contributor")]
     pub contributor_code: String,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(rename = "side_a")]
     pub side_a_pk: Pubkey,
     #[tabled(skip)]
     pub side_a_name: String,
     pub side_a_iface_name: String,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(rename = "side_z")]
     pub side_z_pk: Pubkey,
     #[tabled(skip)]
@@ -51,7 +51,7 @@ pub struct LinkDisplay {
     pub tunnel_id: u16,
     pub tunnel_net: NetworkV4,
     pub status: LinkStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/location/list.rs
+++ b/smartcontract/cli/src/location/list.rs
@@ -1,6 +1,8 @@
 use crate::doublezerocommand::CliCommand;
 use clap::Args;
-use doublezero_sdk::{commands::location::list::ListLocationCommand, *};
+use doublezero_sdk::{
+    commands::location::list::ListLocationCommand, serializer, Location, LocationStatus,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -18,7 +20,7 @@ pub struct ListLocationCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct LocationDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     pub name: String,
@@ -26,7 +28,7 @@ pub struct LocationDisplay {
     pub lat: f64,
     pub lng: f64,
     pub status: LocationStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/multicastgroup/list.rs
+++ b/smartcontract/cli/src/multicastgroup/list.rs
@@ -1,6 +1,9 @@
 use crate::doublezerocommand::CliCommand;
 use clap::Args;
-use doublezero_sdk::{commands::multicastgroup::list::ListMulticastGroupCommand, *};
+use doublezero_sdk::{
+    commands::multicastgroup::list::ListMulticastGroupCommand, serializer, MulticastGroup,
+    MulticastGroupStatus,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr};
@@ -18,21 +21,21 @@ pub struct ListMulticastGroupCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct MulticastGroupDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub code: String,
     pub multicast_ip: Ipv4Addr,
-    #[serde(serialize_with = "crate::serializer::serialize_bandwidth_as_string")]
+    #[serde(serialize_with = "serializer::serialize_bandwidth_as_string")]
     #[tabled(display = "doublezero_serviceability::types::bandwidth_to_string")]
     pub max_bandwidth: u64,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkeylist_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkeylist_as_string")]
     #[tabled(display = "crate::util::display_count")]
     pub publishers: Vec<Pubkey>,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkeylist_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkeylist_as_string")]
     #[tabled(display = "crate::util::display_count")]
     pub subscribers: Vec<Pubkey>,
     pub status: MulticastGroupStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -5,7 +5,7 @@ use doublezero_sdk::{
         device::list::ListDeviceCommand, location::list::ListLocationCommand,
         multicastgroup::list::ListMulticastGroupCommand, user::list::ListUserCommand,
     },
-    MulticastGroup, *,
+    serializer, MulticastGroup, NetworkV4, User, UserCYOA, UserStatus, UserType,
 };
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
@@ -24,19 +24,19 @@ pub struct ListUserCliCommand {
 
 #[derive(Tabled, Serialize)]
 pub struct UserDisplay {
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub account: Pubkey,
     pub user_type: UserType,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(skip)]
     pub device_pk: Pubkey,
     #[tabled(rename = "groups")]
     pub multicast: String,
     #[tabled(skip)]
-    #[serde(serialize_with = "crate::serializer::serialize_pubkeylist_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkeylist_as_string")]
     pub publishers: Vec<Pubkey>,
     #[tabled(skip)]
-    #[serde(serialize_with = "crate::serializer::serialize_pubkeylist_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkeylist_as_string")]
     pub subscribers: Vec<Pubkey>,
     #[tabled(rename = "device")]
     pub device_name: String,
@@ -50,7 +50,7 @@ pub struct UserDisplay {
     pub tunnel_id: u16,
     pub tunnel_net: NetworkV4,
     pub status: UserStatus,
-    #[serde(serialize_with = "crate::serializer::serialize_pubkey_as_string")]
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
 

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -35,6 +35,7 @@ mod dztransaction;
 mod errors;
 
 pub mod commands;
+pub mod serializer;
 pub mod tests;
 pub mod utils;
 

--- a/smartcontract/sdk/rs/src/serializer.rs
+++ b/smartcontract/sdk/rs/src/serializer.rs
@@ -1,4 +1,4 @@
-use doublezero_sdk::bandwidth_to_string;
+use crate::bandwidth_to_string;
 use doublezero_serviceability::types::NetworkV4List;
 use solana_program::pubkey::Pubkey;
 


### PR DESCRIPTION
Summary
----
This PR moves the custom serializer.rs module from smartcontract/cli to smartcontract/sdk/rs; additionally it removes the glob style imports from the cli modules.

The primary reason for this change is so that users can easily access common custom serialization methods exposed directly from the rust sdk instead of having to use the cli as a dependent library.
