### PR TITLE
client: deflake LatencyUDPPing test

### DIFF
--- a/client/doublezerod/internal/latency/manager_test.go
+++ b/client/doublezerod/internal/latency/manager_test.go
@@ -197,16 +197,17 @@ func TestLatencyManager(t *testing.T) {
 }
 
 func TestLatencyUdpPing(t *testing.T) {
+	devices := []serviceability.Device{
+		{
+			AccountType: serviceability.DeviceType,
+			PublicIp:    [4]uint8{127, 0, 0, 1},
+			PubKey:      [32]byte{1},
+			Code:        "dev01",
+		},
+	}
+
 	mockSmartContractFunc := func(context.Context, string, string) (*latency.ContractData, error) {
-		return &latency.ContractData{
-			Devices: []serviceability.Device{
-				{
-					AccountType: serviceability.DeviceType,
-					PublicIp:    [4]uint8{127, 0, 0, 1},
-					PubKey:      [32]byte{1},
-				},
-			},
-		}, nil
+		return &latency.ContractData{Devices: devices}, nil
 	}
 
 	resultChan := make(chan struct{})
@@ -221,15 +222,8 @@ func TestLatencyUdpPing(t *testing.T) {
 		SmartContractFunc: mockSmartContractFunc,
 		ProberFunc:        mockProber,
 		DeviceCache: &latency.DeviceCache{
-			Devices: []serviceability.Device{
-				{
-					AccountType: serviceability.DeviceType,
-					PublicIp:    [4]uint8{127, 0, 0, 1},
-					PubKey:      [32]byte{1},
-					Code:        "dev01",
-				},
-			},
-			Lock: sync.Mutex{},
+			Devices: devices,
+			Lock:    sync.Mutex{},
 		},
 		ResultsCache: &latency.LatencyResults{Results: []latency.LatencyResult{}, Lock: sync.RWMutex{}},
 	}


### PR DESCRIPTION
## Summary of Changes
This attempts to deflake the LatencyUDPPing test we've seen fail since https://github.com/malbeclabs/doublezero/pull/1016 landed. We pre-populate the device cache in this test to avoid waiting on devices to be fetched but we are missing the device code in the mocked function used to fetch serviceability devices. There is a race here where the device without the code field was overwriting the pre-populated device with the code field in the device cache:
```
=== RUN   TestLatencyUdpPing
    manager_test.go:272: ResultsCache mismatch (-want +got):   []latency.LatencyResult{
          	{
          		... // 3 ignored fields
          		Loss: 0,
          		Device: serviceability.Device{
          			... // 7 identical fields
          			PublicIp:               {0x7f, 0x00, 0x00, 0x01},
          			Status:                 0,
        - 			Code:                   "dev01",
        + 			Code:                   "",
          			DzPrefixes:             nil,
          			MetricsPublisherPubKey: {0x00, 0x00, 0x00, 0x00, ...},
          			... // 8 identical fields
          		},
          		Reachable: true,
          	},
          }
        
--- FAIL: TestLatencyUdpPing (4.08s)
```

This PR refactors the test to use the same device cache for both pre-populating and fetching mocked onchain data.

## Testing Verification

```
for i in {1..100}; do echo "Running test iteration $i..."; go test -count=1 -run TestLatencyUdpPing ./client/doublezerod/internal/latency/...;   if [ $? -ne 0 ]; then echo "Test failed on iteration $i. Stopping."; break; fi; done
Running test iteration 100...
ok      github.com/malbeclabs/doublezero/client/doublezerod/internal/latency    4.101s
```
