### PR TITLE
release: add retries to validation

### DIFF
--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -13,6 +13,9 @@ jobs:
   validate_pipeline:
     runs-on: ubuntu-24.04-16c-64gb
     strategy:
+      fail-fast: false
+      max-retries: 3
+      delay-seconds: 10
       matrix:
         include:
           - release: activator


### PR DESCRIPTION
## Summary of Changes
Over the past week, we've been seeing transient errors with goreleaser fetching an external json schema file from github runners. There's a discussion opened [here](https://github.com/orgs/goreleaser/discussions/5954) with them but in the mean time, we should retry the validation jobs on failure in an attempt to maintain sanity.

## Testing Verification

Release validation CI tests should be green.