### PR TITLE
e2e: deflake device metrics startup

### DIFF
--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -258,7 +258,7 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 	err = la2MetricsClient.Fetch(t.Context())
 	require.NoError(t, err)
 	ny5MetricsClient := dn.Devices["ny5-dz01"].GetTelemetryMetricsClient()
-	require.NoError(t, ny5MetricsClient.WaitForReady(t.Context(), 10*time.Second))
+	require.NoError(t, ny5MetricsClient.WaitForReady(t.Context(), 60*time.Second))
 	err = ny5MetricsClient.Fetch(t.Context())
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary of Changes
- Update prometheus metrics wait for ready in device e2e test to have larger timeout for the device that has a management namespace configured
- Fixes https://github.com/malbeclabs/doublezero/issues/1061

## Testing Verification
- TBD
