### PR TITLE
funder: fund internet latency collector

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	inetlatencyconfig "github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/pkg/config"
 	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
@@ -19,9 +20,10 @@ var (
 )
 
 type NetworkConfig struct {
-	LedgerRPCURL            string
-	ServiceabilityProgramID solana.PublicKey
-	TelemetryProgramID      solana.PublicKey
+	LedgerRPCURL               string
+	ServiceabilityProgramID    solana.PublicKey
+	TelemetryProgramID         solana.PublicKey
+	InternetLatencyCollectorPK solana.PublicKey
 }
 
 func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
@@ -35,10 +37,15 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse telemetry program ID: %w", err)
 		}
+		internetLatencyCollectorPK, err := solana.PublicKeyFromBase58(inetlatencyconfig.TestnetCollectorPK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse internet latency collector oracle agent PK: %w", err)
+		}
 		return &NetworkConfig{
-			LedgerRPCURL:            dzsdk.DZ_LEDGER_RPC_URL,
-			ServiceabilityProgramID: serviceabilityProgramID,
-			TelemetryProgramID:      telemetryProgramID,
+			LedgerRPCURL:               dzsdk.DZ_LEDGER_RPC_URL,
+			ServiceabilityProgramID:    serviceabilityProgramID,
+			TelemetryProgramID:         telemetryProgramID,
+			InternetLatencyCollectorPK: internetLatencyCollectorPK,
 		}, nil
 	case EnvDevnet:
 		serviceabilityProgramID, err := solana.PublicKeyFromBase58(serviceability.SERVICEABILITY_PROGRAM_ID_DEVNET)
@@ -49,10 +56,15 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse telemetry program ID: %w", err)
 		}
+		internetLatencyCollectorPK, err := solana.PublicKeyFromBase58(inetlatencyconfig.DevnetCollectorPK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse internet latency collector oracle agent PK: %w", err)
+		}
 		return &NetworkConfig{
-			LedgerRPCURL:            dzsdk.DZ_LEDGER_RPC_URL,
-			ServiceabilityProgramID: serviceabilityProgramID,
-			TelemetryProgramID:      telemetryProgramID,
+			LedgerRPCURL:               dzsdk.DZ_LEDGER_RPC_URL,
+			ServiceabilityProgramID:    serviceabilityProgramID,
+			TelemetryProgramID:         telemetryProgramID,
+			InternetLatencyCollectorPK: internetLatencyCollectorPK,
 		}, nil
 	default:
 		return nil, ErrInvalidEnvironment

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/malbeclabs/doublezero/config"
+	inetlatencyconfig "github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/pkg/config"
 	dzsdk "github.com/malbeclabs/doublezero/smartcontract/sdk/go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
@@ -20,17 +21,19 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 		{
 			env: config.EnvTestnet,
 			want: &config.NetworkConfig{
-				LedgerRPCURL:            dzsdk.DZ_LEDGER_RPC_URL,
-				ServiceabilityProgramID: solana.MustPublicKeyFromBase58(serviceability.SERVICEABILITY_PROGRAM_ID_TESTNET),
-				TelemetryProgramID:      solana.MustPublicKeyFromBase58(telemetry.TELEMETRY_PROGRAM_ID_TESTNET),
+				LedgerRPCURL:               dzsdk.DZ_LEDGER_RPC_URL,
+				ServiceabilityProgramID:    solana.MustPublicKeyFromBase58(serviceability.SERVICEABILITY_PROGRAM_ID_TESTNET),
+				TelemetryProgramID:         solana.MustPublicKeyFromBase58(telemetry.TELEMETRY_PROGRAM_ID_TESTNET),
+				InternetLatencyCollectorPK: solana.MustPublicKeyFromBase58(inetlatencyconfig.TestnetCollectorPK),
 			},
 		},
 		{
 			env: config.EnvDevnet,
 			want: &config.NetworkConfig{
-				LedgerRPCURL:            dzsdk.DZ_LEDGER_RPC_URL,
-				ServiceabilityProgramID: solana.MustPublicKeyFromBase58(serviceability.SERVICEABILITY_PROGRAM_ID_DEVNET),
-				TelemetryProgramID:      solana.MustPublicKeyFromBase58(telemetry.TELEMETRY_PROGRAM_ID_DEVNET),
+				LedgerRPCURL:               dzsdk.DZ_LEDGER_RPC_URL,
+				ServiceabilityProgramID:    solana.MustPublicKeyFromBase58(serviceability.SERVICEABILITY_PROGRAM_ID_DEVNET),
+				TelemetryProgramID:         solana.MustPublicKeyFromBase58(telemetry.TELEMETRY_PROGRAM_ID_DEVNET),
+				InternetLatencyCollectorPK: solana.MustPublicKeyFromBase58(inetlatencyconfig.DevnetCollectorPK),
 			},
 		},
 		{

--- a/controlplane/funder/internal/funder/config.go
+++ b/controlplane/funder/internal/funder/config.go
@@ -8,18 +8,17 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
-	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
 var (
-	ErrLoggerRequired         = errors.New("logger is required")
-	ErrServiceabilityRequired = errors.New("serviceability is required")
-	ErrSolanaRequired         = errors.New("solana is required")
-	ErrSignerRequired         = errors.New("signer is required")
-	ErrSignerInvalid          = errors.New("signer is invalid")
-	ErrMinBalanceRequired     = errors.New("min balance is required")
-	ErrTopUpSOLRequired       = errors.New("top up is required")
-	ErrIntervalRequired       = errors.New("interval is required")
+	ErrLoggerRequired            = errors.New("logger is required")
+	ErrGetRecipientsFuncRequired = errors.New("get recipients func is required")
+	ErrSolanaRequired            = errors.New("solana is required")
+	ErrSignerRequired            = errors.New("signer is required")
+	ErrSignerInvalid             = errors.New("signer is invalid")
+	ErrMinBalanceRequired        = errors.New("min balance is required")
+	ErrTopUpSOLRequired          = errors.New("top up is required")
+	ErrIntervalRequired          = errors.New("interval is required")
 )
 
 const (
@@ -28,9 +27,9 @@ const (
 )
 
 type Config struct {
-	Logger         *slog.Logger
-	Serviceability ServiceabilityClient
-	Solana         SolanaClient
+	Logger            *slog.Logger
+	GetRecipientsFunc func(ctx context.Context) ([]Recipient, error)
+	Solana            SolanaClient
 
 	Signer                     solana.PrivateKey
 	MinBalanceSOL              float64
@@ -52,8 +51,8 @@ func (c *Config) Validate() error {
 	if c.Logger == nil {
 		return ErrLoggerRequired
 	}
-	if c.Serviceability == nil {
-		return ErrServiceabilityRequired
+	if c.GetRecipientsFunc == nil {
+		return ErrGetRecipientsFuncRequired
 	}
 	if c.Solana == nil {
 		return ErrSolanaRequired
@@ -80,11 +79,6 @@ func (c *Config) Validate() error {
 		c.WaitForBalancePollInterval = defaultWaitForBalancePollInterval
 	}
 	return nil
-}
-
-type ServiceabilityClient interface {
-	GetProgramData(ctx context.Context) (*serviceability.ProgramData, error)
-	ProgramID() solana.PublicKey
 }
 
 type SolanaClient interface {

--- a/controlplane/funder/internal/funder/main_test.go
+++ b/controlplane/funder/internal/funder/main_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/lmittmann/tint"
-	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
 var (
@@ -37,19 +36,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-type mockServiceability struct {
-	GetProgramDataFunc func(ctx context.Context) (*serviceability.ProgramData, error)
-	ProgramIDFunc      func() solana.PublicKey
-}
-
-func (m *mockServiceability) GetProgramData(ctx context.Context) (*serviceability.ProgramData, error) {
-	return m.GetProgramDataFunc(ctx)
-}
-
-func (m *mockServiceability) ProgramID() solana.PublicKey {
-	return m.ProgramIDFunc()
 }
 
 type mockSolana struct {

--- a/controlplane/funder/internal/funder/recipient.go
+++ b/controlplane/funder/internal/funder/recipient.go
@@ -1,0 +1,15 @@
+package funder
+
+import "github.com/gagliardetto/solana-go"
+
+type Recipient struct {
+	Name   string
+	PubKey solana.PublicKey
+}
+
+func NewRecipient(name string, pubKey solana.PublicKey) Recipient {
+	return Recipient{
+		Name:   name,
+		PubKey: pubKey,
+	}
+}

--- a/controlplane/funder/internal/metrics/metrics.go
+++ b/controlplane/funder/internal/metrics/metrics.go
@@ -19,12 +19,15 @@ const (
 	LabelFunderAccount = "funder_account"
 
 	// Error types.
-	ErrorTypeLoadServiceabilityState           = "load_serviceability_state"
-	ErrorTypeGetFunderAccountBalance           = "get_funder_account_balance"
-	ErrorTypeFunderAccountBalanceBelowMinimum  = "funder_account_balance_below_minimum"
-	ErrorTypeGetMetricsPublisherAccountBalance = "get_metrics_publisher_account_balance"
-	ErrorTypeTransferFundsToMetricsPublisher   = "transfer_funds_to_metrics_publisher"
-	ErrorTypeWaitForMetricsPublisherBalance    = "wait_for_metrics_publisher_balance"
+	ErrorTypeGetRecipients                           = "get_recipients"
+	ErrorTypeGetFunderAccountBalance                 = "get_funder_account_balance"
+	ErrorTypeFunderAccountBalanceBelowMinimum        = "funder_account_balance_below_minimum"
+	ErrorTypeGetRecipientAccountBalance              = "get_recipient_account_balance"
+	ErrorTypeTransferFundsToRecipient                = "transfer_funds_to_recipient"
+	ErrorTypeWaitForRecipientAccountBalance          = "wait_for_recipient_account_balance"
+	ErrorTypeGetInternetLatencyCollectorBalance      = "get_internet_latency_collector_account_balance"
+	ErrorTypeTransferFundsToInternetLatencyCollector = "transfer_funds_to_internet_latency_collector"
+	ErrorTypeWaitForInternetLatencyCollectorBalance  = "wait_for_internet_latency_collector_balance"
 )
 
 var (

--- a/controlplane/internet-latency-collector/pkg/config/constants.go
+++ b/controlplane/internet-latency-collector/pkg/config/constants.go
@@ -1,0 +1,6 @@
+package config
+
+const (
+	DevnetCollectorPK  = "3fXen9LP5JUAkaaDJtyLo1ohPiJ2LdzVqAnmhtGgAmwJ"
+	TestnetCollectorPK = "HWGQSTmXWMB85NY2vFLhM1nGpXA8f4VCARRyeGNbqDF1"
+)


### PR DESCRIPTION
## Summary of Changes
- Update funder to fund internet latency collector accounts
- Generalize funder to fund a set of recipients, constructing recipients as device metrics publishers with internet latency collectors
- Add internet latency constants for devnet and testnet collector account pubkeys
- Update global config getter/structure to include the env-specific internet latency collector account pubkey
- Resolves https://github.com/malbeclabs/doublezero/issues/992

## Testing Verification
- Update existing test coverage to match the generalized funder
