### PR TITLE
Reorder close_account to be the last command in the instruction

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
@@ -95,7 +95,6 @@ pub fn process_closeaccount_device(
     location.reference_count = location.reference_count.saturating_sub(1);
     exchange.reference_count = exchange.reference_count.saturating_sub(1);
 
-    account_close(device_account, owner_account)?;
     account_write(
         contributor_account,
         &contributor,
@@ -104,6 +103,7 @@ pub fn process_closeaccount_device(
     )?;
     account_write(location_account, &location, payer_account, system_program)?;
     account_write(exchange_account, &exchange, payer_account, system_program)?;
+    account_close(device_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: Device closed");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
@@ -97,7 +97,6 @@ pub fn process_closeaccount_link(
     side_a_dev.reference_count = side_a_dev.reference_count.saturating_sub(1);
     side_z_dev.reference_count = side_z_dev.reference_count.saturating_sub(1);
 
-    account_close(link_account, owner_account)?;
     account_write(
         contributor_account,
         &contributor,
@@ -106,6 +105,7 @@ pub fn process_closeaccount_link(
     )?;
     account_write(side_a_account, &side_a_dev, payer_account, system_program)?;
     account_write(side_z_account, &side_z_dev, payer_account, system_program)?;
+    account_close(link_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: Link closed");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -78,8 +78,8 @@ pub fn process_closeaccount_user(
 
     device.reference_count = device.reference_count.saturating_sub(1);
 
-    account_close(user_account, owner_account)?;
     account_write(device_account, &device, payer_account, system_program)?;
+    account_close(user_account, owner_account)?;
 
     #[cfg(test)]
     msg!("CloseAccount: User closed");


### PR DESCRIPTION
This pull request refactors the order of operations in the account closure functions for device, link, and user entities within the smart contract serviceability processors. The main change is moving the `account_close` calls to occur after all related accounts have been updated, ensuring that state changes are written before the account is closed.

**Account Closure Ordering:**

* In `closeaccount.rs` for devices, links, and users, the call to `account_close` for the main account (`device_account`, `link_account`, `user_account`) is moved to after all associated accounts have been updated with `account_write`. This ensures that all reference counts and state changes are saved before the account is closed. [[1]](diffhunk://#diff-4dc8e91e778a76dd97bbc1ef18003e0468937551326f5b20148087e6b2319a3aL98) [[2]](diffhunk://#diff-4dc8e91e778a76dd97bbc1ef18003e0468937551326f5b20148087e6b2319a3aR106) [[3]](diffhunk://#diff-ecef143d352ffddccdb98889b4a782236a9b5c7d27df5520517f166196587f55L100) [[4]](diffhunk://#diff-ecef143d352ffddccdb98889b4a782236a9b5c7d27df5520517f166196587f55R108) [[5]](diffhunk://#diff-1a57f330f56ab63fffb0b54730b9719296ffa69aa85db20efd2ab8d3e740a3c2L81-R82)