### PR TITLE
fix: update balance output to use "Credits" instead of "SOL" and improve error messages for account balance checks

### DIFF
--- a/smartcontract/cli/src/balance.rs
+++ b/smartcontract/cli/src/balance.rs
@@ -12,7 +12,7 @@ impl BalanceCliCommand {
 
         let balance = client.get_balance()?;
 
-        writeln!(out, "{} SOL", balance as f64 / 1000000000.0)?;
+        writeln!(out, "{} Credits", balance as f64 / 1000000000.0)?;
 
         Ok(())
     }

--- a/smartcontract/cli/src/requirements.rs
+++ b/smartcontract/cli/src/requirements.rs
@@ -53,7 +53,7 @@ pub fn check_id(spinner: Option<&ProgressBar>) -> eyre::Result<()> {
             }
 
             Err(eyre::eyre!(
-                "Please create a new id.json (doublezero keygen) and transfer balance."
+                "Please create a new id.json (doublezero keygen)"
             ))
         }
     }
@@ -70,7 +70,7 @@ pub fn check_balance(client: &dyn CliCommand, spinner: Option<&ProgressBar>) -> 
                     eprintln!("Insufficient balance");
                 }
                 eyre::bail!(
-                    "Please transfer some balance to your DoubleZero account [{}].",
+                    "This DoubleZero account has no available credits. Please recharge your account. [{}].",
                     client.get_payer().to_string()
                 );
             }


### PR DESCRIPTION
This pull request updates user-facing terminology and messaging in the CLI to improve clarity regarding account balances and credits. The most important changes are grouped below:

Balance terminology updates:

* Changed the output label in the `BalanceCliCommand` implementation from "SOL" to "Credits" to better reflect the unit of balance displayed to users.

User guidance and error messaging improvements:

* Updated the error message in `check_id` to remove instructions about transferring balance, focusing only on creating a new `id.json` using doublezero keygen.
* Revised the insufficient balance error in `check_balance` to clarify that the account has "no available credits" and instruct users to recharge their account, replacing the previous message about transferring balance.
