### PR TITLE
activator: log level info

### DIFF
--- a/activator/src/main.rs
+++ b/activator/src/main.rs
@@ -54,7 +54,7 @@ struct AppArgs {
     #[arg(long)]
     influxdb_bucket: Option<String>,
 
-    #[arg(long, default_value = "warn")]
+    #[arg(long, default_value = "info")]
     log_level: String,
 }
 


### PR DESCRIPTION
## Summary of Changes
- Update activator to have log level `info` instead of `warn`
- Resolves https://github.com/malbeclabs/doublezero/issues/1059

## Testing Verification
- Existing test coverage should remain green
