### PR TITLE
controller: user tunnel acls

### DIFF
--- a/controlplane/controller/internal/controller/fixtures/base.config.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.txt
@@ -115,7 +115,6 @@ router isis 1
 ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 !
-!
 no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
@@ -110,7 +110,6 @@ router isis 1
 ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 !
-!
 no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
@@ -84,7 +84,6 @@ router bgp 65342
 ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 !
-!
 no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.txt
@@ -1262,7 +1262,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.txt
@@ -1333,7 +1333,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT

--- a/controlplane/controller/internal/controller/fixtures/e2e.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.txt
@@ -1351,7 +1351,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT

--- a/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.txt
@@ -1236,7 +1236,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/controlplane/controller/internal/controller/fixtures/interfaces.txt
+++ b/controlplane/controller/internal/controller/fixtures/interfaces.txt
@@ -137,7 +137,6 @@ router isis 1
 ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 !
-!
 no ip access-list SEC-USER-PUB-MCAST-IN
 ip access-list SEC-USER-PUB-MCAST-IN
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/mixed.tunnel.txt
@@ -264,7 +264,6 @@ ip access-list SEC-USER-501-IN
 !
 no ip access-list SEC-USER-502-IN
 no ip access-list SEC-USER-503-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/multicast.tunnel.txt
@@ -214,7 +214,6 @@ ip prefix-list PL-USER-502 seq 10 permit 100.0.0.2/32
 no ip access-list SEC-USER-500-IN
 no ip access-list SEC-USER-501-IN
 no ip access-list SEC-USER-502-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.txt
@@ -253,7 +253,6 @@ ip access-list SEC-USER-501-IN
 !
 no ip access-list SEC-USER-502-IN
 no ip access-list SEC-USER-503-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry

--- a/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
+++ b/controlplane/controller/internal/controller/fixtures/unicast.tunnel.txt
@@ -245,7 +245,6 @@ ip access-list SEC-USER-502-IN
   permit ip 100.0.0.2/32 any
   deny ip any any
 !
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.txt
@@ -248,7 +248,6 @@ ip access-list SEC-USER-502-IN
   permit ip 100.0.0.2/32 any
   deny ip any any
 !
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -305,7 +305,6 @@ ip access-list SEC-USER-{{ .Id }}-IN
 !
 {{- end }}
 {{- end }}
-!
 {{- range .Device.Tunnels }}
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-{{ .Id }}-OUT
 {{- if and .Allocated .IsMulticast }}

--- a/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
@@ -1358,7 +1358,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -1413,7 +1413,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -1373,7 +1373,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -1413,7 +1413,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -1373,7 +1373,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
@@ -1403,7 +1403,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
@@ -1373,7 +1373,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
@@ -1402,7 +1402,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
    counters per-entry

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
@@ -1373,7 +1373,6 @@ no ip access-list SEC-USER-624-IN
 no ip access-list SEC-USER-625-IN
 no ip access-list SEC-USER-626-IN
 no ip access-list SEC-USER-627-IN
-!
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-501-OUT
 no ip access-list standard SEC-USER-MCAST-BOUNDARY-502-OUT


### PR DESCRIPTION
## Summary of Changes
- Update controller agent template to include user tunnel ACLs
- The `ip access-group` entry on the tunnel `interface` isn't supported in the local containerized environment, so we need to exclude it with the `NoHardware` option and will have to test it e2e on devnet instead:
  ```
  ny5-dz01(config)#interface Tunnel500
  ny5-dz01(config-if-Tu500)#ip access-group SEC-USER500-IN in
  % Unavailable command (not supported on this hardware platform)
  ```
- Resolves https://github.com/malbeclabs/doublezero/issues/832
- Resolves https://github.com/malbeclabs/doublezero/issues/833
- Related to https://github.com/malbeclabs/doublezero/issues/821

## Testing Verification
- Updated existing test coverage and fixtures to include these expectations
