### PR TITLE
Enhance contributor creation process by adding owner account transfer and updating command structure

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -811,7 +811,6 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
                 code: "test".to_string(),
-                owner: Pubkey::new_unique(),
             }),
             "CreateContributor",
         );

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -54,16 +54,18 @@ async fn test_contributor() {
     let (contributor_pubkey, _) =
         get_contributor_pda(&program_id, globalstate_account.account_index + 1);
 
+    let owner = Pubkey::new_unique();
+
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "la".to_string(),
-            owner: Pubkey::new_unique(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(owner, false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -139,10 +139,10 @@ async fn test_device() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,
@@ -612,10 +612,10 @@ async fn setup_program_with_location_and_exchange(
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
@@ -136,10 +136,10 @@ async fn exchange_setdevice() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
@@ -265,10 +265,10 @@ async fn test_doublezero_program() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-serviceability/tests/link_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_test.rs
@@ -143,10 +143,10 @@ async fn test_link() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -143,10 +143,10 @@ async fn test_user() {
         program_id,
         DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
             code: "cont".to_string(),
-            owner: payer.pubkey(),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,

--- a/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
@@ -877,9 +877,10 @@ impl ServiceabilityProgramHelper {
         let (contributor_pk, _) = get_contributor_pda(&self.program_id, index);
 
         self.execute_transaction(
-            DoubleZeroInstruction::CreateContributor(ContributorCreateArgs { code, owner }),
+            DoubleZeroInstruction::CreateContributor(ContributorCreateArgs { code }),
             vec![
                 AccountMeta::new(contributor_pk, false),
+                AccountMeta::new(owner, false),
                 AccountMeta::new(self.global_state_pubkey, false),
             ],
         )

--- a/smartcontract/sdk/rs/src/commands/contributor/create.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/create.rs
@@ -23,10 +23,10 @@ impl CreateContributorCommand {
             .execute_transaction(
                 DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
                     code: self.code.clone(),
-                    owner: self.owner,
                 }),
                 vec![
                     AccountMeta::new(pda_pubkey, false),
+                    AccountMeta::new(self.owner, false),
                     AccountMeta::new(globalstate_pubkey, false),
                 ],
             )
@@ -54,6 +54,7 @@ mod tests {
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
+        let owner = Pubkey::new_unique();
 
         client
             .expect_execute_transaction()
@@ -61,11 +62,11 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::CreateContributor(
                     ContributorCreateArgs {
                         code: "test".to_string(),
-                        owner: Pubkey::default(),
                     },
                 )),
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
+                    AccountMeta::new(owner, false),
                     AccountMeta::new(globalstate_pubkey, false),
                 ]),
             )
@@ -73,7 +74,7 @@ mod tests {
 
         let res = CreateContributorCommand {
             code: "test".to_string(),
-            owner: Pubkey::default(),
+            owner,
         }
         .execute(&client);
 

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -50,7 +50,7 @@ solana logs >./logs/instruction.log 2>&1 &
 
 # Build the activator
 echo "Start the activator"
-RUST_LOG=info ./target/doublezero-activator --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX --ws ws://127.0.0.1:8900 >./logs/activator.log 2>&1 &
+RUST_LOG=info ./target/doublezero-activator --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX --rpc http://127.0.0.1:8899 --ws ws://127.0.0.1:8900 --keypair ./keypair.json >./logs/activator.log 2>&1 &
 
 echo "Add allowlist"
 ./target/doublezero global-config allowlist add --pubkey 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX


### PR DESCRIPTION
This pull request introduces an important update to the contributor creation flow in the DoubleZero smart contract, ensuring that the owner account receives sufficient lamports for rent exemption when a contributor is created. The changes affect both the on-chain program logic and the client SDK, as well as test coverage and the local test environment.

**Contributor Account Creation Improvements:**

* Added a transfer of lamports (1 SOL) from the payer to the contributor's owner account during contributor creation to cover rent exemption, using `invoke_signed_unchecked` and `system_instruction::transfer` in `create.rs`. [[1]](diffhunk://#diff-8c4976fb9f1d9a53e9f9a6172903c3f336c7ca526c4c13e94700b9576a3a7e58R12-R15) [[2]](diffhunk://#diff-8c4976fb9f1d9a53e9f9a6172903c3f336c7ca526c4c13e94700b9576a3a7e58R90-R100)
* Updated the contributor creation processor to require and handle the `owner_account` as an explicit account parameter.

**SDK and Test Updates:**

* Modified the SDK command for contributor creation to include the owner account in the required account metadata, ensuring correct instruction construction.
* Updated unit tests for contributor creation to use a unique owner public key and verify that the correct accounts are passed, improving test accuracy.

**Test Environment Enhancement:**

* Enhanced the test startup script to pass the RPC endpoint and keypair to the activator, supporting more robust local testing.