### PR TITLE
smartcontract: add missing serde derive for Device struct

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -246,6 +246,7 @@ impl From<&mut ByteReader<'_>> for Interface {
 }
 
 #[derive(BorshSerialize, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Device {
     pub account_type: AccountType,    // 1
     pub owner: Pubkey,                // 32


### PR DESCRIPTION
Summary
----
One line change to add `serde` derive for `Device` state struct.
