### PR TITLE
release: add missing nightly config for internet latency collector

### DIFF
--- a/release/.goreleaser.base.internet-latency-collector.yaml
+++ b/release/.goreleaser.base.internet-latency-collector.yaml
@@ -80,4 +80,4 @@ nightly:
   publish_release: true
   keep_single_release: true
   version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
-  tag_name: 'funder/daily'
+  tag_name: 'internet-latency-collector/daily'


### PR DESCRIPTION
## Summary of Changes
- Add missing `nightly` stanza to internet latency collector goreleaser config

