### PR TITLE
release: minimal unit service files in packaging of core components

### DIFF
--- a/release/.goreleaser.base.activator.yaml
+++ b/release/.goreleaser.base.activator.yaml
@@ -53,6 +53,16 @@ nfpms:
     bindir: /usr/local/bin
     release: 1
     section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-activator.service
+        dst: /lib/systemd/system/doublezero-activator.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-activator.service
+            dst: /usr/lib/systemd/system/doublezero-activator.service
+            type: config
 
 changelog:
   sort: asc

--- a/release/.goreleaser.base.controller.yaml
+++ b/release/.goreleaser.base.controller.yaml
@@ -51,6 +51,16 @@ nfpms:
     bindir: /usr/local/bin
     release: "1"
     section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-controller.service
+        dst: /lib/systemd/system/doublezero-controller.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-controller.service
+            dst: /usr/lib/systemd/system/doublezero-controller.service
+            type: config
 
 changelog:
   sort: asc

--- a/release/.goreleaser.base.funder.yaml
+++ b/release/.goreleaser.base.funder.yaml
@@ -51,6 +51,16 @@ nfpms:
     bindir: /usr/local/bin
     release: "1"
     section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-funder.service
+        dst: /lib/systemd/system/doublezero-funder.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-funder.service
+            dst: /usr/lib/systemd/system/doublezero-funder.service
+            type: config
 
 changelog:
   sort: asc

--- a/release/.goreleaser.base.internet-latency-collector.yaml
+++ b/release/.goreleaser.base.internet-latency-collector.yaml
@@ -51,6 +51,16 @@ nfpms:
     bindir: /usr/local/bin
     release: "1"
     section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-internet-latency-collector.service
+        dst: /lib/systemd/system/doublezero-internet-latency-collector.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-internet-latency-collector.service
+            dst: /usr/lib/systemd/system/doublezero-internet-latency-collector.service
+            type: config
 
 changelog:
   sort: asc

--- a/release/packaging/systemd/doublezero-activator.service
+++ b/release/packaging/systemd/doublezero-activator.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the activator with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-activator.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Activator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-activator
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/release/packaging/systemd/doublezero-controller.service
+++ b/release/packaging/systemd/doublezero-controller.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the controller with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-controller.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Controller
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-controller
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/release/packaging/systemd/doublezero-funder.service
+++ b/release/packaging/systemd/doublezero-funder.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the funder with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-funder.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Funder
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-funder
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/release/packaging/systemd/doublezero-internet-latency-collector.service
+++ b/release/packaging/systemd/doublezero-internet-latency-collector.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the internet latency collector with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-internet-latency-collector.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Internet Latency Collector
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-internet-latency-collector
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary of Changes
- Update core components to include minimal systemd unit service files in their packaging, to avoid having it removed on snapshot install when not using ansible
- Fixes https://github.com/malbeclabs/doublezero/issues/1139
- Related to https://github.com/malbeclabs/doublezero/issues/978

## Testing Verification
- Tested in devnet on internet latency collector using this branch and ansible updates in https://github.com/malbeclabs/infra/pull/76
