### PR TITLE
controller: update template to render correct syntax for VLAN tagging on sub-interfaces

### DIFF
--- a/controlplane/controller/internal/controller/fixtures/e2e.txt
+++ b/controlplane/controller/internal/controller/fixtures/e2e.txt
@@ -72,7 +72,7 @@ interface Switch1/1/2
 !
 interface Switch1/1/2.100
    mtu 2048
-   encapsulation dot1q 100
+   encapsulation dot1q vlan 100
    ip address 172.16.0.2/31
    pim ipv4 sparse-mode
    isis enable 1

--- a/controlplane/controller/internal/controller/fixtures/interfaces.txt
+++ b/controlplane/controller/internal/controller/fixtures/interfaces.txt
@@ -72,7 +72,7 @@ interface Switch1/1/2
 !
 interface Switch1/1/2.100
    mtu 2048
-   encapsulation dot1q 100
+   encapsulation dot1q vlan 100
    ip address 172.16.0.2/31
    pim ipv4 sparse-mode
    isis enable 1

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -58,7 +58,7 @@ interface {{ .Name }}
    no switchport
    {{- end }}
    {{- if .VlanId}}
-   encapsulation dot1q {{ .VlanId }}
+   encapsulation dot1q vlan {{ .VlanId }}
    {{- end }}
    {{- if .Ip.IsValid }}
    ip address {{ .Ip.Addr }}/{{ .Ip.Bits }}


### PR DESCRIPTION
## Summary of Changes
* Controller template and fixtures update to support sub-interfaces with VLAN tagging on DZD
* We are using this feature extensively to support pseudowires with Jump
