### PR TITLE
CLI: normalize interface names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "indicatif",
  "ipnetwork",
  "mockall",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ipnetwork = "0"
 log = "0"
 metrics = "0"
 mockall = "0"
+regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1"
 serde_bytes = "0"

--- a/smartcontract/cli/Cargo.toml
+++ b/smartcontract/cli/Cargo.toml
@@ -24,6 +24,7 @@ futures-util.workspace = true
 http.workspace = true
 indicatif.workspace = true
 mockall.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -3,7 +3,7 @@ use crate::{
     doublezerocommand::CliCommand,
     poll_for_activation::poll_for_device_activated,
     requirements::{CHECK_BALANCE, CHECK_ID_JSON},
-    validators::validate_pubkey_or_code,
+    validators::{validate_iface, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::{
@@ -19,7 +19,7 @@ pub struct CreateDeviceInterfaceCliCommand {
     #[arg(value_parser = validate_pubkey_or_code, required = true)]
     pub device: String,
     /// Interface name
-    #[arg(required = true)]
+    #[arg(value_parser = validate_iface, required = true)]
     pub name: String,
     /// Interface type
     #[arg()]

--- a/smartcontract/cli/src/device/interface/delete.rs
+++ b/smartcontract/cli/src/device/interface/delete.rs
@@ -2,7 +2,7 @@ use crate::{
     doublezerocommand::CliCommand,
     poll_for_activation::poll_for_device_activated,
     requirements::{CHECK_BALANCE, CHECK_ID_JSON},
-    validators::validate_pubkey_or_code,
+    validators::{validate_iface, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::commands::device::{get::GetDeviceCommand, update::UpdateDeviceCommand};
@@ -14,7 +14,7 @@ pub struct DeleteDeviceInterfaceCliCommand {
     #[arg(value_parser = validate_pubkey_or_code, required = true)]
     pub device: String,
     /// Interface name
-    #[arg(required = true)]
+    #[arg(value_parser = validate_iface, required = true)]
     pub name: String,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]

--- a/smartcontract/cli/src/device/interface/get.rs
+++ b/smartcontract/cli/src/device/interface/get.rs
@@ -1,4 +1,7 @@
-use crate::{doublezerocommand::CliCommand, validators::validate_pubkey_or_code};
+use crate::{
+    doublezerocommand::CliCommand,
+    validators::{validate_iface, validate_pubkey_or_code},
+};
 use clap::Args;
 use doublezero_sdk::commands::device::get::GetDeviceCommand;
 use std::io::Write;
@@ -9,7 +12,7 @@ pub struct GetDeviceInterfaceCliCommand {
     #[arg(value_parser = validate_pubkey_or_code, required = true)]
     pub device: String,
     /// Interface name
-    #[arg(required = true)]
+    #[arg(value_parser = validate_iface, required = true)]
     pub name: String,
 }
 

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -3,7 +3,7 @@ use crate::{
     doublezerocommand::CliCommand,
     poll_for_activation::poll_for_device_activated,
     requirements::{CHECK_BALANCE, CHECK_ID_JSON},
-    validators::validate_pubkey_or_code,
+    validators::{validate_iface, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::{
@@ -18,7 +18,7 @@ pub struct UpdateDeviceInterfaceCliCommand {
     #[arg(value_parser = validate_pubkey_or_code, required = true)]
     pub pubkey_or_code: String,
     /// Interface name
-    #[arg(required = true)]
+    #[arg(value_parser = validate_iface, required = true)]
     pub name: String,
     /// Interface type (Loopback or Physical)
     #[arg(long)]

--- a/smartcontract/cli/src/validators.rs
+++ b/smartcontract/cli/src/validators.rs
@@ -1,5 +1,7 @@
 use doublezero_sdk::bandwidth_parse;
+use regex::Regex;
 use solana_sdk::pubkey::Pubkey;
+use std::sync::LazyLock;
 
 pub fn validate_code(val: &str) -> Result<String, String> {
     if val
@@ -83,6 +85,45 @@ pub fn validate_parse_jitter_ms(val: &str) -> Result<f64, String> {
     }
 }
 
+static INTERFACE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)^(Ethernet\d+(/\d+)?|Switch\d+/\d+/\d+|Loopback\d+|Port-Channel\d+|Vlan\d+)(\.\d+)?$",
+    )
+    .unwrap()
+});
+
+static INTERFACE_SHORTHAND_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^(et\d+(/\d+)?|sw\d+/\d+/\d+|lo\d+|po\d+|vl\d+)(\.\d*)?$").unwrap()
+});
+
+fn capitalize(s: String) -> String {
+    let ls = s.to_lowercase();
+    let mut c = ls.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+pub fn validate_iface(val: &str) -> Result<String, String> {
+    if INTERFACE_REGEX.is_match(val) {
+        Ok(capitalize(val.to_string()))
+    } else if INTERFACE_SHORTHAND_REGEX.is_match(val) {
+        match val[0..2].to_lowercase().as_str() {
+            "et" => Ok(format!("Ethernet{}", &val[2..])),
+            "sw" => Ok(format!("Switch{}", &val[2..])),
+            "lo" => Ok(format!("Loopback{}", &val[2..])),
+            "po" => Ok(format!("Port-Channel{}", &val[2..])),
+            "vl" => Ok(format!("Vlan{}", &val[2..])),
+            _ => Err(String::from("Invalid interface shorthand")),
+        }
+    } else {
+        Err(String::from(
+            "Interface name not valid. Must match: EthernetX[/X], SwitchX/X/X, LoopbackX, Port-ChannelX, or VlanX",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +182,28 @@ mod tests {
         assert!(validate_parse_jitter_ms("0.5").is_err());
         assert!(validate_parse_jitter_ms("1001").is_err());
         assert!(validate_parse_jitter_ms("not_a_number").is_err());
+    }
+
+    #[test]
+    fn test_validate_iface() {
+        assert!(validate_iface("Ethernet1").is_ok());
+        assert!(validate_iface("Ethernet1/1").is_ok());
+        assert!(validate_iface("ethernet2/2").unwrap() == "Ethernet2/2");
+        assert!(validate_iface("ETHERNET2/2").unwrap() == "Ethernet2/2");
+        assert!(validate_iface("Ethernet1/1.123").is_ok());
+        assert!(validate_iface("Ethernet1/1.abc").is_err());
+        assert!(validate_iface("et2/4").unwrap() == "Ethernet2/4");
+        assert!(validate_iface("Switch1/1/1").is_ok());
+        assert!(validate_iface("Switch1/1/1.42").is_ok());
+        assert!(validate_iface("Switch1/1/1.foobar").is_err());
+        assert!(validate_iface("sw3/12/20").unwrap() == "Switch3/12/20");
+        assert!(validate_iface("Loopback0").is_ok());
+        assert!(validate_iface("Port-Channel1").is_ok());
+        assert!(validate_iface("Port-Channel1.5000").is_ok());
+        assert!(validate_iface("Port-Channel1.").is_err());
+        assert!(validate_iface("Vlan123").is_ok());
+        assert!(validate_iface("Vlan123.456").is_ok());
+        assert!(validate_iface("vl1001").unwrap() == "Vlan1001");
+        assert!(validate_iface("InvalidInterface").is_err());
     }
 }


### PR DESCRIPTION
Issue #1110

## Summary of Changes
* Normalizes interface names and prevent users from creating arbitrary names.
* Supports EthernetX/X, SwitchX/X/X, LoopbackX, Port-ChanellX. Case is always made into a capital letter, followed by lowercase.
* Support shorthand etX/X, swX/X/X, loX, poX and automatically normalizes these

## Testing Verification
* added unit tests for matching and normalization
