### PR TITLE
add in env (testnet, devnet) as a param to cilent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
  "clap_complete",
  "console",
  "ctor",
+ "doublezero-config",
  "doublezero-serviceability",
  "doublezero_cli",
  "doublezero_sdk",

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -40,6 +40,7 @@ tokio.workspace = true
 # Dependencies from this workspace
 doublezero_sdk.workspace = true
 doublezero_cli.workspace = true
+doublezero-config.workspace = true
 doublezero-serviceability.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary of Changes
This PR adds in an `env` param which allows a user to set `testnet` or `devnet` instead of entering an `url`, `ws` and `program_id`.  Once we have mainnet-beta up, we'll add in a `mainnet` config. 

There's some cleanup that can be done in the config but not necessary for mainnet-beta. Tracked here. #1168
## Testing Verification
* e2e tests pass
