### PR TITLE
add mainnet program_id to mirror dev/testnets

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/addresses/mainnet/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/addresses/mainnet/mod.rs
@@ -1,0 +1,1 @@
+pub mod program_id;

--- a/smartcontract/programs/doublezero-serviceability/src/addresses/mainnet/program_id.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/addresses/mainnet/program_id.rs
@@ -1,0 +1,1 @@
+solana_program::declare_id!("ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv");

--- a/smartcontract/programs/doublezero-serviceability/src/addresses/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/addresses/mod.rs
@@ -1,3 +1,4 @@
 pub mod devnet;
 pub mod doublezero_foundation;
+pub mod mainnet;
 pub mod testnet;


### PR DESCRIPTION
## Summary of Changes
* Adds program id macro declaration for mainnet serviceability
* Consistently declares program ID across all valid instances of the serviceability program
* addresses https://github.com/malbeclabs/doublezero/issues/1182
* No existing tests fail

## Testing Verification
* Show evidence of testing the change
