### PR TITLE
changelog: fix typo in v0.5.0 diff link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.5.0] (https://github.com/malbeclabs/doublezero/compare/client/v0.4.0...client/v0.5.0) – 2025-08-11
+## [v0.5.0](https://github.com/malbeclabs/doublezero/compare/client/v0.4.0...client/v0.5.0) – 2025-08-11
 
 - **CLI & UX Improvements**
     - `doublezero connect` now waits for the user account to be visible onchain.


### PR DESCRIPTION
## Summary of Changes
- Removes extra space in v0.5.0 diff link in the changelog
