### PR TITLE
feat(internet-latency-collector): #1213 add ripeatlas credit metric

### DIFF
--- a/controlplane/internet-latency-collector/internal/metrics/metrics.go
+++ b/controlplane/internet-latency-collector/internal/metrics/metrics.go
@@ -50,6 +50,11 @@ var (
 		Help: "Total number of failed ripeatlas measurement management runs",
 	})
 
+	RipeatlasCreditBalance = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "doublezero_internet_latency_collector_ripeatlas_credit_balance",
+		Help: "Current RIPE Atlas credit balance",
+	})
+
 	// Wheresitup specific metrics
 	WheresitupJobCreationRunsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "doublezero_internet_latency_collector_wheresitup_job_creation_runs_total",

--- a/controlplane/internet-latency-collector/internal/ripeatlas/client.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client.go
@@ -368,3 +368,22 @@ func (c *Client) StopMeasurement(ctx context.Context, measurementID int) error {
 		slog.Int("status_code", resp.StatusCode))
 	return nil
 }
+
+func (c *Client) GetCreditBalance(ctx context.Context) (float64, error) {
+	endpoint := "/credits/"
+	resp, err := c.makeRequest(ctx, endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get credit balance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var response struct {
+		CurrentBalance float64 `json:"current_balance"`
+	}
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&response); err != nil {
+		return 0, fmt.Errorf("failed to decode credit balance response: %w", err)
+	}
+
+	return response.CurrentBalance, nil
+}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
@@ -942,3 +942,33 @@ func TestInternetLatency_RIPEAtlas_GetMeasurementResultsIncremental(t *testing.T
 		})
 	}
 }
+
+func TestInternetLatency_RIPEAtlas_GetCreditBalance(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	client := &Client{
+		log:     log,
+		BaseURL: "https://atlas.ripe.net/api/v2",
+		HTTPClient: &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				response := struct {
+					CurrentBalance float64 `json:"current_balance"`
+				}{
+					CurrentBalance: 1000.0,
+				}
+				body, _ := json.Marshal(response)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}, nil
+			},
+		},
+	}
+
+	balance, err := client.GetCreditBalance(t.Context())
+
+	require.NoError(t, err, "GetCreditBalance() should not return error")
+	require.Equal(t, 1000.0, balance, "Expected credit balance to be 1000")
+}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -30,6 +30,7 @@ type clientInterface interface {
 	GetAllMeasurements(ctx context.Context, env string) ([]Measurement, error)
 	GetMeasurementResultsIncremental(ctx context.Context, measurementID int, startTimestamp int64) ([]any, error)
 	StopMeasurement(ctx context.Context, measurementID int) error
+	GetCreditBalance(ctx context.Context) (float64, error)
 }
 
 type LocationProbeMatch struct {
@@ -821,6 +822,12 @@ func (c *Collector) Run(ctx context.Context, dryRun bool, probesPerLocation int,
 					metrics.CollectionFailuresTotal.WithLabelValues("ripeatlas").Inc()
 				} else {
 					metrics.CollectionRunsTotal.WithLabelValues("ripeatlas").Inc()
+				}
+
+				if balance, err := c.client.GetCreditBalance(ctx); err != nil {
+					c.log.Warn("Failed to get RIPE Atlas credit balance", slog.String("error", err.Error()))
+				} else {
+					metrics.RipeatlasCreditBalance.Set(balance)
 				}
 			}
 		}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
@@ -29,6 +29,7 @@ type MockClient struct {
 	GetMeasurementResultsFunc            func(ctx context.Context, measurementID int) ([]any, error)
 	GetMeasurementResultsIncrementalFunc func(ctx context.Context, measurementID int, startTimestamp int64) ([]any, error)
 	StopMeasurementFunc                  func(ctx context.Context, measurementID int) error
+	GetCreditBalanceFunc                 func(ctx context.Context) (float64, error)
 }
 
 func (m *MockClient) GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int) ([]Probe, error) {
@@ -78,6 +79,13 @@ func (m *MockClient) StopMeasurement(ctx context.Context, measurementID int) err
 		return m.StopMeasurementFunc(ctx, measurementID)
 	}
 	return nil
+}
+
+func (m *MockClient) GetCreditBalance(ctx context.Context) (float64, error) {
+	if m.GetCreditBalanceFunc != nil {
+		return m.GetCreditBalanceFunc(ctx)
+	}
+	return 0, nil
 }
 
 func TestInternetLatency_RIPEAtlas_GetNearestProbesSorted(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes
* Add a metric tracking ripeatlas credits
* To be used for alerting, and to track behavior of credit usage over time

## Testing Verification
* Unit tests
