### PR TITLE
CLI: device interface names comparisons should be case-insensitive

### DIFF
--- a/smartcontract/cli/src/device/interface/delete.rs
+++ b/smartcontract/cli/src/device/interface/delete.rs
@@ -32,9 +32,15 @@ impl DeleteDeviceInterfaceCliCommand {
             })
             .map_err(|_| eyre::eyre!("Device not found"))?;
 
+        let len_before = device.interfaces.len();
         device
             .interfaces
-            .retain(|i| i.into_current_version().name != self.name);
+            .retain(|i| i.into_current_version().name.to_lowercase() != self.name.to_lowercase());
+        let len_after = device.interfaces.len();
+
+        if len_before == len_after {
+            return Err(eyre::eyre!("Interface '{}' not found", self.name));
+        }
 
         let signature = client.update_device(UpdateDeviceCommand {
             pubkey,
@@ -162,7 +168,7 @@ mod tests {
         let mut output = Vec::new();
         let res = DeleteDeviceInterfaceCliCommand {
             device: device_pk.to_string(),
-            name: "eth0".to_string(),
+            name: "Eth0".to_string(),
             wait: false,
         }
         .execute(&client, &mut output);

--- a/smartcontract/cli/src/device/interface/get.rs
+++ b/smartcontract/cli/src/device/interface/get.rs
@@ -25,7 +25,7 @@ impl GetDeviceInterfaceCliCommand {
         let interface = device
             .interfaces
             .iter()
-            .find(|i| i.into_current_version().name == self.name)
+            .find(|i| i.into_current_version().name.to_lowercase() == self.name.to_lowercase())
             .map(|i| i.into_current_version())
             .ok_or_else(|| eyre::eyre!("Interface '{}' not found", self.name))?;
 
@@ -120,7 +120,7 @@ mod tests {
         let mut output = Vec::new();
         let res = GetDeviceInterfaceCliCommand {
             device: Pubkey::new_unique().to_string(),
-            name: "eth0".to_string(),
+            name: "Eth0".to_string(),
         }
         .execute(&client, &mut output);
         assert!(res.is_err(), "I shouldn't find anything.");

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -56,7 +56,7 @@ impl UpdateDeviceInterfaceCliCommand {
         let idx = device
             .interfaces
             .iter()
-            .position(|i| i.into_current_version().name == self.name)
+            .position(|i| i.into_current_version().name.to_lowercase() == self.name.to_lowercase())
             .ok_or_else(|| {
                 eyre::eyre!(
                     "Interface with name '{}' does not exist on device '{}'",
@@ -242,7 +242,7 @@ mod tests {
         let mut output = Vec::new();
         let res = UpdateDeviceInterfaceCliCommand {
             pubkey_or_code: device1_pubkey.to_string(),
-            name: "lo0".to_string(),
+            name: "Lo0".to_string(),
             interface_type: None,
             loopback_type: Some(super::LoopbackType::Ipv4),
             vlan_id: Some(20),

--- a/smartcontract/cli/src/validators.rs
+++ b/smartcontract/cli/src/validators.rs
@@ -70,7 +70,7 @@ pub fn validate_parse_jitter_ms(val: &str) -> Result<f64, String> {
 
 static INTERFACE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?i)^(Ethernet\d+(/\d+)?|Switch\d+/\d+/\d+|Loopback\d+|Port-Channel\d+|Vlan\d+)(\.\d+)?$",
+        r"(?i)^(Ethernet\d+(/\d+)?|Switch\d+/\d+/\d+|Loopback\d+|Port-channel\d+|Vlan\d+)(\.\d+)?$",
     )
     .unwrap()
 });
@@ -96,13 +96,13 @@ pub fn validate_iface(val: &str) -> Result<String, String> {
             "et" => Ok(format!("Ethernet{}", &val[2..])),
             "sw" => Ok(format!("Switch{}", &val[2..])),
             "lo" => Ok(format!("Loopback{}", &val[2..])),
-            "po" => Ok(format!("Port-Channel{}", &val[2..])),
+            "po" => Ok(format!("Port-channel{}", &val[2..])),
             "vl" => Ok(format!("Vlan{}", &val[2..])),
             _ => Err(String::from("Invalid interface shorthand")),
         }
     } else {
         Err(String::from(
-            "Interface name not valid. Must match: EthernetX[/X], SwitchX/X/X, LoopbackX, Port-ChannelX, or VlanX",
+            "Interface name not valid. Must match: EthernetX[/X], SwitchX/X/X, LoopbackX, Port-channelX, or VlanX",
         ))
     }
 }
@@ -183,8 +183,10 @@ mod tests {
         assert!(validate_iface("sw3/12/20").unwrap() == "Switch3/12/20");
         assert!(validate_iface("Loopback0").is_ok());
         assert!(validate_iface("Port-Channel1").is_ok());
+        assert!(validate_iface("Port-Channel1").unwrap() == "Port-channel1");
         assert!(validate_iface("Port-Channel1.5000").is_ok());
         assert!(validate_iface("Port-Channel1.").is_err());
+        assert!(validate_iface("po1000.2035").unwrap() == "Port-channel1000.2035");
         assert!(validate_iface("Vlan123").is_ok());
         assert!(validate_iface("Vlan123.456").is_ok());
         assert!(validate_iface("vl1001").unwrap() == "Vlan1001");


### PR DESCRIPTION
Bug: the interface normalization code was normalizing, incorrectly, po1000.2035 to Port-Channel1000.2035. The 'C' in channel should be lowercase to match the normalization rules. This meant that if an interface was create with shorthand notation and was then deleted with regular notation, it wouldn't find the interface.

## Summary of Changes
* Change "po" mapping in the validation code to map to "Port-channelXXX"
* Make all name comparisons case insensitive
* Add an error message to delete if the interface name is not found

## Testing Verification
* Updated tests to include mixed case
* Added validation code test specifically for the the case in question
