### PR TITLE
qa: add prom metrics

### DIFF
--- a/e2e/internal/rpc/metrics.go
+++ b/e2e/internal/rpc/metrics.go
@@ -1,0 +1,18 @@
+package rpc
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	BuildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "doublezero_qaagent_build_info",
+		Help: "Build information of the QA agent",
+	},
+		[]string{"version", "commit", "date"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(BuildInfo)
+}


### PR DESCRIPTION
## Summary of Changes
This exposes prometheus metrics from the QA agent. Build info is exposed similar to other services as well as go runtime stats.

## Testing Verification

The default values for commit, data and version are expected since they aren't being set by LDFLAGS, which is done as part of our build pipeline:
```
root ➜ /workspaces/doublezero/e2e (feature/qa_metrics) $ curl -s http://localhost:2112/metrics | grep version
doublezero_qaagent_build_info{commit="none",date="unknown",version="dev"} 1
```
