### PR TITLE
config: use ledger RPC LB endpoint

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	// Mainnet constants.
-	MainnetLedgerPublicRPCURL         = "https://doublezero-mainnet-beta-local.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
+	MainnetLedgerPublicRPCURL         = "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
 	MainnetServiceabilityProgramID    = "ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv"
 	MainnetTelemetryProgramID         = "tE1exJ5VMyoC9ByZeSmgtNzJCFF74G9JAv338sJiqkC"
 	MainnetInternetLatencyCollectorPK = "8xHn4r7oQuqNZ5cLYwL5YZcDy1JjDQcpVkyoA8Dw5uXH"

--- a/config/src/env.rs
+++ b/config/src/env.rs
@@ -24,8 +24,8 @@ impl Environment {
     pub fn config(&self) -> eyre::Result<NetworkConfig> {
         let mut config = match self {
             Environment::Mainnet => NetworkConfig {
-                ledger_public_rpc_url: "https://doublezero-mainnet-beta-local.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab".to_string(),
-                ledger_public_ws_rpc_url: "wss://doublezero-mainnet-beta-local.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig".to_string(),
+                ledger_public_rpc_url: "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab".to_string(),
+                ledger_public_ws_rpc_url: "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig".to_string(),
                 serviceability_program_id: "ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv".parse()?,
                 telemetry_program_id: "tE1exJ5VMyoC9ByZeSmgtNzJCFF74G9JAv338sJiqkC".parse()?,
                 internet_latency_collector_pk: "8xHn4r7oQuqNZ5cLYwL5YZcDy1JjDQcpVkyoA8Dw5uXH".parse()?,
@@ -98,9 +98,9 @@ mod tests {
         let config = Environment::Mainnet.config().unwrap();
         assert_eq!(
             config.ledger_public_rpc_url,
-            "https://doublezero-mainnet-beta-local.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
+            "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
         );
-        assert_eq!(config.ledger_public_ws_rpc_url, "wss://doublezero-mainnet-beta-local.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig");
+        assert_eq!(config.ledger_public_ws_rpc_url, "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig");
         assert_eq!(
             config.serviceability_program_id.to_string(),
             "ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv"


### PR DESCRIPTION
## Summary of Changes
- Update ledger RPC endpoints to use new LBd endpoint

## Testing Verification
- Confirmed endpoint works
   ```console
   $ solana epoch -u https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab
   4
   ```