### PR TITLE
fix: ensure max_users check only triggers when max_users is greater than zero

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -93,7 +93,7 @@ pub fn process_create_user(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    if device.users_count >= device.max_users {
+    if device.max_users > 0 && device.users_count >= device.max_users {
         msg!("{:?}", device);
         return Err(DoubleZeroError::MaxUsersExceeded.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -110,7 +110,7 @@ pub fn process_create_subscribe_user(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    if device.users_count >= device.max_users {
+    if device.max_users > 0 && device.users_count >= device.max_users {
         msg!("{:?}", device);
         return Err(DoubleZeroError::MaxUsersExceeded.into());
     }


### PR DESCRIPTION
This pull request updates the logic for enforcing the maximum number of users allowed on a device in user creation flows. The changes ensure that the maximum user check is only applied when a positive limit is set, preventing errors when `max_users` is zero or unset.

## Summary of Changes

* Updated the user limit check in `process_create_user` (`smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs`) to only enforce the maximum if `max_users` is greater than zero.
* Applied the same conditional user limit check in `process_create_subscribe_user` (`smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs`) for consistency.

## Testing Verification
* test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
