### PR TITLE
qa: add qa action for testnet

### DIFF
--- a/.github/workflows/qa.devnet.yml
+++ b/.github/workflows/qa.devnet.yml
@@ -1,0 +1,16 @@
+name: qa.devnet
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  qa:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test -v e2e/qa_test.go --args -hosts=chi-dn-bm2,chi-dn-bm3 -env devnet

--- a/.github/workflows/qa.testnet.yml
+++ b/.github/workflows/qa.testnet.yml
@@ -1,4 +1,4 @@
-name: qa
+name: qa.devnet
 
 on:
   workflow_call:
@@ -13,4 +13,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test -v e2e/qa_test.go --args -hosts=chi-dn-bm2,chi-dn-bm3 -env devnet
+      - run: go test -v e2e/qa_test.go -run TestConnectivityUnicast --args -hosts=nyc-tn-qa01,sfo-tn-qa01,fra-tn-qa01,sgp-tn-qa01 -env testnet

--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/release.devnet.smartcontract.daily.yml
     secrets: inherit
   qa:
-    uses: ./.github/workflows/qa.yml
+    uses: ./.github/workflows/qa.devnet.yml
     needs:
       - release
       - smartcontract

--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -150,8 +150,6 @@ func TestConnectivityUnicast(t *testing.T) {
 	// Run connectivity checks only between hosts participating in the test
 	for _, host := range hostList {
 		t.Run("connectivity_check_from_"+host, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
 			client, err := getQAClient(host)
 			require.NoError(t, err, "Failed to create QA client")
 
@@ -170,12 +168,13 @@ func TestConnectivityUnicast(t *testing.T) {
 
 			for _, peer := range peers {
 				t.Run("to_"+peer, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 					defer cancel()
 					pingReq := &pb.PingRequest{
 						TargetIp:    peer,
 						SourceIp:    localAddr,
 						SourceIface: "doublezero0",
+						PingType:    pb.PingRequest_ICMP,
 					}
 					pingResp, err := client.Ping(ctx, pingReq)
 					require.NoError(t, err, "Ping failed for %s", peer)


### PR DESCRIPTION
## Summary of Changes
This PR adds a github action to run a QA test on testnet. It uses 4 regionally distributed hosts and verifies there is unicast connectivity from all hosts to all hosts. Multicast will come afterwards.

This also fixes an error that showed up during a longer test runtime where a short parent context was incorrectly used.

## Testing Verification
The test runs on testnet successfully:
```
➜  doublezero git:(main) ✗ go test -v e2e/qa_test.go -run TestConnectivityUnicast --args -hosts=nyc-tn-qa01,sfo-tn-qa01,fra-tn-qa01,sgp-tn-qa01 -env testnet
=== RUN   TestConnectivityUnicast
=== RUN   TestConnectivityUnicast/connect_ibrl_mode_from_nyc-tn-qa01
=== RUN   TestConnectivityUnicast/connect_ibrl_mode_from_sfo-tn-qa01
=== RUN   TestConnectivityUnicast/connect_ibrl_mode_from_fra-tn-qa01
=== RUN   TestConnectivityUnicast/connect_ibrl_mode_from_sgp-tn-qa01
=== RUN   TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01
=== RUN   TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_64.225.32.240
=== RUN   TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_64.225.111.7
=== RUN   TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_128.199.180.160
=== RUN   TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01
=== RUN   TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_137.184.101.183
=== RUN   TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_64.225.111.7
=== RUN   TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_128.199.180.160
=== RUN   TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01
=== RUN   TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_64.225.32.240
=== RUN   TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_128.199.180.160
=== RUN   TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_137.184.101.183
=== RUN   TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01
=== RUN   TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_137.184.101.183
=== RUN   TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_64.225.32.240
=== RUN   TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_64.225.111.7
=== RUN   TestConnectivityUnicast/disconnect_from_nyc-tn-qa01
=== RUN   TestConnectivityUnicast/disconnect_from_sfo-tn-qa01
=== RUN   TestConnectivityUnicast/disconnect_from_fra-tn-qa01
=== RUN   TestConnectivityUnicast/disconnect_from_sgp-tn-qa01
--- PASS: TestConnectivityUnicast (163.35s)
    --- PASS: TestConnectivityUnicast/connect_ibrl_mode_from_nyc-tn-qa01 (26.81s)
    --- PASS: TestConnectivityUnicast/connect_ibrl_mode_from_sfo-tn-qa01 (27.36s)
    --- PASS: TestConnectivityUnicast/connect_ibrl_mode_from_fra-tn-qa01 (28.05s)
    --- PASS: TestConnectivityUnicast/connect_ibrl_mode_from_sgp-tn-qa01 (20.52s)
    --- PASS: TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01 (12.73s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_64.225.32.240 (4.18s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_64.225.111.7 (4.21s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_nyc-tn-qa01/to_128.199.180.160 (4.34s)
    --- PASS: TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01 (12.98s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_137.184.101.183 (4.28s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_64.225.111.7 (4.35s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sfo-tn-qa01/to_128.199.180.160 (4.35s)
    --- PASS: TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01 (12.89s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_64.225.32.240 (4.32s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_128.199.180.160 (4.32s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_fra-tn-qa01/to_137.184.101.183 (4.25s)
    --- PASS: TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01 (13.51s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_137.184.101.183 (4.55s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_64.225.32.240 (4.49s)
        --- PASS: TestConnectivityUnicast/connectivity_check_from_sgp-tn-qa01/to_64.225.111.7 (4.46s)
    --- PASS: TestConnectivityUnicast/disconnect_from_nyc-tn-qa01 (0.76s)
    --- PASS: TestConnectivityUnicast/disconnect_from_sfo-tn-qa01 (1.80s)
    --- PASS: TestConnectivityUnicast/disconnect_from_fra-tn-qa01 (1.66s)
    --- PASS: TestConnectivityUnicast/disconnect_from_sgp-tn-qa01 (3.80s)
PASS
ok      command-line-arguments  163.591s
```
