### PR TITLE
qa: add multicast qa test to testnet

### DIFF
--- a/.github/workflows/qa.testnet.yml
+++ b/.github/workflows/qa.testnet.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test -v e2e/qa_test.go -run TestConnectivityUnicast --args -hosts=nyc-tn-qa01,sfo-tn-qa01,fra-tn-qa01,sgp-tn-qa01 -env testnet
+      - run: go test -v e2e/qa_test.go --args -hosts=sfo-tn-qa01,nyc-tn-qa01,fra-tn-qa01,sgp-tn-qa01 -env testnet -use-group mg01


### PR DESCRIPTION
## Summary of Changes
This enables automated multicast QA testing for testnet. A `-use-group` flag has been added to skip group creation/allow-list pubkey updates since these are typically done by the foundation. Group cleanup will also be skipped. 

Also, the context timeout has been increased to 30s for disconnect RPC calls, since SGP can take over 10s to respond due to network latency between the host and the runner.

## Testing Verification
Workflow passed:

https://github.com/malbeclabs/doublezero/actions/runs/17009344384/job/48223275832#step:4:1
