### PR TITLE
Jo/1258

### DIFF
--- a/smartcontract/cli/src/validators.rs
+++ b/smartcontract/cli/src/validators.rs
@@ -162,8 +162,10 @@ mod tests {
     #[test]
     fn test_validate_jitter_ms() {
         assert!(validate_parse_jitter_ms("1").is_ok());
+        assert!(validate_parse_jitter_ms("0.5").is_ok());
         assert!(validate_parse_jitter_ms("1000").is_ok());
-        assert!(validate_parse_jitter_ms("0.5").is_err());
+        assert!(validate_parse_jitter_ms("0").is_err());
+        assert!(validate_parse_jitter_ms("0.0001").is_err());
         assert!(validate_parse_jitter_ms("1001").is_err());
         assert!(validate_parse_jitter_ms("not_a_number").is_err());
     }


### PR DESCRIPTION
This pull request makes a small adjustment to the input validation logic for jitter values in the CLI validator. The minimum allowed jitter value is lowered from 1 ms to 0.01 ms, and the error message is updated accordingly.

* The valid range for jitter in `validate_parse_jitter_ms` in `smartcontract/cli/src/validators.rs` is changed to allow values between 0.01 and 1000 ms, instead of the previous 1 to 1000 ms. The error message is updated to match the new range.

## Testing Verification
* test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
