### PR TITLE
e2e: device interfaces in spec

### DIFF
--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -106,6 +106,13 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 				MetricsAddr:          "0.0.0.0:2114",
 			},
 			AdditionalNetworks: []string{link.Name},
+			Interfaces: map[string]string{
+				"Ethernet2": "physical",
+			},
+			LoopbackInterfaces: map[string]string{
+				"Loopback255": "vpnv4",
+				"Loopback256": "ipv4",
+			},
 		})
 		require.NoError(t, err)
 
@@ -144,6 +151,14 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 				MetricsAddr:          "0.0.0.0:2114",
 			},
 			AdditionalNetworks: []string{link.Name},
+			Interfaces: map[string]string{
+				"Ethernet2": "physical",
+				"Ethernet3": "physical",
+			},
+			LoopbackInterfaces: map[string]string{
+				"Loopback255": "vpnv4",
+				"Loopback256": "ipv4",
+			},
 		})
 		require.NoError(t, err)
 
@@ -163,9 +178,6 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 			doublezero device create --code pit-dzd01 --contributor co01 --location pit --exchange xpit --public-ip "204.16.241.243" --dz-prefixes "204.16.243.243/32" --mgmt-vrf mgmt
 			doublezero device create --code ams-dz001 --contributor co01 --location ams --exchange xams --public-ip "195.219.138.50" --dz-prefixes "195.219.138.56/29" --mgmt-vrf mgmt
 
-			doublezero device interface create la2-dz01 "Ethernet2" physical
-			doublezero device interface create ny5-dz01 "Ethernet2" physical
-			doublezero device interface create ny5-dz01 "Ethernet3" physical
 			doublezero device interface create ld4-dz01 "Ethernet2" physical
 			doublezero device interface create ld4-dz01 "Ethernet3" physical
 			doublezero device interface create ld4-dz01 "Ethernet4" physical
@@ -176,8 +188,6 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 			doublezero device interface create pit-dzd01 "Ethernet2" physical
 			doublezero device interface create ams-dz001 "Ethernet2" physical
 
-			doublezero device interface create la2-dz01 "Loopback255" loopback --loopback-type vpnv4
-			doublezero device interface create ny5-dz01 "Loopback255" loopback --loopback-type vpnv4
 			doublezero device interface create ld4-dz01 "Loopback255" loopback --loopback-type vpnv4
 			doublezero device interface create frk-dz01 "Loopback255" loopback --loopback-type vpnv4
 			doublezero device interface create sg1-dz01 "Loopback255" loopback --loopback-type vpnv4
@@ -185,8 +195,6 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 			doublezero device interface create pit-dzd01 "Loopback255" loopback --loopback-type vpnv4
 			doublezero device interface create ams-dz001 "Loopback255" loopback --loopback-type vpnv4
 
-			doublezero device interface create la2-dz01 "Loopback256" loopback --loopback-type ipv4
-			doublezero device interface create ny5-dz01 "Loopback256" loopback --loopback-type ipv4
 			doublezero device interface create ld4-dz01 "Loopback256" loopback --loopback-type ipv4
 			doublezero device interface create frk-dz01 "Loopback256" loopback --loopback-type ipv4
 			doublezero device interface create sg1-dz01 "Loopback256" loopback --loopback-type ipv4

--- a/e2e/internal/devnet/cmd/add-device.go
+++ b/e2e/internal/devnet/cmd/add-device.go
@@ -41,6 +41,13 @@ func (c *AddDeviceCmd) Command() *cobra.Command {
 					ManagementNS: "ns-management",
 					Verbose:      true,
 				},
+				Interfaces: map[string]string{
+					"Ethernet2": "physical",
+				},
+				LoopbackInterfaces: map[string]string{
+					"Loopback255": "vpnv4",
+					"Loopback256": "ipv4",
+				},
 			})
 			if err != nil {
 				return fmt.Errorf("failed to add device: %w", err)

--- a/e2e/multi_client_test.go
+++ b/e2e/multi_client_test.go
@@ -51,16 +51,14 @@ func TestE2E_MultiClient(t *testing.T) {
 		// .8/29 has network address .8, allocatable up to .14, and broadcast .15
 		CYOANetworkIPHostID:          8,
 		CYOANetworkAllocatablePrefix: 29,
+		LoopbackInterfaces: map[string]string{
+			"Loopback255": "vpnv4",
+			"Loopback256": "ipv4",
+		},
 	})
 	require.NoError(t, err)
 	devicePK := device.ID
 	log.Info("--> Device added", "deviceCode", deviceCode, "devicePK", devicePK)
-
-	err = dn.CreateDeviceLoopbackInterface(t.Context(), deviceCode, "Loopback255", "vpnv4")
-	require.NoError(t, err, "failed to create VPNv4 loopback interface for device %s: %w", deviceCode, err)
-
-	err = dn.CreateDeviceLoopbackInterface(t.Context(), deviceCode, "Loopback256", "ipv4")
-	require.NoError(t, err, "failed to create IPv4 loopback interface for device %s: %w", deviceCode, err)
 
 	// Wait for device to exist onchain.
 	log.Info("==> Waiting for device to exist onchain")

--- a/e2e/no_ifaces_peers_test.go
+++ b/e2e/no_ifaces_peers_test.go
@@ -53,16 +53,14 @@ func TestE2E_Controller_NoIfacesAndPeers(t *testing.T) {
 		// .8/29 has network address .8, allocatable up to .14, and broadcast .15
 		CYOANetworkIPHostID:          8,
 		CYOANetworkAllocatablePrefix: 29,
+		LoopbackInterfaces: map[string]string{
+			"Loopback255": "vpnv4",
+			"Loopback256": "ipv4",
+		},
 	})
 	require.NoError(t, err)
 	devicePK := device.ID
 	log.Info("--> Device added", "deviceCode", deviceCode, "devicePK", devicePK)
-
-	err = dn.CreateDeviceLoopbackInterface(t.Context(), deviceCode, "Loopback255", "vpnv4")
-	require.NoError(t, err, "failed to create VPNv4 loopback interface for device %s: %w", deviceCode, err)
-
-	err = dn.CreateDeviceLoopbackInterface(t.Context(), deviceCode, "Loopback256", "ipv4")
-	require.NoError(t, err, "failed to create IPv4 loopback interface for device %s: %w", deviceCode, err)
 
 	// Wait for device to exist onchain.
 	log.Info("==> Waiting for device to exist onchain")


### PR DESCRIPTION
## Summary of Changes
- Update e2e device spec to include `LoopbackInterfaces` that results in those interfaces being automatically added on create/start, and remove manual creation in e2e tests.
- Add the 2 required loopback interfaces to the local devnet `add-device` spec so that we get a fully functioning device on bootstrap there as well without the manual work

## Testing Verification
-  E2E tests updated to use this spec
- `dev/dzctl` workflow functions without manually adding interfaces after startup
