### PR TITLE
internet-latency-collector: remove failed wheresitup jobs from state

### DIFF
--- a/controlplane/internet-latency-collector/internal/wheresitup/state_test.go
+++ b/controlplane/internet-latency-collector/internal/wheresitup/state_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,19 +20,19 @@ func TestInternetLatency_Wheresitup_State_LoadSave(t *testing.T) {
 	// Test loading non-existent file
 	err := jt.Load()
 	require.NoError(t, err, "Load() on non-existent file should not error")
-	require.Empty(t, jt.JobIDs, "JobIDs should be empty initially")
+	require.Empty(t, jt.Jobs, "Jobs should be empty initially")
 
-	// Test saving
-	jt.JobIDs = []string{"job1", "job2", "job3"}
-	err = jt.Save()
-	require.NoError(t, err, "Save() should not error")
+	// Test saving via AddJobIDs
+	err = jt.AddJobIDs([]string{"job1", "job2", "job3"})
+	require.NoError(t, err, "AddJobIDs() should not error")
 
 	// Test loading existing file
 	jt2 := NewState(filename)
 	err = jt2.Load()
 	require.NoError(t, err, "Load() should not error")
-	require.Len(t, jt2.JobIDs, 3, "Expected 3 job IDs")
-	require.Equal(t, []string{"job1", "job2", "job3"}, jt2.JobIDs, "JobIDs should match expected values")
+	jobIDs := jt2.GetJobIDs()
+	require.Len(t, jobIDs, 3, "Expected 3 job IDs")
+	require.Equal(t, []string{"job1", "job2", "job3"}, jobIDs, "JobIDs should match expected values")
 }
 
 func TestInternetLatency_Wheresitup_State_AddJobIDs(t *testing.T) {
@@ -54,7 +55,8 @@ func TestInternetLatency_Wheresitup_State_AddJobIDs(t *testing.T) {
 	jt2 := NewState(filename)
 	err = jt2.Load()
 	require.NoError(t, err, "Load() should not error")
-	require.Len(t, jt2.JobIDs, 4, "Expected 4 job IDs")
+	jobIDs := jt2.GetJobIDs()
+	require.Len(t, jobIDs, 4, "Expected 4 job IDs")
 }
 
 func TestInternetLatency_Wheresitup_State_RemoveJobIDs(t *testing.T) {
@@ -64,9 +66,8 @@ func TestInternetLatency_Wheresitup_State_RemoveJobIDs(t *testing.T) {
 	filename := filepath.Join(tempDir, "test_jobs.json")
 
 	jt := NewState(filename)
-	jt.JobIDs = []string{"job1", "job2", "job3", "job4"}
-	err := jt.Save()
-	require.NoError(t, err, "Save() should not error")
+	err := jt.AddJobIDs([]string{"job1", "job2", "job3", "job4"})
+	require.NoError(t, err, "AddJobIDs() should not error")
 
 	// Remove some jobs
 	err = jt.RemoveJobIDs([]string{"job2", "job4"})
@@ -76,8 +77,9 @@ func TestInternetLatency_Wheresitup_State_RemoveJobIDs(t *testing.T) {
 	jt2 := NewState(filename)
 	err = jt2.Load()
 	require.NoError(t, err, "Load() should not error")
-	require.Len(t, jt2.JobIDs, 2, "Expected 2 job IDs")
-	require.Equal(t, []string{"job1", "job3"}, jt2.JobIDs, "Expected [job1, job3]")
+	jobIDs := jt2.GetJobIDs()
+	require.Len(t, jobIDs, 2, "Expected 2 job IDs")
+	require.Equal(t, []string{"job1", "job3"}, jobIDs, "Expected [job1, job3]")
 }
 
 func TestInternetLatency_Wheresitup_State_InvalidFile(t *testing.T) {
@@ -91,13 +93,14 @@ func TestInternetLatency_Wheresitup_State_InvalidFile(t *testing.T) {
 	err := jt.Save()
 	require.Error(t, err, "Expected error for non-JSON file")
 
-	// Test corrupted JSON
+	// Test corrupted JSON - should start fresh instead of erroring
 	jsonFile := filepath.Join(tempDir, "corrupted.json")
 	err = os.WriteFile(jsonFile, []byte("{invalid json"), 0644)
 	require.NoError(t, err, "Failed to write corrupted JSON file")
 	jt2 := NewState(jsonFile)
 	err = jt2.Load()
-	require.Error(t, err, "Expected error for corrupted JSON")
+	require.NoError(t, err, "Load() should not error on corrupted JSON, should start fresh")
+	require.Empty(t, jt2.Jobs, "Jobs should be empty after loading corrupted file")
 }
 
 func TestInternetLatency_Wheresitup_State_GetJobIDs(t *testing.T) {
@@ -107,8 +110,41 @@ func TestInternetLatency_Wheresitup_State_GetJobIDs(t *testing.T) {
 	filename := filepath.Join(tempDir, "test_jobs.json")
 
 	jt := NewState(filename)
-	jt.JobIDs = []string{"job1", "job2"}
+	err := jt.AddJobIDs([]string{"job1", "job2"})
+	require.NoError(t, err, "AddJobIDs() should not error")
 
 	jobIDs := jt.GetJobIDs()
 	require.Len(t, jobIDs, 2, "GetJobIDs() should return 2 items")
+}
+
+func TestInternetLatency_Wheresitup_State_JobExpiration(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	filename := filepath.Join(tempDir, "test_jobs.json")
+
+	jt := NewState(filename)
+
+	// Add jobs with different timestamps
+	now := time.Now()
+	jt.Jobs = []JobEntry{
+		{JobID: "recent", CreatedAt: now.Add(-30 * time.Minute)},
+		{JobID: "old", CreatedAt: now.Add(-3 * time.Hour)},
+		{JobID: "very_recent", CreatedAt: now.Add(-5 * time.Minute)},
+	}
+
+	// Save should filter out the old job
+	err := jt.Save()
+	require.NoError(t, err, "Save() should not error")
+
+	// Load and verify only recent jobs remain
+	jt2 := NewState(filename)
+	err = jt2.Load()
+	require.NoError(t, err, "Load() should not error")
+
+	jobIDs := jt2.GetJobIDs()
+	require.Len(t, jobIDs, 2, "Expected 2 jobs after filtering")
+	require.Contains(t, jobIDs, "recent", "Recent job should be present")
+	require.Contains(t, jobIDs, "very_recent", "Very recent job should be present")
+	require.NotContains(t, jobIDs, "old", "Old job should have been filtered out")
 }


### PR DESCRIPTION
## Summary of Changes
* internet-latency-collector now removes wheresitup jobs from state when they were created >2 hours ago
* This gives plenty of time to retry collection of the job several times, but won't keep retrying indefinitely

## Testing Verification
* Unit tests updated
