### PR TITLE
e2e/telemetry: deflake with longer wait for interfaces timeout

### DIFF
--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -239,7 +239,7 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 			return true
 		}
 		return false
-	}, 120*time.Second, 3*time.Second, "Timed out waiting for the devices to be reachable via their link tunnel")
+	}, 180*time.Second, 3*time.Second, "Timed out waiting for the devices to be reachable via their link tunnel")
 
 	// Wait for the devices to be reachable from each other via their link tunnel using TWAMP UDP probes.
 	log.Info("==> Waiting for devices to be reachable from each other via their link tunnel using TWAMP")


### PR DESCRIPTION
## Summary of Changes
- Increase wait-for-interfaces timeout in e2e device telemetry test to mitigate a flake we've seen a few times. Example: https://github.com/malbeclabs/doublezero/actions/runs/17052929565/job/48344636521?pr=1283
