### PR TITLE
client: increase timeout for fetch program data

### DIFF
--- a/client/doublezerod/internal/latency/manager.go
+++ b/client/doublezerod/internal/latency/manager.go
@@ -15,6 +15,10 @@ import (
 	probing "github.com/prometheus-community/pro-bing"
 )
 
+const (
+	serviceabilityProgramDataFetchTimeout = 20 * time.Second
+)
+
 type ProberFunc func(context.Context, serviceability.Device) LatencyResult
 
 func UdpPing(ctx context.Context, d serviceability.Device) LatencyResult {
@@ -110,7 +114,7 @@ func (l *LatencyManager) Start(ctx context.Context, programId string, rpcEndpoin
 	// start goroutine for fetching smartcontract devices
 	go func() {
 		fetch := func() {
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, serviceabilityProgramDataFetchTimeout)
 			defer cancel()
 			contractData, err := l.SmartContractFunc(ctx, programId, rpcEndpoint)
 			if err != nil {


### PR DESCRIPTION
## Summary of Changes
- Update the fetch timeout for servicability program data in doublezerod latency manager from 5s to 20s
- We have been seeing timeouts on the Singapore QA clients here

## Testing Verification
- Existing tests should continue to pass. We will deploy and see if we continue to see timeouts. This is a pretty safe change since we run the polling interval on a ticker anyway.
