### PR TITLE
config: remove whirligig path from mainnet WS RPC URL

### DIFF
--- a/config/env_test.go
+++ b/config/env_test.go
@@ -63,7 +63,7 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 
 func TestConfig_NetworkConfigForEnv_RPCURLOverrideFromEnvVars(t *testing.T) {
 	os.Setenv("DZ_LEDGER_RPC_URL", "https://other-rpc-url.com")
-	os.Setenv("DZ_LEDGER_WS_RPC_URL", "wss://other-ws-rpc-url.com/whirligig")
+	os.Setenv("DZ_LEDGER_WS_RPC_URL", "wss://other-ws-rpc-url.com")
 	got, err := config.NetworkConfigForEnv(config.EnvMainnet)
 	require.NoError(t, err)
 	require.Equal(t, "https://other-rpc-url.com", got.LedgerPublicRPCURL)

--- a/config/src/env.rs
+++ b/config/src/env.rs
@@ -25,7 +25,7 @@ impl Environment {
         let mut config = match self {
             Environment::Mainnet => NetworkConfig {
                 ledger_public_rpc_url: "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab".to_string(),
-                ledger_public_ws_rpc_url: "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig".to_string(),
+                ledger_public_ws_rpc_url: "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab".to_string(),
                 serviceability_program_id: "ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv".parse()?,
                 telemetry_program_id: "tE1exJ5VMyoC9ByZeSmgtNzJCFF74G9JAv338sJiqkC".parse()?,
                 internet_latency_collector_pk: "8xHn4r7oQuqNZ5cLYwL5YZcDy1JjDQcpVkyoA8Dw5uXH".parse()?,
@@ -100,7 +100,10 @@ mod tests {
             config.ledger_public_rpc_url,
             "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
         );
-        assert_eq!(config.ledger_public_ws_rpc_url, "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig");
+        assert_eq!(
+            config.ledger_public_ws_rpc_url,
+            "wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab"
+        );
         assert_eq!(
             config.serviceability_program_id.to_string(),
             "ser2VaTMAcYTaauMrTSfSrxBaUDq7BLNs2xfUugTAGv"
@@ -171,15 +174,12 @@ mod tests {
     #[serial]
     fn test_network_config_rpc_url_env_override() {
         std::env::set_var("DZ_LEDGER_RPC_URL", "https://other-rpc-url.com");
-        std::env::set_var(
-            "DZ_LEDGER_WS_RPC_URL",
-            "wss://other-ws-rpc-url.com/whirligig",
-        );
+        std::env::set_var("DZ_LEDGER_WS_RPC_URL", "wss://other-ws-rpc-url.com");
         let config = Environment::Mainnet.config().unwrap();
         assert_eq!(config.ledger_public_rpc_url, "https://other-rpc-url.com");
         assert_eq!(
             config.ledger_public_ws_rpc_url,
-            "wss://other-ws-rpc-url.com/whirligig"
+            "wss://other-ws-rpc-url.com"
         );
 
         // reset the values in the environment when complete


### PR DESCRIPTION
## Summary of Changes
- Remove the whiligig path suffix from the mainnet websocket RPC URL on configs
- The mainnet LB RPC should not include this path suffix. This fixes WS connectivity issues in mainnet.
- Resolves https://github.com/malbeclabs/doublezero/issues/1299

## Testing Verification

```
❯ wscat -c wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab
Connected (press CTRL+C to quit)
> {"jsonrpc": "2.0","id": 1,"method": "slotSubscribe"}
< {"jsonrpc":"2.0","result":2,"id":1}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934635,"parent":2934634,"root":2934603},"subscription":2}}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934636,"parent":2934635,"root":2934604},"subscription":2}}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934637,"parent":2934636,"root":2934605},"subscription":2}}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934638,"parent":2934637,"root":2934606},"subscription":2}}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934639,"parent":2934638,"root":2934607},"subscription":2}}
< {"jsonrpc":"2.0","method":"slotNotification","params":{"result":{"slot":2934640,"parent":2934639,"root":2934608},"subscription":2}}

❯ wscat -c wss://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab/whirligig
error: Unexpected server response: 405
```
