### PR TITLE
monitor: initial implementation

### DIFF
--- a/controlplane/monitor/cmd/monitor/main.go
+++ b/controlplane/monitor/cmd/monitor/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/config"
+	"github.com/malbeclabs/doublezero/controlplane/monitor/internal/worker"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	defaultInterval = 1 * time.Minute
+)
+
+var (
+	env                     = flag.String("env", "", "the environment to run the component in (devnet, testnet, mainnet)")
+	ledgerRPCURL            = flag.String("ledger-rpc-url", "", "the url of the ledger rpc")
+	serviceabilityProgramID = flag.String("serviceability-program-id", "", "the id of the serviceability program")
+	telemetryProgramID      = flag.String("telemetry-program-id", "", "the id of the telemetry program")
+	interval                = flag.Duration("interval", defaultInterval, "the interval to execute watcher ticks")
+	verbose                 = flag.Bool("verbose", false, "enable verbose logging")
+	showVersion             = flag.Bool("version", false, "Print the version of the doublezero-agent and exit")
+	metricsAddr             = flag.String("metrics-addr", ":8080", "Address to listen on for prometheus metrics")
+
+	// Set by LDFLAGS
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("version: %s, commit: %s, date: %s\n", version, commit, date)
+		os.Exit(0)
+	}
+
+	// Initialize logger.
+	logLevel := slog.LevelInfo
+	if *verbose {
+		logLevel = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+
+	// Initialize program IDs and ledger RPC URL.
+	var networkConfig *config.NetworkConfig
+	if *env == "" {
+		if *ledgerRPCURL == "" {
+			log.Error("Missing required flag", "flag", "ledger-rpc-url")
+			flag.Usage()
+			os.Exit(1)
+		}
+		if *serviceabilityProgramID == "" {
+			log.Error("Missing required flag", "flag", "serviceability-program-id")
+			flag.Usage()
+			os.Exit(1)
+		}
+		if *telemetryProgramID == "" {
+			log.Error("Missing required flag", "flag", "telemetry-program-id")
+			flag.Usage()
+			os.Exit(1)
+		}
+		serviceabilityProgramID, err := solana.PublicKeyFromBase58(*serviceabilityProgramID)
+		if err != nil {
+			log.Error("Failed to parse serviceability program id", "error", err)
+			flag.Usage()
+			os.Exit(1)
+		}
+		telemetryProgramID, err := solana.PublicKeyFromBase58(*telemetryProgramID)
+		if err != nil {
+			log.Error("Failed to parse telemetry program id", "error", err)
+			flag.Usage()
+			os.Exit(1)
+		}
+		networkConfig = &config.NetworkConfig{
+			LedgerPublicRPCURL:      *ledgerRPCURL,
+			ServiceabilityProgramID: serviceabilityProgramID,
+			TelemetryProgramID:      telemetryProgramID,
+		}
+	} else {
+		var err error
+		networkConfig, err = config.NetworkConfigForEnv(*env)
+		if err != nil {
+			log.Error("Failed to get network config", "error", err)
+			flag.Usage()
+			os.Exit(1)
+		}
+	}
+
+	// Initialize ledger clients.
+	rpcClient := solanarpc.New(networkConfig.LedgerPublicRPCURL)
+	serviceabilityClient := serviceability.New(rpcClient, networkConfig.ServiceabilityProgramID)
+	telemetryClient := telemetry.New(log, rpcClient, nil, networkConfig.TelemetryProgramID)
+
+	// Initialize prometheus metrics server.
+	worker.MetricBuildInfo.WithLabelValues(version, commit, date).Set(1)
+	go func() {
+		listener, err := net.Listen("tcp", *metricsAddr)
+		if err != nil {
+			log.Error("Failed to start prometheus metrics server listener", "error", err)
+			return
+		}
+		log.Info("Prometheus metrics server listening", "address", listener.Addr())
+		http.Handle("/metrics", promhttp.Handler())
+		if err := http.Serve(listener, nil); err != nil {
+			log.Error("Failed to start prometheus metrics server", "error", err)
+		}
+	}()
+
+	// Initialize worker.
+	worker, err := worker.New(&worker.Config{
+		Logger:          log,
+		LedgerRPCClient: rpcClient,
+		Serviceability:  serviceabilityClient,
+		Telemetry:       telemetryClient,
+		Interval:        *interval,
+	})
+	if err != nil {
+		log.Error("Failed to create worker", "error", err)
+		os.Exit(1)
+	}
+
+	// Start the worker.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	err = worker.Run(ctx)
+	if err != nil {
+		log.Error("Failed to run worker", "error", err)
+		os.Exit(1)
+	}
+}

--- a/controlplane/monitor/internal/device-telemetry/config.go
+++ b/controlplane/monitor/internal/device-telemetry/config.go
@@ -1,0 +1,60 @@
+package devicetelemetry
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+)
+
+const (
+	defaultMaxConcurrency = 16
+)
+
+type LedgerRPCClient interface {
+	GetEpochInfo(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error)
+}
+
+type ServiceabilityClient interface {
+	GetProgramData(context.Context) (*serviceability.ProgramData, error)
+}
+
+type TelemetryProgramClient interface {
+	GetDeviceLatencySamples(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error)
+}
+
+type Config struct {
+	Logger          *slog.Logger
+	LedgerRPCClient LedgerRPCClient
+	Serviceability  ServiceabilityClient
+	Telemetry       TelemetryProgramClient
+	Interval        time.Duration
+	MaxConcurrency  int
+}
+
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if c.LedgerRPCClient == nil {
+		return errors.New("ledger rpc client is required")
+	}
+	if c.Serviceability == nil {
+		return errors.New("serviceability client is required")
+	}
+	if c.Telemetry == nil {
+		return errors.New("telemetry client is required")
+	}
+	if c.Interval <= 0 {
+		return errors.New("interval must be greater than 0")
+	}
+	if c.MaxConcurrency <= 0 {
+		c.MaxConcurrency = defaultMaxConcurrency
+	}
+	return nil
+}

--- a/controlplane/monitor/internal/device-telemetry/config_test.go
+++ b/controlplane/monitor/internal/device-telemetry/config_test.go
@@ -1,0 +1,68 @@
+package devicetelemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitor_DeviceTelemetry_Config(t *testing.T) {
+	t.Parallel()
+
+	valid := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return &serviceability.ProgramData{}, nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{}, nil
+			}},
+		Interval: 50 * time.Millisecond,
+	}
+
+	t.Run("valid config passes", func(t *testing.T) {
+		require.NoError(t, valid.Validate())
+	})
+
+	t.Run("missing logger fails", func(t *testing.T) {
+		c := *valid
+		c.Logger = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing ledger RPC fails", func(t *testing.T) {
+		c := *valid
+		c.LedgerRPCClient = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing serviceability fails", func(t *testing.T) {
+		c := *valid
+		c.Serviceability = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing telemetry fails", func(t *testing.T) {
+		c := *valid
+		c.Telemetry = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing interval fails", func(t *testing.T) {
+		c := *valid
+		c.Interval = 0
+		require.Error(t, c.Validate())
+	})
+}

--- a/controlplane/monitor/internal/device-telemetry/metrics.go
+++ b/controlplane/monitor/internal/device-telemetry/metrics.go
@@ -1,0 +1,57 @@
+package devicetelemetry
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Metrics names.
+	MetricNameErrors    = "doublezero_monitor_device_telemetry_errors_total"
+	MetricNameSamples   = "doublezero_monitor_device_telemetry_samples_total"
+	MetricNameSuccesses = "doublezero_monitor_device_telemetry_successes_total"
+	MetricNameLosses    = "doublezero_monitor_device_telemetry_losses_total"
+
+	// Labels.
+	MetricLabelErrorType = "error_type"
+	MetricLabelCircuit   = "circuit"
+
+	// Error types.
+	MetricErrorTypeGetCircuits       = "get_circuits"
+	MetricErrorTypeGetEpochInfo      = "get_epoch_info"
+	MetricErrorTypeGetLatencySamples = "get_latency_samples"
+)
+
+var (
+	MetricErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameErrors,
+			Help: "Number of errors encountered",
+		},
+		[]string{MetricLabelErrorType},
+	)
+
+	MetricSamples = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameSamples,
+			Help: "Number of samples",
+		},
+		[]string{MetricLabelCircuit},
+	)
+
+	MetricSuccesses = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameSuccesses,
+			Help: "Number of successes",
+		},
+		[]string{MetricLabelCircuit},
+	)
+
+	MetricLosses = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameLosses,
+			Help: "Number of losses",
+		},
+		[]string{MetricLabelCircuit},
+	)
+)

--- a/controlplane/monitor/internal/device-telemetry/watcher.go
+++ b/controlplane/monitor/internal/device-telemetry/watcher.go
@@ -1,0 +1,200 @@
+package devicetelemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	telemetrycircuits "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/circuits"
+)
+
+const (
+	watcherName = "device-telemetry"
+)
+
+type DeviceTelemetryWatcher struct {
+	log *slog.Logger
+	cfg *Config
+
+	lastEpoch uint64
+	epochSet  bool
+	stats     map[string]CircuitTelemetryStats
+	mu        sync.RWMutex
+}
+
+func NewDeviceTelemetryWatcher(cfg *Config) (*DeviceTelemetryWatcher, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &DeviceTelemetryWatcher{
+		log:   cfg.Logger.With("watcher", watcherName),
+		cfg:   cfg,
+		stats: map[string]CircuitTelemetryStats{},
+	}, nil
+}
+
+func (w *DeviceTelemetryWatcher) Name() string {
+	return watcherName
+}
+
+func (w *DeviceTelemetryWatcher) Run(ctx context.Context) error {
+	ticker := time.NewTicker(w.cfg.Interval)
+	defer ticker.Stop()
+
+	err := w.Tick(ctx)
+	if err != nil {
+		w.log.Error("failed to tick", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.log.Debug("context done, stopping")
+			return nil
+		case <-ticker.C:
+			err := w.Tick(ctx)
+			if err != nil {
+				w.log.Error("failed to tick", "error", err)
+			}
+		}
+	}
+}
+
+type CircuitTelemetryStats struct {
+	SuccessCount uint32
+	LossCount    uint32
+}
+
+func (w *DeviceTelemetryWatcher) Tick(ctx context.Context) error {
+	circuits, err := telemetrycircuits.GetDeviceLinkCircuits(ctx, w.log, w.cfg.Serviceability)
+	if err != nil {
+		MetricErrors.WithLabelValues(MetricErrorTypeGetCircuits).Inc()
+		return fmt.Errorf("failed to get circuits: %w", err)
+	}
+	if len(circuits) == 0 {
+		return nil
+	}
+
+	epochInfo, err := w.cfg.LedgerRPCClient.GetEpochInfo(ctx, solanarpc.CommitmentFinalized)
+	if err != nil {
+		MetricErrors.WithLabelValues(MetricErrorTypeGetEpochInfo).Inc()
+		w.log.Error("failed to get epoch info", "error", err)
+		return err
+	}
+	epoch := epochInfo.Epoch
+
+	var wg sync.WaitGroup
+	errorChan := make(chan error, len(circuits))
+	sem := make(chan struct{}, w.cfg.MaxConcurrency)
+
+	for _, circuit := range circuits {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(circuit telemetrycircuits.DeviceLinkCircuit) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			linkPK := solana.PublicKeyFromBytes(circuit.Link.PubKey[:])
+			linkCode := circuit.Link.Code
+			originCode := circuit.OriginDevice.Code
+			targetCode := circuit.TargetDevice.Code
+			originPK := solana.PublicKeyFromBytes(circuit.OriginDevice.PubKey[:])
+			targetPK := solana.PublicKeyFromBytes(circuit.TargetDevice.PubKey[:])
+
+			account, err := w.cfg.Telemetry.GetDeviceLatencySamples(ctx, originPK, targetPK, linkPK, epoch)
+			if err != nil {
+				MetricErrors.WithLabelValues(MetricErrorTypeGetLatencySamples).Inc()
+				w.log.Error("failed to get device latency samples", "error", err)
+				errorChan <- err
+				return
+			}
+
+			var successCount, lossCount uint32
+			for _, sample := range account.Samples {
+				if sample == 0 {
+					lossCount++
+				} else {
+					successCount++
+				}
+			}
+
+			key := fmt.Sprintf("%d-%s", epoch, circuit.Code)
+
+			var successCountDelta, lossCountDelta, samplesDelta uint32
+			w.mu.RLock()
+			if prevStats, ok := w.stats[key]; ok && w.epochSet && w.lastEpoch == epoch {
+				if successCount >= prevStats.SuccessCount {
+					successCountDelta = successCount - prevStats.SuccessCount
+				} else {
+					w.log.Warn("success counter decreased unexpectedly",
+						"circuit_code", circuit.Code,
+						"epoch", epoch,
+						"prev_success_count", prevStats.SuccessCount,
+						"current_success_count", successCount,
+					)
+					successCountDelta = 0 // counter shrank; treat as no delta
+				}
+				if lossCount >= prevStats.LossCount {
+					lossCountDelta = lossCount - prevStats.LossCount
+				} else {
+					w.log.Warn("loss counter decreased unexpectedly",
+						"circuit_code", circuit.Code,
+						"epoch", epoch,
+						"prev_loss_count", prevStats.LossCount,
+						"current_loss_count", lossCount,
+					)
+					lossCountDelta = 0
+				}
+				samplesDelta = successCountDelta + lossCountDelta
+
+				if successCountDelta > 0 {
+					MetricSuccesses.WithLabelValues(circuit.Code).Add(float64(successCountDelta))
+				}
+				if lossCountDelta > 0 {
+					MetricLosses.WithLabelValues(circuit.Code).Add(float64(lossCountDelta))
+				}
+				if samplesDelta > 0 {
+					MetricSamples.WithLabelValues(circuit.Code).Add(float64(samplesDelta))
+				}
+			}
+			w.mu.RUnlock()
+
+			w.mu.Lock()
+			w.stats[key] = CircuitTelemetryStats{
+				SuccessCount: successCount,
+				LossCount:    lossCount,
+			}
+			w.epochSet = true
+			w.lastEpoch = epoch
+			w.mu.Unlock()
+
+			w.log.Debug("circuit telemetry",
+				"code", circuit.Code,
+				"origin_device", originCode,
+				"target_device", targetCode,
+				"link", linkCode,
+				"link_pk", linkPK.String(),
+				"epoch", epoch,
+				"samples", len(account.Samples),
+				"success_count", successCount,
+				"loss_count", lossCount,
+				"success_count_delta", successCountDelta,
+				"loss_count_delta", lossCountDelta,
+			)
+		}(circuit)
+	}
+
+	wg.Wait()
+
+	select {
+	case err := <-errorChan:
+		return err
+	default:
+	}
+
+	return nil
+}

--- a/controlplane/monitor/internal/device-telemetry/watcher_test.go
+++ b/controlplane/monitor/internal/device-telemetry/watcher_test.go
@@ -1,0 +1,484 @@
+package devicetelemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitor_DeviceTelemetry_Watcher_NewAndName(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.Equal(t, watcherName, w.Name())
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_RunStopsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 5 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Run(ctx); close(done) }()
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop after cancel")
+	}
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_NoCircuits(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, w.Tick(context.Background()))
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	require.False(t, w.epochSet)
+	require.Equal(t, uint64(0), w.lastEpoch)
+	require.Empty(t, w.stats)
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_ErrorFromGetProgramData(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return nil, errors.New("boom") }},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.Error(t, w.Tick(context.Background()))
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_ErrorFromGetEpochInfo(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return nil, errors.New("epoch fail")
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData("OR-A", "TG-A", origin, target, link, "LK-A"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{1}}, nil
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.Error(t, w.Tick(context.Background()))
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_ErrorFromGetDeviceLatencySamples(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData("OR-A", "TG-A", origin, target, link, "LK-A"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, _, _, _ solana.PublicKey, _ uint64) (*telemetry.DeviceLatencySamples, error) {
+				return nil, errors.New("telemetry fail")
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.Error(t, w.Tick(context.Background()))
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_SameEpoch_BaselineThenUpdate(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+	originCode, targetCode := "OR-A", "TG-A"
+
+	// local step only toggled BETWEEN ticks (never during a tick)
+	step := 0
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData(originCode, targetCode, origin, target, link, "LK-A"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, o, t, l solana.PublicKey, e uint64) (*telemetry.DeviceLatencySamples, error) {
+				if o == origin && t == target {
+					if step == 0 {
+						return &telemetry.DeviceLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil
+					} // 3/1
+					return &telemetry.DeviceLatencySamples{Samples: []uint32{1, 2, 0, 5, 9}}, nil // 4/1
+				}
+				if step == 0 {
+					return &telemetry.DeviceLatencySamples{Samples: []uint32{0, 0, 7}}, nil
+				} // 1/2
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{0, 0, 7, 3, 0}}, nil // 2/3
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keyFwd := "10-" + circuitKey(originCode, targetCode, link)
+	keyRev := "10-" + circuitKey(targetCode, originCode, link)
+
+	require.NoError(t, w.Tick(ctx))
+	w.mu.RLock()
+	require.Equal(t, uint64(10), w.lastEpoch)
+	require.True(t, w.epochSet)
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[keyFwd])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 1, LossCount: 2}, w.stats[keyRev])
+	w.mu.RUnlock()
+
+	step = 1
+	require.NoError(t, w.Tick(ctx))
+	w.mu.RLock()
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 4, LossCount: 1}, w.stats[keyFwd])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 2, LossCount: 3}, w.stats[keyRev])
+	w.mu.RUnlock()
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_EpochRollover(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+	originCode, targetCode := "OR-A", "TG-A"
+
+	epochVal := uint64(10) // changed only between ticks
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: epochVal}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData(originCode, targetCode, origin, target, link, "LK-A"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, o, t, l solana.PublicKey, e uint64) (*telemetry.DeviceLatencySamples, error) {
+				if e == 10 {
+					if o == origin && t == target {
+						return &telemetry.DeviceLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil
+					} // 3/1
+					return &telemetry.DeviceLatencySamples{Samples: []uint32{0, 0, 7}}, nil // 1/2
+				}
+				if o == origin && t == target {
+					return &telemetry.DeviceLatencySamples{Samples: []uint32{8, 8, 0}}, nil
+				} // 2/1
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{0}}, nil // 0/1
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key10F := "10-" + circuitKey(originCode, targetCode, link)
+	key10R := "10-" + circuitKey(targetCode, originCode, link)
+	key11F := "11-" + circuitKey(originCode, targetCode, link)
+	key11R := "11-" + circuitKey(targetCode, originCode, link)
+
+	require.NoError(t, w.Tick(ctx))
+	w.mu.RLock()
+	require.Equal(t, uint64(10), w.lastEpoch)
+	require.True(t, w.epochSet)
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[key10F])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 1, LossCount: 2}, w.stats[key10R])
+	w.mu.RUnlock()
+
+	epochVal = 11
+	require.NoError(t, w.Tick(ctx))
+	w.mu.RLock()
+	require.Equal(t, uint64(11), w.lastEpoch)
+	require.True(t, w.epochSet)
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 2, LossCount: 1}, w.stats[key11F])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 0, LossCount: 1}, w.stats[key11R])
+	// old totals remain
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[key10F])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 1, LossCount: 2}, w.stats[key10R])
+	w.mu.RUnlock()
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_MixedCircuits_ErrorBubbles(t *testing.T) {
+	t.Parallel()
+
+	a := solana.NewWallet().PublicKey()
+	b := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 42}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			// one link → two circuits (A→B and B→A)
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData("A", "B", a, b, link, "L"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			// succeed for one direction, fail for the other
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, o, t, l solana.PublicKey, e uint64) (*telemetry.DeviceLatencySamples, error) {
+				if o == a && t == b {
+					return &telemetry.DeviceLatencySamples{Samples: []uint32{1, 2, 3}}, nil
+				}
+				return nil, errors.New("reflector timeout")
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.Error(t, w.Tick(context.Background()))
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Run_ContinuesAfterTickError(t *testing.T) {
+	t.Parallel()
+
+	var step atomic.Int32 // 0=failing, 1=success
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, ct solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 777}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				if step.Load() == 0 {
+					return nil, errors.New("boom")
+				}
+				return &serviceability.ProgramData{}, nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(context.Context, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 5 * time.Millisecond,
+	}
+
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Run(ctx); close(done) }()
+
+	time.Sleep(8 * time.Millisecond) // first Tick should fail
+	step.Store(1)                    // subsequent Ticks succeed
+	time.Sleep(8 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not stop after cancel")
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	require.False(t, w.epochSet)
+	require.Empty(t, w.stats)
+}
+
+func TestMonitor_DeviceTelemetry_Watcher_Tick_EmptySamples_WritesZeroStatsAndSetsEpoch(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	link := solana.NewWallet().PublicKey()
+	originCode, targetCode := "OR-Z", "TG-Z"
+
+	cfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, ct solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 77}, nil
+			}},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return makeProgramData(originCode, targetCode, origin, target, link, "LK-Z"), nil
+			}},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(context.Context, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			}},
+		Interval: 10 * time.Millisecond,
+	}
+	w, err := NewDeviceTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	keyFwd := "77-" + circuitKey(originCode, targetCode, link)
+	keyRev := "77-" + circuitKey(targetCode, originCode, link)
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	require.True(t, w.epochSet)
+	require.Equal(t, uint64(77), w.lastEpoch)
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 0, LossCount: 0}, w.stats[keyFwd])
+	require.Equal(t, CircuitTelemetryStats{SuccessCount: 0, LossCount: 0}, w.stats[keyRev])
+}
+
+type mockLedgerRPC struct {
+	GetEpochInfoFunc func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error)
+}
+
+func (m *mockLedgerRPC) GetEpochInfo(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+	return m.GetEpochInfoFunc(ctx, c)
+}
+
+type mockServiceabilityClient struct {
+	GetProgramDataFunc func(ctx context.Context) (*serviceability.ProgramData, error)
+}
+
+func (m *mockServiceabilityClient) GetProgramData(ctx context.Context) (*serviceability.ProgramData, error) {
+	return m.GetProgramDataFunc(ctx)
+}
+
+type mockTelemetryProgramClient struct {
+	GetDeviceLatencySamplesFunc func(ctx context.Context, o, t, l solana.PublicKey, e uint64) (*telemetry.DeviceLatencySamples, error)
+}
+
+func (m *mockTelemetryProgramClient) GetDeviceLatencySamples(ctx context.Context, o, t, l solana.PublicKey, e uint64) (*telemetry.DeviceLatencySamples, error) {
+	return m.GetDeviceLatencySamplesFunc(ctx, o, t, l, e)
+}
+
+func newTestLogger(t *testing.T) *slog.Logger {
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	log = log.With("test", t.Name())
+	return log
+}
+
+func circuitKey(origin, target string, linkPK solana.PublicKey) string {
+	linkPKStr := linkPK.String()
+	shortLinkPK := linkPKStr[len(linkPKStr)-7:]
+	return fmt.Sprintf("%s → %s (%s)", origin, target, shortLinkPK)
+}
+
+func makeProgramData(devA, devZ string, pkA, pkZ, linkPK solana.PublicKey, linkCode string) *serviceability.ProgramData {
+	return &serviceability.ProgramData{
+		Devices: []serviceability.Device{
+			{Code: devA, PubKey: pkAsBytes(pkA)},
+			{Code: devZ, PubKey: pkAsBytes(pkZ)},
+		},
+		Links: []serviceability.Link{
+			{
+				Code:        linkCode,
+				PubKey:      pkAsBytes(linkPK),
+				SideAPubKey: pkAsBytes(pkA),
+				SideZPubKey: pkAsBytes(pkZ),
+			},
+		},
+	}
+}
+
+func pkAsBytes(pk solana.PublicKey) (out [32]byte) {
+	copy(out[:], pk[:])
+	return
+}

--- a/controlplane/monitor/internal/worker/config.go
+++ b/controlplane/monitor/internal/worker/config.go
@@ -1,0 +1,52 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+)
+
+type LedgerRPCClient interface {
+	GetEpochInfo(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error)
+}
+
+type ServiceabilityClient interface {
+	GetProgramData(context.Context) (*serviceability.ProgramData, error)
+}
+
+type TelemetryProgramClient interface {
+	GetDeviceLatencySamples(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error)
+}
+
+type Config struct {
+	Logger          *slog.Logger
+	LedgerRPCClient LedgerRPCClient
+	Serviceability  ServiceabilityClient
+	Telemetry       TelemetryProgramClient
+	Interval        time.Duration
+}
+
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if c.LedgerRPCClient == nil {
+		return errors.New("ledger rpc client is required")
+	}
+	if c.Serviceability == nil {
+		return errors.New("serviceability client is required")
+	}
+	if c.Telemetry == nil {
+		return errors.New("telemetry client is required")
+	}
+	if c.Interval <= 0 {
+		return errors.New("interval must be greater than 0")
+	}
+	return nil
+}

--- a/controlplane/monitor/internal/worker/metrics.go
+++ b/controlplane/monitor/internal/worker/metrics.go
@@ -1,0 +1,38 @@
+package worker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Metrics names.
+	MetricNameBuildInfo = "doublezero_monitor_build_info"
+	MetricNameErrors    = "doublezero_monitor_errors_total"
+
+	// Labels.
+	MetricLabelVersion   = "version"
+	MetricLabelCommit    = "commit"
+	MetricLabelDate      = "date"
+	MetricLabelErrorType = "error_type"
+
+	// Error types.
+)
+
+var (
+	MetricBuildInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameBuildInfo,
+			Help: "Build information of the monitor agent",
+		},
+		[]string{MetricLabelVersion, MetricLabelCommit, MetricLabelDate},
+	)
+
+	MetricErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameErrors,
+			Help: "Number of errors encountered",
+		},
+		[]string{MetricLabelErrorType},
+	)
+)

--- a/controlplane/monitor/internal/worker/worker.go
+++ b/controlplane/monitor/internal/worker/worker.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+
+	devicetelemetry "github.com/malbeclabs/doublezero/controlplane/monitor/internal/device-telemetry"
+)
+
+type Watcher interface {
+	Name() string
+	Run(ctx context.Context) error
+}
+
+type Worker struct {
+	log *slog.Logger
+	cfg *Config
+
+	watchers []Watcher
+}
+
+func New(cfg *Config) (*Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	deviceTelemetryWatcher, err := devicetelemetry.NewDeviceTelemetryWatcher(&devicetelemetry.Config{
+		Logger:          cfg.Logger,
+		LedgerRPCClient: cfg.LedgerRPCClient,
+		Serviceability:  cfg.Serviceability,
+		Telemetry:       cfg.Telemetry,
+		Interval:        cfg.Interval,
+	})
+	if err != nil {
+		return nil, err
+	}
+	watchers := []Watcher{
+		deviceTelemetryWatcher,
+	}
+	return &Worker{
+		log:      cfg.Logger,
+		cfg:      cfg,
+		watchers: watchers,
+	}, nil
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	w.log.Info("Starting worker")
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, watcher := range w.watchers {
+		go func(watcher Watcher) {
+			name := watcher.Name()
+			w.log.Info("Starting watcher", "name", name)
+			err := watcher.Run(ctx)
+			if err != nil {
+				w.log.Error("Failed to run watcher", "name", name, "error", err)
+				cancel()
+			}
+		}(watcher)
+	}
+
+	<-ctx.Done()
+	w.log.Info("Shutting down worker")
+
+	return nil
+}

--- a/controlplane/monitor/internal/worker/worker_test.go
+++ b/controlplane/monitor/internal/worker/worker_test.go
@@ -1,0 +1,178 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitor_Worker(t *testing.T) {
+	t.Parallel()
+
+	validCfg := &Config{
+		Logger: newTestLogger(t),
+		LedgerRPCClient: &mockLedgerRPC{
+			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+			},
+		},
+		Serviceability: &mockServiceabilityClient{
+			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+				return &serviceability.ProgramData{}, nil
+			},
+		},
+		Telemetry: &mockTelemetryProgramClient{
+			GetDeviceLatencySamplesFunc: func(context.Context, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.DeviceLatencySamples, error) {
+				return &telemetry.DeviceLatencySamples{Samples: []uint32{}}, nil
+			},
+		},
+		Interval: 10 * time.Millisecond,
+	}
+
+	t.Run("New_setsUpDeviceTelemetryWatcher", func(t *testing.T) {
+		t.Parallel()
+		w, err := New(validCfg)
+		require.NoError(t, err)
+		require.NotNil(t, w)
+		require.Len(t, w.watchers, 1)
+		require.Equal(t, "device-telemetry", w.watchers[0].Name())
+	})
+
+	t.Run("New_failsOnBadConfig", func(t *testing.T) {
+		t.Parallel()
+		c := *validCfg
+		c.Logger = nil
+		w, err := New(&c)
+		require.Error(t, err)
+		require.Nil(t, w)
+	})
+
+	t.Run("Run_cancelsWhenWatcherReturnsError", func(t *testing.T) {
+		t.Parallel()
+
+		errWatcher := &mockWatcher{
+			NameFunc: func() string { return "err-w" },
+			RunFunc: func(ctx context.Context) error {
+				time.Sleep(5 * time.Millisecond)
+				return errors.New("boom")
+			},
+		}
+		w := &Worker{
+			log:      newTestLogger(t),
+			cfg:      validCfg,
+			watchers: []Watcher{errWatcher},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() { _ = w.Run(ctx); close(done) }()
+
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("worker did not exit after watcher error")
+		}
+	})
+
+	t.Run("Run_exitsOnParentContextCancel", func(t *testing.T) {
+		t.Parallel()
+
+		blocking := &mockWatcher{
+			NameFunc: func() string { return "block" },
+			RunFunc: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		}
+		w := &Worker{
+			log:      newTestLogger(t),
+			cfg:      validCfg,
+			watchers: []Watcher{blocking},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() { _ = w.Run(ctx); close(done) }()
+
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("worker did not exit after cancel")
+		}
+	})
+
+	t.Run("Run_startsAllWatchers", func(t *testing.T) {
+		t.Parallel()
+
+		var started1, started2 atomic.Int32
+
+		w1 := &mockWatcher{
+			NameFunc: func() string { return "w1" },
+			RunFunc: func(ctx context.Context) error {
+				started1.Store(1)
+				<-ctx.Done()
+				return nil
+			},
+		}
+		w2 := &mockWatcher{
+			NameFunc: func() string { return "w2" },
+			RunFunc: func(ctx context.Context) error {
+				started2.Store(1)
+				<-ctx.Done()
+				return nil
+			},
+		}
+
+		w := &Worker{
+			log:      newTestLogger(t),
+			cfg:      validCfg,
+			watchers: []Watcher{w1, w2},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() { _ = w.Run(ctx); close(done) }()
+
+		time.Sleep(10 * time.Millisecond)
+		require.Equal(t, int32(1), started1.Load())
+		require.Equal(t, int32(1), started2.Load())
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("worker did not exit after cancel")
+		}
+	})
+}
+
+type mockWatcher struct {
+	NameFunc func() string
+	RunFunc  func(ctx context.Context) error
+}
+
+func (m *mockWatcher) Name() string {
+	if m.NameFunc != nil {
+		return m.NameFunc()
+	}
+	return "mock"
+}
+func (m *mockWatcher) Run(ctx context.Context) error {
+	if m.RunFunc != nil {
+		return m.RunFunc(ctx)
+	}
+	return nil
+}

--- a/controlplane/telemetry/internal/data/device/circuits.go
+++ b/controlplane/telemetry/internal/data/device/circuits.go
@@ -3,10 +3,9 @@ package data
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/gagliardetto/solana-go"
-	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/circuits"
 )
 
 type Device struct {
@@ -41,121 +40,37 @@ func (p *provider) GetCircuits(ctx context.Context) ([]Circuit, error) {
 		return cached, nil
 	}
 
-	data, err := p.cfg.ServiceabilityClient.GetProgramData(ctx)
+	deviceLinkCircuits, err := circuits.GetDeviceLinkCircuits(ctx, p.cfg.Logger, p.cfg.ServiceabilityClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load serviceability data: %w", err)
+		return nil, fmt.Errorf("failed to get device link circuits: %w", err)
 	}
 
-	circuits := make([]Circuit, 0, 2*len(data.Links))
-
-	devicesByPK := map[string]serviceability.Device{}
-	for _, device := range data.Devices {
-		pk := solana.PublicKeyFromBytes(device.PubKey[:])
-		devicesByPK[pk.String()] = device
-	}
-
-	locationsByPK := map[string]serviceability.Location{}
-	for _, location := range data.Locations {
-		pk := solana.PublicKeyFromBytes(location.PubKey[:])
-		locationsByPK[pk.String()] = location
-	}
-
-	for _, link := range data.Links {
-		deviceAPK := solana.PublicKeyFromBytes(link.SideAPubKey[:])
-		deviceZPK := solana.PublicKeyFromBytes(link.SideZPubKey[:])
-		linkPK := solana.PublicKeyFromBytes(link.PubKey[:])
-
-		deviceA, ok := devicesByPK[deviceAPK.String()]
-		if !ok {
-			p.cfg.Logger.Warn("device A not found, skipping link", "link_code", link.Code, "device_a_pk", deviceAPK.String())
-			continue
-		}
-		deviceZ, ok := devicesByPK[deviceZPK.String()]
-		if !ok {
-			p.cfg.Logger.Warn("device Z not found, skipping link", "link_code", link.Code, "device_z_pk", deviceZPK.String())
-			continue
-		}
-
-		// Forward circuit
-		forwardKey := circuitKey(deviceA.Code, deviceZ.Code, linkPK)
-		originLocation := locationsByPK[solana.PublicKeyFromBytes(deviceA.LocationPubKey[:]).String()]
-		targetLocation := locationsByPK[solana.PublicKeyFromBytes(deviceZ.LocationPubKey[:]).String()]
+	circuits := make([]Circuit, 0, len(deviceLinkCircuits))
+	for _, circuit := range deviceLinkCircuits {
 		circuits = append(circuits, Circuit{
-			Code: forwardKey,
+			Code: circuit.Code,
 			OriginDevice: Device{
-				PK:   deviceAPK,
-				Code: deviceA.Code,
+				PK:   circuit.OriginDevice.PubKey,
+				Code: circuit.OriginDevice.Code,
 				Location: Location{
-					PK:        solana.PublicKeyFromBytes(originLocation.PubKey[:]),
-					Name:      originLocation.Name,
-					Country:   originLocation.Country,
-					Latitude:  originLocation.Lat,
-					Longitude: originLocation.Lng,
+					PK: circuit.OriginDevice.LocationPubKey,
 				},
 			},
 			TargetDevice: Device{
-				PK:   deviceZPK,
-				Code: deviceZ.Code,
+				PK:   circuit.TargetDevice.PubKey,
+				Code: circuit.TargetDevice.Code,
 				Location: Location{
-					PK:        solana.PublicKeyFromBytes(targetLocation.PubKey[:]),
-					Name:      targetLocation.Name,
-					Country:   targetLocation.Country,
-					Latitude:  targetLocation.Lat,
-					Longitude: targetLocation.Lng,
+					PK: circuit.TargetDevice.LocationPubKey,
 				},
 			},
 			Link: Link{
-				PK:   linkPK,
-				Code: link.Code,
-			},
-		})
-
-		// Reverse circuit
-		reverseKey := circuitKey(deviceZ.Code, deviceA.Code, linkPK)
-		originLocation = locationsByPK[solana.PublicKeyFromBytes(deviceZ.LocationPubKey[:]).String()]
-		targetLocation = locationsByPK[solana.PublicKeyFromBytes(deviceA.LocationPubKey[:]).String()]
-		circuits = append(circuits, Circuit{
-			Code: reverseKey,
-			OriginDevice: Device{
-				PK:   deviceZPK,
-				Code: deviceZ.Code,
-				Location: Location{
-					PK:        solana.PublicKeyFromBytes(targetLocation.PubKey[:]),
-					Name:      targetLocation.Name,
-					Country:   targetLocation.Country,
-					Latitude:  targetLocation.Lat,
-					Longitude: targetLocation.Lng,
-				},
-			},
-			TargetDevice: Device{
-				PK:   deviceAPK,
-				Code: deviceA.Code,
-				Location: Location{
-					PK:        solana.PublicKeyFromBytes(originLocation.PubKey[:]),
-					Name:      originLocation.Name,
-					Country:   originLocation.Country,
-					Latitude:  originLocation.Lat,
-					Longitude: originLocation.Lng,
-				},
-			},
-			Link: Link{
-				PK:   linkPK,
-				Code: link.Code,
+				PK:   circuit.Link.PubKey,
+				Code: circuit.Link.Code,
 			},
 		})
 	}
-
-	sort.Slice(circuits, func(i, j int) bool {
-		return circuits[i].Code < circuits[j].Code
-	})
 
 	p.SetCachedCircuits(ctx, circuits)
 
 	return circuits, nil
-}
-
-func circuitKey(origin, target string, linkPK solana.PublicKey) string {
-	linkPKStr := linkPK.String()
-	shortLinkPK := linkPKStr[len(linkPKStr)-7:]
-	return fmt.Sprintf("%s → %s (%s)", origin, target, shortLinkPK)
 }

--- a/controlplane/telemetry/pkg/circuits/device.go
+++ b/controlplane/telemetry/pkg/circuits/device.go
@@ -1,0 +1,88 @@
+package circuits
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+)
+
+type ServiceabilityClient interface {
+	GetProgramData(context.Context) (*serviceability.ProgramData, error)
+}
+
+type DeviceLinkCircuit struct {
+	Code         string
+	OriginDevice serviceability.Device
+	TargetDevice serviceability.Device
+	Link         serviceability.Link
+}
+
+func GetDeviceLinkCircuits(ctx context.Context, log *slog.Logger, serviceabilityClient ServiceabilityClient) ([]DeviceLinkCircuit, error) {
+	data, err := serviceabilityClient.GetProgramData(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load serviceability data: %w", err)
+	}
+
+	circuits := make([]DeviceLinkCircuit, 0, 2*len(data.Links))
+
+	devicesByPK := map[string]serviceability.Device{}
+	for _, device := range data.Devices {
+		pk := solana.PublicKeyFromBytes(device.PubKey[:])
+		devicesByPK[pk.String()] = device
+	}
+
+	for _, link := range data.Links {
+		deviceAPK := solana.PublicKeyFromBytes(link.SideAPubKey[:])
+		deviceZPK := solana.PublicKeyFromBytes(link.SideZPubKey[:])
+		linkPK := solana.PublicKeyFromBytes(link.PubKey[:])
+
+		deviceA, ok := devicesByPK[deviceAPK.String()]
+		if !ok {
+			log.Warn("device A not found, skipping link", "link_code", link.Code, "device_a_pk", deviceAPK.String())
+			continue
+		}
+		deviceZ, ok := devicesByPK[deviceZPK.String()]
+		if !ok {
+			log.Warn("device Z not found, skipping link", "link_code", link.Code, "device_z_pk", deviceZPK.String())
+			continue
+		}
+
+		// Forward circuit
+		forwardKey := deviceLinkCircuitKey(deviceA.Code, deviceZ.Code, linkPK)
+		circuits = append(circuits, DeviceLinkCircuit{
+			Code:         forwardKey,
+			OriginDevice: deviceA,
+			TargetDevice: deviceZ,
+			Link:         link,
+		})
+
+		// Reverse circuit
+		reverseKey := deviceLinkCircuitKey(deviceZ.Code, deviceA.Code, linkPK)
+		circuits = append(circuits, DeviceLinkCircuit{
+			Code:         reverseKey,
+			OriginDevice: deviceZ,
+			TargetDevice: deviceA,
+			Link:         link,
+		})
+	}
+
+	sort.Slice(circuits, func(i, j int) bool {
+		return circuits[i].Code < circuits[j].Code
+	})
+
+	return circuits, nil
+}
+
+func deviceLinkCircuitKey(origin, target string, linkPK solana.PublicKey) string {
+	linkPKStr := linkPK.String()
+	start := 0
+	if len(linkPKStr) > 7 {
+		start = len(linkPKStr) - 7
+	}
+	shortLinkPK := linkPKStr[start:]
+	return fmt.Sprintf("%s → %s (%s)", origin, target, shortLinkPK)
+}


### PR DESCRIPTION
## Summary of Changes
- Add component that monitors onchain telemetry, exposing prometheus metrics for alerting when telemetry is not being written onchain for some period of time
- The `monitor` component is generalized to have many "watchers" so it can be extended to monitor other non-telemetry things, like serviceability program version, or users stuck in pending/deleting state, for example.
- Related to https://github.com/malbeclabs/doublezero/issues/1126
- This PR does not include release config for the component, which will be added in a follow-up PR
- This PR does not include a watcher for the internet latency onchain telemetry, which will be added in a follow-up PR

## Testing Verification
- Unit tests added for functionality of the new component
