### PR TITLE
cli: increase wait-for-user-activation timeout

### DIFF
--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -497,7 +497,7 @@ Disconnect and connect again!"#,
     ) -> eyre::Result<User> {
         spinner.set_message("Waiting for user activation...");
         let start_time = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(20);
+        let timeout = std::time::Duration::from_secs(60);
         let poll_interval = std::time::Duration::from_secs(1);
         let mut last_error: Option<eyre::Error> = None;
 
@@ -505,10 +505,10 @@ Disconnect and connect again!"#,
             if start_time.elapsed() >= timeout {
                 return Err(match last_error {
                     Some(e) => eyre::eyre!(
-                        "Timeout waiting for user activation after 20 seconds. Last error: {}",
+                        "Timeout waiting for user activation after 60 seconds. Last error: {}",
                         e
                     ),
-                    None => eyre::eyre!("Timeout waiting for user activation after 20 seconds"),
+                    None => eyre::eyre!("Timeout waiting for user activation after 60 seconds"),
                 });
             }
 

--- a/smartcontract/cli/src/poll_for_activation.rs
+++ b/smartcontract/cli/src/poll_for_activation.rs
@@ -96,7 +96,7 @@ pub fn poll_for_user_activated(
     user_pubkey: &Pubkey,
 ) -> eyre::Result<User> {
     let start_time = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(20);
+    let timeout = std::time::Duration::from_secs(60);
     let poll_interval = std::time::Duration::from_secs(1);
     let mut last_error: Option<eyre::Error> = None;
 
@@ -104,10 +104,10 @@ pub fn poll_for_user_activated(
         if start_time.elapsed() >= timeout {
             return Err(match last_error {
                 Some(e) => eyre::eyre!(
-                    "Timeout waiting for user activation after 20 seconds. Last error: {}",
+                    "Timeout waiting for user activation after 60 seconds. Last error: {}",
                     e
                 ),
-                None => eyre::eyre!("Timeout waiting for user activation after 20 seconds"),
+                None => eyre::eyre!("Timeout waiting for user activation after 60 seconds"),
             });
         }
 


### PR DESCRIPTION
## Summary of Changes
- Increase the "waiting for user activation" timeout in the CLI
- We're seeing the 20 second timeout being exceeded a lot in CI tests since introducing DZD metadata where the activator now assigning IPs for device interfaces, so it has more work to do, more ledger transactions to get through, to initialize everything in the tests.
- Alternatively we could update the tests to wait for everything to be initialized before moving onto user connections, but arguably a 60 second timeout on this in the CLI is a better user experience in the scenarios where there is an activator delay anyway.
- Example: https://github.com/malbeclabs/doublezero/actions/runs/17099437179/job/48491738474
- Resolves https://github.com/malbeclabs/doublezero/issues/1296

## Testing Verification
- Existing tests continue to pass
