### PR TITLE
refactor: remove redundant owner check for link account in process_update_link

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -76,10 +76,6 @@ pub fn process_update_link(
 
     let mut link: Link = Link::try_from(link_account)?;
 
-    if link.owner != *payer_account.key {
-        return Err(solana_program::program_error::ProgramError::Custom(0));
-    }
-
     if let Some(ref code) = value.code {
         link.code = validate_account_code(code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;
     }


### PR DESCRIPTION
This pull request makes a targeted change to the link update processor in the Solana smart contract codebase. The main update removes the check that previously ensured only the link owner could update a link, potentially allowing broader access to the update functionality.

Access control modification:

* In `smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs`, the ownership check (`link.owner != *payer_account.key`) was removed from the `process_update_link` function, which means updates to a link are no longer restricted to the owner.

## Testing Verification
* Show evidence of testing the change
