### PR TITLE
e2e: deflake user reconnect race

### DIFF
--- a/e2e/no_ifaces_peers_test.go
+++ b/e2e/no_ifaces_peers_test.go
@@ -114,7 +114,7 @@ func TestE2E_Controller_NoIfacesAndPeers(t *testing.T) {
 
 	// Run IBRL with allocated IP workflow test.
 	if !t.Run("ibrl_with_allocated_ip", func(t *testing.T) {
-		runMultiClientIBRLWithAllocatedIPWorkflowTest(t, log, client1, client2)
+		runMultiClientIBRLWithAllocatedIPWorkflowTest(t, log, dn, client1, client2)
 	}) {
 		t.Fail()
 	}


### PR DESCRIPTION
## Summary of Changes
- Update multi client e2e test to wait for user to be deleted onchain before moving onto next workflow and attempting to reconnect
- Fixes https://github.com/malbeclabs/doublezero/issues/1296 - the issue was that sometimes the reconnect would race the disconnect/deactivate transaction (moving to deleting state) being finalized, so the CLI would pick up the previous user connection as a matched activated user on reconnect, but then it would be moved to deleting state when the txn finalized and deleted by the activator, so the CLI would just time out while waiting for the user to exist and be activated from there, but it never actually created the new user/connection.

## Testing Verification
- Ran this in an until fail loop for a bit and didn't not reproduce, where it was relatively quick to reproduce without the change
