### PR TITLE
monitor: release configs

### DIFF
--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -19,6 +19,8 @@ jobs:
             playbook: playbooks/controllers.yml
           - component: funder
             playbook: playbooks/funders.yml
+          - component: monitor
+            playbook: playbooks/monitors.yml
           - component: client
             playbook: playbooks/validators.yml
           - component: device-telemetry-agent

--- a/.github/workflows/release.devnet.monitor.yml
+++ b/.github/workflows/release.devnet.monitor.yml
@@ -1,0 +1,15 @@
+name: release.devnet.monitor.daily
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.daily.yml
+    with:
+      component: monitor
+      playbook: playbooks/monitors.yml
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write

--- a/.github/workflows/release.monitor.yml
+++ b/.github/workflows/release.monitor.yml
@@ -1,0 +1,37 @@
+name: releaser.monitor
+
+on:
+  push:
+    tags:
+      - "monitor/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install squashfs-tools rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.testnet.monitor.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -27,6 +27,8 @@ jobs:
             languages: ["go"]
           - release: funder
             languages: ["go"]
+          - release: monitor
+            languages: ["go"]
           - release: qa-agent
             languages: ["go"]
     name: release-validation-${{ matrix.release }}

--- a/release/.goreleaser.base.monitor.yaml
+++ b/release/.goreleaser.base.monitor.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: doublezero-monitor
+
+monorepo:
+  tag_prefix: monitor/
+  dir: controlplane/monitor
+
+builds:
+  - id: doublezero-monitor
+    main: cmd/monitor/main.go
+    binary: doublezero-monitor
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - id: monitor_archive
+    formats: ['tar.gz']
+    ids: [doublezero-monitor]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+nfpms:
+  - id: doublezero-monitor
+    package_name: doublezero-monitor
+    ids: [doublezero-monitor]
+    vendor: doublezero
+    homepage: doublezero.xyz
+    maintainer: dev <dev@malbeclabs.com>
+    description: |-
+      DoubleZero Monitor
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/local/bin
+    release: "1"
+    section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-monitor.service
+        dst: /lib/systemd/system/doublezero-monitor.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-monitor.service
+            dst: /usr/lib/systemd/system/doublezero-monitor.service
+            type: config
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: malbeclabs
+    name: doublezero
+  draft: false
+  replace_existing_artifacts: true
+
+announce:
+  slack:
+    enabled: true
+    message_template: "DoubleZero Monitor {{.Tag}} has been released! Check it out at {{ .ReleaseURL }}"
+    channel: "#bots"
+
+git:
+  ignore_tags:
+    - monitor/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
+  tag_name: 'monitor/daily'

--- a/release/.goreleaser.devnet.monitor.yaml
+++ b/release/.goreleaser.devnet.monitor.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.monitor.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.monitor.yaml
+++ b/release/.goreleaser.testnet.monitor.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.monitor.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-monitor.service
+++ b/release/packaging/systemd/doublezero-monitor.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the monitor with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-monitor.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-monitor
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary of Changes
- Add release configs for the monitor component from https://github.com/malbeclabs/doublezero/pull/1307
- Related to https://github.com/malbeclabs/doublezero/issues/1126
- Depends on https://github.com/malbeclabs/infra/pull/100

## Testing Verification
- Executed daily devnet release workflow on this branch ([components dashboard](https://doublezero.grafana.net/d/bf3dece9-51ac-4087-b6b1-579b3859ce14/doublezero-system-metrics?orgId=1&from=now-6h&to=now&timezone=browser&var-Filters=&var-env=devnet))
