### PR TITLE
Single device stress test 

### DIFF
--- a/e2e/docker/client/Dockerfile
+++ b/e2e/docker/client/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE} AS base
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y curl jq iproute2 iputils-ping iproute2 net-tools tcpdump vim iperf
+    apt-get install -y curl jq iproute2 iputils-ping iproute2 net-tools tcpdump vim iperf fping
 
 COPY --from=base /doublezero/bin/doublezero /usr/local/bin/
 COPY --from=base /doublezero/bin/doublezerod /usr/local/bin/


### PR DESCRIPTION
## Summary of Changes
* e2e/device_stress_test.go connects clients one at a time to a single device until something breaks
* currently limited to 128 by MaxTunnelSlots (related - [pr 1337](https://github.com/malbeclabs/doublezero/pull/1337))