### PR TITLE
device/telemetry: periodically recreate sender instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
     - Add single device stress test
 - CLI
     - Refactor: Updated `SetAccessPassCliCommand` (`doublezero access-pass set`) to use `--epochs` instead of `--last_access_epoch`, with sensible default values.
+- Device Agents
+    - Periodically recreate telemetry agent sender instances in case of interface reconfiguration.
 
 ## [v0.5.3](https://github.com/malbeclabs/doublezero/compare/client/v0.5.0...client/v0.5.3) – 2025-08-19
 

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -33,6 +33,7 @@ const (
 	defaultTWAMPReflectorTimeout = 1 * time.Second
 	defaultPeersRefreshInterval  = 10 * time.Second
 	defaultTWAMPSenderTimeout    = 1 * time.Second
+	defaultSenderTTL             = 5 * time.Minute
 	defaultLedgerRPCURL          = ""
 	defaultProgramId             = ""
 	defaultLocalDevicePubkey     = ""
@@ -54,6 +55,7 @@ var (
 	twampSenderTimeout      = flag.Duration("twamp-sender-timeout", defaultTWAMPSenderTimeout, "The timeout for sending twamp probes.")
 	twampReflectorTimeout   = flag.Duration("twamp-reflector-timeout", defaultTWAMPReflectorTimeout, "The timeout for the twamp reflector.")
 	peersRefreshInterval    = flag.Duration("peers-refresh-interval", defaultPeersRefreshInterval, "The interval to refresh the peer discovery.")
+	senderTTL               = flag.Duration("sender-ttl", defaultSenderTTL, "The time to live for a sender instance until it's recreated.")
 	managementNamespace     = flag.String("management-namespace", "", "The name of the management namespace to use for ledger communication. If not provided, the default namespace will be used. (default: '')")
 	verbose                 = flag.Bool("verbose", false, "Enable verbose logging.")
 	showVersion             = flag.Bool("version", false, "Print the version of the doublezero-agent and exit.")
@@ -158,6 +160,7 @@ func main() {
 		"probeInterval", *probeInterval,
 		"submissionInterval", *submissionInterval,
 		"twampListenPort", *twampListenPort,
+		"senderTTL", *senderTTL,
 	)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -268,6 +271,7 @@ func main() {
 			}
 			return epochInfo.Epoch, nil
 		},
+		SenderTTL: *senderTTL,
 	})
 	if err != nil {
 		log.Error("failed to create telemetry collector", "error", err)

--- a/controlplane/telemetry/internal/telemetry/config.go
+++ b/controlplane/telemetry/internal/telemetry/config.go
@@ -36,6 +36,12 @@ type Config struct {
 
 	// TWAMPSenderTimeout is the timeout for sending TWAMP probes.
 	TWAMPSenderTimeout time.Duration
+
+	// NowFunc is the function to get the current time.
+	NowFunc func() time.Time
+
+	// SenderTTL is the time to live for a sender instance until it's recreated.
+	SenderTTL time.Duration
 }
 
 func (c *Config) Validate() error {
@@ -62,6 +68,14 @@ func (c *Config) Validate() error {
 	}
 	if c.TelemetryProgramClient == nil {
 		return errors.New("telemetry program client is required")
+	}
+	if c.NowFunc == nil {
+		c.NowFunc = func() time.Time {
+			return time.Now().UTC()
+		}
+	}
+	if c.SenderTTL <= 0 {
+		return errors.New("sender ttl must be greater than 0")
 	}
 	return nil
 }

--- a/tools/twamp/pkg/light/sender_linux.go
+++ b/tools/twamp/pkg/light/sender_linux.go
@@ -196,6 +196,7 @@ func (s *LinuxSender) Probe(ctx context.Context) (time.Duration, error) {
 				// syscall latency, or NTP adjustments, the kernel timestamp can occasionally appear earlier
 				// than the user-space send time. This results in a spurious negative RTT, which we
 				// conservatively clamp to 0.
+				// This can also happen if the interface is misconfigured.
 				rtt = max(rtt, 0)
 
 				return rtt, nil


### PR DESCRIPTION
## Summary of Changes
- Update device telemetry agent to periodically recreate sender instances in case of interface reconfiguration
- Resolves https://github.com/malbeclabs/doublezero/issues/1359

## Testing Verification
- Added test coverage for new sender TTL functionality
