### PR TITLE
refactor: Update SetAccessPassCliCommand to use 'epochs' instead of 'last_access_epoch' and set default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented in this file.
     - Add user ban workflow test
     - Deflake user reconnect race and device interface assigned IP race
     - Add single device stress test
+- CLI
+    - Refactor: Updated `SetAccessPassCliCommand` (`doublezero access-pass set`) to use `--epochs` instead of `--last_access_epoch`, with sensible default values.
 
 ## [v0.5.3](https://github.com/malbeclabs/doublezero/compare/client/v0.5.0...client/v0.5.3) – 2025-08-19
 

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -497,7 +497,7 @@ Disconnect and connect again!"#,
     ) -> eyre::Result<User> {
         spinner.set_message("Waiting for user activation...");
         let start_time = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(20);
+        let timeout = std::time::Duration::from_secs(50);
         let poll_interval = std::time::Duration::from_secs(1);
         let mut last_error: Option<eyre::Error> = None;
 
@@ -505,10 +505,10 @@ Disconnect and connect again!"#,
             if start_time.elapsed() >= timeout {
                 return Err(match last_error {
                     Some(e) => eyre::eyre!(
-                        "Timeout waiting for user activation after 20 seconds. Last error: {}",
+                        "Timeout waiting for user activation after 50 seconds. Last error: {}",
                         e
                     ),
-                    None => eyre::eyre!("Timeout waiting for user activation after 20 seconds"),
+                    None => eyre::eyre!("Timeout waiting for user activation after 50 seconds"),
                 });
             }
 

--- a/e2e/ibrl_test.go
+++ b/e2e/ibrl_test.go
@@ -237,7 +237,7 @@ func checkIBRLPostConnect(t *testing.T, dn *TestDevnet, device *devnet.Device, c
 			dn.CreateMulticastGroupOnchain(t, client, "mg01")
 
 			// Set access pass for the client.
-			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 			require.NoError(t, err)
 
 			_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast publisher mg01 --client-ip " + client.CYOANetworkIP})

--- a/e2e/ibrl_with_allocated_ip_test.go
+++ b/e2e/ibrl_with_allocated_ip_test.go
@@ -49,19 +49,19 @@ func createMultipleIBRLUsersOnSameDeviceWithAllocatedIPs(t *testing.T, dn *TestD
 	dn.log.Info("==> Creating multiple IBRL users on a single device with allocated IP addresses")
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 1.2.3.4 --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 1.2.3.4 --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 2.3.4.5 --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 2.3.4.5 --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 3.4.5.6 --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 3.4.5.6 --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 4.5.6.7 --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 4.5.6.7 --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 5.6.7.8 --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip 5.6.7.8 --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", `

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -236,7 +236,7 @@ func (dn *TestDevnet) Start(t *testing.T) (*devnet.Device, *devnet.Client) {
 	require.NoError(t, err)
 
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(ctx, []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(ctx, []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	// Add null routes to test latency selection to ny5-dz01.
@@ -351,7 +351,7 @@ func (dn *TestDevnet) ConnectIBRLUserTunnel(t *testing.T, client *devnet.Client)
 	dn.log.Info("==> Connecting IBRL user tunnel")
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect ibrl --client-ip " + client.CYOANetworkIP})
@@ -365,7 +365,7 @@ func (dn *TestDevnet) ConnectUserTunnelWithAllocatedIP(t *testing.T, client *dev
 	dn.log.Info("==> Connecting user tunnel with allocated IP")
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect ibrl --client-ip " + client.CYOANetworkIP + " --allocate-addr"})
@@ -378,7 +378,7 @@ func (dn *TestDevnet) ConnectMulticastPublisher(t *testing.T, client *devnet.Cli
 	dn.log.Info("==> Connecting multicast publisher", "clientIP", client.CYOANetworkIP)
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast publisher " + multicastGroupCode + " --client-ip " + client.CYOANetworkIP})
@@ -392,7 +392,7 @@ func (dn *TestDevnet) DisconnectMulticastPublisher(t *testing.T, client *devnet.
 	dn.log.Info("==> Disconnecting multicast publisher", "clientIP", client.CYOANetworkIP)
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero disconnect multicast --client-ip " + client.CYOANetworkIP})
@@ -405,7 +405,7 @@ func (dn *TestDevnet) ConnectMulticastSubscriber(t *testing.T, client *devnet.Cl
 	dn.log.Info("==> Connecting multicast subscriber", "clientIP", client.CYOANetworkIP)
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast subscriber " + multicastGroupCode + " --client-ip " + client.CYOANetworkIP})
@@ -418,7 +418,7 @@ func (dn *TestDevnet) DisconnectMulticastSubscriber(t *testing.T, client *devnet
 	dn.log.Info("==> Disconnecting multicast subscriber", "clientIP", client.CYOANetworkIP)
 
 	// Set access pass for the client.
-	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
 	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero disconnect multicast --client-ip " + client.CYOANetworkIP})

--- a/e2e/multi_client_test.go
+++ b/e2e/multi_client_test.go
@@ -104,10 +104,10 @@ func TestE2E_MultiClient(t *testing.T) {
 	log.Info("--> Clients added to user allowlist")
 
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey})
 	require.NoError(t, err)
 
 	// Run IBRL workflow test.

--- a/e2e/multicast_publisher_test.go
+++ b/e2e/multicast_publisher_test.go
@@ -33,7 +33,7 @@ func TestE2E_Multicast_Publisher(t *testing.T) {
 		dn.CreateMulticastGroupOnchain(t, client, "mg02")
 
 		// Set access pass for the client.
-		_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+		_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 		require.NoError(t, err)
 
 		output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast publisher mg02 --client-ip " + client.CYOANetworkIP})
@@ -207,7 +207,7 @@ func checkMulticastPublisherPostConnect(t *testing.T, dn *TestDevnet, device *de
 
 		if !t.Run("only_one_tunnel_allowed", func(t *testing.T) {
 			// Set access pass for the client.
-			_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+			_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 			require.NoError(t, err)
 
 			_, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect ibrl --client-ip " + client.CYOANetworkIP})

--- a/e2e/multicast_subscriber_test.go
+++ b/e2e/multicast_subscriber_test.go
@@ -34,7 +34,7 @@ func TestE2E_Multicast_Subscriber(t *testing.T) {
 		dn.CreateMulticastGroupOnchain(t, client, "mg02")
 
 		// Set access pass for the client.
-		_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+		_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 		require.NoError(t, err)
 
 		output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast subscriber mg02 --client-ip " + client.CYOANetworkIP})
@@ -220,7 +220,7 @@ func checkMulticastSubscriberPostConnect(t *testing.T, dn *TestDevnet, device *d
 
 		if !t.Run("only_one_tunnel_allowed", func(t *testing.T) {
 			// Set access pass for the client.
-			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey + " --last-access-epoch 99999"})
+			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 			require.NoError(t, err)
 
 			_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect ibrl --client-ip " + client.CYOANetworkIP})

--- a/e2e/no_ifaces_peers_test.go
+++ b/e2e/no_ifaces_peers_test.go
@@ -106,10 +106,10 @@ func TestE2E_Controller_NoIfacesAndPeers(t *testing.T) {
 	log.Info("--> Clients added to user allowlist")
 
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey})
 	require.NoError(t, err)
 
 	// Run IBRL with allocated IP workflow test.

--- a/e2e/user_ban_test.go
+++ b/e2e/user_ban_test.go
@@ -108,10 +108,10 @@ func TestE2E_UserBan(t *testing.T) {
 	log.Info("--> Clients added to user allowlist")
 
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client1.CYOANetworkIP + " --user-payer " + client1.Pubkey})
 	require.NoError(t, err)
 	// Set access pass for the client.
-	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey + " --last-access-epoch 99999"})
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type Prepaid --client-ip " + client2.CYOANetworkIP + " --user-payer " + client2.Pubkey})
 	require.NoError(t, err)
 
 	// Run IBRL workflow test.

--- a/smartcontract/cli/src/poll_for_activation.rs
+++ b/smartcontract/cli/src/poll_for_activation.rs
@@ -96,7 +96,7 @@ pub fn poll_for_user_activated(
     user_pubkey: &Pubkey,
 ) -> eyre::Result<User> {
     let start_time = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(20);
+    let timeout = std::time::Duration::from_secs(50);
     let poll_interval = std::time::Duration::from_secs(1);
     let mut last_error: Option<eyre::Error> = None;
 
@@ -104,10 +104,10 @@ pub fn poll_for_user_activated(
         if start_time.elapsed() >= timeout {
             return Err(match last_error {
                 Some(e) => eyre::eyre!(
-                    "Timeout waiting for user activation after 20 seconds. Last error: {}",
+                    "Timeout waiting for user activation after 50 seconds. Last error: {}",
                     e
                 ),
-                None => eyre::eyre!("Timeout waiting for user activation after 20 seconds"),
+                None => eyre::eyre!("Timeout waiting for user activation after 50 seconds"),
             });
         }
 

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -155,12 +155,12 @@ echo "Accepting external link"
 
 # create access pass
 echo "Create AccessPass for users"
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 177.54.159.95 --user-payer me --last-access-epoch MAX
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 147.28.171.51 --user-payer me --last-access-epoch MAX
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.100.100.100 --user-payer me --last-access-epoch MAX
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 200.200.200.200 --user-payer me --last-access-epoch MAX
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.0.0.5 --user-payer me --last-access-epoch MAX
-./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.0.0.6 --user-payer me --last-access-epoch MAX
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 177.54.159.95 --user-payer me 
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 147.28.171.51 --user-payer me 
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.100.100.100 --user-payer me 
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 200.200.200.200 --user-payer me
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.0.0.5 --user-payer me
+./target/doublezero access-pass set --accesspass-type PrePaid --client-ip 100.0.0.6 --user-payer me
 
 # create a user
 echo "Creating users"


### PR DESCRIPTION
This pull request refactors how access pass epochs are specified and handled in the CLI and related test scripts. The main change is replacing the `last_access_epoch` argument with a more intuitive `epochs` argument, simplifying both user experience and internal logic. The computation of the last access epoch now uses the current epoch plus the specified number of epochs, making the command easier to use and understand.

**Access Pass Argument Refactor:**

* The `SetAccessPassCliCommand` struct replaces the `last_access_epoch` argument with an `epochs` argument, which defaults to `"max"`. This makes the CLI more user-friendly and aligns with common usage patterns.
* The logic for determining the last access epoch now computes it as the current epoch plus the number of epochs specified, or sets it to `u64::MAX` if `"max"` is provided. This improves clarity and correctness in how access passes are configured.

**Test Updates:**

* The test mock setup now returns a fixed current epoch (`10`) to support the new calculation logic for the last access epoch.
* Test cases are updated to use the new `epochs` argument instead of `last_access_epoch`, ensuring consistency with the refactored CLI command. [[1]](diffhunk://#diff-dd0b8fce2acca223e0b8169ce27bb2986acabb1d568a7ccc5fb4c94464c0d595L96-R100) [[2]](diffhunk://#diff-dd0b8fce2acca223e0b8169ce27bb2986acabb1d568a7ccc5fb4c94464c0d595L105-R109)

**Script Updates:**

* The `start-test.sh` script is updated to remove the `--last-access-epoch` argument from `access-pass set` commands, relying on the new default behavior for epochs. This simplifies test setup and usage.

## Testing Verification
* Show evidence of testing the change
