### PR TITLE
telemetry/data: smaller api responses with field filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ All notable changes to this project will be documented in this file.
     - Refactor: Updated `SetAccessPassCliCommand` (`doublezero access-pass set`) to use `--epochs` instead of `--last_access_epoch`, with sensible default values.
 - Device Agents
     - Periodically recreate telemetry agent sender instances in case of interface reconfiguration.
+- Telemetry
+    - Optimize onchain data dashboard API responses with field filtering
+    - Optimize onchain data data CLI execution with parallel queries
 
 ## [v0.5.3](https://github.com/malbeclabs/doublezero/compare/client/v0.5.0...client/v0.5.3) – 2025-08-19
 

--- a/controlplane/telemetry/cmd/data-api/Dockerfile
+++ b/controlplane/telemetry/cmd/data-api/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:24.04 AS builder
 
 # Install build dependencies and other utilities
-RUN apt update -qq && \
+RUN apt update && \
     apt install --no-install-recommends -y \
     ca-certificates \
     curl \
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ----------------------------------------------------------------------------
 FROM ubuntu:24.04
 
-RUN apt update -qq && \
+RUN apt update && \
     apt install --no-install-recommends -y \
     ca-certificates \
     curl

--- a/controlplane/telemetry/internal/data/device/provider.go
+++ b/controlplane/telemetry/internal/data/device/provider.go
@@ -22,7 +22,7 @@ const (
 	defaultCurrentEpochLatenciesCacheTTL  = 1 * time.Minute
 	defaultHistoricEpochLatenciesCacheTTL = 24 * time.Hour
 
-	defaultGetCircuitLatenciesPoolSize = 16
+	defaultGetCircuitLatenciesPoolSize = 64
 )
 
 type Unit string

--- a/controlplane/telemetry/internal/data/internet/provider.go
+++ b/controlplane/telemetry/internal/data/internet/provider.go
@@ -21,7 +21,7 @@ const (
 	defaultCurrentEpochLatenciesCacheTTL  = 1 * time.Minute
 	defaultHistoricEpochLatenciesCacheTTL = 24 * time.Hour
 
-	defaultGetCircuitLatenciesPoolSize = 16
+	defaultGetCircuitLatenciesPoolSize = 64
 )
 
 type Unit string

--- a/controlplane/telemetry/internal/data/internet/server.go
+++ b/controlplane/telemetry/internal/data/internet/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/malbeclabs/doublezero/config"
+	datajson "github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data/json"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data/stats"
 )
 
@@ -46,6 +48,8 @@ func NewServer(log *slog.Logger, mainnetProvider, testnetProvider, devnetProvide
 func (s *Server) provider(env string) (Provider, error) {
 	switch env {
 	case config.EnvMainnetBeta:
+		return s.mainnet, nil
+	case config.EnvMainnet:
 		return s.mainnet, nil
 	case config.EnvTestnet:
 		return s.testnet, nil
@@ -112,6 +116,7 @@ func (s *Server) handleInternetCircuitLatencies(w http.ResponseWriter, r *http.R
 	intervalStr := r.URL.Query().Get("interval")
 	unit := r.URL.Query().Get("unit")
 	dataProvider := r.URL.Query().Get("data_provider")
+	metrics := parseMultiParam(r, "metrics")
 
 	s.log.Debug("[/location-internet/circuit-latencies]", "env", env, "from", fromStr, "to", toStr, "circuits", circuits, "max_points", maxPointsStr, "interval", intervalStr, "unit", unit, "full", r.URL.String())
 
@@ -198,7 +203,20 @@ func (s *Server) handleInternetCircuitLatencies(w http.ResponseWriter, r *http.R
 		return output[i].Timestamp < output[j].Timestamp
 	})
 
-	if err := json.NewEncoder(w).Encode(output); err != nil {
+	var encoder datajson.Encoder
+	if len(metrics) > 0 {
+		if !slices.Contains(metrics, "timestamp") {
+			metrics = append([]string{"timestamp"}, metrics...)
+		}
+		if !slices.Contains(metrics, "circuit") {
+			metrics = append([]string{"circuit"}, metrics...)
+		}
+		encoder = datajson.NewFieldFilteringEncoder(w, metrics)
+	} else {
+		encoder = json.NewEncoder(w)
+	}
+
+	if err := encoder.Encode(output); err != nil {
 		s.log.Error("failed to encode latencies", "error", err)
 		http.Error(w, fmt.Sprintf("failed to encode latencies: %v", err), http.StatusInternalServerError)
 		return

--- a/controlplane/telemetry/internal/data/json/encoder.go
+++ b/controlplane/telemetry/internal/data/json/encoder.go
@@ -1,0 +1,250 @@
+package datajson
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+type Encoder interface{ Encode(v any) error }
+
+type FieldFilteringEncoder struct {
+	w      io.Writer
+	fields map[string]struct{}
+}
+
+func NewFieldFilteringEncoder(w io.Writer, fields []string) *FieldFilteringEncoder {
+	fs := make(map[string]struct{}, len(fields))
+	for _, f := range fields {
+		fs[f] = struct{}{}
+	}
+	return &FieldFilteringEncoder{w: w, fields: fs}
+}
+
+func (e *FieldFilteringEncoder) Encode(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	return e.encodeFromDecoder(dec)
+}
+
+func (e *FieldFilteringEncoder) EncodeReader(r io.Reader) error {
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	return e.encodeFromDecoder(dec)
+}
+
+func (e *FieldFilteringEncoder) encodeFromDecoder(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	switch d := tok.(type) {
+	case json.Delim:
+		switch d {
+		case '{':
+			if _, err := e.w.Write([]byte{'{'}); err != nil {
+				return err
+			}
+			first := true
+			for dec.More() {
+				kt, err := dec.Token()
+				if err != nil {
+					return err
+				}
+				k := kt.(string)
+				if _, ok := e.fields[k]; ok {
+					if !first {
+						if _, err := e.w.Write([]byte{','}); err != nil {
+							return err
+						}
+					}
+					first = false
+					if err := writeString(e.w, k); err != nil {
+						return err
+					}
+					if _, err := e.w.Write([]byte{':'}); err != nil {
+						return err
+					}
+					if err := copyValue(dec, e.w); err != nil {
+						return err
+					}
+				} else {
+					if err := skipValue(dec); err != nil {
+						return err
+					}
+				}
+			}
+			_, err = dec.Token()
+			if err != nil {
+				return err
+			}
+			_, err = e.w.Write([]byte{'}'})
+			return err
+		case '[':
+			if _, err := e.w.Write([]byte{'['}); err != nil {
+				return err
+			}
+			first := true
+			for dec.More() {
+				if !first {
+					if _, err := e.w.Write([]byte{','}); err != nil {
+						return err
+					}
+				}
+				first = false
+				if err := copyValue(dec, e.w); err != nil {
+					return err
+				}
+			}
+			_, err = dec.Token()
+			if err != nil {
+				return err
+			}
+			_, err = e.w.Write([]byte{']'})
+			return err
+		default:
+			_, err := e.w.Write([]byte(string(d)))
+			return err
+		}
+	default:
+		return writeToken(e.w, tok)
+	}
+}
+
+func copyValue(dec *json.Decoder, w io.Writer) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	switch d := tok.(type) {
+	case json.Delim:
+		switch d {
+		case '{':
+			if _, err := w.Write([]byte{'{'}); err != nil {
+				return err
+			}
+			first := true
+			for dec.More() {
+				if !first {
+					if _, err := w.Write([]byte{','}); err != nil {
+						return err
+					}
+				}
+				first = false
+				kt, err := dec.Token()
+				if err != nil {
+					return err
+				}
+				if err := writeString(w, kt.(string)); err != nil {
+					return err
+				}
+				if _, err := w.Write([]byte{':'}); err != nil {
+					return err
+				}
+				if err := copyValue(dec, w); err != nil {
+					return err
+				}
+			}
+			_, err = dec.Token()
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte{'}'})
+			return err
+		case '[':
+			if _, err := w.Write([]byte{'['}); err != nil {
+				return err
+			}
+			first := true
+			for dec.More() {
+				if !first {
+					if _, err := w.Write([]byte{','}); err != nil {
+						return err
+					}
+				}
+				first = false
+				if err := copyValue(dec, w); err != nil {
+					return err
+				}
+			}
+			_, err = dec.Token()
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte{']'})
+			return err
+		default:
+			_, err := w.Write([]byte(string(d)))
+			return err
+		}
+	default:
+		return writeToken(w, tok)
+	}
+}
+
+func skipValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := tok.(json.Delim); ok {
+		switch d {
+		case '{':
+			for dec.More() {
+				if err := skipValue(dec); err != nil {
+					return err
+				}
+			}
+			_, err = dec.Token()
+		case '[':
+			for dec.More() {
+				if err := skipValue(dec); err != nil {
+					return err
+				}
+			}
+			_, err = dec.Token()
+		}
+	}
+	return err
+}
+
+func writeString(w io.Writer, s string) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func writeToken(w io.Writer, tok any) error {
+	switch v := tok.(type) {
+	case string:
+		return writeString(w, v)
+	case json.Number:
+		_, err := w.Write([]byte(v.String()))
+		return err
+	case bool:
+		if v {
+			_, err := w.Write([]byte("true"))
+			return err
+		}
+		_, err := w.Write([]byte("false"))
+		return err
+	case nil:
+		_, err := w.Write([]byte("null"))
+		return err
+	default:
+		// fallback (shouldn't hit with UseNumber): re-marshal the token
+		b, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	}
+}

--- a/controlplane/telemetry/internal/data/json/encoder_test.go
+++ b/controlplane/telemetry/internal/data/json/encoder_test.go
@@ -1,0 +1,113 @@
+package datajson
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func decUseNumber(t *testing.T, s string) any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return v
+}
+
+func TestTopLevelObject_FilterOnlyTopLevel_NumbersAndLists(t *testing.T) {
+	raw := `{"a":1,"b":2.5,"c":9223372036854775807,"nested":{"x":1,"y":[1,2,3]},"arr":[{"k":1},{"k":2}], "z":null}`
+	var out bytes.Buffer
+	e := NewFieldFilteringEncoder(&out, []string{"c", "arr"})
+	if err := e.EncodeReader(strings.NewReader(raw)); err != nil {
+		t.Fatalf("EncodeReader: %v", err)
+	}
+
+	v := decUseNumber(t, out.String()).(map[string]any)
+	if _, ok := v["a"]; ok {
+		t.Fatal("a should be filtered")
+	}
+	if _, ok := v["b"]; ok {
+		t.Fatal("b should be filtered")
+	}
+	if _, ok := v["nested"]; ok {
+		t.Fatal("nested should be filtered")
+	}
+	if _, ok := v["z"]; ok {
+		t.Fatal("z should be filtered")
+	}
+
+	c, ok := v["c"].(json.Number)
+	if !ok || c.String() != "9223372036854775807" {
+		t.Fatalf("c not preserved as json.Number: %#v", v["c"])
+	}
+	arr, ok := v["arr"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("arr bad: %#v", v["arr"])
+	}
+	k0 := arr[0].(map[string]any)["k"].(json.Number)
+	k1 := arr[1].(map[string]any)["k"].(json.Number)
+	if k0.String() != "1" || k1.String() != "2" {
+		t.Fatalf("array order changed: %#v", arr)
+	}
+}
+
+func TestTopLevelArray_PassThroughOrder(t *testing.T) {
+	raw := `[{"i":0},{"i":1},{"i":2},{"i":3}]`
+	var out bytes.Buffer
+	e := NewFieldFilteringEncoder(&out, []string{"unused"})
+	if err := e.EncodeReader(strings.NewReader(raw)); err != nil {
+		t.Fatalf("EncodeReader: %v", err)
+	}
+	if out.String() != raw {
+		t.Fatalf("array should pass through unchanged; got=%s", out.String())
+	}
+
+	raw2 := `{"keep":[1,2,3,4],"drop":[9,9]}`
+	out.Reset()
+	e = NewFieldFilteringEncoder(&out, []string{"keep"})
+	if err := e.EncodeReader(strings.NewReader(raw2)); err != nil {
+		t.Fatalf("EncodeReader: %v", err)
+	}
+	v := decUseNumber(t, out.String()).(map[string]any)
+	if _, ok := v["drop"]; ok {
+		t.Fatal("drop should be filtered")
+	}
+	want := []any{json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4")}
+	if !reflect.DeepEqual(v["keep"], want) {
+		t.Fatalf("list order/values changed: %#v", v["keep"])
+	}
+}
+
+func TestTopLevelPrimitive_PassThrough(t *testing.T) {
+	for _, raw := range []string{`true`, `false`, `null`, `"s"`, `12345678901234567890`} {
+		var out bytes.Buffer
+		e := NewFieldFilteringEncoder(&out, []string{"x"})
+		if err := e.EncodeReader(strings.NewReader(raw)); err != nil {
+			t.Fatalf("EncodeReader: %v", err)
+		}
+		if out.String() != raw {
+			t.Fatalf("primitive changed: got=%s want=%s", out.String(), raw)
+		}
+	}
+}
+
+func TestEncode_FromValue_MapFiltered_NoKeyOrderAssumption(t *testing.T) {
+	in := map[string]any{"a": 1, "b": 2, "c": 3}
+	var out bytes.Buffer
+	e := NewFieldFilteringEncoder(&out, []string{"c", "a"})
+	if err := e.Encode(in); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	m := decUseNumber(t, out.String()).(map[string]any)
+	if len(m) != 2 {
+		t.Fatalf("unexpected keys: %#v", m)
+	}
+	if m["a"].(json.Number).String() != "1" || m["c"].(json.Number).String() != "3" {
+		t.Fatalf("values wrong: %#v", m)
+	}
+}


### PR DESCRIPTION
## Summary of Changes
- Update telemetry data/dashboard API to support filtering by specific metrics to reduce JSON response size so Grafana is able to process and render larger time frames of timeseries data
- Increase parallelism of get circuit latencies requests
- Execute CLI queries in parallel
- Support both `mainnet` and `mainnet-beta` shorthand network envs in API params for backward compatibility with existing dashboard URLs
- Resolves https://github.com/malbeclabs/doublezero/issues/1378

## Testing Verification
- This has been tested with local Grafana and has been deployed to the dashboard API
