### PR TITLE
fix: User creation must verify that last epoch 0 blocks the user.

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -51,6 +51,8 @@ pub enum DoubleZeroError {
     Unauthorized, // variant 22
     #[error("Invalid Solana Validator Pubkey")]
     InvalidSolanaValidatorPubkey, // variant 23
+    #[error("Invalid Access Pass")]
+    AccessPassUnauthorized,
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -80,6 +82,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidLastAccessEpoch => ProgramError::Custom(21),
             DoubleZeroError::Unauthorized => ProgramError::Custom(22),
             DoubleZeroError::InvalidSolanaValidatorPubkey => ProgramError::Custom(23),
+            DoubleZeroError::AccessPassUnauthorized => ProgramError::Custom(24),
         }
     }
 }
@@ -110,6 +113,7 @@ impl From<u32> for DoubleZeroError {
             21 => DoubleZeroError::InvalidLastAccessEpoch,
             22 => DoubleZeroError::Unauthorized,
             23 => DoubleZeroError::InvalidSolanaValidatorPubkey,
+            24 => DoubleZeroError::AccessPassUnauthorized,
             _ => DoubleZeroError::Custom(e),
         }
     }
@@ -142,6 +146,7 @@ impl From<ProgramError> for DoubleZeroError {
                 21 => DoubleZeroError::InvalidLastAccessEpoch,
                 22 => DoubleZeroError::Unauthorized,
                 23 => DoubleZeroError::InvalidSolanaValidatorPubkey,
+                24 => DoubleZeroError::AccessPassUnauthorized,
                 _ => DoubleZeroError::Custom(e),
             },
             _ => DoubleZeroError::Custom(0),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -106,12 +106,13 @@ pub fn process_create_user(
     // Check Initial epoch
     let clock = Clock::get()?;
     let current_epoch = clock.epoch;
-    if accesspass.last_access_epoch > 0 && accesspass.last_access_epoch < current_epoch {
+    if accesspass.last_access_epoch < current_epoch {
         msg!(
-            "Invalid epoch current_epoch: {current_epoch} < last_access_epoch: {}",
-            accesspass.last_access_epoch
+            "Invalid epoch last_access_epoch: {} < current_epoch: {}",
+            accesspass.last_access_epoch,
+            current_epoch
         );
-        return Err(DoubleZeroError::Unauthorized.into());
+        return Err(DoubleZeroError::AccessPassUnauthorized.into());
     }
 
     accesspass.connection_count += 1;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -109,8 +109,13 @@ pub fn process_create_subscribe_user(
     // Check Initial epoch
     let clock = Clock::get()?;
     let current_epoch = clock.epoch;
-    if accesspass.last_access_epoch > 0 && accesspass.last_access_epoch < current_epoch {
-        return Err(DoubleZeroError::Unauthorized.into());
+    if accesspass.last_access_epoch < current_epoch {
+        msg!(
+            "Invalid epoch last_access_epoch: {} < current_epoch: {}",
+            accesspass.last_access_epoch,
+            current_epoch
+        );
+        return Err(DoubleZeroError::AccessPassUnauthorized.into());
     }
 
     accesspass.connection_count += 1;


### PR DESCRIPTION
This pull request introduces a new error variant to improve the granularity of access pass authorization checks in the serviceability smart contract. The main change is the addition of the `AccessPassUnauthorized` error, which is now used in epoch validation logic for user creation and subscription processes. This helps distinguish access pass-specific authorization failures from general unauthorized errors.

Error handling improvements:

* Added `AccessPassUnauthorized` variant to the `DoubleZeroError` enum to provide a more specific error for access pass authorization failures.
* Updated all relevant error conversion implementations (`From<DoubleZeroError> for ProgramError`, `From<u32> for DoubleZeroError`, and `From<ProgramError> for DoubleZeroError`) to support the new `AccessPassUnauthorized` error code (23). [[1]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R82) [[2]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R112) [[3]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122R145)

Access control logic updates:

* Replaced the use of the generic `Unauthorized` error with the new `AccessPassUnauthorized` error in the epoch validation logic in `process_create_user` and `process_create_subscribe_user`. This ensures that access pass authorization failures are reported more accurately. [[1]](diffhunk://#diff-50a1438f8af41564d2206a2bc66f4efbd8d410b02b1273d63634342dc8ba321eL109-R114) [[2]](diffhunk://#diff-cddaff613b96778de97f99ba3220571784cbb1d1d3533c475f24ad47af738624L112-R113)

## Testing Verification
* Show evidence of testing the change
