### PR TITLE
telemetry/data: support grafana pagination via circuit set partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ All notable changes to this project will be documented in this file.
 - Activator
     - Introduce new user monitoring thread in activator for access pass functionality
     - Remove validator verification via gossip. This functionality is migrated to AccessPass.
-
 - Device controller
     - Implement user tunnel ACLs in device agent configuration
     - Add "mpls icmp ttl-exceeded tunneling" config statement so intermediate hops in the doublezero network respond to traceroutes.
@@ -50,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - Telemetry
     - Optimize onchain data dashboard API responses with field filtering
     - Optimize onchain data data CLI execution with parallel queries
+    - Dashboard API support for circuit set partitioning using query parameters
 
 ## [v0.5.3](https://github.com/malbeclabs/doublezero/compare/client/v0.5.0...client/v0.5.3) – 2025-08-19
 

--- a/controlplane/telemetry/internal/data/internet/server_test.go
+++ b/controlplane/telemetry/internal/data/internet/server_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -213,6 +215,208 @@ func TestTelemetry_Data_Internet_Server(t *testing.T) {
 		})
 		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
+
+	t.Run("GET /location-internet/circuit-latencies expands circuits via GetCircuits when circuit=all", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		from, to := now.Format(time.RFC3339), now.Add(10*time.Second).Format(time.RFC3339)
+
+		var got []string
+		var mu sync.Mutex
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{
+			GetCircuitsFunc: func(context.Context) ([]data.Circuit, error) {
+				// Intentionally unsorted to ensure handler sorts before partitioning/querying
+				return []data.Circuit{{Code: "b"}, {Code: "a"}, {Code: "c"}}, nil
+			},
+			GetCircuitLatenciesFunc: func(_ context.Context, cfg data.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error) {
+				mu.Lock()
+				got = append(got, cfg.Circuit)
+				mu.Unlock()
+				return []stats.CircuitLatencyStat{{Circuit: cfg.Circuit, RTTMean: 1}}, nil
+			},
+		}, &mockProvider{})
+		defer closeFn()
+
+		res, body := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":     {"testnet"},
+			"from":    {from},
+			"to":      {to},
+			"circuit": {"all"},
+		})
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		var out []stats.CircuitLatencyStat
+		require.NoError(t, json.Unmarshal(body, &out))
+		assert.Len(t, out, 3)
+
+		// Order is not guaranteed (timestamps may tie); compare as sets.
+		toSet := func(ss []string) map[string]struct{} {
+			m := make(map[string]struct{}, len(ss))
+			for _, s := range ss {
+				m[s] = struct{}{}
+			}
+			return m
+		}
+		outSet := make([]string, 0, len(out))
+		for _, s := range out {
+			outSet = append(outSet, s.Circuit)
+		}
+
+		assert.Equal(t, toSet([]string{"a", "b", "c"}), toSet(outSet))
+		assert.Equal(t, toSet([]string{"a", "b", "c"}), toSet(got))
+	})
+
+	t.Run("GET /location-internet/circuit-latencies expands circuits via GetCircuits when circuit omitted", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		from, to := now.Format(time.RFC3339), now.Add(10*time.Second).Format(time.RFC3339)
+
+		var got []string
+		var mu sync.Mutex
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{
+			GetCircuitsFunc: func(context.Context) ([]data.Circuit, error) {
+				return []data.Circuit{{Code: "x"}, {Code: "y"}}, nil
+			},
+			GetCircuitLatenciesFunc: func(_ context.Context, cfg data.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error) {
+				mu.Lock()
+				got = append(got, cfg.Circuit)
+				mu.Unlock()
+				return []stats.CircuitLatencyStat{{Circuit: cfg.Circuit, RTTMean: 2}}, nil
+			},
+		}, &mockProvider{})
+		defer closeFn()
+
+		res, body := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":  {"testnet"},
+			"from": {from},
+			"to":   {to},
+		})
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		var out []stats.CircuitLatencyStat
+		require.NoError(t, json.Unmarshal(body, &out))
+		assert.Len(t, out, 2)
+
+		gotSet := map[string]struct{}{}
+		for _, c := range got {
+			gotSet[c] = struct{}{}
+		}
+		outSet := map[string]struct{}{}
+		for _, s := range out {
+			outSet[s.Circuit] = struct{}{}
+		}
+		want := map[string]struct{}{"x": {}, "y": {}}
+
+		assert.Equal(t, want, gotSet)
+		assert.Equal(t, want, outSet)
+	})
+
+	t.Run("GET /location-internet/circuit-latencies circuit list retrieval error", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		from, to := now.Format(time.RFC3339), now.Add(10*time.Second).Format(time.RFC3339)
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{
+			GetCircuitsFunc: func(context.Context) ([]data.Circuit, error) {
+				return nil, errors.New("boom")
+			},
+		}, &mockProvider{})
+		defer closeFn()
+
+		// Using "all" triggers the GetCircuits path.
+		res, _ := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":     {"testnet"},
+			"from":    {from},
+			"to":      {to},
+			"circuit": {"all"},
+		})
+		assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	})
+
+	t.Run("GET /location-internet/circuit-latencies partitions circuits deterministically", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		from, to := now.Format(time.RFC3339), now.Add(10*time.Second).Format(time.RFC3339)
+
+		var mu sync.Mutex
+		var gotCircuits []string
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{
+			GetCircuitLatenciesFunc: func(_ context.Context, cfg data.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error) {
+				mu.Lock()
+				gotCircuits = append(gotCircuits, cfg.Circuit)
+				mu.Unlock()
+				return []stats.CircuitLatencyStat{{Circuit: cfg.Circuit, RTTMean: 1}}, nil
+			},
+		}, &mockProvider{})
+		defer closeFn()
+
+		// circuits unsorted; handler should sort -> a,b,c,d,e
+		// total_partitions=3 => sizes: [2,2,1], partition=1 => [c,d]
+		res, body := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":              {"testnet"},
+			"from":             {from},
+			"to":               {to},
+			"circuit":          {"{e,d,c,b,a}"},
+			"data_provider":    {"foo"},
+			"partition":        {"1"},
+			"total_partitions": {"3"},
+		})
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		var out []stats.CircuitLatencyStat
+		require.NoError(t, json.Unmarshal(body, &out))
+		require.Len(t, out, 2)
+
+		wantSet := map[string]struct{}{"c": {}, "d": {}}
+		for _, s := range out {
+			_, ok := wantSet[s.Circuit]
+			assert.True(t, ok, "unexpected circuit %q", s.Circuit)
+			delete(wantSet, s.Circuit)
+		}
+		assert.Empty(t, wantSet, "missing expected circuits")
+
+		sort.Strings(gotCircuits)
+		assert.Equal(t, []string{"c", "d"}, gotCircuits)
+	})
+
+	t.Run("GET /location-internet/circuit-latencies with only one of partition/total_partitions errors", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		from, to := now.Format(time.RFC3339), now.Add(10*time.Second).Format(time.RFC3339)
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{
+			GetCircuitLatenciesFunc: func(_ context.Context, _ data.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error) {
+				return []stats.CircuitLatencyStat{{Circuit: "should-not-be-called"}}, nil
+			},
+		}, &mockProvider{})
+		defer closeFn()
+
+		res1, _ := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":       {"testnet"},
+			"from":      {from},
+			"to":        {to},
+			"circuit":   {"{a,b}"},
+			"partition": {"0"},
+		})
+		assert.Equal(t, http.StatusBadRequest, res1.StatusCode)
+
+		res2, _ := get(t, baseURL, "/location-internet/circuit-latencies", url.Values{
+			"env":              {"testnet"},
+			"from":             {from},
+			"to":               {to},
+			"circuit":          {"{a,b}"},
+			"total_partitions": {"2"},
+		})
+		assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+	})
+
 }
 
 func startServer(t *testing.T, mainnet, testnet, devnet data.Provider) (baseURL string, closeFn func()) {

--- a/controlplane/telemetry/internal/data/json/encoder_test.go
+++ b/controlplane/telemetry/internal/data/json/encoder_test.go
@@ -19,7 +19,7 @@ func decUseNumber(t *testing.T, s string) any {
 	return v
 }
 
-func TestTopLevelObject_FilterOnlyTopLevel_NumbersAndLists(t *testing.T) {
+func TestTopLevelObject_FilterDeep_NumbersAndLists(t *testing.T) {
 	raw := `{"a":1,"b":2.5,"c":9223372036854775807,"nested":{"x":1,"y":[1,2,3]},"arr":[{"k":1},{"k":2}], "z":null}`
 	var out bytes.Buffer
 	e := NewFieldFilteringEncoder(&out, []string{"c", "arr"})
@@ -49,37 +49,88 @@ func TestTopLevelObject_FilterOnlyTopLevel_NumbersAndLists(t *testing.T) {
 	if !ok || len(arr) != 2 {
 		t.Fatalf("arr bad: %#v", v["arr"])
 	}
-	k0 := arr[0].(map[string]any)["k"].(json.Number)
-	k1 := arr[1].(map[string]any)["k"].(json.Number)
-	if k0.String() != "1" || k1.String() != "2" {
-		t.Fatalf("array order changed: %#v", arr)
+	// Deep filtering: objects inside arr have their fields filtered too,
+	// and since "k" isn't allowed, they become empty objects.
+	if _, ok := arr[0].(map[string]any); !ok {
+		t.Fatalf("arr[0] not an object: %#v", arr[0])
+	}
+	if _, ok := arr[1].(map[string]any); !ok {
+		t.Fatalf("arr[1] not an object: %#v", arr[1])
+	}
+	if len(arr[0].(map[string]any)) != 0 || len(arr[1].(map[string]any)) != 0 {
+		t.Fatalf("nested objects should be empty after filtering: %#v", arr)
 	}
 }
 
-func TestTopLevelArray_PassThroughOrder(t *testing.T) {
+func TestTopLevelObject_FilterDeep_WithNestedAllowedKey(t *testing.T) {
+	raw := `{"keep":true,"arr":[{"k":1,"x":9},{"k":2,"y":8}],"nested":{"k":3,"x":7}}`
+	var out bytes.Buffer
+	// Allow "arr" and "k" so that inner objects keep only "k" fields.
+	e := NewFieldFilteringEncoder(&out, []string{"arr", "k"})
+	if err := e.EncodeReader(strings.NewReader(raw)); err != nil {
+		t.Fatalf("EncodeReader: %v", err)
+	}
+	v := decUseNumber(t, out.String()).(map[string]any)
+
+	if _, ok := v["keep"]; ok {
+		t.Fatal("keep should be filtered")
+	}
+	if _, ok := v["nested"]; ok {
+		t.Fatal("nested top-level key should be filtered entirely")
+	}
+
+	arr, ok := v["arr"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("arr bad: %#v", v["arr"])
+	}
+	m0 := arr[0].(map[string]any)
+	m1 := arr[1].(map[string]any)
+	if len(m0) != 1 || len(m1) != 1 {
+		t.Fatalf("nested objects should only have 'k': %#v", arr)
+	}
+	k0, ok0 := m0["k"].(json.Number)
+	k1, ok1 := m1["k"].(json.Number)
+	if !ok0 || !ok1 || k0.String() != "1" || k1.String() != "2" {
+		t.Fatalf("nested k values wrong: %#v", arr)
+	}
+}
+
+func TestTopLevelArray_FilterElementsDeep(t *testing.T) {
 	raw := `[{"i":0},{"i":1},{"i":2},{"i":3}]`
 	var out bytes.Buffer
+	// No allowed field "i", so each object becomes {}.
 	e := NewFieldFilteringEncoder(&out, []string{"unused"})
 	if err := e.EncodeReader(strings.NewReader(raw)); err != nil {
 		t.Fatalf("EncodeReader: %v", err)
 	}
-	if out.String() != raw {
-		t.Fatalf("array should pass through unchanged; got=%s", out.String())
+	v := decUseNumber(t, out.String()).([]any)
+	if len(v) != 4 {
+		t.Fatalf("array length changed: %#v", v)
+	}
+	for idx, el := range v {
+		m, ok := el.(map[string]any)
+		if !ok {
+			t.Fatalf("element %d not object: %#v", idx, el)
+		}
+		if len(m) != 0 {
+			t.Fatalf("element %d should be empty object: %#v", idx, m)
+		}
 	}
 
+	// Filtering within object with arrays of primitives remains pass-through for values.
 	raw2 := `{"keep":[1,2,3,4],"drop":[9,9]}`
 	out.Reset()
 	e = NewFieldFilteringEncoder(&out, []string{"keep"})
 	if err := e.EncodeReader(strings.NewReader(raw2)); err != nil {
 		t.Fatalf("EncodeReader: %v", err)
 	}
-	v := decUseNumber(t, out.String()).(map[string]any)
-	if _, ok := v["drop"]; ok {
+	m := decUseNumber(t, out.String()).(map[string]any)
+	if _, ok := m["drop"]; ok {
 		t.Fatal("drop should be filtered")
 	}
 	want := []any{json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4")}
-	if !reflect.DeepEqual(v["keep"], want) {
-		t.Fatalf("list order/values changed: %#v", v["keep"])
+	if !reflect.DeepEqual(m["keep"], want) {
+		t.Fatalf("list order/values changed: %#v", m["keep"])
 	}
 }
 


### PR DESCRIPTION
## Summary of Changes
- Update dashboard API to support querying by circuit set partitions, so that Grafana can paginate, which allows it to render many series' without breaking - so the 7+ day mainnet-beta views on the device telemetry dashboard are working again
- Fix metrics filtering logic, where it was only filtering if the top level was an object before
- Add `circuits=all` query option so the dashboards don't need to send in all circuits as query params
- Resolves https://github.com/malbeclabs/doublezero/issues/1378

## Testing Verification
- Added test coverage for the new functionality
