### PR TITLE
fix: ensure access pass account is initialized with lamports check

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -113,7 +113,7 @@ pub fn process_set_access_pass(
         return Err(DoubleZeroError::InvalidLastAccessEpoch.into());
     }
 
-    if accesspass_account.data_is_empty() {
+    if accesspass_account.data_is_empty() && accesspass_account.lamports() == 0 {
         let accesspass = AccessPass {
             account_type: AccountType::AccessPass,
             bump_seed,
@@ -151,7 +151,21 @@ pub fn process_set_access_pass(
             "Invalid PDA Account Owner"
         );
 
-        let mut accesspass = AccessPass::try_from(accesspass_account)?;
+        let mut accesspass = if !accesspass_account.data_is_empty() {
+            AccessPass::try_from(accesspass_account)?
+        } else {
+            AccessPass {
+                account_type: AccountType::AccessPass,
+                bump_seed,
+                accesspass_type: value.accesspass_type,
+                client_ip: value.client_ip,
+                user_payer: *user_payer.key,
+                last_access_epoch: value.last_access_epoch,
+                connection_count: 0,
+                status: AccessPassStatus::Requested,
+                owner: *payer_account.key,
+            }
+        };
 
         accesspass.accesspass_type = value.accesspass_type;
         accesspass.last_access_epoch = value.last_access_epoch;


### PR DESCRIPTION
This pull request updates the logic for initializing and loading the `AccessPass` account in the `process_set_access_pass` function to handle cases where the account exists but is uninitialized (i.e., has zero lamports and empty data). The changes improve robustness when working with Solana accounts, especially for scenarios involving account creation and initialization.

**Account initialization and loading improvements:**

* Updated the condition for creating a new `AccessPass` instance to check both if the account data is empty and if the account has zero lamports, ensuring that only truly uninitialized accounts are created.
* Refactored the loading logic for `AccessPass` to initialize a new struct with default values if the account is empty, otherwise deserialize from account data, making account handling more explicit and less error-prone.

## Testing Verification
* Show evidence of testing the change
