### PR TITLE
e2e: configure additional device networks for link connectivity in local devnet

### DIFF
--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -65,8 +65,8 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 	err = dn.Start(t.Context(), nil)
 	require.NoError(t, err)
 
-	link := devnet.NewMiscNetwork(dn, log, "la2-dz01:ny5-dz01")
-	_, err = link.CreateIfNotExists(t.Context())
+	linkNetwork := devnet.NewMiscNetwork(dn, log, "la2-dz01:ny5-dz01")
+	_, err = linkNetwork.CreateIfNotExists(t.Context())
 	require.NoError(t, err)
 
 	// Add and start the 2 devices in parallel.
@@ -105,7 +105,7 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 				MetricsEnable:        true,
 				MetricsAddr:          "0.0.0.0:2114",
 			},
-			AdditionalNetworks: []string{link.Name},
+			AdditionalNetworks: []string{linkNetwork.Name},
 			Interfaces: map[string]string{
 				"Ethernet2": "physical",
 			},
@@ -150,7 +150,7 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 				MetricsEnable:        true,
 				MetricsAddr:          "0.0.0.0:2114",
 			},
-			AdditionalNetworks: []string{link.Name},
+			AdditionalNetworks: []string{linkNetwork.Name},
 			Interfaces: map[string]string{
 				"Ethernet2": "physical",
 				"Ethernet3": "physical",

--- a/e2e/internal/devnet/device.go
+++ b/e2e/internal/devnet/device.go
@@ -534,8 +534,7 @@ func (d *Device) Start(ctx context.Context) error {
 	}
 
 	for _, additionalNetwork := range spec.AdditionalNetworks {
-		name := d.dn.Spec.DeployID + "-" + additionalNetwork
-		err = d.dn.dockerClient.NetworkConnect(ctx, name, containerID, nil)
+		err = d.dn.dockerClient.NetworkConnect(ctx, additionalNetwork, containerID, nil)
 		if err != nil {
 			return fmt.Errorf("failed to attach device %s to additional network %s: %w", spec.Code, additionalNetwork, err)
 		}


### PR DESCRIPTION
## Summary of Changes
- Add support to local e2e devnet for configuring additional docker networks so device-to-device interfaces can be tested, using `AdditionalNetworks` support added in https://github.com/malbeclabs/doublezero/pull/1091

## Testing Verification
- Tested using `dev/dzctl` in local e2e devnet:

```sh
$ dev/dzctl start -v
...
$ dev/dzctl add-device --code dz1 --exchange xams --location ams --cyoa-network-host-id 8 --additional-networks dz1:dz2
...
$ dev/dzctl add-device --code dz2 --exchange xams --location ams --cyoa-network-host-id 16 --additional-networks dz1:dz2
...
$ docker exec -it dz-local-manager doublezero link create wan --code dz1:dz2 --contributor co01 --side-a dz1 --side-a-interface Ethernet2 --side-z dz2 --side-z-interface Ethernet2 --bandwidth "10 Gbps" --mtu 9000 --delay-ms 40 --jitter-ms 3
Signature: 5QJmxGcjKqzkpwDQBFwvSYT7EHwjMSDPH2bRKaWYpBE3ZamS9n5KUEKqxcN7Qh9GwuXiKyHA468oxSeAELJhVSyK
$ docker exec -it dz-local-device-dz1 Cli -c "show ip interface brief"
                                                                                Address
Interface          IP Address           Status       Protocol            MTU    Owner
------------------ -------------------- ------------ -------------- ----------- -------
Ethernet1          10.169.90.8/24       up           up                 1500
Ethernet2          172.16.0.6/31        up           up                 2048
Loopback0          8.8.8.8/32           up           up                65535
Loopback255        172.16.0.2/32        up           up                65535
Loopback256        172.16.0.1/32        up           up                65535
Loopback1000       10.0.0.0/32          up           up                65535
Management0        172.18.0.7/16        up           up                 1500

$ docker exec -it dz-local-device-dz1 ping -I eth2 172.16.0.7 -c 3
PING 172.16.0.7 (172.16.0.7) from 172.16.0.6 eth2: 56(84) bytes of data.
64 bytes from 172.16.0.7: icmp_seq=1 ttl=64 time=0.082 ms
64 bytes from 172.16.0.7: icmp_seq=2 ttl=64 time=0.065 ms
64 bytes from 172.16.0.7: icmp_seq=3 ttl=64 time=0.125 ms

--- 172.16.0.7 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2016ms
rtt min/avg/max/mdev = 0.065/0.090/0.125/0.025 ms
```
