### PR TITLE
feat: add serde serialization for validator_pubkey in User struct

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -192,7 +192,14 @@ pub struct User {
         )
     )]
     pub subscribers: Vec<Pubkey>, // 4 + 32 * len
-    pub validator_pubkey: Pubkey,  // 32
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "doublezero_program_common::serializer::serialize_pubkey_as_string",
+            deserialize_with = "doublezero_program_common::serializer::deserialize_pubkey_from_string"
+        )
+    )]
+    pub validator_pubkey: Pubkey, // 32
 }
 
 impl fmt::Display for User {


### PR DESCRIPTION
This pull request makes a small change to the `User` struct in `smartcontract/programs/doublezero-serviceability/src/state/user.rs` to improve serialization and deserialization of the `validator_pubkey` field when the `serde` feature is enabled.

* Serialization improvements:
  * Added custom `serde` attributes to the `validator_pubkey` field to ensure it is serialized as a string and deserialized correctly using helper functions from `doublezero_program_common::serializer`.

## Testing Verification
* Show evidence of testing the change
