### PR TITLE
docs: remove mistakenly added changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Onchain programs
-    - Restored the `validator_pubkey` field from AccessPass. This field had been removed in the previous version but is required by Sentinel.
-    - Telemetry program: embed serviceability program ID via build feature instead of env variable
 - Telemetry
     - Fix dashboard API to handle partitioned query with no samples
     - Add summary view with committed RTT and jitter, compared to measured values


### PR DESCRIPTION
## Summary of Changes
- Remove entries added to the changelog in https://github.com/malbeclabs/doublezero/pull/1495 that were carried over from a rebase that shouldn't have been
