### PR TITLE
monitor: emit metric when telemetry account not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain monitor
+    - Emit metric with 0 samples when account not found in device and internet telemetry watchers
 - Telemetry
     - Fix dashboard API to handle partitioned query with no samples
     - Add summary view with committed RTT and jitter, compared to measured values
@@ -15,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ## [v0.6.2](https://github.com/malbeclabs/doublezero/compare/client/v0.6.0...client/v0.6.2) – 2025-09-02
 
 ### Breaking
+
 - None for this release
 
 ### Changes

--- a/controlplane/monitor/internal/device-telemetry/config.go
+++ b/controlplane/monitor/internal/device-telemetry/config.go
@@ -30,6 +30,7 @@ type TelemetryProgramClient interface {
 
 type Config struct {
 	Logger          *slog.Logger
+	Metrics         *Metrics
 	LedgerRPCClient LedgerRPCClient
 	Serviceability  ServiceabilityClient
 	Telemetry       TelemetryProgramClient
@@ -40,6 +41,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Logger == nil {
 		return errors.New("logger is required")
+	}
+	if c.Metrics == nil {
+		return errors.New("metrics is required")
 	}
 	if c.LedgerRPCClient == nil {
 		return errors.New("ledger rpc client is required")

--- a/controlplane/monitor/internal/device-telemetry/config_test.go
+++ b/controlplane/monitor/internal/device-telemetry/config_test.go
@@ -16,7 +16,8 @@ func TestMonitor_DeviceTelemetry_Config(t *testing.T) {
 	t.Parallel()
 
 	valid := &Config{
-		Logger: newTestLogger(t),
+		Logger:  newTestLogger(t),
+		Metrics: NewMetrics(),
 		LedgerRPCClient: &mockLedgerRPC{
 			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
 				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
@@ -39,6 +40,12 @@ func TestMonitor_DeviceTelemetry_Config(t *testing.T) {
 	t.Run("missing logger fails", func(t *testing.T) {
 		c := *valid
 		c.Logger = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing metrics fails", func(t *testing.T) {
+		c := *valid
+		c.Metrics = nil
 		require.Error(t, c.Validate())
 	})
 

--- a/controlplane/monitor/internal/device-telemetry/metrics.go
+++ b/controlplane/monitor/internal/device-telemetry/metrics.go
@@ -2,15 +2,15 @@ package devicetelemetry
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
-	// Metrics names.
-	MetricNameErrors    = "doublezero_monitor_device_telemetry_errors_total"
-	MetricNameSamples   = "doublezero_monitor_device_telemetry_samples_total"
-	MetricNameSuccesses = "doublezero_monitor_device_telemetry_successes_total"
-	MetricNameLosses    = "doublezero_monitor_device_telemetry_losses_total"
+	// Metric names.
+	MetricNameErrors          = "doublezero_monitor_device_telemetry_errors_total"
+	MetricNameSamples         = "doublezero_monitor_device_telemetry_samples_total"
+	MetricNameSuccesses       = "doublezero_monitor_device_telemetry_successes_total"
+	MetricNameLosses          = "doublezero_monitor_device_telemetry_losses_total"
+	MetricNameAccountNotFound = "doublezero_monitor_device_telemetry_account_not_found_total"
 
 	// Labels.
 	MetricLabelErrorType = "error_type"
@@ -22,36 +22,56 @@ const (
 	MetricErrorTypeGetLatencySamples = "get_latency_samples"
 )
 
-var (
-	MetricErrors = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameErrors,
-			Help: "Number of errors encountered",
-		},
-		[]string{MetricLabelErrorType},
-	)
+type Metrics struct {
+	Errors          *prometheus.CounterVec
+	Samples         *prometheus.CounterVec
+	Successes       *prometheus.CounterVec
+	Losses          *prometheus.CounterVec
+	AccountNotFound *prometheus.CounterVec
+}
 
-	MetricSamples = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameSamples,
-			Help: "Number of samples",
-		},
-		[]string{MetricLabelCircuit},
-	)
+// NewMetrics creates the collectors but does not auto-register them.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		Errors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameErrors,
+				Help: "Number of errors encountered",
+			},
+			[]string{MetricLabelErrorType},
+		),
+		Samples: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameSamples,
+				Help: "Number of samples",
+			},
+			[]string{MetricLabelCircuit},
+		),
+		Successes: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameSuccesses,
+				Help: "Number of successes",
+			},
+			[]string{MetricLabelCircuit},
+		),
+		Losses: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameLosses,
+				Help: "Number of losses",
+			},
+			[]string{MetricLabelCircuit},
+		),
+		AccountNotFound: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameAccountNotFound,
+				Help: "Number of account not found",
+			},
+			[]string{MetricLabelCircuit},
+		),
+	}
+}
 
-	MetricSuccesses = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameSuccesses,
-			Help: "Number of successes",
-		},
-		[]string{MetricLabelCircuit},
-	)
-
-	MetricLosses = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameLosses,
-			Help: "Number of losses",
-		},
-		[]string{MetricLabelCircuit},
-	)
-)
+// Register all metrics with the provided registry.
+func (m *Metrics) Register(r prometheus.Registerer) {
+	r.MustRegister(m.Errors, m.Samples, m.Successes, m.Losses, m.AccountNotFound)
+}

--- a/controlplane/monitor/internal/internet-telemetry/config.go
+++ b/controlplane/monitor/internal/internet-telemetry/config.go
@@ -30,6 +30,7 @@ type TelemetryProgramClient interface {
 
 type Config struct {
 	Logger                     *slog.Logger
+	Metrics                    *Metrics
 	LedgerRPCClient            LedgerRPCClient
 	Serviceability             ServiceabilityClient
 	InternetLatencyCollectorPK solana.PublicKey
@@ -41,6 +42,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Logger == nil {
 		return errors.New("logger is required")
+	}
+	if c.Metrics == nil {
+		return errors.New("metrics is required")
 	}
 	if c.LedgerRPCClient == nil {
 		return errors.New("ledger rpc client is required")

--- a/controlplane/monitor/internal/internet-telemetry/config_test.go
+++ b/controlplane/monitor/internal/internet-telemetry/config_test.go
@@ -16,7 +16,8 @@ func TestMonitor_DeviceTelemetry_Config(t *testing.T) {
 	t.Parallel()
 
 	valid := &Config{
-		Logger: newTestLogger(t),
+		Logger:  newTestLogger(t),
+		Metrics: NewMetrics(),
 		LedgerRPCClient: &mockLedgerRPC{
 			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
 				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
@@ -46,6 +47,12 @@ func TestMonitor_DeviceTelemetry_Config(t *testing.T) {
 	t.Run("missing ledger RPC fails", func(t *testing.T) {
 		c := *valid
 		c.LedgerRPCClient = nil
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("missing metrics fails", func(t *testing.T) {
+		c := *valid
+		c.Metrics = nil
 		require.Error(t, c.Validate())
 	})
 

--- a/controlplane/monitor/internal/internet-telemetry/metrics.go
+++ b/controlplane/monitor/internal/internet-telemetry/metrics.go
@@ -1,16 +1,14 @@
 package internettelemetry
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
+import "github.com/prometheus/client_golang/prometheus"
 
 const (
-	// Metrics names.
-	MetricNameErrors    = "doublezero_monitor_internet_telemetry_errors_total"
-	MetricNameSamples   = "doublezero_monitor_internet_telemetry_samples_total"
-	MetricNameSuccesses = "doublezero_monitor_internet_telemetry_successes_total"
-	MetricNameLosses    = "doublezero_monitor_internet_telemetry_losses_total"
+	// Metric names.
+	MetricNameErrors          = "doublezero_monitor_internet_telemetry_errors_total"
+	MetricNameSamples         = "doublezero_monitor_internet_telemetry_samples_total"
+	MetricNameSuccesses       = "doublezero_monitor_internet_telemetry_successes_total"
+	MetricNameLosses          = "doublezero_monitor_internet_telemetry_losses_total"
+	MetricNameAccountNotFound = "doublezero_monitor_internet_telemetry_account_not_found_total"
 
 	// Labels.
 	MetricLabelErrorType    = "error_type"
@@ -23,36 +21,57 @@ const (
 	MetricErrorTypeGetLatencySamples = "get_latency_samples"
 )
 
-var (
-	MetricErrors = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameErrors,
-			Help: "Number of errors encountered",
-		},
-		[]string{MetricLabelErrorType},
-	)
+// Metrics groups all Prometheus collectors for Internet telemetry.
+type Metrics struct {
+	Errors          *prometheus.CounterVec
+	Samples         *prometheus.CounterVec
+	Successes       *prometheus.CounterVec
+	Losses          *prometheus.CounterVec
+	AccountNotFound *prometheus.CounterVec
+}
 
-	MetricSamples = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameSamples,
-			Help: "Number of samples",
-		},
-		[]string{MetricLabelDataProvider, MetricLabelCircuit},
-	)
+// NewMetrics constructs collectors but does not register them.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		Errors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameErrors,
+				Help: "Number of errors encountered",
+			},
+			[]string{MetricLabelErrorType},
+		),
+		Samples: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameSamples,
+				Help: "Number of samples",
+			},
+			[]string{MetricLabelDataProvider, MetricLabelCircuit},
+		),
+		Successes: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameSuccesses,
+				Help: "Number of successes",
+			},
+			[]string{MetricLabelDataProvider, MetricLabelCircuit},
+		),
+		Losses: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameLosses,
+				Help: "Number of losses",
+			},
+			[]string{MetricLabelDataProvider, MetricLabelCircuit},
+		),
+		AccountNotFound: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameAccountNotFound,
+				Help: "Number of account not found",
+			},
+			[]string{MetricLabelDataProvider, MetricLabelCircuit},
+		),
+	}
+}
 
-	MetricSuccesses = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameSuccesses,
-			Help: "Number of successes",
-		},
-		[]string{MetricLabelDataProvider, MetricLabelCircuit},
-	)
-
-	MetricLosses = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: MetricNameLosses,
-			Help: "Number of losses",
-		},
-		[]string{MetricLabelDataProvider, MetricLabelCircuit},
-	)
-)
+// Register all metrics with the provided registerer.
+func (m *Metrics) Register(r prometheus.Registerer) {
+	r.MustRegister(m.Errors, m.Samples, m.Successes, m.Losses, m.AccountNotFound)
+}

--- a/controlplane/monitor/internal/internet-telemetry/watcher_test.go
+++ b/controlplane/monitor/internal/internet-telemetry/watcher_test.go
@@ -14,27 +14,25 @@ import (
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMonitor_InternetTelemetry_Watcher_NewAndName(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
 
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
@@ -45,29 +43,26 @@ func TestMonitor_InternetTelemetry_Watcher_NewAndName(t *testing.T) {
 func TestMonitor_InternetTelemetry_Watcher_RunStopsOnCancel(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   5 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 1}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Run(ctx); close(done) }()
-	time.Sleep(10 * time.Millisecond)
 	cancel()
+
 	select {
 	case <-done:
 	case <-time.After(500 * time.Millisecond):
@@ -78,21 +73,18 @@ func TestMonitor_InternetTelemetry_Watcher_RunStopsOnCancel(t *testing.T) {
 func TestMonitor_InternetTelemetry_Watcher_Tick_NoCircuits(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return &serviceability.ProgramData{}, nil }}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 
@@ -107,24 +99,23 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_NoCircuits(t *testing.T) {
 func TestMonitor_InternetTelemetry_Watcher_Tick_ErrorFromGetProgramData(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return nil, errors.New("boom") }},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, reg := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 9}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) { return nil, errors.New("boom") }}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 	require.Error(t, w.Tick(context.Background()))
+
+	require.Equal(t, 1.0, counterTotal(t, reg, MetricNameErrors)) // MetricErrorTypeGetCircuits
 }
 
 func TestMonitor_InternetTelemetry_Watcher_Tick_ErrorFromGetEpochInfo(t *testing.T) {
@@ -133,26 +124,26 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_ErrorFromGetEpochInfo(t *testing
 	origin := solana.NewWallet().PublicKey()
 	target := solana.NewWallet().PublicKey()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return nil, errors.New("epoch fail")
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData("OR-A", "TG-A", origin, target), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{1}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, reg := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return nil, errors.New("epoch fail")
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData("OR-A", "TG-A", origin, target), nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{1}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 	require.Error(t, w.Tick(context.Background()))
+
+	// exactly one error increment (GetEpochInfo failure)
+	require.Equal(t, 1.0, counterTotal(t, reg, MetricNameErrors))
 }
 
 func TestMonitor_InternetTelemetry_Watcher_Tick_ErrorFromGetInternetLatencySamples(t *testing.T) {
@@ -161,155 +152,117 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_ErrorFromGetInternetLatencySampl
 	origin := solana.NewWallet().PublicKey()
 	target := solana.NewWallet().PublicKey()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData("OR-A", "TG-A", origin, target), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, _ string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
+	cfg, reg := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData("OR-A", "TG-A", origin, target), nil
+		}}
+	// Fail only one provider/direction to make the expected count 1.
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(_ context.Context, provider string, o, t, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
+			if provider == "ripeatlas" && o == origin && t == target {
 				return nil, errors.New("telemetry fail")
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+			}
+			return &telemetry.InternetLatencySamples{Samples: []uint32{1}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 	require.Error(t, w.Tick(context.Background()))
+
+	require.Equal(t, 1.0, counterTotal(t, reg, MetricNameErrors)) // MetricErrorTypeGetLatencySamples
 }
 
-func TestMonitor_InternetTelemetry_Watcher_Tick_SameEpoch_BaselineThenUpdate(t *testing.T) {
+func TestMonitor_InternetTelemetry_Watcher_Tick_SameEpoch_EmitsMetricDeltas_Aggregated(t *testing.T) {
+	t.Parallel()
+
+	origin := solana.NewWallet().PublicKey()
+	target := solana.NewWallet().PublicKey()
+	originCode, targetCode := "OR-A", "TG-A"
+	var step int32
+
+	cfg, reg := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(context.Context, solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData(originCode, targetCode, origin, target), nil
+		}}
+	cfg.Telemetry = providerStepTelemetryMock(origin, target, &step)
+
+	w, err := NewInternetTelemetryWatcher(cfg)
+	require.NoError(t, err)
+
+	// First tick seeds state; no deltas
+	require.NoError(t, w.Tick(context.Background()))
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameSuccesses))
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameLosses))
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameSamples))
+
+	// Second tick (same epoch) emits deltas across providers:
+	// forward +1 success (ripeatlas), reverse +1 success +1 loss (wheresitup) → totals: succ=2, loss=1, samples=3
+	atomic.StoreInt32(&step, 1)
+	require.NoError(t, w.Tick(context.Background()))
+	require.Equal(t, 2.0, counterTotal(t, reg, MetricNameSuccesses))
+	require.Equal(t, 1.0, counterTotal(t, reg, MetricNameLosses))
+	require.Equal(t, 3.0, counterTotal(t, reg, MetricNameSamples))
+}
+
+func TestMonitor_InternetTelemetry_Watcher_Tick_EpochRollover_NoMetricDeltas(t *testing.T) {
 	t.Parallel()
 
 	origin := solana.NewWallet().PublicKey()
 	target := solana.NewWallet().PublicKey()
 	originCode, targetCode := "OR-A", "TG-A"
 
-	// local step only toggled BETWEEN ticks (never during a tick)
-	step := 0
+	epochVal := uint64(10)
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 10}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData(originCode, targetCode, origin, target), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, dataProviderName string, o, t, l solana.PublicKey, e uint64) (*telemetry.InternetLatencySamples, error) {
-				if dataProviderName == "ripeatlas" {
-					if step == 0 {
-						return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil
-					} // 3/1
-					return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5, 9}}, nil // 4/1
+	cfg, reg := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: epochVal}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData(originCode, targetCode, origin, target), nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(_ context.Context, provider string, o, t, _ solana.PublicKey, e uint64) (*telemetry.InternetLatencySamples, error) {
+			if e == 10 {
+				if provider == "ripeatlas" {
+					return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil // 3/1
 				}
-				if dataProviderName == "wheresitup" {
-					return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7}}, nil
-				} // 1/2
-				return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7, 3, 0}}, nil // 2/3
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+				if provider == "wheresitup" {
+					return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7, 8}}, nil // 2/2
+				}
+			}
+			if provider == "ripeatlas" {
+				return &telemetry.InternetLatencySamples{Samples: []uint32{8, 8, 0}}, nil // 2/1
+			}
+			if provider == "wheresitup" {
+				return &telemetry.InternetLatencySamples{Samples: []uint32{4, 5, 0, 6, 7}}, nil // 4/1
+			}
+			return &telemetry.InternetLatencySamples{Samples: []uint32{0}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	keyRipeatlas := "epoch=10, data_provider=ripeatlas, circuit=" + circuitKey(originCode, targetCode)
-	keyWheresitup := "epoch=10, data_provider=wheresitup, circuit=" + circuitKey(originCode, targetCode)
-
-	require.NoError(t, w.Tick(ctx))
-	w.mu.RLock()
-	require.Equal(t, uint64(10), w.lastEpoch)
-	require.True(t, w.epochSet)
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[keyRipeatlas])
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 1, LossCount: 2}, w.stats[keyWheresitup])
-	w.mu.RUnlock()
-
-	step = 1
-	require.NoError(t, w.Tick(ctx))
-	w.mu.RLock()
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 4, LossCount: 1}, w.stats[keyRipeatlas])
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 1, LossCount: 2}, w.stats[keyWheresitup])
-	w.mu.RUnlock()
-}
-
-func TestMonitor_InternetTelemetry_Watcher_Tick_EpochRollover(t *testing.T) {
-	t.Parallel()
-
-	origin := solana.NewWallet().PublicKey()
-	target := solana.NewWallet().PublicKey()
-	originCode, targetCode := "OR-A", "TG-A"
-
-	epochVal := uint64(10) // changed only between ticks
-
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: epochVal}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData(originCode, targetCode, origin, target), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(ctx context.Context, dataProviderName string, o, t, a solana.PublicKey, e uint64) (*telemetry.InternetLatencySamples, error) {
-				if e == 10 {
-					if dataProviderName == "ripeatlas" {
-						return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil
-					}
-					if dataProviderName == "wheresitup" {
-						return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7, 8}}, nil
-					}
-				}
-				if dataProviderName == "ripeatlas" {
-					return &telemetry.InternetLatencySamples{Samples: []uint32{8, 8, 0}}, nil
-				}
-				if dataProviderName == "wheresitup" {
-					return &telemetry.InternetLatencySamples{Samples: []uint32{4, 5, 0, 6, 7}}, nil
-				}
-				return &telemetry.InternetLatencySamples{Samples: []uint32{0}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
-	w, err := NewInternetTelemetryWatcher(cfg)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	key10FRipeatlas := "epoch=10, data_provider=ripeatlas, circuit=" + circuitKey(originCode, targetCode)
-	key10FWheresitup := "epoch=10, data_provider=wheresitup, circuit=" + circuitKey(originCode, targetCode)
-	key11FRipeatlas := "epoch=11, data_provider=ripeatlas, circuit=" + circuitKey(originCode, targetCode)
-	key11FWheresitup := "epoch=11, data_provider=wheresitup, circuit=" + circuitKey(originCode, targetCode)
-
-	require.NoError(t, w.Tick(ctx))
-	w.mu.RLock()
-	require.Equal(t, uint64(10), w.lastEpoch)
-	require.True(t, w.epochSet)
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[key10FRipeatlas])
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 2, LossCount: 2}, w.stats[key10FWheresitup])
-	w.mu.RUnlock()
-
+	// Baseline at epoch 10
+	require.NoError(t, w.Tick(context.Background()))
+	// Rollover to epoch 11 → no deltas emitted for new epoch
 	epochVal = 11
-	require.NoError(t, w.Tick(ctx))
-	w.mu.RLock()
-	require.Equal(t, uint64(11), w.lastEpoch)
-	require.True(t, w.epochSet)
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 2, LossCount: 1}, w.stats[key11FRipeatlas])
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 4, LossCount: 1}, w.stats[key11FWheresitup])
-	// old totals remain
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 3, LossCount: 1}, w.stats[key10FRipeatlas])
-	require.Equal(t, CircuitTelemetryStats{SuccessCount: 2, LossCount: 2}, w.stats[key10FWheresitup])
-	w.mu.RUnlock()
+	require.NoError(t, w.Tick(context.Background()))
+
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameSuccesses))
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameLosses))
+	require.Equal(t, 0.0, counterTotal(t, reg, MetricNameSamples))
 }
 
 func TestMonitor_InternetTelemetry_Watcher_Tick_MixedCircuits_ErrorBubbles(t *testing.T) {
@@ -318,27 +271,24 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_MixedCircuits_ErrorBubbles(t *te
 	a := solana.NewWallet().PublicKey()
 	b := solana.NewWallet().PublicKey()
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 42}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData("A", "B", a, b), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			// succeed for one data provider, fail for the other
-			GetInternetLatencySamplesFunc: func(ctx context.Context, dataProviderName string, o, t, l solana.PublicKey, e uint64) (*telemetry.InternetLatencySamples, error) {
-				if dataProviderName == "ripeatlas" {
-					return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 3}}, nil
-				}
-				return nil, errors.New("wheresitup timeout") // ripeatlas
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 42}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData("A", "B", a, b), nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		// succeed for one provider, fail for the other
+		GetInternetLatencySamplesFunc: func(_ context.Context, provider string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
+			if provider == "ripeatlas" {
+				return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 3}}, nil
+			}
+			return nil, errors.New("wheresitup timeout")
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 	require.Error(t, w.Tick(context.Background()))
@@ -349,26 +299,22 @@ func TestMonitor_InternetTelemetry_Watcher_Run_ContinuesAfterTickError(t *testin
 
 	var step atomic.Int32 // 0=failing, 1=success
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, ct solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 777}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				if step.Load() == 0 {
-					return nil, errors.New("boom")
-				}
-				return &serviceability.ProgramData{}, nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   5 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 777}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			if step.Load() == 0 {
+				return nil, errors.New("boom")
+			}
+			return &serviceability.ProgramData{}, nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
 
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
@@ -401,30 +347,28 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_EmptySamples_WritesZeroStatsAndS
 	target := solana.NewWallet().PublicKey()
 	originCode, targetCode := "OR-Z", "TG-Z"
 
-	cfg := &Config{
-		Logger: newTestLogger(t),
-		LedgerRPCClient: &mockLedgerRPC{
-			GetEpochInfoFunc: func(ctx context.Context, ct solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
-				return &solanarpc.GetEpochInfoResult{Epoch: 77}, nil
-			}},
-		Serviceability: &mockServiceabilityClient{
-			GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
-				return makeProgramData(originCode, targetCode, origin, target), nil
-			}},
-		Telemetry: &mockTelemetryProgramClient{
-			GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
-				return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
-			}},
-		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
-		Interval:                   10 * time.Millisecond,
-	}
+	cfg, _ := baseCfg(t)
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, _ solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 77}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData(originCode, targetCode, origin, target), nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(context.Context, string, solana.PublicKey, solana.PublicKey, solana.PublicKey, uint64) (*telemetry.InternetLatencySamples, error) {
+			return &telemetry.InternetLatencySamples{Samples: []uint32{}}, nil
+		}}
+
 	w, err := NewInternetTelemetryWatcher(cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Tick(context.Background()))
 
-	keyFwd := "77-" + circuitKey(originCode, targetCode)
-	keyRev := "77-" + circuitKey(targetCode, originCode)
+	keyFwd := "epoch=77, data_provider=ripeatlas, circuit=" + circuitKey(originCode, targetCode)
+	keyRev := "epoch=77, data_provider=ripeatlas, circuit=" + circuitKey(targetCode, originCode)
+	// Note: depending on your watcher’s formatting, adjust keys if needed or skip these if you only care about metrics.
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
@@ -432,6 +376,34 @@ func TestMonitor_InternetTelemetry_Watcher_Tick_EmptySamples_WritesZeroStatsAndS
 	require.Equal(t, uint64(77), w.lastEpoch)
 	require.Equal(t, CircuitTelemetryStats{SuccessCount: 0, LossCount: 0}, w.stats[keyFwd])
 	require.Equal(t, CircuitTelemetryStats{SuccessCount: 0, LossCount: 0}, w.stats[keyRev])
+}
+
+func TestWatcher_Tick_AccountNotFound_IncrementsAccountNotFoundMetric(t *testing.T) {
+	t.Parallel()
+
+	cfg, _ := baseCfg(t)
+
+	a := solana.NewWallet().PublicKey()
+	b := solana.NewWallet().PublicKey()
+
+	cfg.LedgerRPCClient = &mockLedgerRPC{
+		GetEpochInfoFunc: func(ctx context.Context, c solanarpc.CommitmentType) (*solanarpc.GetEpochInfoResult, error) {
+			return &solanarpc.GetEpochInfoResult{Epoch: 5}, nil
+		}}
+	cfg.Serviceability = &mockServiceabilityClient{
+		GetProgramDataFunc: func(context.Context) (*serviceability.ProgramData, error) {
+			return makeProgramData("A", "B", a, b), nil
+		}}
+	cfg.Telemetry = &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(ctx context.Context, provider string, _, _, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
+			return nil, telemetry.ErrAccountNotFound
+		}}
+
+	w, err := NewInternetTelemetryWatcher(cfg)
+	require.NoError(t, err)
+	require.NoError(t, w.Tick(context.Background()))
+
+	require.Equal(t, 1.0, testutil.ToFloat64(cfg.Metrics.AccountNotFound.WithLabelValues("ripeatlas", "A → B")))
 }
 
 type mockLedgerRPC struct {
@@ -480,4 +452,69 @@ func makeProgramData(exchangeCode1, exchangeCode2 string, exchangePK1, exchangeP
 func pkAsBytes(pk solana.PublicKey) (out [32]byte) {
 	copy(out[:], pk[:])
 	return
+}
+
+func newTestMetrics() (*prometheus.Registry, *Metrics) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics()
+	m.Register(reg)
+	return reg, m
+}
+
+func baseCfg(t *testing.T) (*Config, *prometheus.Registry) {
+	reg, metrics := newTestMetrics()
+	return &Config{
+		Logger:   newTestLogger(t),
+		Metrics:  metrics,
+		Interval: 5 * time.Millisecond,
+		// InternetLatencyCollectorPK is required by the watcher; set a dummy.
+		InternetLatencyCollectorPK: solana.NewWallet().PublicKey(),
+	}, reg
+}
+
+// providerStepTelemetryMock simulates two providers ("ripeatlas" and "wheresitup")
+// and returns per-provider forward-direction samples. Step 0 seeds a baseline; step 1 adds deltas:
+// - ripeatlas forward: +1 success
+// - wheresitup forward: +1 success and +1 loss
+func providerStepTelemetryMock(origin, target solana.PublicKey, step *int32) *mockTelemetryProgramClient {
+	return &mockTelemetryProgramClient{
+		GetInternetLatencySamplesFunc: func(_ context.Context, provider string, o, t, _ solana.PublicKey, _ uint64) (*telemetry.InternetLatencySamples, error) {
+			// Only the forward circuit is exercised by the watcher.
+			if o != origin || t != target {
+				return &telemetry.InternetLatencySamples{Samples: nil}, nil
+			}
+			switch provider {
+			case "ripeatlas":
+				if atomic.LoadInt32(step) == 0 {
+					return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5}}, nil
+				} // 3/1
+				return &telemetry.InternetLatencySamples{Samples: []uint32{1, 2, 0, 5, 9}}, nil // +1 success (4/1)
+			case "wheresitup":
+				if atomic.LoadInt32(step) == 0 {
+					return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7}}, nil
+				} // 1/2
+				return &telemetry.InternetLatencySamples{Samples: []uint32{0, 0, 7, 3, 0}}, nil // +1 success, +1 loss (2/3)
+			default:
+				return &telemetry.InternetLatencySamples{Samples: nil}, nil
+			}
+		},
+	}
+}
+
+// counterTotal sums a metric family across all labels.
+func counterTotal(t *testing.T, g prometheus.Gatherer, metric string) float64 {
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	var total float64
+	for _, mf := range mfs {
+		if mf.GetName() != metric {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if c := m.GetCounter(); c != nil {
+				total += c.GetValue()
+			}
+		}
+	}
+	return total
 }

--- a/controlplane/monitor/internal/worker/worker.go
+++ b/controlplane/monitor/internal/worker/worker.go
@@ -6,6 +6,7 @@ import (
 
 	devicetelemetry "github.com/malbeclabs/doublezero/controlplane/monitor/internal/device-telemetry"
 	internettelemetry "github.com/malbeclabs/doublezero/controlplane/monitor/internal/internet-telemetry"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Watcher interface {
@@ -25,8 +26,11 @@ func New(cfg *Config) (*Worker, error) {
 		return nil, err
 	}
 
+	deviceTelemetryMetrics := devicetelemetry.NewMetrics()
+	deviceTelemetryMetrics.Register(prometheus.DefaultRegisterer)
 	deviceTelemetryWatcher, err := devicetelemetry.NewDeviceTelemetryWatcher(&devicetelemetry.Config{
 		Logger:          cfg.Logger,
+		Metrics:         deviceTelemetryMetrics,
 		LedgerRPCClient: cfg.LedgerRPCClient,
 		Serviceability:  cfg.Serviceability,
 		Telemetry:       cfg.Telemetry,
@@ -36,8 +40,11 @@ func New(cfg *Config) (*Worker, error) {
 		return nil, err
 	}
 
+	internetTelemetryMetrics := internettelemetry.NewMetrics()
+	internetTelemetryMetrics.Register(prometheus.DefaultRegisterer)
 	internetTelemetryWatcher, err := internettelemetry.NewInternetTelemetryWatcher(&internettelemetry.Config{
 		Logger:                     cfg.Logger,
+		Metrics:                    internetTelemetryMetrics,
 		LedgerRPCClient:            cfg.LedgerRPCClient,
 		Serviceability:             cfg.Serviceability,
 		Telemetry:                  cfg.Telemetry,


### PR DESCRIPTION
## Summary of Changes
- Update onchain device and internet latency telemetry monitor to emit metrics for account not found, so we can alert on this case
- Resolves https://github.com/malbeclabs/doublezero/issues/1126

## Testing Verification
- Added test coverage that checks metrics for each watcher
- Validated this locally against devnet and testnet