### PR TITLE
qa: publisher send for 60s

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -378,9 +378,9 @@ func TestConnectivityMulticast(t *testing.T) {
 		sendReq := &pb.MulticastSendRequest{
 			Group:    groupAddr.String(),
 			Port:     7000,
-			Duration: 30,
+			Duration: 60,
 		}
-		ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 		_, err = client.MulticastSend(ctx, sendReq)
 		require.NoError(t, err, "MulticastSend failed")


### PR DESCRIPTION
## Summary of Changes
There's a race between the publisher and subscribers in the QA test where the publisher can finish sending (set to 30s) before the multicast state has been setup in the network for the subscriber. It seems the state gets built when the subscriber first connects, is then removed, then gets rebuilt sometime after, where sometime after could be after the publisher has already sent for 30s.

This is a short term fix to raise the publisher send time to 60s to allow subscribers to be setup properly. Why their state is torn down and rebuilt needs to be further investigated but this is to eliminate flakey devnet QA tests.


## Testing Verification
Ran the devnet QA test 4 times and it passed: https://github.com/malbeclabs/doublezero/actions/runs/17449998279
