### PR TITLE
pim: run tests in container

### DIFF
--- a/client/doublezerod/internal/pim/container-test.yaml
+++ b/client/doublezerod/internal/pim/container-test.yaml
@@ -1,0 +1,3 @@
+dockerfile: test.dockerfile
+docker-run-args:
+  - --privileged

--- a/client/doublezerod/internal/pim/pim_test.go
+++ b/client/doublezerod/internal/pim/pim_test.go
@@ -1,3 +1,5 @@
+//go:build container_tests
+
 package pim_test
 
 import (

--- a/client/doublezerod/internal/pim/server_test.go
+++ b/client/doublezerod/internal/pim/server_test.go
@@ -1,3 +1,5 @@
+//go:build container_tests
+
 package pim_test
 
 import (

--- a/client/doublezerod/internal/pim/test.dockerfile
+++ b/client/doublezerod/internal/pim/test.dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.24.3-alpine AS builder
+WORKDIR /work
+COPY . .
+WORKDIR /work/client/doublezerod/internal/pim
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go test -c -o /bin/runtime.test -tags container_tests .
+
+FROM ubuntu:22.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates iproute2
+WORKDIR /work
+COPY --from=builder /bin/runtime.test /bin/
+COPY --from=builder /work/client/doublezerod/internal/pim .
+ENTRYPOINT ["/bin/runtime.test"]
+CMD ["-test.v"]


### PR DESCRIPTION
## Summary of Changes
The pim server tests are integration tests and should be ran in a container environment.

## Testing Verification
CI passes
