### PR TITLE
client: reduce bgp hold time to match device

### DIFF
--- a/client/doublezerod/internal/bgp/bgp_test.go
+++ b/client/doublezerod/internal/bgp/bgp_test.go
@@ -114,7 +114,7 @@ func (p *dummyPlugin) handleUpdate(peer corebgp.PeerConfig, u []byte) *corebgp.N
 
 func TestBgpServer(t *testing.T) {
 	nlr := &mockRouteReaderWriter{}
-	b, err := bgp.NewBgpServer(net.IP{1, 1, 1, 1}, nlr)
+	b, err := bgp.NewBgpServer(net.IP{1, 1, 1, 1}, nlr, 90)
 	if err != nil {
 		t.Fatalf("error creating bgp server: %v", err)
 	}

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -17,9 +17,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Run(ctx context.Context, sockFile string, enableLatencyProbing bool, programId string, rpcEndpoint string, probeInterval, cacheUpdateInterval int) error {
+func Run(ctx context.Context, sockFile string, enableLatencyProbing bool, programId string, rpcEndpoint string, probeInterval, cacheUpdateInterval, bgpHoldTime int) error {
 	nlr := routing.Netlink{}
-	bgp, err := bgp.NewBgpServer(net.IPv4(1, 1, 1, 1), nlr)
+	bgp, err := bgp.NewBgpServer(net.IPv4(1, 1, 1, 1), nlr, uint16(bgpHoldTime))
 	if err != nil {
 		return fmt.Errorf("error creating bgp server: %v", err)
 	}

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -159,7 +159,7 @@ func runIBRLTest(t *testing.T, userType api.UserType, provisioningRequest map[st
 		sockFile := filepath.Join(rootPath, "doublezerod.sock")
 		go func() {
 			programId := ""
-			err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+			err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 			errChan <- err
 		}()
 
@@ -378,7 +378,7 @@ func runIBRLTest(t *testing.T, userType api.UserType, provisioningRequest map[st
 		ctx, cancel = context.WithCancel(context.Background())
 		go func() {
 			programId := ""
-			err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+			err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 			errChan <- err
 		}()
 
@@ -494,7 +494,7 @@ func TestEndToEnd_EdgeFiltering(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -642,7 +642,7 @@ func TestEndToEnd_EdgeFiltering(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -863,7 +863,7 @@ func TestMulticastPublisher(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1024,7 +1024,7 @@ func TestMulticastPublisher(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1231,7 +1231,7 @@ func TestMulticastSubscriber(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1492,7 +1492,7 @@ func TestMulticastSubscriber(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1652,7 +1652,7 @@ func TestServiceNoCoExistence(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1833,7 +1833,7 @@ func TestServiceCoexistence(t *testing.T) {
 	sockFile := filepath.Join(rootPath, "doublezerod.sock")
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 
@@ -1950,7 +1950,7 @@ func TestServiceCoexistence(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
 		programId := ""
-		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30)
+		err := runtime.Run(ctx, sockFile, false, programId, "", 30, 30, 3)
 		errChan <- err
 	}()
 


### PR DESCRIPTION
## Summary of Changes
* Reduce default BGP hold time to 3s
* Add a command line flag to override the default
* This now matches the hold time set on the device
* It will now take up to 3s (previously 90s) to remove routes when the remove device becomes unreachable. During this time, outbound traffic is dropped.
## Testing
* Tested by hand in devcontainernet. Is this worth an e2e test? 
