### PR TITLE
controller: add msg size metric

### DIFF
--- a/controlplane/controller/internal/controller/metrics.go
+++ b/controlplane/controller/internal/controller/metrics.go
@@ -34,6 +34,12 @@ var (
 		[]string{"pubkey"},
 	)
 
+	getConfigMsgSize = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "controller_grpc_getconfig_msg_size_bytes",
+		Help:    "The size of GetConfig response messages in bytes",
+		Buckets: prometheus.ExponentialBucketsRange(16384, 1048576, 8),
+	})
+
 	// cache update metrics
 	cacheUpdateErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "controller_cache_update_errors_total",
@@ -73,6 +79,7 @@ func init() {
 	prometheus.MustRegister(getConfigPubkeyErrors)
 	prometheus.MustRegister(getConfigRenderErrors)
 	prometheus.MustRegister(getConfigOps)
+	prometheus.MustRegister(getConfigMsgSize)
 
 	// cache update metrics
 	prometheus.MustRegister(cacheUpdateErrors)

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/malbeclabs/doublezero/config"
 	pb "github.com/malbeclabs/doublezero/controlplane/proto/controller/gen/pb-go"
 	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
@@ -589,7 +590,9 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		err := status.Errorf(codes.Aborted, "config rendering for pubkey %s failed: %v", req.Pubkey, err)
 		return nil, err
 	}
-	return &pb.ConfigResponse{Config: config}, nil
+	resp := &pb.ConfigResponse{Config: config}
+	getConfigMsgSize.Observe(float64(proto.Size(resp)))
+	return resp, nil
 }
 
 // formatCIDR formats a 5-byte network block into CIDR notation


### PR DESCRIPTION
## Summary of Changes
This adds a histogram metric to track the protobuf message size returned to agents over time and is a takeaway from the garbage collection issue we saw over the weekend with gRPC tiered pools.

## Testing Verification
```
$ curl http://localhost:2112/metrics | grep controller
...
# HELP controller_grpc_getconfig_msg_size_bytes The size of GetConfig response messages in bytes
# TYPE controller_grpc_getconfig_msg_size_bytes histogram
controller_grpc_getconfig_msg_size_bytes_bucket{le="16384"} 0
controller_grpc_getconfig_msg_size_bytes_bucket{le="29678.75303059969"} 0
controller_grpc_getconfig_msg_size_bytes_bucket{le="53761.497891316554"} 0
controller_grpc_getconfig_msg_size_bytes_bucket{le="97386.12173287904"} 6
controller_grpc_getconfig_msg_size_bytes_bucket{le="176409.83004870816"} 6
controller_grpc_getconfig_msg_size_bytes_bucket{le="319557.11536777794"} 6
controller_grpc_getconfig_msg_size_bytes_bucket{le="578860.8829450156"} 6
controller_grpc_getconfig_msg_size_bytes_bucket{le="1.0485759999999997e+06"} 6
controller_grpc_getconfig_msg_size_bytes_bucket{le="+Inf"} 6
controller_grpc_getconfig_msg_size_bytes_sum 402324
controller_grpc_getconfig_msg_size_bytes_count 6
```
