### PR TITLE
monitor: use json formatted logs

### DIFF
--- a/controlplane/monitor/cmd/monitor/main.go
+++ b/controlplane/monitor/cmd/monitor/main.go
@@ -55,7 +55,7 @@ func main() {
 	if *verbose {
 		logLevel = slog.LevelDebug
 	}
-	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: logLevel,
 	}))
 

--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -87,14 +87,14 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 
 	if w.cacheDevices != nil {
 		deviceEvents := CompareDevice(w.cacheDevices, data.Devices)
-		w.log.Info("device events", "count", len(deviceEvents))
+		w.log.Debug("device events", "count", len(deviceEvents))
 		for _, e := range deviceEvents {
 			logEvent(e)
 		}
 	}
 	if w.cacheLinks != nil {
 		linkEvents := CompareLink(w.cacheLinks, data.Links)
-		w.log.Info("link events", "count", len(linkEvents))
+		w.log.Debug("link events", "count", len(linkEvents))
 		for _, e := range linkEvents {
 			logEvent(e)
 		}


### PR DESCRIPTION
## Summary of Changes
This moves monitor to use json formatted logs. 

## Testing Verification
```
{"time":"2025-09-08T20:16:40.992367137Z","level":"INFO","msg":"Starting worker"}
{"time":"2025-09-08T20:16:40.993513262Z","level":"INFO","msg":"Starting watcher","name":"serviceability"}
{"time":"2025-09-08T20:16:40.993501178Z","level":"INFO","msg":"Starting watcher","name":"internet-telemetry"}
{"time":"2025-09-08T20:16:40.993631303Z","level":"INFO","msg":"Starting watcher","name":"device-telemetry"}
{"time":"2025-09-08T20:16:41.00271597Z","level":"INFO","msg":"Prometheus metrics server listening","address":{"IP":"::","Port":8080,"Zone":""}}
```
