### PR TITLE
monitor: string fmt for action/entity_type

### DIFF
--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -78,8 +78,8 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 	logEvent := func(events ServiceabilityEventer) {
 		w.log.Info(
 			"serviceability event",
-			"entity_type", events.EntityType(),
-			"action", events.Type(),
+			"entity_type", events.EntityType().String(),
+			"action", events.Type().String(),
 			"id", events.Id(),
 			"pub_key", events.PubKey(),
 			"diff", events.Diff())


### PR DESCRIPTION
## Summary of Changes
Since moving to json logs in monitor, event_type and action fields for serviceability events are improperly formatted as strings. This fixes that.

## Testing Verification

Previous:
```
{"time":"2025-09-08T20:36:57.45157529Z","level":"INFO","msg":"serviceability event","watcher":"serviceability","entity_type":1,"action":1...
```
Now:
```
{"time":"2025-09-08T20:53:07.612419968Z","level":"INFO","msg":"serviceability event","watcher":"serviceability","entity_type":"device","action":"removed"...
```
