### PR TITLE
Fix bug preventing re-opening of AccessPass after closure

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -146,12 +146,12 @@ pub fn process_set_access_pass(
         #[cfg(test)]
         msg!("Created: {:?}", accesspass);
     } else {
-        assert_eq!(
-            accesspass_account.owner, program_id,
-            "Invalid PDA Account Owner"
-        );
-
         let mut accesspass = if !accesspass_account.data_is_empty() {
+            assert_eq!(
+                accesspass_account.owner, program_id,
+                "Invalid PDA Account Owner"
+            );
+
             AccessPass::try_from(accesspass_account)?
         } else {
             AccessPass {
@@ -187,6 +187,7 @@ pub fn process_set_access_pass(
         .saturating_add(globalstate.user_airdrop_lamports)
         .saturating_sub(user_payer.lamports());
     if deposit != 0 {
+        msg!("Airdropping {} lamports to user", deposit);
         invoke_signed_unchecked(
             &system_instruction::transfer(payer_account.key, user_payer.key, deposit),
             &[

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -1,0 +1,217 @@
+use doublezero_serviceability::{
+    entrypoint::*,
+    instructions::*,
+    pda::*,
+    processors::accesspass::{close::CloseAccessPassArgs, set::SetAccessPassArgs},
+    state::accesspass::{AccessPassStatus, AccessPassType},
+};
+use solana_program_test::*;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
+use std::net::Ipv4Addr;
+
+mod test_helpers;
+use test_helpers::*;
+
+#[tokio::test]
+async fn test_accesspass() {
+    let program_id = Pubkey::new_unique();
+    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    )
+    .start()
+    .await;
+
+    /***********************************************************************************************************************************/
+    println!("🟢  Start test_accesspass");
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    println!("🟢 1. Global Initialization...");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    /***********************************************************************************************************************************/
+    // AccessPass tests
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 1);
+    let user_payer = payer.pubkey();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    let solana_identity = Pubkey::new_unique();
+
+    /***********************************************************************************************************************************/
+    println!("🟢 1. Create AccessPass...");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 10,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.accesspass_type, AccessPassType::Prepaid);
+    assert_eq!(accesspass.client_ip, client_ip);
+    assert_eq!(accesspass.last_access_epoch, 10);
+    println!("✅ AccessPass created successfully");
+
+    /***********************************************************************************************************************************/
+    println!("🟢 2. Update AccessPass...");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::SolanaValidator(solana_identity),
+            client_ip,
+            last_access_epoch: u64::MAX,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(
+        accesspass.accesspass_type,
+        AccessPassType::SolanaValidator(solana_identity)
+    );
+    assert_eq!(accesspass.client_ip, client_ip);
+    assert_eq!(accesspass.last_access_epoch, u64::MAX);
+    println!("✅ AccessPass updated successfully");
+
+    /***********************************************************************************************************************************/
+    println!("🟢 3. Close AccessPass...");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CloseAccessPass(CloseAccessPassArgs {}),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(
+        accesspass.accesspass_type,
+        AccessPassType::SolanaValidator(solana_identity)
+    );
+    assert_eq!(accesspass.client_ip, client_ip);
+    assert_eq!(accesspass.last_access_epoch, 0);
+    assert_eq!(accesspass.status, AccessPassStatus::Expired);
+
+    println!("✅ AccessPass closed successfully");
+
+    /***********************************************************************************************************************************/
+    println!("🟢 4. Create AccessPass again...");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 101,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+
+    assert_eq!(accesspass.accesspass_type, AccessPassType::Prepaid);
+    assert_eq!(accesspass.client_ip, client_ip);
+    assert_eq!(accesspass.last_access_epoch, 101);
+    println!("✅ AccessPass recreated successfully");
+
+    /***********************************************************************************************************************************/
+    println!("🟢 5. Update AccessPass last_epoch = 0...");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 0,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+
+    assert_eq!(accesspass.accesspass_type, AccessPassType::Prepaid);
+    assert_eq!(accesspass.client_ip, client_ip);
+    assert_eq!(accesspass.last_access_epoch, 0);
+    println!("✅ AccessPass update last_epoch successfully");
+
+    /***********************************************************************************************************************************/
+
+    println!("🟢  End test_accesspass");
+}


### PR DESCRIPTION
This pull request introduces improvements to the handling and testing of the AccessPass lifecycle in the DoubleZero serviceability program. The main changes include refactoring how AccessPass accounts are closed and resized, enhancing logging for easier debugging, and adding an integration test to verify AccessPass creation, update, closure, and recreation. These updates improve reliability, maintainability, and test coverage for AccessPass functionality.

### AccessPass lifecycle improvements

* Refactored the AccessPass close logic to update the status and last access epoch, resize the account as needed using `resize_account_if_needed`, and serialize the updated state, ensuring proper cleanup and state management.
* Improved the update logic for AccessPass accounts to ensure correct deserialization and mutation of existing accounts.

### Logging enhancements

* Added detailed `msg!` logging for account creation, resizing, and lamport transfers in both production and test code, making debugging and test output more informative. [[1]](diffhunk://#diff-f2d7a3b26e20df79d358db4658f66f966de16f45501a074617ecf2ce981c541aR1-R2) [[2]](diffhunk://#diff-f2d7a3b26e20df79d358db4658f66f966de16f45501a074617ecf2ce981c541aR34-R39) [[3]](diffhunk://#diff-f2d7a3b26e20df79d358db4658f66f966de16f45501a074617ecf2ce981c541aR49-R54) [[4]](diffhunk://#diff-f2d7a3b26e20df79d358db4658f66f966de16f45501a074617ecf2ce981c541aR65-R66) [[5]](diffhunk://#diff-535d30342766bf91b24868a6585cfb47852f365617445470bc5ed6edf8259da2R190)

### Test coverage

* Added a comprehensive integration test (`accesspass_test.rs`) that exercises AccessPass creation, update, closure, and recreation, verifying correct behavior and state transitions.

## Testing Verification
* test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s
