### PR TITLE
client: depend on doublezero-solana

### DIFF
--- a/release/.goreleaser.base.client.yaml
+++ b/release/.goreleaser.base.client.yaml
@@ -63,6 +63,8 @@ nfpms:
     bindir: /usr/bin
     release: 1
     section: default
+    dependencies:
+      - doublezero-solana
     contents:
       - src: client/doublezerod/cmd/doublezerod/doublezerod.service
         dst: /usr/lib/systemd/system/doublezerod.service


### PR DESCRIPTION
## Summary of Changes
The access workflows for users depend on the doublezero-solana package. This changes the doublezero package to depend on doublezero-solana so users get this by installing doublezero.

## Testing Verification
Snapshot build install via apt; doublezero-solana is installed as a dependency:
```
ubuntu@chi-dn-bm4:~$ sudo apt install ./doublezero_0.6.3-SNAPSHOT-e99d8e90_linux_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'doublezero' instead of './doublezero_0.6.3-SNAPSHOT-e99d8e90_linux_amd64.deb'
The following additional packages will be installed:
  doublezero-solana
The following NEW packages will be installed:
  doublezero-solana
The following packages will be DOWNGRADED:
  doublezero
0 upgraded, 1 newly installed, 1 downgraded, 0 to remove and 27 not upgraded.
Need to get 2,921 kB/21.4 MB of archives.
After this operation, 6,328 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 /home/ubuntu/doublezero_0.6.3-SNAPSHOT-e99d8e90_linux_amd64.deb doublezero amd64 0.6.3~SNAPSHOT-e99d8e90-1 [18.5 MB]
Get:2 https://dl.cloudsmith.io/public/malbeclabs/doublezero/deb/ubuntu noble/main amd64 doublezero-solana amd64 0.0.2-1 [2,921 kB]
Fetched 2,921 kB in 1s (2,074 kB/s)
Selecting previously unselected package doublezero-solana.
(Reading database ... 127286 files and directories currently installed.)
Preparing to unpack .../doublezero-solana_0.0.2-1_amd64.deb ...
Unpacking doublezero-solana (0.0.2-1) ...
dpkg: warning: downgrading doublezero from 0.6.4~git20250909173037.d8b83042-1 to 0.6.3~SNAPSHOT-e99d8e90-1
Preparing to unpack .../doublezero_0.6.3-SNAPSHOT-e99d8e90_linux_amd64.deb ...
Unpacking doublezero (0.6.3~SNAPSHOT-e99d8e90-1) over (0.6.4~git20250909173037.d8b83042-1) ...
Setting up doublezero-solana (0.0.2-1) ...
Setting up doublezero (0.6.3~SNAPSHOT-e99d8e90-1) ...

ubuntu@chi-dn-bm4:~$ doublezero-solana -V
doublezero-solana 0.0.2
```
