### PR TITLE
Don't render user tunnel when client ip or dz ip are 0.0.0.0

### DIFF
--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -353,6 +353,14 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 				c.log.Error("client ip is not set for user", "user pubkey", userPubKey)
 				return false
 			}
+			if user.ClientIp == [4]byte{0, 0, 0, 0} {
+				slog.Error("client ip is set to 0.0.0.0 for user", "user pubkey", userPubKey)
+				return false
+			}
+			if user.DzIp == [4]byte{0, 0, 0, 0} {
+				slog.Error("DZ IP is set to 0.0.0.0 for user", "user pubkey", userPubKey)
+				return false
+			}
 			if user.TunnelNet[4] != 31 {
 				c.log.Error("tunnel network mask is not 31\n", "tunnel network mask", user.TunnelNet[4])
 				return false
@@ -549,7 +557,7 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 	}
 
 	if len(unknownPeers) != 0 {
-		c.log.Error("device returned unknown peers", "device pubkey", req.GetPubkey(), "number of unknown peers", len(unknownPeers), "peers", unknownPeers)
+		slog.Info("device returned unknown peers to be deleted", "device pubkey", req.GetPubkey(), "number of unknown peers", len(unknownPeers), "peers", unknownPeers)
 	}
 
 	multicastGroupBlock := formatCIDR(&c.cache.Config.MulticastGroupBlock)

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -666,6 +666,48 @@ func TestStateCache(t *testing.T) {
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
 				},
+				{
+					// Should not be added to StateCache due to invalid ClientIp
+					AccountType:  serviceability.AccountType(0),
+					Owner:        [32]uint8{},
+					UserType:     serviceability.UserUserType(serviceability.UserTypeMulticast),
+					DevicePubKey: [32]uint8{1},
+					CyoaType:     serviceability.CyoaTypeGREOverDIA,
+					ClientIp:     [4]uint8{0, 0, 0, 0},
+					DzIp:         [4]uint8{100, 100, 100, 102},
+					TunnelId:     uint16(502),
+					TunnelNet:    [5]uint8{10, 1, 1, 3, 31},
+					Status:       serviceability.UserStatusActivated,
+					Subscribers:  [][32]uint8{{1}},
+				},
+				{
+					// Should not be added to StateCache due to invalid DzIp
+					AccountType:  serviceability.AccountType(0),
+					Owner:        [32]uint8{},
+					UserType:     serviceability.UserUserType(serviceability.UserTypeMulticast),
+					DevicePubKey: [32]uint8{1},
+					CyoaType:     serviceability.CyoaTypeGREOverDIA,
+					ClientIp:     [4]uint8{5, 5, 5, 5},
+					DzIp:         [4]uint8{0, 0, 0, 0},
+					TunnelId:     uint16(502),
+					TunnelNet:    [5]uint8{10, 1, 1, 4, 31},
+					Status:       serviceability.UserStatusActivated,
+					Subscribers:  [][32]uint8{{1}},
+				},
+				{
+					// Should not be added to StateCache due to invalid ClientIp and DzIp
+					AccountType:  serviceability.AccountType(0),
+					Owner:        [32]uint8{},
+					UserType:     serviceability.UserUserType(serviceability.UserTypeMulticast),
+					DevicePubKey: [32]uint8{1},
+					CyoaType:     serviceability.CyoaTypeGREOverDIA,
+					ClientIp:     [4]uint8{0, 0, 0, 0},
+					DzIp:         [4]uint8{0, 0, 0, 0},
+					TunnelId:     uint16(502),
+					TunnelNet:    [5]uint8{10, 1, 1, 5, 31},
+					Status:       serviceability.UserStatusActivated,
+					Subscribers:  [][32]uint8{{1}},
+				},
 			},
 			Devices: []serviceability.Device{
 				{


### PR DESCRIPTION
## Summary of Changes
* Check whether user client ip or dz ip are 0.0.0.0, and if so do not render the user tunnel
* There is validation logic in serviceability that should prevent this from happening, but we check it just in case
* Also changed the log level of "device returned unknown peers" from error to info

## Testing Verification
* Updated unit test shows the controller does not render the tunnel when client ip or dz ip are 0.0.0.0
* No e2e test because serviceability now prevents setting client ip and dz ip to 0.0.0.0
