### PR TITLE
e2e: fix reused device interfaces on links

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -162,7 +162,7 @@ func (dn *TestDevnet) Start(t *testing.T) (*devnet.Device, *devnet.Client) {
 
 	// Add the other devices and links onchain.
 	dn.log.Info("==> Creating other devices and links onchain")
-	dn.Manager.Exec(ctx, []string{"bash", "-c", `
+	_, err = dn.Manager.Exec(ctx, []string{"bash", "-c", `
 		set -euo pipefail
 
 		echo "==> Populate device information onchain"

--- a/e2e/sdk_device_telemetry_test.go
+++ b/e2e/sdk_device_telemetry_test.go
@@ -54,7 +54,7 @@ func TestE2E_SDK_Telemetry_DeviceLatencySamples(t *testing.T) {
 	ny5DeviceAgentPrivateKey := solana.NewWallet().PrivateKey
 
 	log.Info("==> Creating other devices and links onchain")
-	dn.Manager.Exec(ctx, []string{"bash", "-c", `
+	_, err = dn.Manager.Exec(ctx, []string{"bash", "-c", `
 		set -euo pipefail
 
 		doublezero device create --code la2-dz01 --contributor co01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "207.45.216.136/30,200.12.12.12/29" --metrics-publisher ` + la2DeviceAgentPrivateKey.PublicKey().String() + ` --mgmt-vrf mgmt


### PR DESCRIPTION
## Summary of Changes
- Update e2e tests to not reuse the same device interface on multiple links
- Add missing error checks on a couple manager container exec commands

## Testing Verification
- Ran the intermittently failing test from [this example run](https://github.com/malbeclabs/doublezero/actions/runs/17592402907/job/49976135480?pr=1600#step:6:1617) with the until-fails script with no failures
