### PR TITLE
controller: dual listen with tls and non-tls servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Device controller
+    - Support server dual listening on TLS and non-TLS ports
+
+
 ## [v0.6.3](https://github.com/malbeclabs/doublezero/compare/client/v0.6.2...client/v0.6.3) – 2025-09-08
 
 ### Breaking

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"bytes"
 	"context"
+	"io"
 	"log"
+	"log/slog"
 	"net"
 	"net/netip"
 	"os"
@@ -535,6 +537,7 @@ func TestGetConfig(t *testing.T) {
 				}
 			} else {
 				controller = &Controller{
+					log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 					noHardware:     test.NoHardware,
 					deviceLocalASN: 65342,
 				}
@@ -888,6 +891,7 @@ func TestStateCache(t *testing.T) {
 				},
 			}
 			controller, err := NewController(
+				WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 				WithServiceabilityProgramClient(m),
 				WithListener(lis),
 				WithEnableInterfacesAndPeers(),
@@ -931,6 +935,7 @@ func TestServiceabilityProgramClientArg(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			opts := []Option{
+				WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 				WithListener(bufconn.Listen(1024 * 1024)),
 			}
 
@@ -1346,6 +1351,7 @@ func TestEndToEnd(t *testing.T) {
 			var err error
 			if test.InterfacesAndPeers {
 				controller, err = NewController(
+					WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 					WithServiceabilityProgramClient(m),
 					WithListener(listener),
 					WithSignalChan(make(chan struct{})),
@@ -1354,6 +1360,7 @@ func TestEndToEnd(t *testing.T) {
 				)
 			} else {
 				controller, err = NewController(
+					WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 					WithServiceabilityProgramClient(m),
 					WithListener(listener),
 					WithSignalChan(make(chan struct{})),


### PR DESCRIPTION
## Summary of Changes
- Update controller to support listening with a TLS-enabled server as well as the existing non-TLS server, so that we can put it behind a Cloudflare proxy-mode domain while still exposing the non-TLS port to existing agents until they are migrated to the domain.
- Added an optional `--tls-listen-port` flag, that if given enables the TLS server, where `--tls-cert` and `--tls-key` are then required flags
- Did some minor clean up of logging to pass in a tagged logger instance so we can identify the output of each server more easily
- Related to https://github.com/malbeclabs/doublezero/issues/1228

## Testing Verification
- Tested locally with a self-signed cert:

```console
$ go run controlplane/controller/cmd/controller/main.go start -tls-listen-port 8443 -tls-cert server.crt -tls-key server.key -env devnet
{"time":"2025-09-09T21:29:41.092001-04:00","level":"INFO","msg":"starting tls controller","mode":"tls","address":"localhost:8443"}
{"time":"2025-09-09T21:29:41.092048-04:00","level":"INFO","msg":"starting controller","mode":"no-tls","address":"localhost:8080"}
{"time":"2025-09-09T21:29:41.092581-04:00","level":"INFO","msg":"starting fetch of on-chain data","mode":"no-tls","program-id":"GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah"}
{"time":"2025-09-09T21:29:41.092442-04:00","level":"INFO","msg":"starting fetch of on-chain data","mode":"tls","program-id":"GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah"}
```
