### PR TITLE
release: add action to create component tags

### DIFF
--- a/.github/workflows/release.testnet.push.tags.yml
+++ b/.github/workflows/release.testnet.push.tags.yml
@@ -1,0 +1,53 @@
+name: release.testnet.push.tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The semantic version tag to create (format: vX.X.X)'
+        required: true
+        type: string
+
+jobs:
+  create-and-push-tag:
+    name: Push ${{ github.event.inputs.version }} tag for ${{ matrix.component }}
+    runs-on: ubuntu-latest
+    environment: testnet
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        component: [test]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: malbeclabs/doublezero
+          token: ${{ secrets.DOUBLEZERO_PAT }}
+          fetch-tags: true
+
+      - name: Validate format and push tag
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          COMPONENT="${{ matrix.component }}"
+          TAG_NAME="$COMPONENT/$VERSION"
+
+          VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
+
+          if ! [[ "$VERSION" =~ $VERSION_REGEX ]]; then
+            echo "Error: Version format '$VERSION' is invalid. It must be in the format 'vX.X.X'."
+            exit 1
+          fi
+          echo "Version format is valid."
+
+          if git rev-parse -q --verify "refs/tags/$TAG_NAME"; then
+            echo "Error: Tag '$TAG_NAME' already exists in the repository."
+            exit 1
+          fi
+          echo "Tag '$TAG_NAME' will be created."
+
+          git tag "$TAG_NAME"
+          echo "Successfully created tag '$TAG_NAME' locally."
+
+          # git push origin tag "$TAG_NAME"
+          echo "Successfully pushed tag '$TAG_NAME'."


### PR DESCRIPTION
## Summary of Changes
This adds an initial action to push git tags for our components. It takes a semvar as user input, verifies the format, verifies the tag doesn't already exist and creates/pushes the tag. 

This needs a follow-up PR as this workflow needs to land so it can be available to test via a branch.

## Testing Verification
This runs successfully when using act locally:
```
root ➜ /workspaces/doublezero (ss/tag_push) $ cat tag.event 
{
  "action": "workflow_dispatch",
  "inputs": {
      "version": "v0.6.4"
  }
}

➜  doublezero git:(ss/tag_push) ✗ act -s DOUBLEZERO_PAT --eventpath tag.event -W .github/workflows/release.testnet.push.tags.yml workflow_dispatch
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
INFO[0000] Start server on http://10.0.0.176:34567
[release.testnet.push.tags/Push v0.6.4 tag for test] ⭐ Run Set up job
...
| Version format is valid.
| Tag 'test/v0.6.4' will be created.
| Successfully created tag 'test/v0.6.4' locally.
| Successfully pushed tag 'test/v0.6.4'.
```

Sad path:
```
➜  doublezero git:(ss/tag_push) ✗ cat tag.event
{
  "action": "workflow_dispatch",
  "inputs": {
      "version": "v0.6.4.1"
  }
}

➜  doublezero git:(ss/tag_push) ✗ act -s DOUBLEZERO_PAT --eventpath tag.event -W .github/workflows/release.testnet.push.tags.yml workflow_dispatch
...
| Error: Version format 'v0.6.4.1' is invalid. It must be in the format 'vX.X.X'
```
