### PR TITLE
release: push component tags

### DIFF
--- a/.github/workflows/release.testnet.push.tags.yml
+++ b/.github/workflows/release.testnet.push.tags.yml
@@ -17,7 +17,14 @@ jobs:
       contents: write
     strategy:
       matrix:
-        component: [test]
+        component:
+          - activator
+          - controller
+          - internet-latency-collector
+          - agent
+          - device-telemetry-agent
+          - funder
+          - monitor
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,5 +56,5 @@ jobs:
           git tag "$TAG_NAME"
           echo "Successfully created tag '$TAG_NAME' locally."
 
-          # git push origin tag "$TAG_NAME"
+          git push origin tag "$TAG_NAME"
           echo "Successfully pushed tag '$TAG_NAME'."


### PR DESCRIPTION
## Summary of Changes
After #1605 landed and was able to be tested, this PR adds our component list to generate tags for a given release.

## Testing Verification
Since I don't want to trigger a build for our core components during testing, I used QA agent as a canary.

Action ran against this branch w/ QA agent as a component - v2.2.0 was pushed to the repo: https://github.com/malbeclabs/doublezero/actions/runs/17601787024/job/50004986952#step:3:31

Due to the tag push, the release job was then immediately triggered to build a new QA agent package (which I cancelled): https://github.com/malbeclabs/doublezero/actions/runs/17601792561
