### PR TITLE
release: add client tag

### DIFF
--- a/.github/workflows/release.testnet.push.tags.components.yml
+++ b/.github/workflows/release.testnet.push.tags.components.yml
@@ -1,0 +1,40 @@
+name: release.testnet.push.tags.components
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The semantic version tag to create (format: vX.X.X)'
+        required: true
+        type: string
+
+jobs:
+  component-tags:
+    name: Tag ${{ matrix.component }} with version ${{ github.event.inputs.version }}
+    uses: ./.github/workflows/release.testnet.push.tags.yml
+    strategy:
+      matrix:
+        component:
+          #- activator
+          #- controller
+          #- internet-latency-collector
+          #- agent
+          #- device-telemetry-agent
+          #- funder
+          #- monitor
+          - test
+    with:
+      version: ${{ github.event.inputs.version }}
+      component: ${{ matrix.component }}
+    secrets:
+      DOUBLEZERO_PAT: ${{ secrets.DOUBLEZERO_PAT }}
+  client-tag:
+    name: Tag client with version ${{ github.event.inputs.version }}
+    needs: component-tags
+    uses: ./.github/workflows/release.testnet.push.tags.yml
+    with:
+      version: ${{ github.event.inputs.version }}
+      component: test2
+        # - client
+    secrets:
+      DOUBLEZERO_PAT: ${{ secrets.DOUBLEZERO_PAT }}

--- a/.github/workflows/release.testnet.push.tags.yml
+++ b/.github/workflows/release.testnet.push.tags.yml
@@ -1,30 +1,28 @@
-name: release.testnet.push.tags
+name: Reusable - Push Component Tag
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
         description: 'The semantic version tag to create (format: vX.X.X)'
         required: true
         type: string
+      component:
+        description: 'The component to tag'
+        required: true
+        type: string
+    secrets:
+      DOUBLEZERO_PAT:
+        description: 'PAT to push tags to the repository'
+        required: true
 
 jobs:
   create-and-push-tag:
-    name: Push ${{ github.event.inputs.version }} tag for ${{ matrix.component }}
+    name: Push ${{ inputs.version }} tag for ${{ inputs.component }}
     runs-on: ubuntu-latest
     environment: testnet
     permissions:
       contents: write
-    strategy:
-      matrix:
-        component:
-          - activator
-          - controller
-          - internet-latency-collector
-          - agent
-          - device-telemetry-agent
-          - funder
-          - monitor
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,8 +33,8 @@ jobs:
 
       - name: Validate format and push tag
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          COMPONENT="${{ matrix.component }}"
+          VERSION="${{ inputs.version }}"
+          COMPONENT="${{ inputs.component }}"
           TAG_NAME="$COMPONENT/$VERSION"
 
           VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"


### PR DESCRIPTION
## Summary of Changes
This converts the action for pushing component tags added in #1605 and #1607 to a reusable job and adds a second job stage for pushing the client tag. The components are intentionally commented out here so this can land which allows the action to be tested from a local branch. The behavior that needs to be tested is the second `client-tag` job should required a second approval as this is happens after component verification.

## Testing Verification
It runs locally in the correct order but workflow approval cannot be tested locally:
```
➜  doublezero git:(ss/tag_push) ✗ act -s DOUBLEZERO_PAT --eventpath tag.event -W .github/workflows/release.testnet.push.tags.components.yml workflow_dispatch
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
INFO[0000] Start server on http://10.0.0.176:34567
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] ⭐ Run Set up job
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] 🚀  Start image=catthehacker/ubuntu:act-latest
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   ✅  Success - Set up job
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] ⭐ Run Main Checkout repository
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker cp src=/Users/fach/Documents/code/doublezero/. dst=/Users/fach/Documents/code/doublezero
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   ✅  Success - Main Checkout repository [1.5944585s]
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] ⭐ Run Main Validate format and push tag
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/1] user= workdir=
| Version format is valid.
| Tag 'test/v0.6.4' will be created.
| Successfully created tag 'test/v0.6.4' locally.
| Successfully pushed tag 'test/v0.6.4'.
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   ✅  Success - Main Validate format and push tag [204.773792ms]
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] ⭐ Run Complete job
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] Cleaning up container for job Push v0.6.4 tag for test
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test]   ✅  Success - Complete job
[Tag test with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test] 🏁  Job succeeded
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] ⭐ Run Set up job
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] 🚀  Start image=catthehacker/ubuntu:act-latest
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   ✅  Success - Set up job
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] ⭐ Run Main Checkout repository
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker cp src=/Users/fach/Documents/code/doublezero/. dst=/Users/fach/Documents/code/doublezero
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   ✅  Success - Main Checkout repository [895.759917ms]
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] ⭐ Run Main Validate format and push tag
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/1] user= workdir=
| Version format is valid.
| Tag 'test2/v0.6.4' will be created.
| Successfully created tag 'test2/v0.6.4' locally.
| Successfully pushed tag 'test2/v0.6.4'.
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   ✅  Success - Main Validate format and push tag [164.967792ms]
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] ⭐ Run Complete job
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] Cleaning up container for job Push v0.6.4 tag for test2
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2]   ✅  Success - Complete job
[Tag client with version v0.6.4/Reusable - Push Component Tag/Push v0.6.4 tag for test2] 🏁  Job succeeded
```
