### PR TITLE
release: add two-stage workflow for component tagging

### DIFF
--- a/.github/workflows/release.testnet.push.tags.components.yml
+++ b/.github/workflows/release.testnet.push.tags.components.yml
@@ -12,17 +12,18 @@ jobs:
   component-tags:
     name: Tag ${{ matrix.component }} with version ${{ github.event.inputs.version }}
     uses: ./.github/workflows/release.testnet.push.tags.yml
+    permissions:
+      contents: write
     strategy:
       matrix:
         component:
-          #- activator
-          #- controller
-          #- internet-latency-collector
-          #- agent
-          #- device-telemetry-agent
-          #- funder
-          #- monitor
-          - test
+          - activator
+          - controller
+          - internet-latency-collector
+          - agent
+          - device-telemetry-agent
+          - funder
+          - monitor
     with:
       version: ${{ github.event.inputs.version }}
       component: ${{ matrix.component }}
@@ -32,9 +33,10 @@ jobs:
     name: Tag client with version ${{ github.event.inputs.version }}
     needs: component-tags
     uses: ./.github/workflows/release.testnet.push.tags.yml
+    permissions:
+      contents: write
     with:
       version: ${{ github.event.inputs.version }}
-      component: test2
-        # - client
+      component: client
     secrets:
       DOUBLEZERO_PAT: ${{ secrets.DOUBLEZERO_PAT }}

--- a/.github/workflows/release.testnet.push.tags.yml
+++ b/.github/workflows/release.testnet.push.tags.yml
@@ -21,8 +21,6 @@ jobs:
     name: Push ${{ inputs.version }} tag for ${{ inputs.component }}
     runs-on: ubuntu-latest
     environment: testnet
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary of Changes
This adds a two-stage workflow for automatically tagging our components. Once each tag is pushed, the relevant release workflow will be triggered by the tag push. Users are required to enter the appropriate semvar tag before starting the job:

<img width="828" height="422" alt="Screenshot 2025-09-10 at 10 21 22 AM" src="https://github.com/user-attachments/assets/1e98657b-9307-4e85-8af6-8599bb4261ff" />


---
Two reviews are required, one for non-client components then one for the client:

<img width="1422" height="1024" alt="Screenshot 2025-09-10 at 10 22 10 AM" src="https://github.com/user-attachments/assets/6ca888c0-7d23-42ae-842a-e6fdf4befe38" />

## Testing Verification

https://github.com/malbeclabs/doublezero/actions/runs/17616559489
