### PR TITLE
smartcontract: Fix serialization for AccessPassType

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -16,7 +16,16 @@ use std::{fmt, net::Ipv4Addr};
 pub enum AccessPassType {
     #[default]
     Prepaid,
-    SolanaValidator(Pubkey),
+    SolanaValidator(
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                serialize_with = "doublezero_program_common::serializer::serialize_pubkey_as_string",
+                deserialize_with = "doublezero_program_common::serializer::deserialize_pubkey_from_string"
+            )
+        )]
+        Pubkey,
+    ),
 }
 
 impl AccessPassType {


### PR DESCRIPTION
Summary
----
Tiny PR to fixup the serialization/deserialization of `AccessPassType` enum which wraps a `Pubkey`