### PR TITLE
sdk/rs: fix accounts list in access pass check status instruction execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - Device controller
     - Update device template to set default BGP timers and admin distance
+- Activator
+    - Fix access pass check status accounts list
 
 ## [v0.6.4](https://github.com/malbeclabs/doublezero/compare/client/v0.6.3...client/v0.6.4) – 2025-09-10
 
@@ -21,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Onchain programs
     - Fix bug preventing re-opening of AccessPass after closure
-    - sc/svc: guard against empty account data 
+    - sc/svc: guard against empty account data
 - Device controller
     - Support server dual listening on TLS and non-TLS ports
 - Device and Internet Latency Telemetry

--- a/smartcontract/sdk/rs/src/commands/accesspass/check_status.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/check_status.rs
@@ -26,7 +26,6 @@ impl CheckStatusAccessPassCommand {
             vec![
                 AccountMeta::new(pda_pubkey, false),
                 AccountMeta::new_readonly(globalstate_pubkey, false),
-                AccountMeta::new(self.user_payer, false),
             ],
         )
     }
@@ -65,7 +64,6 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(pda_pubkey, false),
                     AccountMeta::new_readonly(globalstate_pubkey, false),
-                    AccountMeta::new(payer, false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));


### PR DESCRIPTION
## Summary of Changes
- Fix accounts list in access pass check status instruction execution
- Causing activator to panic with the following:
  ```
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program Logs:
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb invoke [1]
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program log: Instruction: CheckStatusAccessPass()
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program log: panicked at smartcontract/programs/doublezero-serviceability/src/processors/accesspass/check_status.rs:41:5:
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: assertion `left == right` failed: Invalid System Program Account Owner
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]:   left: DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]:  right: 11111111111111111111111111111111
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb consumed 16305 of 200000 compute units
  Sep 14 20:44:55 aws-tn-activator1 doublezero-activator[3949597]: Program DZtnuQ839pSaDMFG5q1ad2V95G82S5EC4RrB3Ndw2Heb failed: SBF program panicked
  ```
- Fixes https://github.com/malbeclabs/doublezero/issues/1651

## Testing Verification
- Updated existing test to match the expectation
