### PR TITLE
e2e: increase qa agent timeout to 60s

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -174,7 +174,7 @@ func (q *QAAgent) ConnectUnicast(ctx context.Context, req *pb.ConnectUnicastRequ
 		return currentState == "up", nil
 	}
 
-	err = poll.Until(ctx, condition, 30*time.Second, 1*time.Second)
+	err = poll.Until(ctx, condition, 60*time.Second, 1*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("failed while polling for session status: %v", err)
 	}


### PR DESCRIPTION
- Increase timeout for qaagent's ConnectUnicast call from 30s to 60s
- Because sometimes it takes longer than 30s for a user tunnel to come up
- For example, from the qa.alldevices test:
```
qa_test.go:626: Testing device chi001-dz001 4/42
qa_test.go:745: Connecting hosts [sgp-mn-qa01] to device chi001-dz001
qa_test.go:732: Disconnecting sgp-mn-qa01 from device chi001-dz001
qa_test.go:634: Device chi001-dz001 failed: failed to connect sgp-mn-qa01: rpc error: code = Unknown desc = failed while polling for session status: polling cancelled or timed out: context deadline exceeded
```
- Corresponding logs from qaagent:
```
Sep 15 19:15:08 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:08.179Z level=INFO source=agent.go:141 msg="Received ConnectUnicast request" client_ip="" device_code=chi001-dz001
Sep 15 19:15:13 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:13.883Z level=INFO source=agent.go:158 msg="Successfully connected IBRL mode tunnel"
Sep 15 19:15:13 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:13.888Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:14 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:14.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:15 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:15.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:16 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:16.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:17 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:17.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:18 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:18.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:19 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:19.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:20 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:20.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:21 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:21.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:22 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:22.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:23 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:23.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:24 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:24.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:25 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:25.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:26 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:26.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:27 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:27.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:28 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:28.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:29 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:29.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:30 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:30.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:31 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:31.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:32 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:32.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:33 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:33.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:34 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:34.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:35 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:35.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:36 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:36.889Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:37 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:37.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:38 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:38.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:39 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:39.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:40 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:40.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:41 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:41.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:42 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:42.886Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:43 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:43.885Z level=INFO source=agent.go:173 msg="Polling tunnel status" state=down tunnel_name=doublezero0 doublezero_ip=159.223.46.72
Sep 15 19:15:44 sgp-mn-qa01 doublezero-qaagent[478737]: time=2025-09-15T19:15:44.103Z level=INFO source=agent.go:187 msg="Received Disconnect request"
```