### PR TITLE
monitor: make slack notifications conditional

### DIFF
--- a/controlplane/monitor/cmd/monitor/main.go
+++ b/controlplane/monitor/cmd/monitor/main.go
@@ -51,11 +51,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	if slackWebhookURL == nil || *slackWebhookURL == "" {
-		fmt.Println("Missing required flag: -slack-webhook-url")
-		flag.Usage()
-		os.Exit(1)
-	}
 	// Initialize logger.
 	logLevel := slog.LevelInfo
 	if *verbose {

--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -117,7 +117,7 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 				userAdds++
 			}
 		}
-		if userAdds > 0 {
+		if userAdds > 0 && w.cfg.SlackWebhookURL != "" {
 			msg, err := w.buildSlackMessage(userEvents, data.Devices)
 			if err != nil {
 				w.log.Error("failed to build slack message", "error", err)


### PR DESCRIPTION
## Summary of Changes
Slack notifications were a mandatory flag #1661 which was an oversight as we only want these for mainnet-beta. This changes the behavior to only post if a slack url is passed as a flag.

## Testing Verification
Verified a notification was sent w/o the `-slack-webhook-url flag`
