### PR TITLE
monitor: check for unlinked interfaces in a link

### DIFF
--- a/controlplane/monitor/internal/serviceability/audits.go
+++ b/controlplane/monitor/internal/serviceability/audits.go
@@ -1,0 +1,34 @@
+package serviceability
+
+import (
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/mr-tron/base58"
+)
+
+// checkUnlinkedInterfaces checks if an interface is in an unlinked state but is part of an activated link.
+func checkUnlinkedInterfaces(device serviceability.Device, iface serviceability.Interface, links []serviceability.Link) {
+	if iface.Status != serviceability.InterfaceStatusUnlinked {
+		return
+	}
+	for _, link := range links {
+		if link.Status != serviceability.LinkStatusActivated {
+			continue
+		}
+		if link.SideAPubKey == device.PubKey && link.SideAIfaceName == iface.Name {
+			MetricUnlinkedInterfaceErrors.WithLabelValues(
+				base58.Encode(device.PubKey[:]),
+				device.Code,
+				iface.Name,
+				base58.Encode(link.PubKey[:]),
+			).Inc()
+		}
+		if link.SideZPubKey == device.PubKey && link.SideZIfaceName == iface.Name {
+			MetricUnlinkedInterfaceErrors.WithLabelValues(
+				base58.Encode(device.PubKey[:]),
+				device.Code,
+				iface.Name,
+				base58.Encode(link.PubKey[:]),
+			).Inc()
+		}
+	}
+}

--- a/controlplane/monitor/internal/serviceability/metrics.go
+++ b/controlplane/monitor/internal/serviceability/metrics.go
@@ -7,8 +7,9 @@ import (
 
 const (
 	// Metrics names.
-	MetricNameErrors           = "doublezero_monitor_serviceability_errors_total"
-	MetricNameProgramBuildInfo = "doublezero_monitor_serviceability_program_build_info"
+	MetricNameErrors                  = "doublezero_monitor_serviceability_errors_total"
+	MetricNameProgramBuildInfo        = "doublezero_monitor_serviceability_program_build_info"
+	MetricNameUnlinkedInterfaceErrors = "doublezero_monitor_unlinked_interface_errors_total"
 
 	// Labels.
 	MetricLabelErrorType      = "error_type"
@@ -33,5 +34,13 @@ var (
 			Help: "Program build info",
 		},
 		[]string{MetricLabelProgramVersion},
+	)
+
+	MetricUnlinkedInterfaceErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameUnlinkedInterfaceErrors,
+			Help: "Onchain error when a device interface is unlinked but participating in an activated link",
+		},
+		[]string{"device_pubkey", "device_code", "interface_name", "link_pubkey"},
 	)
 )

--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -138,6 +138,13 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 		}
 	}
 
+	if w.cacheDevices != nil || w.cacheLinks != nil {
+		for _, device := range data.Devices {
+			for _, iface := range device.Interfaces {
+				checkUnlinkedInterfaces(device, iface, data.Links)
+			}
+		}
+	}
 	// save current on-chain state for next comparison interval
 	w.cacheLinks = data.Links
 	w.cacheDevices = data.Devices


### PR DESCRIPTION
## Summary of Changes
This adds a counter to monitor to audit whether an interface is in an unlinked state yet part of an activated link.

## Testing Verification

Unlinked interface participating in an activated link:
```
ubuntu@nyc-mn-qa01:~$ doublezero link list | grep Fn2EJucjUakS99N9D4MFcykP7W8uiZ9PmCzBihfBi51s
 Fn2EJucjUakS99N9D4MFcykP7W8uiZ9PmCzBihfBi51s | was001-dz001:was001-dz002  | jump_       | was001-dz001  | Port-Channel2000      | was001-dz002  | Port-Channel2000      | WAN       | 10Gbps    | 9000 | 0.15ms   | 1.00ms    | 5         | 172.16.0.124/31 | activated | H647kAwTcWsGXZUK3BTr1JyTBZmbNcYyCmRFFCEnXUVp

ubuntu@nyc-mn-qa01:~$ doublezero device interface list was001-dz002 | grep Port-Channel2000
 Port-Channel2000      | none          | 0       | 0.0.0.0/0      | 0                | false                | unlinked
```

Timeseries generated for the link:
```
$ curl -s localhost:8080/metrics | grep unlinked 
# HELP doublezero_monitor_unlinked_interface_errors_total Onchain error when a device interface is unlinked but participating in an activated link
# TYPE doublezero_monitor_unlinked_interface_errors_total counter
doublezero_monitor_unlinked_interface_errors_total{device_code="was001-dz002",device_pubkey="DESzDP8GkSTpQLkrUegLkt4S2ynGfZX5bTDzZf3sEE58",interface_name="Port-Channel2000",link_pubkey="Fn2EJucjUakS99N9D4MFcykP7W8uiZ9PmCzBihfBi51s"} 1
```