### PR TITLE
Remove status field from UpdateLinkCliCommand and related structures

### DIFF
--- a/smartcontract/cli/src/link/update.rs
+++ b/smartcontract/cli/src/link/update.rs
@@ -41,9 +41,6 @@ pub struct UpdateLinkCliCommand {
     /// Jitter in milliseconds
     #[arg(long, value_parser = validate_parse_jitter_ms)]
     pub jitter_ms: Option<f64>,
-    /// Updated link status (e.g. Activated, Deactivated)
-    #[arg(long)]
-    pub status: Option<String>,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -76,12 +73,6 @@ impl UpdateLinkCliCommand {
             .transpose()
             .map_err(|e| eyre!("Invalid tunnel type: {e}"))?;
 
-        let status = self
-            .status
-            .map(|s| s.parse())
-            .transpose()
-            .map_err(|e| eyre!("Invalid status: {e}"))?;
-
         let signature = client.update_link(UpdateLinkCommand {
             pubkey,
             code: self.code.clone(),
@@ -93,7 +84,6 @@ impl UpdateLinkCliCommand {
             jitter_ns: self
                 .jitter_ms
                 .map(|jitter_ms| (jitter_ms * 1000000.0) as u64),
-            status,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -197,7 +187,6 @@ mod tests {
                 mtu: Some(1500),
                 delay_ns: Some(10000000),
                 jitter_ns: Some(5000000),
-                status: None,
             }))
             .returning(move |_| Ok(signature));
 
@@ -213,7 +202,6 @@ mod tests {
             delay_ms: Some(10.0),
             jitter_ms: Some(5.0),
             wait: false,
-            status: None,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -649,7 +649,6 @@ mod tests {
                 mtu: Some(1500),
                 delay_ns: Some(10000),
                 jitter_ns: Some(100),
-                status: None,
             }),
             "UpdateLink",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -23,7 +23,6 @@ pub struct LinkUpdateArgs {
     pub mtu: Option<u32>,
     pub delay_ns: Option<u64>,
     pub jitter_ns: Option<u64>,
-    pub status: Option<LinkStatus>,
 }
 
 impl fmt::Debug for LinkUpdateArgs {
@@ -97,9 +96,6 @@ pub fn process_update_link(
     }
     if let Some(jitter_ns) = value.jitter_ns {
         link.jitter_ns = jitter_ns;
-    }
-    if let Some(status) = value.status {
-        link.status = status;
     }
 
     account_write(link_account, &link, payer_account, system_program)?;

--- a/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
@@ -632,7 +632,6 @@ async fn test_dzx_link() {
             mtu: Some(8900),
             delay_ns: Some(1000000),
             jitter_ns: Some(100000),
-            status: None,
         }),
         vec![
             AccountMeta::new(tunnel_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -609,7 +609,6 @@ async fn test_wan_link() {
             mtu: Some(8900),
             delay_ns: Some(1000000),
             jitter_ns: Some(100000),
-            status: None,
         }),
         vec![
             AccountMeta::new(tunnel_pubkey, false),

--- a/smartcontract/sdk/rs/src/commands/link/update.rs
+++ b/smartcontract/sdk/rs/src/commands/link/update.rs
@@ -1,9 +1,8 @@
 use crate::{commands::link::get::GetLinkCommand, DoubleZeroClient, GetGlobalStateCommand};
 use doublezero_program_common::validate_account_code;
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    processors::link::update::LinkUpdateArgs,
-    state::link::{LinkLinkType, LinkStatus},
+    instructions::DoubleZeroInstruction, processors::link::update::LinkUpdateArgs,
+    state::link::LinkLinkType,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
@@ -17,7 +16,6 @@ pub struct UpdateLinkCommand {
     pub mtu: Option<u32>,
     pub delay_ns: Option<u64>,
     pub jitter_ns: Option<u64>,
-    pub status: Option<LinkStatus>,
 }
 
 impl UpdateLinkCommand {
@@ -48,7 +46,6 @@ impl UpdateLinkCommand {
                 mtu: self.mtu,
                 delay_ns: self.delay_ns,
                 jitter_ns: self.jitter_ns,
-                status: self.status,
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),


### PR DESCRIPTION
This pull request removes support for updating the link status via the CLI and underlying SDK and processor logic. The `status` field and related code have been eliminated from command structs, processing logic, and tests, simplifying the update operation to only allow changes to MTU, delay, and jitter.

**Removal of link status update functionality:**

* Removed the `status` field from the `UpdateLinkCliCommand` struct and all related parsing logic in `smartcontract/cli/src/link/update.rs`. [[1]](diffhunk://#diff-d54a23f19fc3bd80a6e150e51854b5b7c259f844899a3b829676e4e89f714befL44-L46) [[2]](diffhunk://#diff-d54a23f19fc3bd80a6e150e51854b5b7c259f844899a3b829676e4e89f714befL79-L84) [[3]](diffhunk://#diff-d54a23f19fc3bd80a6e150e51854b5b7c259f844899a3b829676e4e89f714befL96)
* Deleted `status` from the `LinkUpdateArgs` struct and its update logic in `smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs`. [[1]](diffhunk://#diff-737dd6ec397e2114d508957e1ae997dbed3440f60b4742ffca26636461fcf025L26) [[2]](diffhunk://#diff-737dd6ec397e2114d508957e1ae997dbed3440f60b4742ffca26636461fcf025L101-L103)
* Removed the `status` field from the `UpdateLinkCommand` struct and its usage in `smartcontract/sdk/rs/src/commands/link/update.rs`. [[1]](diffhunk://#diff-f8e3898e3c667e87403c53e5c830e2bef971ab205c8851e09d519a927987233eL20) [[2]](diffhunk://#diff-f8e3898e3c667e87403c53e5c830e2bef971ab205c8851e09d519a927987233eL51)

**Test updates:**

* Cleaned up all test cases to remove references to the `status` field, ensuring tests only cover supported update parameters. [[1]](diffhunk://#diff-d54a23f19fc3bd80a6e150e51854b5b7c259f844899a3b829676e4e89f714befL200) [[2]](diffhunk://#diff-d54a23f19fc3bd80a6e150e51854b5b7c259f844899a3b829676e4e89f714befL216) [[3]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL652) [[4]](diffhunk://#diff-4faa5f93913fd25cf85cc39b77688f822dcdac64956b58397d593f60d88fb32aL635) [[5]](diffhunk://#diff-cabf7c61e8e554a646c8b4949355a8b403a4a672a67d8e498031095786a216faL612)

**Imports cleanup:**

* Removed unused imports related to `LinkStatus` from `smartcontract/sdk/rs/src/commands/link/update.rs`.

## Testing Verification
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
