### PR TITLE
e2e/qa: increase connect + tunnel up timeout

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -685,7 +685,7 @@ func connectHosts(t *testing.T, hosts []string, device *Device) (map[string]stri
 		}
 
 		// Connect with timeout
-		connCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		connCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 		result, err := client.ConnectUnicast(connCtx, req)
 		cancel()
 


### PR DESCRIPTION
## Summary of Changes
- Increase connect + tunnel up timeout from 60s to 90s
- We can see [here](https://doublezero.grafana.net/explore?schemaVersion=1&panes=%7B%22w57%22%3A%7B%22datasource%22%3A%22grafanacloud-logs%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22%7Bcomponent%3D%5C%22loki.source.journal%5C%22%2Cenv%3D%5C%22mainnet-beta%5C%22%2Chostname%3D%5C%22sgp-mn-qa01%5C%22%2Cjob%3D%5C%22loki.source.journal.read%5C%22%2Cservice_name%3D%5C%22loki.source.journal%5C%22%2Cunit%3D%5C%22doublezero-qaagent.service%5C%22%7D%22%2C%22queryType%22%3A%22range%22%2C%22refId%22%3A%22log-row-context-query-_0.9184679996034713%22%2C%22maxLines%22%3A1000%2C%22direction%22%3A%22backward%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22grafanacloud-logs%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221758586219158%22%2C%22to%22%3A%221758586505960%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22id%22%3A%22log-row-context-query-_0.9184679996034713_1758586370606335000_db415788%22%7D%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) in this [run](https://github.com/malbeclabs/infra/actions/runs/17932534455/job/50992427754#logs), it timed out after 30 seconds (12:50 to 13:20) even though the tunnel-up timeout is 60s, because the context given to `ConnectUnicast` has a 60s timeout, which has to account for both the `doublezero connect` and tunnel-up.
- Related to https://github.com/malbeclabs/infra/issues/174