### PR TITLE
Add contributor data to export functionality

### DIFF
--- a/smartcontract/cli/src/export.rs
+++ b/smartcontract/cli/src/export.rs
@@ -58,6 +58,7 @@ struct ExchangeData {
 struct LinkData {
     pub pubkey: String,
     pub code: String,
+    pub iface_name: String,
     pub side: LinkSideData,
     pub tunnel_net: String,
     pub link_type: String,
@@ -75,6 +76,7 @@ struct LinkSideData {
     pub tunnel_id: u16,
     pub tunnel_net: String,
     pub public_ip: String,
+    pub iface_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -146,20 +148,35 @@ impl ExportCliCommand {
                             tunnel.side_a_pk == pubkey || tunnel.side_z_pk == pubkey
                         })
                         .filter_map(|(key, link)| {
+                            let iface_name = if link.side_a_pk == pubkey {
+                                link.side_a_iface_name.clone()
+                            } else {
+                                link.side_z_iface_name.clone()
+                            };
+
                             let side_pubkey = if link.side_a_pk == pubkey {
                                 link.side_z_pk
                             } else {
                                 link.side_a_pk
                             };
+
+                            let iface_name2 = if link.side_a_pk == pubkey {
+                                link.side_z_iface_name.clone()
+                            } else {
+                                link.side_a_iface_name.clone()
+                            };
+
                             let side_device = devices.get(&side_pubkey)?;
 
                             Some(LinkData {
                                 pubkey: key.to_string(),
                                 code: link.code.clone(),
                                 tunnel_net: link.tunnel_net.to_string(),
+                                iface_name,
                                 side: LinkSideData {
                                     name: side_device.code.clone(),
                                     pubkey: side_pubkey.to_string(),
+                                    iface_name: iface_name2,
                                     public_ip: side_device.public_ip.to_string(),
                                     tunnel_id: link.tunnel_id,
                                     tunnel_net: link.tunnel_net.to_string(),


### PR DESCRIPTION
This pull request adds contributor information to the device export functionality in the CLI. The main changes involve fetching contributor data, updating the device data structure to include contributor details, and ensuring contributor information is output during export.

**Export enhancements:**

* Added a `contributor` field to the `DeviceData` struct to store contributor information for each device.
* Updated the export logic to fetch contributors using `ListContributorCommand` and retrieve contributor details for each device. [[1]](diffhunk://#diff-b1fc0e1fad86c28a689b0a58130bb31d6d02b6a7b60d3179613912a501ef6dc2R98) [[2]](diffhunk://#diff-b1fc0e1fad86c28a689b0a58130bb31d6d02b6a7b60d3179613912a501ef6dc2R113-R123)
* Modified the export output to include the contributor code for each device.

**Imports and dependencies:**

* Added the `contributor` module to the list of imports in the file to support contributor-related commands.

## Testing Verification
* Show evidence of testing the change
