### PR TITLE
controller: cleanup log spam

### DIFF
--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -556,10 +556,6 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		}
 	}
 
-	if len(unknownPeers) != 0 {
-		slog.Info("device returned unknown peers to be deleted", "device pubkey", req.GetPubkey(), "number of unknown peers", len(unknownPeers), "peers", unknownPeers)
-	}
-
 	multicastGroupBlock := formatCIDR(&c.cache.Config.MulticastGroupBlock)
 
 	// This check avoids the situation where the template produces the following useless output, which happens in any test case with a single DZD.


### PR DESCRIPTION
## Summary of Changes
The controller spams "device returned unknown peers" every time a user disconnects from the network. This isn't useful as peers being unknown are a normal step prior to config removal on the device.

## Testing Verification
Send unknown peers to the controller:
```
$ ./bin/controller agent -controller-port 8080 -device-pubkey 8PQkip3CxWhQTdP7doCyhT2kwjSL2csRTdnRg2zbDPs1 -unknown-peers 169.254.1.1
```

No message is logged:
```
$ ./bin/controller start -env devnet
{"time":"2025-09-24T18:47:28.174692003Z","level":"INFO","msg":"starting controller","mode":"no-tls","address":"localhost:8080"}
{"time":"2025-09-24T18:47:28.175090461Z","level":"INFO","msg":"starting fetch of on-chain data","mode":"no-tls","program-id":"GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah"}
```