### PR TITLE
feat: hide status argument in UpdateLinkCliCommand and enforce foundation allowlist for status updates

### DIFF
--- a/smartcontract/cli/src/link/update.rs
+++ b/smartcontract/cli/src/link/update.rs
@@ -42,7 +42,7 @@ pub struct UpdateLinkCliCommand {
     #[arg(long, value_parser = validate_parse_jitter_ms)]
     pub jitter_ms: Option<f64>,
     /// Updated link status (e.g. Activated, Deactivated)
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub status: Option<String>,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -99,6 +99,10 @@ pub fn process_update_link(
         link.jitter_ns = jitter_ns;
     }
     if let Some(status) = value.status {
+        // Only allow to update the status if the payer is in the foundation allowlist
+        if !globalstate.foundation_allowlist.contains(payer_account.key) {
+            return Err(DoubleZeroError::NotAllowed.into());
+        }
         link.status = status;
     }
 


### PR DESCRIPTION
This pull request introduces a security improvement to the link update flow by restricting who can update the link status, and also makes a minor CLI change to hide the `status` field from help output.

Security and access control:

* Added a check in `process_update_link` (`smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs`) to ensure only accounts in the foundation allowlist can update the link status. If the payer is not allowed, the operation fails with a `NotAllowed` error.

CLI usability:

* Updated the `UpdateLinkCliCommand` struct (`smartcontract/cli/src/link/update.rs`) to hide the `status` argument from the CLI help output, making it less discoverable for general users.

## Testing Verification
* Show evidence of testing the change
