### PR TITLE
monitor: support nil twozoracle watcher for devnet

### DIFF
--- a/controlplane/monitor/internal/worker/config.go
+++ b/controlplane/monitor/internal/worker/config.go
@@ -57,9 +57,6 @@ func (c *Config) Validate() error {
 	if c.Interval <= 0 {
 		return errors.New("interval must be greater than 0")
 	}
-	if c.TwoZOracleClient == nil {
-		return errors.New("twoz oracle client is required")
-	}
 	if c.TwoZOracleInterval <= 0 {
 		return errors.New("twoz oracle interval must be greater than 0")
 	}

--- a/controlplane/monitor/internal/worker/config_test.go
+++ b/controlplane/monitor/internal/worker/config_test.go
@@ -90,6 +90,20 @@ func TestMonitor_Worker_Config(t *testing.T) {
 		c.Interval = 0
 		require.Error(t, c.Validate())
 	})
+
+	t.Run("twoz oracle can be nil", func(t *testing.T) {
+		t.Parallel()
+		c := *valid
+		c.TwoZOracleClient = nil
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("non-positive twoz oracle interval fails", func(t *testing.T) {
+		t.Parallel()
+		c := *valid
+		c.TwoZOracleInterval = 0
+		require.Error(t, c.Validate())
+	})
 }
 
 func newTestLogger(t *testing.T) *slog.Logger {


### PR DESCRIPTION
## Summary of Changes
- Update monitor to support nil 2z oracle watcher for devnet, which doesn't have a 2z oracle and so the watcher is disabled there
- Follow up on https://github.com/malbeclabs/doublezero/pull/1737

## Testing Verification
- Added monitor test coverage for config with nil 2z oracle watcher
