### PR TITLE
monitor/2zoracle: emit response code metrics on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Monitor
+    - Update 2Z oracle to emit response code metrics on errors too
+
 ## [v0.6.5](https://github.com/malbeclabs/doublezero/compare/client/v0.6.4...client/v0.6.5) – 2025-09-25
 
 ### Breaking

--- a/controlplane/monitor/internal/2z-oracle/watcher.go
+++ b/controlplane/monitor/internal/2z-oracle/watcher.go
@@ -59,6 +59,9 @@ func (w *TwoZOracleWatcher) Tick(ctx context.Context) error {
 
 	health, statusCode, err := w.cfg.Client.Health(ctx)
 	if err != nil {
+		if statusCode != 0 {
+			MetricHealthResponse.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+		}
 		MetricErrors.WithLabelValues(MetricErrorTypeGetHealth, strconv.Itoa(statusCode)).Inc()
 		w.log.Error("failed to get health", "error", err)
 		return fmt.Errorf("failed to get health: %w", err)
@@ -72,6 +75,9 @@ func (w *TwoZOracleWatcher) Tick(ctx context.Context) error {
 
 	swapRate, statusCode, err := w.cfg.Client.SwapRate(ctx)
 	if err != nil {
+		if statusCode != 0 {
+			MetricSwapRateResponse.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+		}
 		MetricErrors.WithLabelValues(MetricErrorTypeGetSwapRate, strconv.Itoa(statusCode)).Inc()
 		w.log.Error("failed to get swap rate", "error", err)
 		return fmt.Errorf("failed to get swap rate: %w", err)


### PR DESCRIPTION
## Summary of Changes
- Update monitor's 2zoracle watcher to emit metrics with response status codes on errors too, where previously it was only emitting error metrics in this case and returning, but it's useful to have a view of all http response status codes being returned in a metric
