### PR TITLE
controller: return detailed errors to agent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 * Explain why the change is necessary
 * Note any metrics that were exposed in this PR
 * Is there supporting documentation or external resources that explain the change?
+* Is a CHANGELOG.md update needed?
 
 ## Testing Verification
 * Show evidence of testing the change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Internet telemetry
+    - Add circuit label to metrics; create a new metric for missing circuit samples
     - Submit partitions of samples in parallel
     - Include circuit label on submitter error metric
 - Monitor
     - Reduce logging noise in 2z oracle watcher
+- Device controller
+    - When a device is missing required loopback interfaces, provide detailed errors to agent instead of "<pubkey> not found". Also, log these conditions as warnings instead of errors, and don't emit "unknown pubkey requested" error metrics for these conditions
 
 ## [v0.6.6](https://github.com/malbeclabs/doublezero/compare/client/v0.6.5...client/v0.6.6) – 2025-09-26
 

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -180,10 +180,12 @@ type Device struct {
 	Interfaces            []Interface
 	MgmtVrf               string
 	IsisNet               string
+	DevicePathologies     []string
 }
 
 func NewDevice(ip net.IP, publicKey string) *Device {
 	tunnels := []*Tunnel{}
+	devicePathologies := []string{}
 	for i := 0; i < config.MaxUserTunnelSlots; i++ {
 		id := config.StartUserTunnelNum + i
 		tunnel := &Tunnel{
@@ -193,10 +195,11 @@ func NewDevice(ip net.IP, publicKey string) *Device {
 		tunnels = append(tunnels, tunnel)
 	}
 	return &Device{
-		PublicIP:    ip,
-		PubKey:      publicKey,
-		Tunnels:     tunnels,
-		TunnelSlots: config.MaxUserTunnelSlots,
+		PublicIP:          ip,
+		PubKey:            publicKey,
+		Tunnels:           tunnels,
+		TunnelSlots:       config.MaxUserTunnelSlots,
+		DevicePathologies: devicePathologies,
 	}
 }
 


### PR DESCRIPTION
## Summary of Changes
* When a device has known pathologies, like missing loopback interfaces, return the details to the agent
* Today the controller returns a generic `<pubkey> not found` error, which is not useful for contributors
* One or more of the following errors will now be returned:
    * "no or invalid VPNv4 loopback interface found for device"
    * "no or invalid IPv4 loopback interface found for device"
    * "VPNv4 loopback interface is unassigned (0.0.0.0)"
    * "IPv4 loopback interface is unassigned (0.0.0.0)"
    * "ISIS NET could not be generated"

Previously the agent would log:
```
2025/09/25 21:11:17.810726 dzclient.go:29: Error calling GetConfig: rpc error: code = NotFound desc = pubkey 9Lkn7hnX2pm4pLzyj4QoCi9Kd3oNkpZ35651Fcj5h71E not found 2025/09/25 21:11:17.810747 main.go:54: pollControllerAndConfigureDevice failed to call agent.GetConfigFromServer: "rpc error: code = NotFound desc = pubkey 9Lkn7hnX2pm4pLzyj4QoCi9Kd3oNkpZ35651Fcj5h71E not found" 2025/09/25 21:11:17.810755 main.go:131: ERROR: pollAndConfigureDevice returned rpc error: code = NotFound desc = pubkey 9Lkn7hnX2pm4pLzyj4QoCi9Kd3oNkpZ35651Fcj5h71E not found
```

Now the agent logs:
```
2025/09/27 19:01:57.524575 main.go:54: pollControllerAndConfigureDevice failed to call agent.GetConfigFromServer: "rpc error: code = FailedPrecondition desc = cannot render config for device 8scDVeZ8aB1TRTkBqaZgzxuk7WwpARdF1a39wYA7nR3W: [no or invalid IPv4 loopback interface found for device]"
2025/09/27 19:01:57.524582 main.go:131: ERROR: pollAndConfigureDevice returned rpc error: code = FailedPrecondition desc = cannot render config for device 8scDVeZ8aB1TRTkBqaZgzxuk7WwpARdF1a39wYA7nR3W: [no or invalid IPv4 loopback interface found for device]
```
* This change also stops the controller from logging errors and emitting error metrics on these conditions. 
## Testing Verification
* Unit test updates
