### PR TITLE
qa/agent: disable keep-alives in fetchstatus

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -449,6 +449,9 @@ func fetchStatus(ctx context.Context) ([]StatusResponse, error) {
 				dialer := net.Dialer{}
 				return dialer.DialContext(ctx, "unix", sockFile)
 			},
+
+			// Disable keep-alives to avoid accumulating goroutines.
+			DisableKeepAlives: true,
 		},
 		Timeout: 5 * time.Second,
 	}


### PR DESCRIPTION
## Summary of Changes
- Update QA agent `fetchStatus` http transport to disable keep-alives to avoid accumulating goroutines. The fetch status connections are one-time and short-lived anyway, so there's no need for keep-alives.
