### PR TITLE
release: send daily release alerts to devnet

### DIFF
--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -61,4 +61,4 @@ jobs:
           SLACK_USERNAME: Doublezero Releaser
           SLACK_TITLE: Daily Release Failure
           MSG_MINIMAL: actions url
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DEVNET_ALERTS_WEBHOOK }}


### PR DESCRIPTION
## Summary of Changes
We send notifications for daily release failures to #alerts. They need to go to #alerts-devnet now. This does that.

## Testing Verification
[* Show evidence of testing the change](https://malbeclabs.slack.com/archives/C09FT2ZE4GJ/p1759157498048089)
