### PR TITLE
qa: set 10s ping timeout

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -802,6 +802,7 @@ func testAllToAllConnectivity(t *testing.T, hostIPMap map[string]string, useRetr
 					SourceIp:    sourceIP,
 					SourceIface: "doublezero0",
 					PingType:    pb.PingRequest_ICMP,
+					Timeout:     10,
 				}
 				pingResp, err := client.Ping(ctx, pingReq)
 				cancel()


### PR DESCRIPTION
## Summary of Changes
We don't set a ping timeout in the request on Ping RPC calls. This may be causing failed connectivity checks to fail due to an RPC timeout instead of a ping timeout since there isn't one set.

## Testing Verification
[* Show evidence of testing the change](https://github.com/malbeclabs/doublezero/actions/runs/18102427651/job/51511482121)
