### PR TITLE
client: max user check not being applied in the multicast connect workflow

### DIFF
--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -21,7 +21,7 @@ use doublezero_sdk::{
             get::GetUserCommand, list::ListUserCommand, update::UpdateUserCommand,
         },
     },
-    Device, DeviceStatus, User, UserCYOA, UserStatus, UserType,
+    Device, User, UserCYOA, UserStatus, UserType,
 };
 use eyre;
 use indicatif::ProgressBar;
@@ -348,10 +348,8 @@ impl ProvisioningCliCommand {
         let users = client.list_user(ListUserCommand)?;
         let mut devices = client.list_device(ListDeviceCommand)?;
 
-        // Filter devices activated
-        devices.retain(|_, d| {
-            d.status == DeviceStatus::Activated && (d.max_users > 0 && d.users_count < d.max_users)
-        });
+        // Filter to retain only activated devices with available user slots
+        devices.retain(|_, d| d.is_device_eligible_for_provisioning());
 
         let matched_users = users
             .iter()
@@ -449,12 +447,10 @@ impl ProvisioningCliCommand {
         spinner.inc(1);
 
         let users = client.list_user(ListUserCommand)?;
-        let devices = client.list_device(ListDeviceCommand)?;
+        let mut devices = client.list_device(ListDeviceCommand)?;
 
-        // Filter devices activated
-        devices.retain(|_, d| {
-            d.status == DeviceStatus::Activated && (d.max_users > 0 && d.users_count < d.max_users)
-        });
+        // Filter to retain only activated devices with available user slots
+        devices.retain(|_, d| d.is_device_eligible_for_provisioning());
 
         let matched_users = users
             .iter()

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -389,6 +389,11 @@ impl Device {
             .find(|(_, iface)| iface.name.eq_ignore_ascii_case(name))
             .ok_or_else(|| format!("Interface with name '{name}' not found"))
     }
+
+    pub fn is_device_eligible_for_provisioning(&self) -> bool {
+        self.status == DeviceStatus::Activated
+            && (self.max_users > 0 && self.users_count < self.max_users)
+    }
 }
 
 impl fmt::Display for Device {


### PR DESCRIPTION
This pull request introduces a device filtering step to the provisioning command logic, ensuring that only eligible devices are considered for further actions. The main change is the addition of a filter that retains only devices that are activated and have available user slots.

Device filtering logic:

* In `client/doublezero/src/command/connect.rs`, within the `ProvisioningCliCommand` implementation, added a filter to retain only devices with `DeviceStatus::Activated` and where `users_count` is less than `max_users` and `max_users` is greater than zero.