### PR TITLE
qa: raise wait time after disconnect

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -585,8 +585,8 @@ func runUnicastConnectivityTest(t *testing.T, hosts []string, devices []*Device)
 
 	for i, device := range devices {
 		if i > 0 {
-			t.Logf("Waiting 5 seconds before next connection attempt...")
-			time.Sleep(5 * time.Second)
+			t.Logf("Waiting 30 seconds before next connection attempt...")
+			time.Sleep(30 * time.Second)
 		}
 
 		t.Logf("Attempting to connect %s to device %s", firstHost, device.Code)


### PR DESCRIPTION
## Summary of Changes
In order to avoid a temporary race in the CLI, we need to wait longer between each disconnect/reconnect iteration.

## Testing Verification
N/A
