### PR TITLE
activator: no get_all before subscribe

### DIFF
--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -100,10 +100,10 @@ pub async fn get_snapshot_poll(
     stop_signal: Arc<AtomicBool>,
 ) -> eyre::Result<()> {
     while !stop_signal.load(std::sync::atomic::Ordering::Relaxed) {
-        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
         for (pubkey, data) in client.get_all()? {
             tx.send((pubkey, data, false)).await?;
         }
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary of Changes
- Reduce logging noise by replacing `gets_and_subscribe` with just `subscribe` in activator `process_events_thread`, since we do a snapshot event backfill from the full state every 60s anyway
- Make activator snapshot backfill happen immediately then wait/sleep, as opposed to waiting then doing it, so that it runs immediately on start up
- Related to https://github.com/malbeclabs/infra/issues/219

## Testing Verification
- Existing test coverage
