### PR TITLE
qa: wait 30s to avoid race

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -633,6 +633,7 @@ func runUnicastConnectivityTest(t *testing.T, hosts []string, devices []*Device)
 			if !result.Success {
 				t.Errorf("Device %s failed: %s", device.Code, result.Error)
 			}
+			time.Sleep(30 * time.Second) // wait 30s between devices to avoid race in client diconnect/connect
 		})
 	}
 


### PR DESCRIPTION
## Summary of Changes
We need to wait 30s after each device disconnect to avoid a client disconnect/connect race.

## Testing Verification
N/A
