### PR TITLE
Add User Deprovisioning Monitor and CLI Account Retrieval Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Added a wait in the `disconnect` command to ensure the account is fully closed before returning, preventing failures during rapid disconnect/reconnect sequences.
+
 - Activator
     - Reduce logging noise when processing snapshot events
     - Wrap main select handler in loop to avoid shutdown on branch error

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -99,7 +99,7 @@ use doublezero_serviceability::state::{
     accesspass::AccessPass, contributor::Contributor, programconfig::ProgramConfig,
 };
 use mockall::automock;
-use solana_sdk::{pubkey::Pubkey, signature::Signature};
+use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signature};
 use std::collections::HashMap;
 
 #[automock]
@@ -117,6 +117,7 @@ pub trait CliCommand {
     fn get_balance(&self) -> eyre::Result<u64>;
     fn get_epoch(&self) -> eyre::Result<u64>;
     fn get_logs(&self, pubkey: &Pubkey) -> eyre::Result<Vec<String>>;
+    fn get_account(&self, pubkey: Pubkey) -> eyre::Result<Account>;
 
     fn init_globalstate(&self, cmd: InitGlobalStateCommand) -> eyre::Result<Signature>;
     fn get_globalstate(&self, cmd: GetGlobalStateCommand) -> eyre::Result<(Pubkey, GlobalState)>;
@@ -321,6 +322,9 @@ impl CliCommand for CliCommandImpl<'_> {
     }
     fn get_logs(&self, pubkey: &Pubkey) -> eyre::Result<Vec<String>> {
         self.client.get_logs(pubkey)
+    }
+    fn get_account(&self, pubkey: Pubkey) -> eyre::Result<Account> {
+        self.client.get_account(pubkey)
     }
 
     fn init_globalstate(&self, cmd: InitGlobalStateCommand) -> eyre::Result<Signature> {

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -14,6 +14,7 @@ use solana_client::{
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
 };
 use solana_sdk::{
+    account::Account,
     commitment_config::CommitmentConfig,
     instruction::{AccountMeta, Instruction, InstructionError},
     program_error::ProgramError,
@@ -122,6 +123,10 @@ impl DZClient {
             .get_epoch_info()
             .map_err(|e| eyre!(e))
             .map(|info| info.epoch)
+    }
+
+    pub fn get_account(&self, pubkey: Pubkey) -> eyre::Result<Account> {
+        self.client.get_account(&pubkey).map_err(|e| eyre!(e))
     }
 
     /******************************************************************************************************************************************/


### PR DESCRIPTION
This pull request introduces a new mechanism for monitoring the deprovisioning of user accounts, along with supporting changes to expose account retrieval functionality through the CLI and client layers. The main focus is on improving feedback during user account deletion by checking the account status in a loop and updating the CLI interface accordingly.

**Deprovisioning workflow improvements:**

* Added a loop in `DecommissioningCliCommand` (`disconnect.rs`) to poll the user account status after deletion, providing more granular feedback ("deleting...", "closed", or "deprovisioned") to the user as the account state changes.

**CLI and client interface enhancements:**

* Extended the `CliCommand` trait to include a new `get_account` method for retrieving account details by public key.
* Implemented the `get_account` method in `CliCommandImpl`, delegating the call to the underlying client.
* Added the `get_account` method to `DZClient`, allowing retrieval of account information from the Solana RPC client.

**Dependency updates:**

* Included the `account::Account` import from `solana_sdk` in relevant files to support the new account retrieval methods. [[1]](diffhunk://#diff-430587015023e7ac3057101cd2e2553b6b773181e0c6aec15c42b22d01dd132eL102-R102) [[2]](diffhunk://#diff-b0decf3341561973c730de1be7d3c81a98ae032c15eb2ca322b39adc624dc7a5R17)

## Testing Verification
* test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s