### PR TITLE
qa: accommodate race in the client

### DIFF
--- a/e2e/qa_test.go
+++ b/e2e/qa_test.go
@@ -417,6 +417,7 @@ func disconnectUsers(t *testing.T, hosts []string) {
 			require.NoError(t, err, "Disconnect failed")
 		})
 	}
+	time.Sleep(30 * time.Second) // TODO: remove this after the race in the client is fixed
 }
 
 func removeMulticastGroup(t *testing.T, code, publisher string) {


### PR DESCRIPTION
## Summary of Changes
In the post-deploy QA test, we need to pause after disconnect to accomodate the race in the client.

## Testing Verification
N/A
