### PR TITLE
device/telemetry: submit partitions in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Added a wait in the `disconnect` command to ensure the account is fully closed before returning, preventing failures during rapid disconnect/reconnect sequences.
-
+- CLI
+    - Added a wait in the `disconnect` command to ensure the account is fully closed before returning, preventing failures during rapid disconnect/reconnect sequences.
 - Activator
     - Reduce logging noise when processing snapshot events
     - Wrap main select handler in loop to avoid shutdown on branch error
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - Device controller
     - When a device is missing required loopback interfaces, provide detailed errors to agent instead of "<pubkey> not found". Also, log these conditions as warnings instead of errors, and don't emit "unknown pubkey requested" error metrics for these conditions
     - Add device info as labels to `controller_grpc_getconfig_requests_total` metric
+- Device agents
+    - Submit device-link telemetry partitions in parallel
 
 ## [v0.6.6](https://github.com/malbeclabs/doublezero/compare/client/v0.6.5...client/v0.6.6) – 2025-09-26
 

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -27,17 +27,17 @@ import (
 )
 
 const (
-	defaultProbeInterval         = 10 * time.Second
-	defaultSubmissionInterval    = 60 * time.Second
-	defaultTWAMPListenPort       = telemetryconfig.TWAMPListenPort
-	defaultTWAMPReflectorTimeout = 1 * time.Second
-	defaultPeersRefreshInterval  = 10 * time.Second
-	defaultTWAMPSenderTimeout    = 1 * time.Second
-	defaultSenderTTL             = 5 * time.Minute
-	defaultLedgerRPCURL          = ""
-	defaultProgramId             = ""
-	defaultLocalDevicePubkey     = ""
-	defaultAristaEAPIGRPCAddress = "127.0.0.1:9543"
+	defaultProbeInterval           = 10 * time.Second
+	defaultSubmissionInterval      = 60 * time.Second
+	defaultTWAMPListenPort         = telemetryconfig.TWAMPListenPort
+	defaultTWAMPReflectorTimeout   = 1 * time.Second
+	defaultPeersRefreshInterval    = 10 * time.Second
+	defaultTWAMPSenderTimeout      = 1 * time.Second
+	defaultSenderTTL               = 5 * time.Minute
+	defaultLedgerRPCURL            = ""
+	defaultProgramId               = ""
+	defaultLocalDevicePubkey       = ""
+	defaultSubmitterMaxConcurrency = 10
 
 	waitForNamespaceTimeout = 30 * time.Second
 )
@@ -56,6 +56,7 @@ var (
 	twampReflectorTimeout   = flag.Duration("twamp-reflector-timeout", defaultTWAMPReflectorTimeout, "The timeout for the twamp reflector.")
 	peersRefreshInterval    = flag.Duration("peers-refresh-interval", defaultPeersRefreshInterval, "The interval to refresh the peer discovery.")
 	senderTTL               = flag.Duration("sender-ttl", defaultSenderTTL, "The time to live for a sender instance until it's recreated.")
+	submitterMaxConcurrency = flag.Int("submitter-max-concurrency", defaultSubmitterMaxConcurrency, "The maximum number of concurrent submissions.")
 	managementNamespace     = flag.String("management-namespace", "", "The name of the management namespace to use for ledger communication. If not provided, the default namespace will be used. (default: '')")
 	verbose                 = flag.Bool("verbose", false, "Enable verbose logging.")
 	showVersion             = flag.Bool("version", false, "Print the version of the doublezero-agent and exit.")
@@ -270,7 +271,8 @@ func main() {
 			}
 			return epochInfo.Epoch, nil
 		},
-		SenderTTL: *senderTTL,
+		SenderTTL:               *senderTTL,
+		SubmitterMaxConcurrency: *submitterMaxConcurrency,
 	})
 	if err != nil {
 		log.Error("failed to create telemetry collector", "error", err)

--- a/controlplane/telemetry/internal/telemetry/collector_test.go
+++ b/controlplane/telemetry/internal/telemetry/collector_test.go
@@ -267,14 +267,15 @@ func TestAgentTelemetry_Collector(t *testing.T) {
 		})
 
 		collector, err := telemetry.New(log, telemetry.Config{
-			LocalDevicePK:          devicePK,
-			ProbeInterval:          100 * time.Millisecond,
-			SubmissionInterval:     250 * time.Millisecond,
-			TWAMPSenderTimeout:     250 * time.Millisecond,
-			SenderTTL:              1 * time.Millisecond,
-			TWAMPReflector:         reflector,
-			PeerDiscovery:          peerDiscovery,
-			TelemetryProgramClient: telemetryProgram,
+			LocalDevicePK:           devicePK,
+			ProbeInterval:           100 * time.Millisecond,
+			SubmissionInterval:      250 * time.Millisecond,
+			TWAMPSenderTimeout:      250 * time.Millisecond,
+			SenderTTL:               1 * time.Millisecond,
+			SubmitterMaxConcurrency: 10,
+			TWAMPReflector:          reflector,
+			PeerDiscovery:           peerDiscovery,
+			TelemetryProgramClient:  telemetryProgram,
 			GetCurrentEpochFunc: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -454,15 +455,16 @@ func TestAgentTelemetry_Collector(t *testing.T) {
 
 		// Small TTL so we can force rotation quickly; run fast probes.
 		collector, err := telemetry.New(log, telemetry.Config{
-			LocalDevicePK:          devicePK,
-			ProbeInterval:          75 * time.Millisecond,
-			SubmissionInterval:     200 * time.Millisecond,
-			TWAMPSenderTimeout:     200 * time.Millisecond,
-			TWAMPReflector:         reflector,
-			PeerDiscovery:          peerDiscovery,
-			TelemetryProgramClient: telemetryProgram,
-			GetCurrentEpochFunc:    func(ctx context.Context) (uint64, error) { return 100, nil },
-			SenderTTL:              250 * time.Millisecond,
+			LocalDevicePK:           devicePK,
+			ProbeInterval:           75 * time.Millisecond,
+			SubmissionInterval:      200 * time.Millisecond,
+			TWAMPSenderTimeout:      200 * time.Millisecond,
+			SubmitterMaxConcurrency: 10,
+			TWAMPReflector:          reflector,
+			PeerDiscovery:           peerDiscovery,
+			TelemetryProgramClient:  telemetryProgram,
+			GetCurrentEpochFunc:     func(ctx context.Context) (uint64, error) { return 100, nil },
+			SenderTTL:               250 * time.Millisecond,
 			NowFunc: func() time.Time {
 				nowMu.Lock()
 				defer nowMu.Unlock()
@@ -568,14 +570,15 @@ func newTestCollector(t *testing.T, log *slog.Logger, localDevicePK solana.Publi
 	peerDiscovery.UpdatePeers(t, peers)
 
 	collector, err := telemetry.New(log, telemetry.Config{
-		LocalDevicePK:          localDevicePK,
-		ProbeInterval:          100 * time.Millisecond,
-		SubmissionInterval:     submissionInterval,
-		TWAMPSenderTimeout:     1 * time.Second,
-		SenderTTL:              1 * time.Millisecond,
-		TWAMPReflector:         reflector,
-		PeerDiscovery:          peerDiscovery,
-		TelemetryProgramClient: telemetryProgramClient,
+		LocalDevicePK:           localDevicePK,
+		ProbeInterval:           100 * time.Millisecond,
+		SubmissionInterval:      submissionInterval,
+		TWAMPSenderTimeout:      1 * time.Second,
+		SenderTTL:               1 * time.Millisecond,
+		SubmitterMaxConcurrency: 10,
+		TWAMPReflector:          reflector,
+		PeerDiscovery:           peerDiscovery,
+		TelemetryProgramClient:  telemetryProgramClient,
 		GetCurrentEpochFunc: func(ctx context.Context) (uint64, error) {
 			return 100, nil
 		},

--- a/controlplane/telemetry/internal/telemetry/config.go
+++ b/controlplane/telemetry/internal/telemetry/config.go
@@ -42,6 +42,9 @@ type Config struct {
 
 	// SenderTTL is the time to live for a sender instance until it's recreated.
 	SenderTTL time.Duration
+
+	// SubmitterMaxConcurrency is the maximum number of concurrent submissions.
+	SubmitterMaxConcurrency int
 }
 
 func (c *Config) Validate() error {
@@ -76,6 +79,9 @@ func (c *Config) Validate() error {
 	}
 	if c.SenderTTL <= 0 {
 		return errors.New("sender ttl must be greater than 0")
+	}
+	if c.SubmitterMaxConcurrency <= 0 {
+		return errors.New("submitter max concurrency must be greater than 0")
 	}
 	return nil
 }

--- a/controlplane/telemetry/internal/telemetry/submitter_test.go
+++ b/controlplane/telemetry/internal/telemetry/submitter_test.go
@@ -54,11 +54,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, newTestSample())
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour, // unused
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   1,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour, // unused
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -97,11 +98,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		})
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour, // unused
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   5,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour, // unused
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    5,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -140,11 +142,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		})
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour, // unused
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   5,
-			BackoffFunc:   func(_ int) time.Duration { return 10 * time.Millisecond },
+			Interval:       time.Hour, // unused
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    5,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 10 * time.Millisecond },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -181,11 +184,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour, // unused
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   3,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour, // unused
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    3,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -226,11 +230,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   3,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    3,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -271,11 +276,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   5,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    5,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -316,10 +322,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		defer cancel()
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   5,
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    5,
+			MaxConcurrency: 10,
 			BackoffFunc: func(_ int) time.Duration {
 				cancel() // cancel immediately after first failure
 				return 10 * time.Millisecond
@@ -364,11 +371,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		}
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   1,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -402,11 +410,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		telemetryProgram := &mockTelemetryProgramClient{}
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   1,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return currentEpoch, nil
 			},
@@ -441,11 +450,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](1024)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   1,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -517,11 +527,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   1,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -546,10 +557,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 
 		var attempts int
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:    time.Hour,
-			Buffer:      buffer,
-			MaxAttempts: 1,
-			BackoffFunc: func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			ProgramClient: &mockTelemetryProgramClient{
 				WriteDeviceLatencySamplesFunc: func(ctx context.Context, _ sdktelemetry.WriteDeviceLatencySamplesInstructionConfig) (solana.Signature, *solanarpc.GetTransactionResult, error) {
 					return solana.Signature{}, nil, nil
@@ -584,10 +596,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		var submissionCalled bool
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:    time.Hour,
-			Buffer:      buffer,
-			MaxAttempts: 1,
-			BackoffFunc: func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			ProgramClient: &mockTelemetryProgramClient{
 				WriteDeviceLatencySamplesFunc: func(ctx context.Context, _ sdktelemetry.WriteDeviceLatencySamplesInstructionConfig) (solana.Signature, *solanarpc.GetTransactionResult, error) {
 					submissionCalled = true
@@ -630,11 +643,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   3,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    3,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -677,11 +691,12 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buffer.Add(key, sample)
 
 		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval:      time.Hour,
-			Buffer:        buffer,
-			ProgramClient: telemetryProgram,
-			MaxAttempts:   2,
-			BackoffFunc:   func(_ int) time.Duration { return 0 },
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    2,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
 				return 100, nil
 			},
@@ -718,6 +733,7 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 			Buffer:          buf,
 			ProgramClient:   telemetryProgram,
 			MaxAttempts:     1,
+			MaxConcurrency:  10,
 			BackoffFunc:     func(_ int) time.Duration { return 0 },
 			GetCurrentEpoch: func(context.Context) (uint64, error) { return 100, nil },
 		})
@@ -751,7 +767,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buf.Add(key, first)
 
 		s, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval: time.Hour, Buffer: buf, ProgramClient: prog, MaxAttempts: 1,
+			Interval:        time.Hour,
+			Buffer:          buf,
+			ProgramClient:   prog,
+			MaxAttempts:     1,
+			MaxConcurrency:  10,
 			BackoffFunc:     func(int) time.Duration { return 0 },
 			GetCurrentEpoch: func(context.Context) (uint64, error) { return 100, nil },
 		})
@@ -778,7 +798,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buf.Add(key, newTestSample())
 
 		s, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval: time.Hour, Buffer: buf, ProgramClient: prog, MaxAttempts: 1,
+			Interval:        time.Hour,
+			Buffer:          buf,
+			ProgramClient:   prog,
+			MaxAttempts:     1,
+			MaxConcurrency:  10,
 			BackoffFunc:     func(int) time.Duration { return 0 },
 			GetCurrentEpoch: func(context.Context) (uint64, error) { return 100, nil },
 		})
@@ -816,7 +840,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		buf.Add(key, second)
 
 		s, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
-			Interval: time.Hour, Buffer: buf, ProgramClient: prog, MaxAttempts: 2,
+			Interval:        time.Hour,
+			Buffer:          buf,
+			ProgramClient:   prog,
+			MaxAttempts:     2,
+			MaxConcurrency:  10,
 			BackoffFunc:     func(int) time.Duration { return 0 },
 			GetCurrentEpoch: func(context.Context) (uint64, error) { return 100, nil },
 		})


### PR DESCRIPTION
## Summary of Changes
- Update device telemetry agent to submit partitions of samples in parallel instead of sequentially, with a max concurrency of 10, similar to https://github.com/malbeclabs/doublezero/pull/1772
- Simplify and fix flush on close logic, pass a new context with 30s timeout
- Resolves https://github.com/malbeclabs/doublezero/issues/1773

## Testing Verification
- Updated existing test coverage to match changes
