### PR TITLE
release: fix qaagent daily version format

### DIFF
--- a/release/.goreleaser.base.qa-agent.yaml
+++ b/release/.goreleaser.base.qa-agent.yaml
@@ -51,3 +51,13 @@ announce:
     enabled: true
     message_template: "DoubleZero QA Agent {{.Tag}} has been released! Check it out at {{ .ReleaseURL }}"
     channel: "#bots"
+
+git:
+  ignore_tags:
+    - qaagent/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
+  tag_name: 'qaagent/daily'


### PR DESCRIPTION
## Summary of Changes
- Fix QA agent daily release version format to include the build date so that it sorts correct and latest is reliably installed on deploy
- We're currently seeing version formats like `2.1.7~ccdc3b67-nightly-1` which doesn't include the build date
