### PR TITLE
Validate public IP doesn't clash with dz_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
   - Standardized the `device_type` enum to `Edge`, `Transit`, and `Hybrid`, added validation rules, and defaulted existing devices to `Hybrid` for backward compatibility.
   - Add `contributor.ops_manager_key` for authorizing incident management operations.
   - Enable on-chain storage of InterfaceV2, allowing devices to register updated interface metadata
+  - Serviceability: validate that a device's public IP doesn't clash with its dz_prefixes
 - QA
   - Traceroute when packet loss is detected
 - Tools

--- a/e2e/device_telemetry_test.go
+++ b/e2e/device_telemetry_test.go
@@ -171,10 +171,10 @@ func TestE2E_DeviceTelemetry(t *testing.T) {
 	log.Info("==> Adding dummy devices onchain")
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
 			set -euo pipefail
-			doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29" --mgmt-vrf mgmt
-			doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29" --mgmt-vrf mgmt
-			doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.104/29" --mgmt-vrf mgmt
-			doublezero device create --code ty2-dz01 --contributor co01 --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "180.87.154.112/29" --mgmt-vrf mgmt
+			doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.80/29" --mgmt-vrf mgmt
+			doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.96/29" --mgmt-vrf mgmt
+			doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.112/29" --mgmt-vrf mgmt
+			doublezero device create --code ty2-dz01 --contributor co01 --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "180.87.154.120/29" --mgmt-vrf mgmt
 			doublezero device create --code pit-dzd01 --contributor co01 --location pit --exchange xpit --public-ip "204.16.241.243" --dz-prefixes "204.16.243.243/32" --mgmt-vrf mgmt
 			doublezero device create --code ams-dz001 --contributor co01 --location ams --exchange xams --public-ip "195.219.138.50" --dz-prefixes "195.219.138.56/29" --mgmt-vrf mgmt
 

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
@@ -1,9 +1,9 @@
 account     | code        | contributor | location | exchange | device_type | public_ip        | dz_prefixes                              | users | max_users | status    | owner              | mgmt_vrf
 IGNORED     | la2-dz01    | co01        | lax      | xlax     | hybrid      | 207.45.216.134   | 207.45.216.136/30, 200.12.12.12/29       | 5     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ty2-dz01    | co01        | tyo      | xtyo     | hybrid      | 180.87.154.112   | 180.87.154.112/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
+IGNORED     | ty2-dz01    | co01        | tyo      | xtyo     | hybrid      | 180.87.154.112   | 180.87.154.120/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
 IGNORED     | ams-dz001   | co01        | ams      | xams     | hybrid      | 195.219.138.50   | 195.219.138.56/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
 IGNORED     | pit-dzd01   | co01        | pit      | xpit     | hybrid      | 204.16.241.243   | 204.16.243.243/32                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | frk-dz01    | co01        | fra      | xfra     | hybrid      | 195.219.220.88   | 195.219.220.88/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | sg1-dz01    | co01        | sin      | xsin     | hybrid      | 180.87.102.104   | 180.87.102.104/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ny5-dz01    | co01        | ewr      | xewr     | hybrid      | {{.DeviceIP}}    | {{.DeviceIP}}/{{.DeviceAllocatablePrefix}}| 1     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ld4-dz01    | co01        | lhr      | xlhr     | hybrid      | 195.219.120.72   | 195.219.120.72/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
+IGNORED     | frk-dz01    | co01        | fra      | xfra     | hybrid      | 195.219.220.88   | 195.219.220.96/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
+IGNORED     | sg1-dz01    | co01        | sin      | xsin     | hybrid      | 180.87.102.104   | 180.87.102.112/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
+IGNORED     | ny5-dz01    | co01        | ewr      | xewr     | hybrid      | {{.DeviceIP}}    | {{.DeviceDZPrefix}}                      | 1     | 128       | activated | {{.ManagerPubkey}} | mgmt
+IGNORED     | ld4-dz01    | co01        | lhr      | xlhr     | hybrid      | 195.219.120.72   | 195.219.120.80/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt

--- a/e2e/internal/netutil/ip.go
+++ b/e2e/internal/netutil/ip.go
@@ -31,3 +31,12 @@ func DeriveIPFromCIDR(cidr string, hostID uint32) (net.IP, error) {
 	binary.BigEndian.PutUint32(result, ipInt)
 	return result, nil
 }
+
+// ParseCIDR parses a CIDR string and returns the IP and network.
+func ParseCIDR(cidr string) (string, *net.IPNet, error) {
+	ip, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", nil, err
+	}
+	return ip.String(), network, nil
+}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -166,10 +166,10 @@ func (dn *TestDevnet) Start(t *testing.T) (*devnet.Device, *devnet.Client) {
 		set -euo pipefail
 
 		echo "==> Populate device information onchain"
-		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29" --mgmt-vrf mgmt
-		doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29" --mgmt-vrf mgmt
-		doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.104/29" --mgmt-vrf mgmt
-		doublezero device create --code ty2-dz01 --contributor co01 --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "180.87.154.112/29" --mgmt-vrf mgmt
+		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.80/29" --mgmt-vrf mgmt
+		doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.96/29" --mgmt-vrf mgmt
+		doublezero device create --code sg1-dz01 --contributor co01 --location sin --exchange xsin --public-ip "180.87.102.104" --dz-prefixes "180.87.102.112/29" --mgmt-vrf mgmt
+		doublezero device create --code ty2-dz01 --contributor co01 --location tyo --exchange xtyo --public-ip "180.87.154.112" --dz-prefixes "180.87.154.120/29" --mgmt-vrf mgmt
 		doublezero device create --code pit-dzd01 --contributor co01 --location pit --exchange xpit --public-ip "204.16.241.243" --dz-prefixes "204.16.243.243/32" --mgmt-vrf mgmt
 		doublezero device create --code ams-dz001 --contributor co01 --location ams --exchange xams --public-ip "195.219.138.50" --dz-prefixes "195.219.138.56/29" --mgmt-vrf mgmt
 		echo "--> Device information onchain:"

--- a/e2e/sdk_device_telemetry_test.go
+++ b/e2e/sdk_device_telemetry_test.go
@@ -59,8 +59,8 @@ func TestE2E_SDK_Telemetry_DeviceLatencySamples(t *testing.T) {
 
 		doublezero device create --code la2-dz01 --contributor co01 --location lax --exchange xlax --public-ip "207.45.216.134" --dz-prefixes "207.45.216.136/30,200.12.12.12/29" --metrics-publisher ` + la2DeviceAgentPrivateKey.PublicKey().String() + ` --mgmt-vrf mgmt
 		doublezero device create --code ny5-dz01 --contributor co01 --location ewr --exchange xewr --public-ip "207.45.21.134" --dz-prefixes "200.12.12.12/29" --metrics-publisher ` + ny5DeviceAgentPrivateKey.PublicKey().String() + ` --mgmt-vrf mgmt
-		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.72/29" --mgmt-vrf mgmt
-		doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.88/29" --mgmt-vrf mgmt
+		doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr --public-ip "195.219.120.72" --dz-prefixes "195.219.120.80/29" --mgmt-vrf mgmt
+		doublezero device create --code frk-dz01 --contributor co01 --location fra --exchange xfra --public-ip "195.219.220.88" --dz-prefixes "195.219.220.96/29" --mgmt-vrf mgmt
 
 		doublezero device update --pubkey ld4-dz01 --max-users 128
 		doublezero device update --pubkey frk-dz01 --max-users 128

--- a/smartcontract/programs/common/src/types/network_v4.rs
+++ b/smartcontract/programs/common/src/types/network_v4.rs
@@ -26,6 +26,10 @@ impl NetworkV4 {
     pub fn nth(&self, n: u32) -> Option<Ipv4Addr> {
         self.0.nth(n)
     }
+
+    pub fn contains(&self, ip: Ipv4Addr) -> bool {
+        self.0.contains(ip)
+    }
 }
 
 impl Default for NetworkV4 {

--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -125,6 +125,8 @@ pub enum DoubleZeroError {
     InvalidMinCompatibleVersion, // variant 59
     #[error("Invalid Actual Location")]
     InvalidActualLocation, // variant 60
+    #[error("Invalid Public IP: IP conflicts with DZ prefix")]
+    InvalidPublicIp, // variant 61
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -191,6 +193,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidLoopbackType => ProgramError::Custom(58),
             DoubleZeroError::InvalidMinCompatibleVersion => ProgramError::Custom(59),
             DoubleZeroError::InvalidActualLocation => ProgramError::Custom(60),
+            DoubleZeroError::InvalidPublicIp => ProgramError::Custom(61),
         }
     }
 }
@@ -258,6 +261,7 @@ impl From<u32> for DoubleZeroError {
             58 => DoubleZeroError::InvalidLoopbackType,
             59 => DoubleZeroError::InvalidMinCompatibleVersion,
             60 => DoubleZeroError::InvalidActualLocation,
+            61 => DoubleZeroError::InvalidPublicIp,
             _ => DoubleZeroError::Custom(e),
         }
     }
@@ -345,6 +349,7 @@ mod tests {
             InvalidLoopbackType,
             InvalidMinCompatibleVersion,
             InvalidActualLocation,
+            InvalidPublicIp,
         ];
         for err in variants {
             let pe: ProgramError = err.clone().into();

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -117,6 +117,18 @@ pub fn process_create_device(
     location.reference_count += 1;
     exchange.reference_count += 1;
 
+    for prefix in value.dz_prefixes.iter() {
+        if prefix.contains(value.public_ip) {
+            #[cfg(test)]
+            msg!(
+                "Public IP {} conflicts with dz_prefix {}",
+                value.public_ip,
+                prefix
+            );
+            return Err(DoubleZeroError::InvalidPublicIp.into());
+        }
+    }
+
     let device: Device = Device {
         account_type: AccountType::Device,
         owner: *payer_account.key,


### PR DESCRIPTION
Resolves: #1836

## Summary of Changes
* **Added two-level validation to prevent public IP conflicts with DZ prefixes:**
  - **CLI validation**: Checks that the device's public IP doesn't belong to any existing device's dz_prefixes (preventing conflicts with already deployed devices)
  - **On-chain validation**: Verifies that the device's public IP doesn't belong to its own dz_prefix (preventing self-configuration errors)
* **Extended NetworkV4 type** with a `contains()` method to check if an IPv4 address falls within a CIDR range
* **Added new error variant** `InvalidPublicIp` (error code 53) to `DoubleZeroError` enum for clear error reporting
* **Added unit tests** covering both validation scenarios

**Why this change is necessary:**
This validation prevents IP address conflicts that could cause routing issues, network misconfiguration, and operational problems in the DoubleZero network. Without this check, a device's public IP could overlap with DZ tunnel ranges, causing traffic routing conflicts.


## Testing Verification
Added Unit tests.
