### PR TITLE
Add curr and new version numbers to device list cmd

### DIFF
--- a/smartcontract/cli/src/checkversion.rs
+++ b/smartcontract/cli/src/checkversion.rs
@@ -16,7 +16,7 @@ pub fn check_version<C: CliCommand, W: Write>(
         }
         // If the program version is compatible, but the client version is behind, print a warning
         if pconfig.version.warning(&client_version) {
-            writeln!(out, "A new version of the client is available. We recommend updating to the latest version for the best experience.")?;
+            writeln!(out, "A new version of the client is available: {} → {}\nWe recommend updating to the latest version for the best experience.", client_version, pconfig.version)?;
         }
     }
 
@@ -104,6 +104,6 @@ mod tests {
         );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "A new version of the client is available. We recommend updating to the latest version for the best experience.\n");
+        assert_eq!(output_str, "A new version of the client is available: 1.2.0 → 1.2.10\nWe recommend updating to the latest version for the best experience.\n");
     }
 }


### PR DESCRIPTION
Resolves: #1799

## Summary of Changes
* Updated the client version check warning message in `smartcontract/cli/src/checkversion.rs` to display both the current client version and the new available version in the format "current → new" (e.g., "0.5.2 → 0.6.0")
* Users previously saw a generic warning with no version information; now they can see exactly which versions are involved to make informed update decisions

## Testing Verification
* `cargo check -p doublezero_cli` passes successfully with no compilation errors
* Updated unit test `test_check_version_build_warning` to verify the new message format includes version numbers