### PR TITLE
Handle DoubleZeroError::InvalidStatus gracefully in process_user_event logging

### DIFF
--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -338,7 +338,7 @@ pub fn process_user_event(
 }
 
 fn log_error_ignore_invalid_status(log_msg: &mut String, e: eyre::ErrReport) {
-    // Ignore DoubleZeroError::InvalidStatus errors
+    // Ignore DoubleZeroError::InvalidStatus errors since this only happens when the user is already activated
     if let Some(dz_err) = e.downcast_ref::<DoubleZeroError>() {
         if matches!(dz_err, DoubleZeroError::InvalidStatus) {
             // Do nothing


### PR DESCRIPTION
This pull request updates the error handling logic in the `process_user_event` function to specifically ignore `DoubleZeroError::InvalidStatus` errors, preventing them from being logged as errors. This helps reduce noise in the logs and focuses attention on actionable errors.

Error handling improvements:

* Updated error handling in `process_user_event` to check for `DoubleZeroError::InvalidStatus` and skip logging these errors, while continuing to log all other errors. (`activator/src/process/user.rs`) [[1]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR161-R172) [[2]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dL249-R268)
* Added import for `DoubleZeroError` from `doublezero_serviceability::error` to enable the new error handling logic. (`activator/src/process/user.rs`)

## Testing Verification
* Show evidence of testing the change
