### PR TITLE
cli: status command suggests better dzd

### DIFF
--- a/client/doublezero/src/command/latency.rs
+++ b/client/doublezero/src/command/latency.rs
@@ -1,13 +1,11 @@
 use crate::command::util;
 use clap::Args;
 use doublezero_cli::doublezerocommand::CliCommand;
-use doublezero_sdk::{commands::device::list::ListDeviceCommand, DeviceStatus};
-use solana_sdk::pubkey::Pubkey;
-use std::str::FromStr;
+use doublezero_sdk::commands::device::list::ListDeviceCommand;
 
 use crate::{
-    requirements::check_doublezero,
-    servicecontroller::{ServiceController, ServiceControllerImpl},
+    dzd_latency::retrieve_latencies, requirements::check_doublezero,
+    servicecontroller::ServiceControllerImpl,
 };
 
 #[derive(Args, Debug)]
@@ -23,27 +21,7 @@ impl LatencyCliCommand {
         check_doublezero(&controller, client, None).await?;
 
         let devices = client.list_device(ListDeviceCommand)?;
-        let mut latencies = controller.latency().await.map_err(|e| eyre::eyre!(e))?;
-
-        // Filter the active devices
-        latencies.retain(|l| {
-            Pubkey::from_str(&l.device_pk)
-                .ok()
-                .and_then(|pubkey| devices.get(&pubkey))
-                .map(|device| device.status == DeviceStatus::Activated)
-                .unwrap_or(false)
-        });
-
-        latencies.sort_by(|a, b| {
-            let reachable_cmp = b.reachable.cmp(&a.reachable);
-            if reachable_cmp != std::cmp::Ordering::Equal {
-                return reachable_cmp;
-            }
-            a.avg_latency_ns
-                .partial_cmp(&b.avg_latency_ns)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
+        let latencies = retrieve_latencies(&controller, &devices, false, None).await?;
         util::show_output(latencies, self.json)?;
 
         Ok(())

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -1,10 +1,17 @@
 use crate::{
     command::util,
+    dzd_latency::best_latency,
     requirements::check_doublezero,
-    servicecontroller::{ServiceController, ServiceControllerImpl},
+    servicecontroller::{ServiceController, ServiceControllerImpl, StatusResponse},
 };
 use clap::Args;
 use doublezero_cli::{doublezerocommand::CliCommand, helpers::print_error};
+use doublezero_sdk::commands::{
+    device::list::ListDeviceCommand, exchange::list::ListExchangeCommand,
+    user::list::ListUserCommand,
+};
+use serde::{Deserialize, Serialize};
+use tabled::Tabled;
 
 #[derive(Args, Debug)]
 pub struct StatusCliCommand {
@@ -13,22 +20,449 @@ pub struct StatusCliCommand {
     json: bool,
 }
 
+#[derive(Tabled, Debug, Deserialize, Serialize)]
+struct AppendedStatusResponse {
+    #[tabled(inline)]
+    response: StatusResponse,
+    #[tabled(rename = "Current Device")]
+    current_device: String,
+    #[tabled(rename = "Lowest Latency Device")]
+    lowest_latency_device: String,
+    #[tabled(rename = "Metro")]
+    metro: String,
+    #[tabled(rename = "Network")]
+    network: String,
+}
+
 impl StatusCliCommand {
-    pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
+    pub async fn execute(&self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
-
-        // Check requirements
         check_doublezero(&controller, client, None).await?;
-
-        match controller.status().await {
-            Err(e) => print_error(e),
-            Ok(status_responses) => {
-                if !status_responses.is_empty() {
-                    util::show_output(status_responses, self.json)?
-                }
+        match self.command_impl(client, &controller).await {
+            Ok(responses) => util::show_output(responses, self.json)?,
+            Err(e) => {
+                print_error(e);
             }
         }
-
         Ok(())
+    }
+
+    async fn command_impl<T: ServiceController>(
+        &self,
+        client: &dyn CliCommand,
+        controller: &T,
+    ) -> eyre::Result<Vec<AppendedStatusResponse>> {
+        let devices = client.list_device(ListDeviceCommand)?;
+        let users = client.list_user(ListUserCommand)?;
+        let exchanges = client.list_exchange(ListExchangeCommand)?;
+
+        let status_responses = controller.status().await?;
+        let mut responses = Vec::with_capacity(status_responses.len());
+        for response in &status_responses {
+            let mut current_device = None;
+            let mut metro = None;
+            let user = users
+                .iter()
+                .find(|(_, u)| Some(u.client_ip.to_string()) == response.tunnel_src)
+                .map(|(_, u)| u);
+            if let Some(user) = user {
+                current_device = Some(&user.device_pk);
+                if let Some(dev) = devices.get(&user.device_pk) {
+                    metro = exchanges.get(&dev.exchange_pk).map(|e| e.name.clone());
+                }
+            }
+            let lowest_latency_device =
+                match best_latency(controller, &devices, true, None, current_device).await {
+                    Ok(best) => {
+                        let is_current = user
+                            .map(|u| best.device_pk == u.device_pk.to_string())
+                            .unwrap_or(false);
+                        if self.json || response.doublezero_status.session_status != "up" {
+                            best.device_code
+                        } else if is_current || current_device.is_none() {
+                            format!("✅ {}", best.device_code)
+                        } else {
+                            format!("⚠️ {}", best.device_code)
+                        }
+                    }
+                    Err(_) => "N/A".to_string(),
+                };
+
+            responses.push(AppendedStatusResponse {
+                response: response.clone(),
+                current_device: current_device
+                    .and_then(|d| devices.get(d))
+                    .map(|d| d.code.clone())
+                    .unwrap_or_else(|| "N/A".to_string()),
+                lowest_latency_device,
+                metro: metro.unwrap_or_else(|| "N/A".to_string()),
+                network: format!("{}", client.get_environment()),
+            });
+        }
+
+        Ok(responses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::servicecontroller::{DoubleZeroStatus, LatencyRecord, MockServiceController};
+    use doublezero_cli::doublezerocommand::MockCliCommand;
+    use doublezero_program_common::types::{NetworkV4, NetworkV4List};
+    use doublezero_sdk::{
+        AccountType, Device, DeviceStatus, DeviceType, Exchange, ExchangeStatus, User, UserCYOA,
+        UserStatus, UserType,
+    };
+    use mockall::predicate::*;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[tokio::test]
+    async fn test_status_command_tunnel_up() {
+        let mut mock_command = MockCliCommand::new();
+        let mut mock_controller = MockServiceController::new();
+
+        let mut devices = std::collections::HashMap::<Pubkey, Device>::new();
+        let mut users = std::collections::HashMap::<Pubkey, User>::new();
+        let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
+        let status_responses = vec![StatusResponse {
+            doublezero_status: DoubleZeroStatus {
+                session_status: "up".to_string(),
+                last_session_update: Some(1625247600),
+            },
+            tunnel_name: Some("tunnel_name".to_string()),
+            tunnel_src: Some("1.2.3.4".to_string()),
+            tunnel_dst: Some("42.42.42.42".to_string()),
+            doublezero_ip: Some("1.2.3.4".to_string()),
+            user_type: Some("IBRL".to_string()),
+        }];
+
+        let exchange_pk = Pubkey::new_unique();
+        exchanges.insert(
+            exchange_pk,
+            Exchange {
+                account_type: AccountType::Exchange,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                lat: 0.0,
+                lng: 0.0,
+                bgp_community: 0,
+                status: ExchangeStatus::Activated,
+                code: "met".to_string(),
+                name: "metro".to_string(),
+                reference_count: 0,
+                device1_pk: Pubkey::default(),
+                device2_pk: Pubkey::default(),
+            },
+        );
+
+        let device1_pk = Pubkey::new_unique();
+        devices.insert(
+            device1_pk,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk,
+                device_type: DeviceType::Switch,
+                public_ip: "5.6.7.8".parse().unwrap(),
+                status: DeviceStatus::Activated,
+                code: "device1".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count: 64,
+                max_users: 128,
+            },
+        );
+
+        let device2_pk = Pubkey::new_unique();
+        devices.insert(
+            device2_pk,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk,
+                device_type: DeviceType::Switch,
+                public_ip: "5.6.7.9".parse().unwrap(),
+                status: DeviceStatus::Activated,
+                code: "device2".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count: 64,
+                max_users: 128,
+            },
+        );
+
+        let user_pk = Pubkey::new_unique();
+        users.insert(
+            user_pk,
+            User {
+                account_type: AccountType::User,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                user_type: UserType::IBRL,
+                tenant_pk: Pubkey::default(),
+                device_pk: device1_pk,
+                cyoa_type: UserCYOA::GREOverDIA,
+                client_ip: "1.2.3.4".parse().unwrap(),
+                dz_ip: "1.2.3.4".parse().unwrap(),
+                tunnel_id: 501,
+                tunnel_net: NetworkV4::default(),
+                status: UserStatus::Activated,
+                publishers: vec![],
+                subscribers: vec![],
+                validator_pubkey: Pubkey::default(),
+            },
+        );
+
+        let latencies = vec![
+            LatencyRecord {
+                device_pk: device1_pk.to_string(),
+                device_code: "device1".to_string(),
+                device_ip: "5.6.7.8".to_string(),
+                min_latency_ns: 5000000,
+                max_latency_ns: 5000000,
+                avg_latency_ns: 5000000,
+                reachable: true,
+            },
+            LatencyRecord {
+                device_pk: device2_pk.to_string(),
+                device_code: "device2".to_string(),
+                device_ip: "5.6.7.9".to_string(),
+                min_latency_ns: 3000000,
+                max_latency_ns: 3000000,
+                avg_latency_ns: 3000000,
+                reachable: true,
+            },
+        ];
+
+        mock_controller
+            .expect_status()
+            .returning(move || Ok(status_responses.clone()));
+        mock_controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+        mock_command
+            .expect_get_environment()
+            .return_const(doublezero_config::Environment::Testnet);
+        mock_command
+            .expect_list_device()
+            .with(eq(ListDeviceCommand))
+            .returning({
+                let devices = devices.clone();
+                move |_| Ok(devices.clone())
+            });
+        mock_command
+            .expect_list_user()
+            .with(eq(ListUserCommand))
+            .returning({
+                let users = users.clone();
+                move |_| Ok(users.clone())
+            });
+        mock_command
+            .expect_list_exchange()
+            .with(eq(ListExchangeCommand))
+            .returning({
+                let exchanges = exchanges.clone();
+                move |_| Ok(exchanges.clone())
+            });
+
+        let result = StatusCliCommand { json: true }
+            .command_impl(&mock_command, &mock_controller)
+            .await;
+
+        // Assert that the result is Ok
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.len(), 1);
+        let status_response = &result[0].response;
+        assert_eq!(status_response.doublezero_status.session_status, "up");
+        assert_eq!(status_response.tunnel_name.as_deref(), Some("tunnel_name"));
+        assert_eq!(status_response.tunnel_src.as_deref(), Some("1.2.3.4"));
+        assert_eq!(status_response.tunnel_dst.as_deref(), Some("42.42.42.42"));
+        assert_eq!(status_response.doublezero_ip.as_deref(), Some("1.2.3.4"));
+        assert_eq!(status_response.user_type.as_deref(), Some("IBRL"));
+        assert_eq!(result[0].current_device, "device1".to_string());
+        assert_eq!(result[0].lowest_latency_device, "device2".to_string());
+        assert_eq!(result[0].metro, "metro".to_string());
+        assert_eq!(result[0].network, "testnet".to_string());
+    }
+
+    #[tokio::test]
+    async fn test_status_command_tunnel_down() {
+        let mut mock_command = MockCliCommand::new();
+        let mut mock_controller = MockServiceController::new();
+
+        let mut devices = std::collections::HashMap::<Pubkey, Device>::new();
+        let users = std::collections::HashMap::<Pubkey, User>::new();
+        let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
+        let status_responses = vec![StatusResponse {
+            doublezero_status: DoubleZeroStatus {
+                session_status: "down".to_string(),
+                last_session_update: None,
+            },
+            tunnel_name: None,
+            tunnel_src: None,
+            tunnel_dst: None,
+            doublezero_ip: None,
+            user_type: None,
+        }];
+
+        let exchange_pk = Pubkey::new_unique();
+        exchanges.insert(
+            exchange_pk,
+            Exchange {
+                account_type: AccountType::Exchange,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                lat: 0.0,
+                lng: 0.0,
+                bgp_community: 0,
+                status: ExchangeStatus::Activated,
+                code: "met".to_string(),
+                name: "metro".to_string(),
+                reference_count: 0,
+                device1_pk: Pubkey::default(),
+                device2_pk: Pubkey::default(),
+            },
+        );
+
+        let device1_pk = Pubkey::new_unique();
+        devices.insert(
+            device1_pk,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk,
+                device_type: DeviceType::Switch,
+                public_ip: "5.6.7.8".parse().unwrap(),
+                status: DeviceStatus::Activated,
+                code: "device1".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count: 64,
+                max_users: 128,
+            },
+        );
+
+        let device2_pk = Pubkey::new_unique();
+        devices.insert(
+            device2_pk,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk,
+                device_type: DeviceType::Switch,
+                public_ip: "5.6.7.9".parse().unwrap(),
+                status: DeviceStatus::Activated,
+                code: "device2".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count: 64,
+                max_users: 128,
+            },
+        );
+
+        let latencies = vec![
+            LatencyRecord {
+                device_pk: device1_pk.to_string(),
+                device_code: "device1".to_string(),
+                device_ip: "5.6.7.8".to_string(),
+                min_latency_ns: 5000000,
+                max_latency_ns: 5000000,
+                avg_latency_ns: 5000000,
+                reachable: true,
+            },
+            LatencyRecord {
+                device_pk: device2_pk.to_string(),
+                device_code: "device2".to_string(),
+                device_ip: "5.6.7.9".to_string(),
+                min_latency_ns: 3000000,
+                max_latency_ns: 3000000,
+                avg_latency_ns: 3000000,
+                reachable: true,
+            },
+        ];
+
+        mock_controller
+            .expect_status()
+            .returning(move || Ok(status_responses.clone()));
+        mock_controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+        mock_command
+            .expect_get_environment()
+            .return_const(doublezero_config::Environment::Testnet);
+        mock_command
+            .expect_list_device()
+            .with(eq(ListDeviceCommand))
+            .returning({
+                let devices = devices.clone();
+                move |_| Ok(devices.clone())
+            });
+        mock_command
+            .expect_list_user()
+            .with(eq(ListUserCommand))
+            .returning({
+                let users = users.clone();
+                move |_| Ok(users.clone())
+            });
+        mock_command
+            .expect_list_exchange()
+            .with(eq(ListExchangeCommand))
+            .returning({
+                let exchanges = exchanges.clone();
+                move |_| Ok(exchanges.clone())
+            });
+
+        let result = StatusCliCommand { json: true }
+            .command_impl(&mock_command, &mock_controller)
+            .await;
+
+        // Assert that the result is Ok
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.len(), 1);
+        let status_response = &result[0].response;
+        assert_eq!(status_response.doublezero_status.session_status, "down");
+        assert_eq!(status_response.tunnel_name.as_deref(), None);
+        assert_eq!(status_response.tunnel_src.as_deref(), None);
+        assert_eq!(status_response.tunnel_dst.as_deref(), None);
+        assert_eq!(status_response.doublezero_ip.as_deref(), None);
+        assert_eq!(status_response.user_type.as_deref(), None);
+        assert_eq!(result[0].current_device, "N/A".to_string());
+        assert_eq!(result[0].lowest_latency_device, "device2".to_string());
+        assert_eq!(result[0].metro, "N/A".to_string());
+        assert_eq!(result[0].network, "testnet".to_string());
     }
 }

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -1,0 +1,333 @@
+use crate::servicecontroller::{LatencyRecord, ServiceController};
+use backon::{ExponentialBuilder, Retryable};
+use doublezero_sdk::{Device, DeviceStatus};
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashMap, str::FromStr, time::Duration};
+
+pub async fn retrieve_latencies<T: ServiceController>(
+    controller: &T,
+    devices: &HashMap<Pubkey, Device>,
+    reachable_only: bool,
+    spinner: Option<&indicatif::ProgressBar>,
+) -> eyre::Result<Vec<LatencyRecord>> {
+    if let Some(spinner) = spinner {
+        spinner.set_message("Retrieving latency stats...");
+    }
+
+    let get_latencies = || async {
+        let mut latencies = controller.latency().await.map_err(|e| eyre::eyre!(e))?;
+        latencies.retain(|l| {
+            Pubkey::from_str(&l.device_pk)
+                .ok()
+                .and_then(|pubkey| devices.get(&pubkey))
+                .map(|device| device.status == DeviceStatus::Activated)
+                .unwrap_or(false)
+        });
+
+        if reachable_only {
+            latencies.retain(|l| l.reachable);
+        }
+
+        match latencies.len() {
+            0 => Err(eyre::eyre!("No devices found")),
+            _ => Ok(latencies),
+        }
+    };
+
+    let builder = ExponentialBuilder::new()
+        .with_max_times(5)
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_delay(Duration::from_secs(10));
+
+    let mut latencies = get_latencies
+        .retry(builder)
+        .when(|e| e.to_string() == "No devices found")
+        .notify(|_, dur| {
+            if let Some(spinner) = spinner {
+                spinner.set_message(format!("Waiting for latency stats after {dur:?}"));
+            }
+        })
+        .await?;
+
+    latencies.sort_by(|a, b| {
+        let reachable_cmp = b.reachable.cmp(&a.reachable);
+        if reachable_cmp != std::cmp::Ordering::Equal {
+            return reachable_cmp;
+        }
+        a.avg_latency_ns
+            .partial_cmp(&b.avg_latency_ns)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(latencies)
+}
+
+const LATENCY_TOLERANCE_NS: i32 = 1_500_000; // 1.5 ms
+
+pub async fn best_latency<T: ServiceController>(
+    controller: &T,
+    devices: &HashMap<Pubkey, Device>,
+    ignore_unprovisionable: bool,
+    spinner: Option<&indicatif::ProgressBar>,
+    current_device: Option<&Pubkey>,
+) -> eyre::Result<LatencyRecord> {
+    let latencies = retrieve_latencies(controller, devices, true, spinner).await?;
+    let mut best: Option<&LatencyRecord> = None;
+    let mut best_latency = i32::MAX;
+
+    if let Some(current_device) = current_device {
+        if let Some(current) = latencies
+            .iter()
+            .find(|latency| latency.device_pk == current_device.to_string())
+        {
+            best = Some(current);
+            best_latency = current.avg_latency_ns;
+        }
+    }
+
+    for latency in &latencies {
+        if let Some(current) = best {
+            if std::ptr::eq(current, latency) {
+                return Ok(current.clone());
+            }
+        }
+
+        let device_pk = Pubkey::from_str(&latency.device_pk)?;
+        let device = devices
+            .get(&device_pk)
+            .ok_or_else(|| eyre::eyre!("Device with pubkey {} not found", &latency.device_pk))?;
+
+        if (!ignore_unprovisionable || device.is_device_eligible_for_provisioning())
+            && (latency.avg_latency_ns - best_latency).abs() > LATENCY_TOLERANCE_NS
+        {
+            best = Some(latency);
+            break;
+        }
+    }
+
+    best.cloned()
+        .ok_or_else(|| eyre::eyre!("No suitable device found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::servicecontroller::{LatencyRecord, MockServiceController};
+    use doublezero_program_common::types::NetworkV4List;
+    use doublezero_sdk::{AccountType, Device, DeviceStatus, DeviceType};
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+
+    fn make_device(status: DeviceStatus, users_count: u16) -> (Pubkey, Device) {
+        let pubkey = Pubkey::new_unique();
+        (
+            pubkey,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk: Pubkey::default(),
+                device_type: DeviceType::Switch,
+                public_ip: std::net::Ipv4Addr::UNSPECIFIED,
+                status,
+                code: "device".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count,
+                max_users: 1,
+            },
+        )
+    }
+
+    fn make_latency(pk: &str, avg_latency_ns: i32, reachable: bool) -> LatencyRecord {
+        LatencyRecord {
+            device_pk: pk.to_string(),
+            device_code: "device".to_string(),
+            device_ip: "0.0.0.0".to_string(),
+            min_latency_ns: avg_latency_ns,
+            max_latency_ns: avg_latency_ns,
+            avg_latency_ns,
+            reachable,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_latencies_filters_and_sorts() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 0);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 0);
+        let (pk3, dev3) = make_device(DeviceStatus::Activated, 0);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+        devices.insert(pk3, dev3);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 10000000, true),
+            make_latency(&pk2.to_string(), 20000000, false),
+            make_latency(&pk3.to_string(), 5000000, true),
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = retrieve_latencies(&controller, &devices, true, None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].device_pk, pk3.to_string());
+        assert_eq!(result[1].device_pk, pk1.to_string());
+
+        let result = retrieve_latencies(&controller, &devices, false, None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].device_pk, pk3.to_string());
+        assert_eq!(result[1].device_pk, pk1.to_string());
+        assert_eq!(result[2].device_pk, pk2.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_best_latency_prefers_current_within_tolerance() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 0);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 0);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 10000000, true),
+            make_latency(&pk2.to_string(), 11000000, true),
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = best_latency(&controller, &devices, true, None, Some(&pk2))
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_pk, pk2.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_best_latency_selects_lowest() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 0);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 0);
+        let (pk3, dev3) = make_device(DeviceStatus::Activated, 0);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+        devices.insert(pk3, dev3);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 12000000, true),
+            make_latency(&pk2.to_string(), 9000000, true),
+            make_latency(&pk3.to_string(), 15000000, true),
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = best_latency(&controller, &devices, true, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_pk, pk2.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_best_latency_ignores_unreachable_devices() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 0);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 0);
+        let (pk3, dev3) = make_device(DeviceStatus::Activated, 0);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+        devices.insert(pk3, dev3);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 12000000, false), // unreachable
+            make_latency(&pk2.to_string(), 9000000, false),  // unreachable
+            make_latency(&pk3.to_string(), 15000000, true),  // reachable
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = best_latency(&controller, &devices, true, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_pk, pk3.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_best_latency_ignores_faster_devices_at_max_users() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 1);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 0);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 9000000, true),
+            make_latency(&pk2.to_string(), 12000000, true),
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = best_latency(&controller, &devices, true, None, Some(&pk2))
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_pk, pk2.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_best_latency_current_faster_but_at_max_users() {
+        let (pk1, dev1) = make_device(DeviceStatus::Activated, 0);
+        let (pk2, dev2) = make_device(DeviceStatus::Activated, 1);
+
+        let mut devices = HashMap::new();
+        devices.insert(pk1, dev1);
+        devices.insert(pk2, dev2);
+
+        let latencies = vec![
+            make_latency(&pk1.to_string(), 12000000, true),
+            make_latency(&pk2.to_string(), 9000000, true),
+        ];
+
+        let mut controller = MockServiceController::new();
+        controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+
+        let result = best_latency(&controller, &devices, true, None, Some(&pk2))
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_pk, pk2.to_string());
+    }
+}

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -3,6 +3,7 @@ use clap_complete::generate;
 use std::path::PathBuf;
 mod cli;
 mod command;
+mod dzd_latency;
 use doublezero_config::Environment;
 mod requirements;
 mod servicecontroller;

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -80,7 +80,7 @@ pub struct RemoveResponse {
     pub description: Option<String>,
 }
 
-#[derive(Tabled, Serialize, Deserialize, Debug)]
+#[derive(Tabled, Serialize, Deserialize, Debug, Clone)]
 #[tabled(display(Option, "display::option", ""))]
 pub struct StatusResponse {
     #[tabled(inline)]
@@ -103,7 +103,7 @@ pub struct GetConfigResponse {
     pub rpc_url: String,
 }
 
-#[derive(Tabled, Serialize, Deserialize, Debug)]
+#[derive(Tabled, Serialize, Deserialize, Debug, Clone)]
 pub struct DoubleZeroStatus {
     #[tabled(rename = "Tunnel status")]
     pub session_status: String,

--- a/e2e/fixtures/ibrl/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type
- up            | 2025-06-03 19:40:58 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ClientIP}}  | IBRL
+ Tunnel status | Last Session Update     | Tunnel Name | Tunnel src    | Tunnel dst  | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network 
+ up            | 2025-10-14 17:59:41 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ClientIP}} | IBRL      | ny5-dz01       | ✅ ny5-dz01           | New York | local   

--- a/e2e/fixtures/ibrl/doublezero_status_disconnected.txt
+++ b/e2e/fixtures/ibrl/doublezero_status_disconnected.txt
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type
- disconnected  | no session data     |             |            |            |               |
+ Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
+ disconnected  | no session data     |             |            |            |               |           | N/A            | ny5-dz01              | N/A   | local

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type
- up            | 2025-06-03 19:58:21 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}}  | IBRLWithAllocatedIP
+ Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
+ up            | 2025-06-03 19:58:21 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}}  | IBRLWithAllocatedIP | ny5-dz01 | ✅ ny5-dz01 | New York | local

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_disconnected.txt
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_disconnected.txt
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type
- disconnected  | no session data     |             |            |            |               |
+ Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
+ disconnected  | no session data     |             |            |            |               |           | N/A            | ny5-dz01              | N/A   | local

--- a/e2e/fixtures/multicast_publisher/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type
- up            | 2025-06-03 20:13:02 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}}  | Multicast
+ Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
+ up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}} | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/fixtures/multicast_publisher/doublezero_status_disconnected.txt
+++ b/e2e/fixtures/multicast_publisher/doublezero_status_disconnected.txt
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type
- disconnected  | no session data     |             |            |            |               |
+ Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
+ disconnected  | no session data     |             |            |            |               |           | N/A            | ny5-dz01              | N/A   | local

--- a/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type
- up            | 2025-06-03 20:17:46 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |               | Multicast
+ Tunnel status | Last Session Update     | Tunnel Name | Tunnel src   | Tunnel dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
+ up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/fixtures/multicast_subscriber/doublezero_status_disconnected.txt
+++ b/e2e/fixtures/multicast_subscriber/doublezero_status_disconnected.txt
@@ -1,2 +1,2 @@
- Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type
- disconnected  | no session data     |             |            |            |               |
+ Tunnel status | Last Session Update | Tunnel Name | Tunnel src | Tunnel dst | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
+ disconnected  | no session data     |             |            |            |               |           | N/A            | ny5-dz01              | N/A   | local


### PR DESCRIPTION
Closes #1862 

## Summary of Changes
* Pulls out latency fetching code into a module
* Adds a new method to get the best latency device
* "status" command now output current device, best device, metro and network

## Testing Verification
* unit tests added
