### PR TITLE
Show unreachable links at the bottom

### DIFF
--- a/client/doublezero/src/command/latency.rs
+++ b/client/doublezero/src/command/latency.rs
@@ -35,7 +35,7 @@ impl LatencyCliCommand {
         });
 
         latencies.sort_by(|a, b| {
-            let reachable_cmp = b.reachable.cmp(&a.reachable);
+            let reachable_cmp = a.reachable.cmp(&b.reachable);
             if reachable_cmp != std::cmp::Ordering::Equal {
                 return reachable_cmp;
             }


### PR DESCRIPTION
Resolves: [#1677](https://github.com/malbeclabs/doublezero/issues/1677)

## Summary of Changes
* Show unreachable links at the bottom by swapping the comparison

## Testing Verification
* I can add tests if team says this is worth it but fix was very simple
