### PR TITLE
monitor/2zoracle: parse swap rate as float

### DIFF
--- a/controlplane/monitor/internal/2z-oracle/client.go
+++ b/controlplane/monitor/internal/2z-oracle/client.go
@@ -10,12 +10,12 @@ import (
 )
 
 type SwapRateResponse struct {
-	SwapRate     int64  `json:"swapRate"`
-	Timestamp    int64  `json:"timestamp"`
-	Signature    string `json:"signature"`
-	SOLPriceUSD  string `json:"solPriceUsd"`
-	TwoZPriceUSD string `json:"twozPriceUsd"`
-	CacheHit     bool   `json:"cacheHit"`
+	SwapRate     float64 `json:"swapRate"`
+	Timestamp    int64   `json:"timestamp"`
+	Signature    string  `json:"signature"`
+	SOLPriceUSD  string  `json:"solPriceUsd"`
+	TwoZPriceUSD string  `json:"twozPriceUsd"`
+	CacheHit     bool    `json:"cacheHit"`
 }
 
 type HealthResponse struct {

--- a/controlplane/monitor/internal/2z-oracle/client_test.go
+++ b/controlplane/monitor/internal/2z-oracle/client_test.go
@@ -25,7 +25,7 @@ func TestMonitor_TwoZOracle_Client(t *testing.T) {
 
 		out, _, err := c.SwapRate(context.Background())
 		r.NoError(err)
-		r.Equal(int64(2764713870), out.SwapRate)
+		r.Equal(float64(2764713870.9234), out.SwapRate)
 		r.Equal(int64(1758741874), out.Timestamp)
 		r.NotEmpty(out.SOLPriceUSD)
 		r.NotEmpty(out.TwoZPriceUSD)
@@ -134,7 +134,7 @@ func NewFakeTwoZOracleServer(t *testing.T) *FakeTwoZOracleServer {
 	// sane defaults mirroring the real API
 	fs.swap.Store(fakeResp{
 		status: 200,
-		body:   `{"swapRate":2764713870,"timestamp":1758741874,"signature":"sig","solPriceUsd":"213.9","twozPriceUsd":"7.73","cacheHit":true}`,
+		body:   `{"swapRate":2764713870.9234,"timestamp":1758741874,"signature":"sig","solPriceUsd":"213.9","twozPriceUsd":"7.73","cacheHit":true}`,
 	})
 	fs.health.Store(fakeResp{
 		status: 200,


### PR DESCRIPTION
## Summary of Changes
- Update monitor 2zoracle watcher to parse swap rate from response as float64 instead of int64
- Fixes https://github.com/malbeclabs/doublezero/issues/1897

## Testing Verification
- Updated test coverage to include float swap rate in response
