### PR TITLE
cli: include user validator pubkey in export output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
     - Display multicast group memberships (publisher/subscriber) in AccessPass listings to improve visibility.
     - Allow AccessPass creation without 'client_ip'
     - Add 'allow_multiple_ip' argument to support AccessPass connections from multiple IPs
+    - Include validator pubkey in `export` output
 - Activator
     - Reduce logging noise when processing snapshot events
     - Wrap main select handler in loop to avoid shutdown on branch error

--- a/smartcontract/cli/src/export.rs
+++ b/smartcontract/cli/src/export.rs
@@ -90,6 +90,7 @@ struct UserData {
     pub dz_ip: String,
     pub status: String,
     pub owner: String,
+    pub validator_pubkey: String,
 }
 
 impl ExportCliCommand {
@@ -203,6 +204,7 @@ impl ExportCliCommand {
                             dz_ip: user.dz_ip.to_string(),
                             status: user.status.to_string(),
                             owner: user.owner.to_string(),
+                            validator_pubkey: user.validator_pubkey.to_string(),
                         })
                         .collect(),
                     owner: data.owner.to_string(),


### PR DESCRIPTION
## Summary of Changes
- Include `validator_pubkey` in `doublezero export` output so it gets included in with influx collection and we can more easily visualize utilization by validator by joining with DZD intf counters data

## Testing Verification
- Ran `doublezero export` for for dn, tn, mn
