### PR TITLE
monitor: use sol-2z-oracle-api domain

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -7,9 +7,8 @@ const (
 	MainnetTelemetryProgramID         = "tE1exJ5VMyoC9ByZeSmgtNzJCFF74G9JAv338sJiqkC"
 	MainnetInternetLatencyCollectorPK = "8xHn4r7oQuqNZ5cLYwL5YZcDy1JjDQcpVkyoA8Dw5uXH"
 	MainnetDeviceLocalASN             = 209321
-	// MainnetTwoZOracleURL              = "https://10qk1zz9ql.execute-api.us-east-1.amazonaws.com/mainnet-beta/api/v1"
-	MainnetTwoZOracleURL = ""
-	MainnetSolanaRPC     = "https://api.mainnet-beta.solana.com"
+	MainnetTwoZOracleURL              = "https://sol-2z-oracle-api-v1.mainnet-beta.doublezero.xyz"
+	MainnetSolanaRPC                  = "https://api.mainnet-beta.solana.com"
 
 	// Testnet constants.
 	TestnetLedgerPublicRPCURL         = "https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16"
@@ -17,7 +16,7 @@ const (
 	TestnetTelemetryProgramID         = "3KogTMmVxc5eUHtjZnwm136H5P8tvPwVu4ufbGPvM7p1"
 	TestnetInternetLatencyCollectorPK = "HWGQSTmXWMB85NY2vFLhM1nGpXA8f4VCARRyeGNbqDF1"
 	TestnetDeviceLocalASN             = 65342
-	TestnetTwoZOracleURL              = "https://7op1fv6sj5.execute-api.us-east-1.amazonaws.com/testnet/api/v1"
+	TestnetTwoZOracleURL              = "https://sol-2z-oracle-api-v1.testnet.doublezero.xyz"
 	TestnetSolanaRPC                  = "https://api.testnet.solana.com"
 
 	// Devnet constants.


### PR DESCRIPTION
## Summary of Changes
- Update config constants to use the sol-2z-oracle-api-v1.{testnet,mainnet-beta}.doublezero.xyz` domain
- Enable monitoring of mainnet-beta oracle

## Testing Verification
```
$ curl -s https://sol-2z-oracle-api-v1.testnet.doublezero.xyz/swap-rate | jq
{
  "swapRate": 69988573623,
  "timestamp": 1760471969,
  "signature": "FtjVpD8xWhc3ZP40WWl0RghDLe2FBdwckr5IPAAsSjIBd4pwMfY0iXtaqcvLVsUkZhplnC9eOmJXGKsJEYp/CQ==",
  "solPriceUsd": "199.08249767",
  "twozPriceUsd": "0.28445",
  "cacheHit": true
}

$ curl -s https://sol-2z-oracle-api-v1.mainnet-beta.doublezero.xyz/swap-rate | jq
{
  "swapRate": 3161328022,
  "timestamp": 1760471982,
  "signature": "NPwVbfqfm15ts2odagppJ0jGDaaHQoX4ycTljwI0qmEIQQkjhWDMg+/nfiz4OBTHaoN1HIgu21Jjq/AezWw7CA==",
  "solPriceUsd": "198.66132373",
  "twozPriceUsd": "6.2841097900000005",
  "cacheHit": false
}
```
