### PR TITLE
monitor tool: ignore checkout during CI

### DIFF
--- a/.github/workflows/release.devnet.doublezero.monitor.tool.yml
+++ b/.github/workflows/release.devnet.doublezero.monitor.tool.yml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          args: release -f release/.goreleaser.devnet.doublezero.monitor.yaml --clean
+          args: release -f release/.goreleaser.devnet.doublezero.monitor.tool.yaml --clean
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 
 # Local devnet deployment artifacts.
 dev/.deploy/
+
+# Ignore the directory used for checking out the monitor tool in CI
+doublezero_monitor/


### PR DESCRIPTION
## Summary of Changes
Goreleaser doesn't like the dirty repo after checking out doublezero monitor. Instead of skipping validation in goreleaser, this adds a the doublezero_monitor checkout dir to our gitignore.

## Testing Verification
Package builds:
```
root ➜ /workspaces/doublezero (ss/monitor_tool) $ goreleaser release --skip=publish --clean -f release/.goreleaser.base.doublezero.monitor.tool.yaml
goreleaser release --skip=publish --clean -f release/.goreleaser.base.doublezero.monitor.tool.yaml
  • by using this software you agree with its EULA, available at https://goreleaser.com/eula
  • running goreleaser v2.12.0 (outdated, latest is v2.12.5)
  • skipping announce and publish...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=08c0a3eafeba5ce76c3e920e6f9bbb478e7a4696 branch=ss/monitor_tool current_tag=doublezero-monitor-tool/v0.0.2 previous_tag=doublezero-monitor-tool/v0.0.1 dirty=false
  • parsing tag
  • setting defaults
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • build prerequisites
  • building binaries
    • building                                       binary=dist/doublezero-monitor-tool_linux_amd64_v1/doublezero-monitor-tool
    • importing prebuilt binary                      name=doublezero-monitor-tool
  • generating changelog
  • archives
    • archiving                                      binary=doublezero-monitor-tool name=monitor_ibrl.py_0.0.2_linux_amd64
  • linux packages
    • creating                                       package=doublezero-monitor-tool format=deb arch=amd64v1 file=dist/doublezero-monitor-tool_0.0.2_linux_amd64.deb
  • calculating checksums
  • storing artifacts metadata
  • release succeeded after 0s
  • thanks for using GoReleaser Pro!
```
