### PR TITLE
cli: remove short flags for RPC_URL, WEBSOCKET_URL, and KEYPAIR arguments

### DIFF
--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -34,16 +34,16 @@ struct App {
     #[arg(short, long, value_name = "ENV", global = true)]
     env: Option<String>,
     /// DZ ledger RPC URL
-    #[arg(short, long, value_name = "RPC_URL", global = true)]
+    #[arg(long, value_name = "RPC_URL", global = true)]
     url: Option<String>,
     /// DZ ledger WebSocket URL
-    #[arg(short, long, value_name = "WEBSOCKET_URL", global = true)]
+    #[arg(long, value_name = "WEBSOCKET_URL", global = true)]
     ws: Option<String>,
     /// DZ program ID (testnet or devnet)
     #[arg(long, value_name = "PROGRAM_ID", global = true)]
     program_id: Option<String>,
     /// Path to the keypair file
-    #[arg(short, long, value_name = "KEYPAIR", global = true)]
+    #[arg(long, value_name = "KEYPAIR", global = true)]
     keypair: Option<PathBuf>,
 }
 

--- a/controlplane/doublezero-admin/src/main.rs
+++ b/controlplane/doublezero-admin/src/main.rs
@@ -30,16 +30,16 @@ struct App {
     #[arg(short, long, value_name = "ENV", global = true)]
     env: Option<String>,
     /// DZ ledger RPC URL
-    #[arg(short, long, value_name = "RPC_URL", global = true)]
+    #[arg(long, value_name = "RPC_URL", global = true)]
     url: Option<String>,
     /// DZ ledger WebSocket URL
-    #[arg(short, long, value_name = "WEBSOCKET_URL", global = true)]
+    #[arg(long, value_name = "WEBSOCKET_URL", global = true)]
     ws: Option<String>,
     /// DZ program ID (testnet or devnet)
     #[arg(long, value_name = "PROGRAM_ID", global = true)]
     program_id: Option<String>,
     /// Path to the keypair file
-    #[arg(short, long, value_name = "KEYPAIR", global = true)]
+    #[arg(long, value_name = "KEYPAIR", global = true)]
     keypair: Option<PathBuf>,
 }
 


### PR DESCRIPTION
This pull request updates the command-line interface for both the client and control plane applications to improve consistency and usability. Specifically, it removes the short flag options for several arguments, requiring users to use the long-form flags when specifying these options.

**Command-line flag updates:**

* Removed short flags for `url`, `ws`, and `keypair` arguments in the `App` struct in `client/doublezero/src/main.rs`, so only long-form flags are now available for these options.
* Removed short flags for `url`, `ws`, and `keypair` arguments in the `App` struct in `controlplane/doublezero-admin/src/main.rs`, matching the client changes for consistency.
## Testing Verification
* test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s
