### PR TITLE
Adjust AccessPass precedence to prioritize IP-based over generic and reorder local test

### DIFF
--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -37,7 +37,7 @@ struct App {
     #[arg(short, long, value_name = "RPC_URL", global = true)]
     url: Option<String>,
     /// DZ ledger WebSocket URL
-    #[arg(short, long, value_name = "WEBSOCKET_URL", global = true)]
+    #[arg(long, value_name = "WEBSOCKET_URL", global = true)]
     ws: Option<String>,
     /// DZ program ID (testnet or devnet)
     #[arg(long, value_name = "PROGRAM_ID", global = true)]

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -157,9 +157,11 @@ pub fn process_create_subscribe_user(
 
     // Check if the user is in the allowlist
     if value.publisher && !accesspass.mgroup_pub_allowlist.contains(mgroup_account.key) {
+        msg!("{} -> {:?}", accesspass_account.key, accesspass);
         return Err(DoubleZeroError::NotAllowed.into());
     }
     if value.subscriber && !accesspass.mgroup_sub_allowlist.contains(mgroup_account.key) {
+        msg!("{} -> {:?}", accesspass_account.key, accesspass);
         return Err(DoubleZeroError::NotAllowed.into());
     }
 

--- a/smartcontract/sdk/rs/src/commands/user/create.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create.rs
@@ -25,14 +25,15 @@ impl CreateUserCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
+        // First try to get AccessPass for the client IP
         let (accesspass_pk, _) = GetAccessPassCommand {
-            client_ip: Ipv4Addr::UNSPECIFIED,
+            client_ip: self.client_ip,
             user_payer: client.get_payer(),
         }
         .execute(client)
         .or_else(|_| {
             GetAccessPassCommand {
-                client_ip: self.client_ip,
+                client_ip: Ipv4Addr::UNSPECIFIED,
                 user_payer: client.get_payer(),
             }
             .execute(client)

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -45,14 +45,15 @@ impl CreateSubscribeUserCommand {
             eyre::bail!("MulticastGroup not active");
         }
 
+        // First try to get AccessPass for the client IP
         let (accesspass_pk, _) = GetAccessPassCommand {
-            client_ip: Ipv4Addr::UNSPECIFIED,
+            client_ip: self.client_ip,
             user_payer: client.get_payer(),
         }
         .execute(client)
         .or_else(|_| {
             GetAccessPassCommand {
-                client_ip: self.client_ip,
+                client_ip: Ipv4Addr::UNSPECIFIED,
                 user_payer: client.get_payer(),
             }
             .execute(client)

--- a/smartcontract/test/start-test.sh
+++ b/smartcontract/test/start-test.sh
@@ -167,7 +167,13 @@ echo "Update devices to set max users"
 
 # create access pass
 echo "Create AccessPass for all IPs"
-./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --allow-multiple-ip
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 100.0.0.5
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 100.0.0.6
+
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 177.54.159.95
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 147.28.171.51
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 100.100.100.100
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 200.200.200.200
 
 # create a user
 echo "Creating users"


### PR DESCRIPTION
This PR updates the precedence logic for AccessPass so that IP-based passes are prioritized over generic ones. Additionally, the local test suite has been reordered to reflect the new precedence and ensure consistent results.

AccessPass handling improvements:

* Updated `CreateUserCommand` and `CreateSubscribeUserCommand` logic to first attempt AccessPass retrieval using the actual client IP, falling back to unspecified IP only if necessary. This ensures more accurate and secure AccessPass assignment. [[1]](diffhunk://#diff-46ccb53d3127ea1dd13683c5018a5d9e2e3d9526ad94db5f02cd3b5d4123fb0dR28-R36) [[2]](diffhunk://#diff-1071c55acfbb778f2b0f6495eeadc46977fdad9032ebe8f12859ff1277144a79R48-R56)

Testing enhancements:

* Modified the test script `start-test.sh` to explicitly create AccessPasses for several specific client IPs instead of using the previous "allow-multiple-ip" flag, providing more realistic test coverage.

Error handling and debugging:

* Added debug logging in `process_create_subscribe_user` to output the AccessPass account key and details when allowlist checks fail, improving visibility into why a user is denied.

CLI usability:

* Removed the short flag for the `ws` (WebSocket URL) argument in the CLI, requiring the long form for clarity and to avoid confusion with other flags.

## Testing Verification
* test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
