### PR TITLE
Add telemetry option to latency command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
     - Check if `accesspass.owner` is equal to system program ([malbeclabs/doublezero#2088](https://github.com/malbeclabs/doublezero/pull/2088))
 - CLI
     - Improve error message when connecting to a device that is at capacity or has max_users=0. Users now receive "Device is not accepting more users (at capacity or max_users=0)" instead of the confusing "Device not found" error when explicitly specifying an ineligible device.
+    - Add `link latency` command to display latency statistics from the telemetry program. Supports filtering by percentile (p50, p90, p95, p99, mean, min, max, stddev, all), querying by link code or all links, and filtering by epoch. Resolves: [#1942](https://github.com/malbeclabs/doublezero/issues/1942)
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "doublezero-program-common",
  "doublezero-record",
  "doublezero-serviceability",
+ "doublezero-telemetry",
  "eyre",
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,7 @@ features = ["no-entrypoint"]
 [workspace.dependencies.doublezero-serviceability]
 path = "smartcontract/programs/doublezero-serviceability"
 features = ["no-entrypoint"]
+
+[workspace.dependencies.doublezero-telemetry]
+path = "smartcontract/programs/doublezero-telemetry"
+features = ["no-entrypoint"]

--- a/client/doublezero/src/cli/link.rs
+++ b/client/doublezero/src/cli/link.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Subcommand};
 
 use doublezero_cli::link::{
-    accept::AcceptLinkCliCommand, delete::*, dzx_create::CreateDZXLinkCliCommand, get::*, list::*,
-    update::*, wan_create::*,
+    accept::AcceptLinkCliCommand, delete::*, dzx_create::CreateDZXLinkCliCommand, get::*,
+    latency::LinkLatencyCliCommand, list::*, update::*, wan_create::*,
 };
 
 #[derive(Args, Debug)]
@@ -44,6 +44,9 @@ pub enum LinkCommands {
     /// Get details for a specific link
     #[clap()]
     Get(GetLinkCliCommand),
+    /// Display latency statistics for a link
+    #[clap()]
+    Latency(LinkLatencyCliCommand),
     /// Delete a link
     #[clap()]
     Delete(DeleteLinkCliCommand),

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -172,6 +172,7 @@ async fn main() -> eyre::Result<()> {
             LinkCommands::Update(args) => args.execute(&client, &mut handle),
             LinkCommands::List(args) => args.execute(&client, &mut handle),
             LinkCommands::Get(args) => args.execute(&client, &mut handle),
+            LinkCommands::Latency(args) => args.execute(&client, &mut handle),
             LinkCommands::Delete(args) => args.execute(&client, &mut handle),
         },
         Command::AccessPass(command) => match command.command {

--- a/smartcontract/cli/src/link/latency.rs
+++ b/smartcontract/cli/src/link/latency.rs
@@ -1,0 +1,676 @@
+use crate::{doublezerocommand::CliCommand, validators::validate_code};
+use clap::Args;
+use doublezero_sdk::commands::link::latency::LatencyLinkCommand;
+use std::io::Write;
+use tabled::{
+    settings::{object::Columns, Remove, Style},
+    Table, Tabled,
+};
+
+#[derive(Tabled)]
+pub struct LatencyStatsRow {
+    #[tabled(rename = "Link")]
+    pub link_code: String,
+    #[tabled(rename = "Epoch")]
+    pub epoch: u64,
+    #[tabled(rename = "Samples")]
+    pub samples: usize,
+    #[tabled(rename = "P50 (ms)")]
+    pub p50: String,
+    #[tabled(rename = "P90 (ms)")]
+    pub p90: String,
+    #[tabled(rename = "P95 (ms)")]
+    pub p95: String,
+    #[tabled(rename = "P99 (ms)")]
+    pub p99: String,
+    #[tabled(rename = "Mean (ms)")]
+    pub mean: String,
+    #[tabled(rename = "Min (ms)")]
+    pub min: String,
+    #[tabled(rename = "Max (ms)")]
+    pub max: String,
+    #[tabled(rename = "StdDev (ms)")]
+    pub stddev: String,
+}
+
+#[derive(Args, Debug)]
+pub struct LinkLatencyCliCommand {
+    /// The pubkey or code of the link to retrieve
+    #[arg(long, value_parser = validate_code)]
+    pub code: Option<String>,
+
+    // Possible statistics to display (p50, p90, p95, p99, mean, min, max, stddev, all)
+    #[arg(long, default_value = "all")]
+    pub p: String,
+
+    // Epoch to query
+    #[arg(long)]
+    pub epoch: Option<u64>,
+}
+
+impl LinkLatencyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let env = client.get_environment();
+        let config = env.config()?;
+
+        // Call the SDK command which handles both single and all links
+        let stats_vec = client.latency_link(LatencyLinkCommand {
+            pubkey_or_code: self.code.clone(),
+            epoch: self.epoch,
+            telemetry_program_id: config.telemetry_program_id,
+        })?;
+
+        // Convert to table rows
+        let rows: Vec<LatencyStatsRow> = stats_vec
+            .into_iter()
+            .map(|stats| LatencyStatsRow {
+                link_code: stats
+                    .link_code
+                    .unwrap_or_else(|| format!("{}", stats.link_pk)),
+                epoch: stats.epoch,
+                samples: stats.sample_count,
+                p50: format!("{:.2}", stats.p50),
+                p90: format!("{:.2}", stats.p90),
+                p95: format!("{:.2}", stats.p95),
+                p99: format!("{:.2}", stats.p99),
+                mean: format!("{:.2}", stats.mean),
+                min: format!("{:.2}", stats.min),
+                max: format!("{:.2}", stats.max),
+                stddev: format!("{:.2}", stats.stddev),
+            })
+            .collect();
+
+        // Build and display table based on --p parameter
+        if rows.is_empty() {
+            writeln!(out, "No latency data found")?;
+        } else {
+            let mut table = Table::new(rows).with(Style::psql()).to_owned();
+
+            // Column indices in LatencyStatsRow
+            // 0 Link, 1 Epoch, 2 Samples, 3 P50, 4 P90, 5 P95, 6 P99, 7 Mean, 8 Min, 9 Max, 10 StdDev
+            match self.p.as_str() {
+                "all" => {
+                    // keep all columns
+                }
+                "p50" => {
+                    for idx in [10, 9, 8, 7, 6, 5, 4] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "p90" => {
+                    for idx in [10, 9, 8, 7, 6, 5, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "p95" => {
+                    for idx in [10, 9, 8, 7, 6, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "p99" => {
+                    for idx in [10, 9, 8, 7, 5, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "mean" => {
+                    for idx in [10, 9, 8, 6, 5, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "min" => {
+                    for idx in [10, 9, 7, 6, 5, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "max" => {
+                    for idx in [10, 8, 7, 6, 5, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                "stddev" => {
+                    for idx in [9, 8, 7, 6, 5, 4, 3] {
+                        table.with(Remove::column(Columns::new(idx..=idx)));
+                    }
+                }
+                invalid => {
+                    eyre::bail!(
+                        "Invalid percentile '{}'. Valid options: p50, p90, p95, p99, mean, min, max, stddev, all",
+                        invalid
+                    );
+                }
+            }
+
+            writeln!(out, "{}", table)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        doublezerocommand::CliCommand, link::latency::LinkLatencyCliCommand,
+        tests::utils::create_test_client,
+    };
+    use doublezero_config::Environment;
+    use doublezero_sdk::{
+        commands::link::{get::GetLinkCommand, latency::LatencyLinkCommand},
+        get_link_pda,
+        telemetry::LinkLatencyStats,
+        AccountType, Link, LinkLinkType, LinkStatus,
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    fn create_test_link(pda_pubkey: Pubkey) -> Link {
+        let contributor_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+        let device1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb");
+        let device2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");
+
+        Link {
+            account_type: AccountType::Link,
+            index: 1,
+            bump_seed: 255,
+            code: "nyc-lax".to_string(),
+            contributor_pk,
+            side_a_pk: device1_pk,
+            side_z_pk: device2_pk,
+            link_type: LinkLinkType::WAN,
+            bandwidth: 1000000000,
+            mtu: 1500,
+            delay_ns: 10000000000,
+            jitter_ns: 5000000000,
+            tunnel_id: 1,
+            tunnel_net: "10.0.0.1/16".parse().unwrap(),
+            status: LinkStatus::Activated,
+            owner: pda_pubkey,
+            side_a_iface_name: "eth0".to_string(),
+            side_z_iface_name: "eth1".to_string(),
+            delay_override_ns: 0,
+        }
+    }
+
+    fn create_test_stats(
+        link_pk: Pubkey,
+        device1_pk: Pubkey,
+        device2_pk: Pubkey,
+    ) -> LinkLatencyStats {
+        LinkLatencyStats {
+            epoch: 19800,
+            link_pk,
+            link_code: Some("nyc-lax".to_string()),
+            origin_device_pk: device1_pk,
+            target_device_pk: device2_pk,
+            sample_count: 1000,
+            p50: 12.34, // milliseconds
+            p90: 23.45,
+            p95: 34.56,
+            p99: 45.67,
+            mean: 15.23,
+            min: 8.12,
+            max: 67.89,
+            stddev: 5.43,
+        }
+    }
+
+    #[test]
+    fn test_cli_link_latency_p99() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+        let telemetry_program_id = env.config().unwrap().telemetry_program_id;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_get_link()
+            .with(predicate::eq(GetLinkCommand {
+                pubkey_or_code: "nyc-lax".to_string(),
+            }))
+            .returning(move |_| Ok((pda_pubkey, link.clone())));
+
+        client
+            .expect_latency_link()
+            .with(predicate::function(move |cmd: &LatencyLinkCommand| {
+                cmd.pubkey_or_code == Some("nyc-lax".to_string())
+                    && cmd.epoch.is_none()
+                    && cmd.telemetry_program_id == telemetry_program_id
+            }))
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "p99".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify we ONLY see P99, not other metrics
+        assert!(output_str.contains("Link"), "Should have Link header");
+        assert!(output_str.contains("Epoch"), "Should have Epoch header");
+        assert!(output_str.contains("Samples"), "Should have Samples header");
+        assert!(output_str.contains("P99 (ms)"), "Should have P99 column");
+
+        // Verify other metric columns are NOT present
+        assert!(
+            !output_str.contains("P50 (ms)"),
+            "Should NOT have P50 column"
+        );
+        assert!(
+            !output_str.contains("P90 (ms)"),
+            "Should NOT have P90 column"
+        );
+        assert!(
+            !output_str.contains("P95 (ms)"),
+            "Should NOT have P95 column"
+        );
+        assert!(
+            !output_str.contains("Mean (ms)"),
+            "Should NOT have Mean column"
+        );
+        assert!(
+            !output_str.contains("StdDev (ms)"),
+            "Should NOT have StdDev column"
+        );
+
+        // Verify data
+        assert!(output_str.contains("nyc-lax"), "Should contain link code");
+        assert!(output_str.contains("45.67"), "Should contain p99 value");
+        assert!(output_str.contains("19800"), "Should contain epoch");
+    }
+
+    #[test]
+    fn test_cli_link_latency_p50() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_get_link()
+            .returning(move |_| Ok((pda_pubkey, link.clone())));
+
+        client
+            .expect_latency_link()
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "p50".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify we ONLY see P50, not other metrics
+        assert!(output_str.contains("Link"), "Should have Link header");
+        assert!(output_str.contains("Epoch"), "Should have Epoch header");
+        assert!(output_str.contains("Samples"), "Should have Samples header");
+        assert!(output_str.contains("P50 (ms)"), "Should have P50 column");
+
+        // Verify other metric columns are NOT present
+        assert!(
+            !output_str.contains("P90 (ms)"),
+            "Should NOT have P90 column"
+        );
+        assert!(
+            !output_str.contains("P95 (ms)"),
+            "Should NOT have P95 column"
+        );
+        assert!(
+            !output_str.contains("P99 (ms)"),
+            "Should NOT have P99 column"
+        );
+        assert!(
+            !output_str.contains("Mean (ms)"),
+            "Should NOT have Mean column"
+        );
+        assert!(
+            !output_str.contains("StdDev (ms)"),
+            "Should NOT have StdDev column"
+        );
+
+        // Verify data
+        assert!(output_str.contains("nyc-lax"), "Should contain link code");
+        assert!(output_str.contains("12.34"), "Should contain p50 value");
+        assert!(output_str.contains("19800"), "Should contain epoch");
+    }
+
+    #[test]
+    fn test_cli_link_latency_mean() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_get_link()
+            .returning(move |_| Ok((pda_pubkey, link.clone())));
+
+        client
+            .expect_latency_link()
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "mean".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify we ONLY see Mean, not other metrics
+        assert!(output_str.contains("Link"), "Should have Link header");
+        assert!(output_str.contains("Epoch"), "Should have Epoch header");
+        assert!(output_str.contains("Samples"), "Should have Samples header");
+        assert!(output_str.contains("Mean (ms)"), "Should have Mean column");
+
+        // Verify other metric columns are NOT present
+        assert!(
+            !output_str.contains("P50 (ms)"),
+            "Should NOT have P50 column"
+        );
+        assert!(
+            !output_str.contains("P90 (ms)"),
+            "Should NOT have P90 column"
+        );
+        assert!(
+            !output_str.contains("P95 (ms)"),
+            "Should NOT have P95 column"
+        );
+        assert!(
+            !output_str.contains("P99 (ms)"),
+            "Should NOT have P99 column"
+        );
+        assert!(
+            !output_str.contains("StdDev (ms)"),
+            "Should NOT have StdDev column"
+        );
+
+        // Verify data
+        assert!(output_str.contains("nyc-lax"), "Should contain link code");
+        assert!(output_str.contains("15.23"), "Should contain mean value");
+        assert!(output_str.contains("19800"), "Should contain epoch");
+    }
+
+    #[test]
+    fn test_cli_link_latency_all() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_get_link()
+            .returning(move |_| Ok((pda_pubkey, link.clone())));
+
+        client
+            .expect_latency_link()
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "all".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify table headers
+        assert!(output_str.contains("Link"), "Should have Link header");
+        assert!(output_str.contains("Epoch"), "Should have Epoch header");
+        assert!(output_str.contains("Samples"), "Should have Samples header");
+        assert!(output_str.contains("P50 (ms)"), "Should have P50 header");
+        assert!(output_str.contains("P99 (ms)"), "Should have P99 header");
+        assert!(output_str.contains("Mean (ms)"), "Should have Mean header");
+
+        // Verify data
+        assert!(output_str.contains("nyc-lax"), "Should contain link code");
+        assert!(output_str.contains("19800"), "Should contain epoch");
+        assert!(output_str.contains("1000"), "Should contain samples");
+        assert!(output_str.contains("12.34"), "Should contain p50");
+        assert!(output_str.contains("45.67"), "Should contain p99");
+        assert!(output_str.contains("15.23"), "Should contain mean");
+    }
+
+    #[test]
+    fn test_cli_link_latency_with_epoch() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+        let telemetry_program_id = env.config().unwrap().telemetry_program_id;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_get_link()
+            .returning(move |_| Ok((pda_pubkey, link.clone())));
+
+        client
+            .expect_latency_link()
+            .with(predicate::function(move |cmd: &LatencyLinkCommand| {
+                cmd.pubkey_or_code == Some("nyc-lax".to_string())
+                    && cmd.epoch == Some(12345)
+                    && cmd.telemetry_program_id == telemetry_program_id
+            }))
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "p99".to_string(),
+            epoch: Some(12345),
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed with epoch");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify we ONLY see P99, not other metrics
+        assert!(output_str.contains("Link"), "Should have Link header");
+        assert!(output_str.contains("Epoch"), "Should have Epoch header");
+        assert!(output_str.contains("Samples"), "Should have Samples header");
+        assert!(output_str.contains("P99 (ms)"), "Should have P99 column");
+
+        // Verify other metric columns are NOT present
+        assert!(
+            !output_str.contains("P50 (ms)"),
+            "Should NOT have P50 column"
+        );
+        assert!(
+            !output_str.contains("Mean (ms)"),
+            "Should NOT have Mean column"
+        );
+
+        // Verify data
+        assert!(output_str.contains("nyc-lax"), "Should contain link code");
+        assert!(output_str.contains("45.67"), "Should contain p99 value");
+    }
+
+    #[test]
+    fn test_cli_link_latency_link_not_found() {
+        let mut client = create_test_client();
+
+        let env = Environment::Devnet;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_latency_link()
+            .returning(|_| Err(eyre::eyre!("Link not found")));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nonexistent".to_string()),
+            p: "p99".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err(), "Should fail when link not found");
+    }
+
+    #[test]
+    fn test_cli_link_latency_invalid_percentile() {
+        let mut client = create_test_client();
+        let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
+        let link = create_test_link(pda_pubkey);
+        let stats = create_test_stats(pda_pubkey, link.side_a_pk, link.side_z_pk);
+
+        let env = Environment::Devnet;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_latency_link()
+            .returning(move |_| Ok(vec![stats.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: Some("nyc-lax".to_string()),
+            p: "invalid".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err(), "Should fail with invalid percentile");
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid percentile"),
+            "Error should mention invalid percentile"
+        );
+        assert!(
+            err.to_string().contains("invalid"),
+            "Error should include the invalid value"
+        );
+        assert!(
+            err.to_string().contains("p50"),
+            "Error should list valid options"
+        );
+    }
+
+    #[test]
+    fn test_cli_link_latency_all_links_multiple() {
+        let mut client = create_test_client();
+
+        // Create two different links
+        let (pda_pubkey1, _) = get_link_pda(&client.get_program_id(), 1);
+        let device1a_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb");
+        let device1z_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");
+
+        let (pda_pubkey2, _) = get_link_pda(&client.get_program_id(), 2);
+        let device2a_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkca");
+        let device2z_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
+
+        // Create stats for both links
+        let stats1 = LinkLatencyStats {
+            epoch: 19800,
+            link_pk: pda_pubkey1,
+            link_code: Some("nyc-lax".to_string()),
+            origin_device_pk: device1a_pk,
+            target_device_pk: device1z_pk,
+            sample_count: 1000,
+            p50: 12.34,
+            p90: 23.45,
+            p95: 34.56,
+            p99: 45.67,
+            mean: 15.23,
+            min: 8.12,
+            max: 67.89,
+            stddev: 5.43,
+        };
+
+        let stats2 = LinkLatencyStats {
+            epoch: 19800,
+            link_pk: pda_pubkey2,
+            link_code: Some("sfo-sea".to_string()),
+            origin_device_pk: device2a_pk,
+            target_device_pk: device2z_pk,
+            sample_count: 850,
+            p50: 8.21,
+            p90: 15.32,
+            p95: 18.45,
+            p99: 22.11,
+            mean: 9.87,
+            min: 5.43,
+            max: 45.21,
+            stddev: 3.21,
+        };
+
+        let env = Environment::Devnet;
+        let telemetry_program_id = env.config().unwrap().telemetry_program_id;
+
+        client.expect_get_environment().returning(move || env);
+
+        client
+            .expect_latency_link()
+            .with(predicate::function(move |cmd: &LatencyLinkCommand| {
+                cmd.pubkey_or_code.is_none()
+                    && cmd.epoch.is_none()
+                    && cmd.telemetry_program_id == telemetry_program_id
+            }))
+            .returning(move |_| Ok(vec![stats1.clone(), stats2.clone()]));
+
+        let mut output = Vec::new();
+        let res = LinkLatencyCliCommand {
+            code: None, // Query all links
+            p: "all".to_string(),
+            epoch: None,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok(), "Should succeed");
+        let output_str = String::from_utf8(output).unwrap();
+
+        // Verify both links are in the output
+        assert!(output_str.contains("nyc-lax"), "Should contain first link");
+        assert!(output_str.contains("sfo-sea"), "Should contain second link");
+
+        // Verify first link stats
+        assert!(output_str.contains("1000")); // samples for nyc-lax
+        assert!(output_str.contains("12.34")); // p50 for nyc-lax
+        assert!(output_str.contains("45.67")); // p99 for nyc-lax
+
+        // Verify second link stats
+        assert!(output_str.contains("850")); // samples for sfo-sea
+        assert!(output_str.contains("8.21")); // p50 for sfo-sea
+        assert!(output_str.contains("22.11")); // p99 for sfo-sea
+
+        // Verify it's a table format
+        assert!(output_str.contains("Link")); // Table header
+        assert!(output_str.contains("Epoch"));
+        assert!(output_str.contains("Samples"));
+    }
+}

--- a/smartcontract/cli/src/link/mod.rs
+++ b/smartcontract/cli/src/link/mod.rs
@@ -2,6 +2,7 @@ pub mod accept;
 pub mod delete;
 pub mod dzx_create;
 pub mod get;
+pub mod latency;
 pub mod list;
 pub mod update;
 pub mod wan_create;

--- a/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
@@ -28,7 +28,6 @@ use doublezero_serviceability::{
     },
 };
 use doublezero_telemetry::{
-    entrypoint::process_instruction as telemetry_process_instruction,
     error::TelemetryError,
     instructions::{TelemetryInstruction, INITIALIZE_DEVICE_LATENCY_SAMPLES_INSTRUCTION_INDEX},
     pda::{derive_device_latency_samples_pda, derive_internet_latency_samples_pda},
@@ -40,6 +39,9 @@ use doublezero_telemetry::{
     },
     serviceability_program_id,
 };
+
+#[cfg(not(feature = "no-entrypoint"))]
+use doublezero_telemetry::entrypoint::process_instruction as telemetry_process_instruction;
 use solana_program_test::*;
 use solana_sdk::{
     account::Account,
@@ -1254,11 +1256,14 @@ pub fn setup_test_programs() -> (ProgramTest, Pubkey, Pubkey) {
 
     // Add telemetry program
     let telemetry_program_id = Pubkey::new_unique();
+    #[cfg(not(feature = "no-entrypoint"))]
     program_test.add_program(
         "doublezero_telemetry",
         telemetry_program_id,
         processor!(telemetry_process_instruction),
     );
+    #[cfg(feature = "no-entrypoint")]
+    program_test.add_program("doublezero_telemetry", telemetry_program_id, None);
 
     // Add serviceability program with its actual processor
     let serviceability_program_id = serviceability_program_id();

--- a/smartcontract/sdk/rs/Cargo.toml
+++ b/smartcontract/sdk/rs/Cargo.toml
@@ -23,6 +23,7 @@ doublezero-config.workspace = true
 doublezero-program-common.workspace = true
 doublezero-record.workspace = true
 doublezero-serviceability.workspace = true
+doublezero-telemetry = { workspace = true, features = ["no-entrypoint", "serde"] }
 eyre.workspace = true
 futures.workspace = true
 mockall.workspace = true

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -391,6 +391,20 @@ impl DoubleZeroClient for DZClient {
         }
     }
 
+    fn get_account(&self, pubkey: Pubkey) -> eyre::Result<Account> {
+        self.client.get_account(&pubkey).map_err(|e| eyre!(e))
+    }
+
+    fn get_program_accounts(
+        &self,
+        program_id: &Pubkey,
+        config: RpcProgramAccountsConfig,
+    ) -> eyre::Result<Vec<(Pubkey, Account)>> {
+        self.client
+            .get_program_accounts_with_config(program_id, config)
+            .map_err(|e| eyre!(e))
+    }
+
     #[allow(deprecated)]
     fn get_transactions(&self, pubkey: Pubkey) -> eyre::Result<Vec<DZTransaction>> {
         let mut transactions: Vec<DZTransaction> = Vec::new();

--- a/smartcontract/sdk/rs/src/commands/link/latency.rs
+++ b/smartcontract/sdk/rs/src/commands/link/latency.rs
@@ -1,0 +1,86 @@
+use crate::{
+    commands::link::{get::GetLinkCommand, list::ListLinkCommand},
+    telemetry::{calculate_stats, get_all_device_latency_samples, LinkLatencyStats},
+    DoubleZeroClient,
+};
+use doublezero_telemetry::{
+    pda::derive_device_latency_samples_pda, state::device_latency_samples::DeviceLatencySamples,
+};
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct LatencyLinkCommand {
+    pub pubkey_or_code: Option<String>,
+    pub epoch: Option<u64>,
+    pub telemetry_program_id: Pubkey,
+}
+
+impl LatencyLinkCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Vec<LinkLatencyStats>> {
+        // Get current or specified epoch
+        let epoch = match self.epoch {
+            Some(e) => e,
+            None => client.get_epoch()?,
+        };
+
+        match &self.pubkey_or_code {
+            Some(code) => {
+                let (link_pk, link) = GetLinkCommand {
+                    pubkey_or_code: code.clone(),
+                }
+                .execute(client)?;
+
+                let (pda, _bump) = derive_device_latency_samples_pda(
+                    &self.telemetry_program_id,
+                    &link.side_a_pk,
+                    &link.side_z_pk,
+                    &link_pk,
+                    epoch,
+                );
+
+                let account = client.get_account(pda)?;
+
+                // Get latency data
+                let latency_data = DeviceLatencySamples::try_from(&account.data[..])?;
+
+                let stats = calculate_stats(
+                    epoch,
+                    link_pk,
+                    Some(link.code.clone()),
+                    link.side_a_pk,
+                    link.side_z_pk,
+                    &latency_data.samples,
+                )?;
+
+                Ok(vec![stats])
+            }
+            None => {
+                // All links case
+                let all_links = ListLinkCommand.execute(client)?;
+                let all_telemetry =
+                    get_all_device_latency_samples(client, &self.telemetry_program_id, epoch)?;
+
+                let mut results = Vec::new();
+                for (link_pk, link) in all_links {
+                    // Find telemetry data for this link
+                    if let Some(telemetry_data) =
+                        all_telemetry.values().find(|t| t.header.link_pk == link_pk)
+                    {
+                        let stats = calculate_stats(
+                            epoch,
+                            link_pk,
+                            Some(link.code.clone()),
+                            link.side_a_pk,
+                            link.side_z_pk,
+                            &telemetry_data.samples,
+                        )?;
+
+                        results.push(stats);
+                    }
+                }
+
+                Ok(results)
+            }
+        }
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/link/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/link/mod.rs
@@ -4,6 +4,7 @@ pub mod closeaccount;
 pub mod create;
 pub mod delete;
 pub mod get;
+pub mod latency;
 pub mod list;
 pub mod reject;
 pub mod resume;

--- a/smartcontract/sdk/rs/src/doublezeroclient.rs
+++ b/smartcontract/sdk/rs/src/doublezeroclient.rs
@@ -2,7 +2,10 @@ use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
     state::{accountdata::AccountData, accounttype::AccountType},
 };
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+use solana_client::rpc_config::RpcProgramAccountsConfig;
+use solana_sdk::{
+    account::Account, instruction::AccountMeta, pubkey::Pubkey, signature::Signature,
+};
 use std::collections::HashMap;
 
 use crate::dztransaction::DZTransaction;
@@ -17,6 +20,12 @@ pub trait DoubleZeroClient {
 
     fn get(&self, pubkey: Pubkey) -> eyre::Result<AccountData>;
     fn gets(&self, account_type: AccountType) -> eyre::Result<HashMap<Pubkey, AccountData>>;
+    fn get_account(&self, pubkey: Pubkey) -> eyre::Result<Account>;
+    fn get_program_accounts(
+        &self,
+        program_id: &Pubkey,
+        config: RpcProgramAccountsConfig,
+    ) -> eyre::Result<Vec<(Pubkey, Account)>>;
 
     fn execute_transaction(
         &self,

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -36,6 +36,7 @@ mod errors;
 
 pub mod commands;
 pub mod record;
+pub mod telemetry;
 pub mod tests;
 pub mod utils;
 

--- a/smartcontract/sdk/rs/src/telemetry/client.rs
+++ b/smartcontract/sdk/rs/src/telemetry/client.rs
@@ -1,0 +1,60 @@
+use crate::DoubleZeroClient;
+use doublezero_telemetry::state::device_latency_samples::DeviceLatencySamples;
+use solana_account_decoder::UiAccountEncoding;
+use solana_client::{
+    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
+};
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
+use std::collections::HashMap;
+
+// Fetch all device latency samples for a specific epoch in a single RPC call
+pub fn get_all_device_latency_samples(
+    client: &dyn DoubleZeroClient,
+    telemetry_program_id: &Pubkey,
+    epoch: u64,
+) -> eyre::Result<HashMap<Pubkey, DeviceLatencySamples>> {
+    const DEVICE_LATENCY_SAMPLES_ACCOUNT_TYPE: u8 = 3;
+
+    // Filter for DeviceLatencySamples account type and specific epoch
+    let filters = vec![
+        RpcFilterType::Memcmp(Memcmp::new(
+            0, // account_type is the first byte
+            MemcmpEncodedBytes::Bytes(vec![DEVICE_LATENCY_SAMPLES_ACCOUNT_TYPE]),
+        )),
+        RpcFilterType::Memcmp(Memcmp::new(
+            1, // epoch starts at byte 1
+            MemcmpEncodedBytes::Bytes(epoch.to_le_bytes().to_vec()),
+        )),
+    ];
+
+    let options = RpcProgramAccountsConfig {
+        filters: Some(filters),
+        account_config: RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            data_slice: None,
+            commitment: Some(CommitmentConfig::confirmed()),
+            min_context_slot: None,
+        },
+        with_context: None,
+        sort_results: None,
+    };
+
+    let accounts = client.get_program_accounts(telemetry_program_id, options)?;
+
+    let mut result = HashMap::new();
+
+    for (pubkey, account) in accounts {
+        match DeviceLatencySamples::try_from(&account.data[..]) {
+            Ok(latency_data) => {
+                result.insert(pubkey, latency_data);
+            }
+            Err(_) => {
+                // Skip accounts that fail to deserialize
+                continue;
+            }
+        }
+    }
+
+    Ok(result)
+}

--- a/smartcontract/sdk/rs/src/telemetry/mod.rs
+++ b/smartcontract/sdk/rs/src/telemetry/mod.rs
@@ -1,0 +1,5 @@
+pub mod client;
+pub mod stats;
+
+pub use client::get_all_device_latency_samples;
+pub use stats::{calculate_stats, LinkLatencyStats};

--- a/smartcontract/sdk/rs/src/telemetry/stats.rs
+++ b/smartcontract/sdk/rs/src/telemetry/stats.rs
@@ -1,0 +1,118 @@
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, Clone)]
+pub struct LinkLatencyStats {
+    pub epoch: u64,
+    pub link_pk: Pubkey,
+    pub link_code: Option<String>,
+    pub origin_device_pk: Pubkey,
+    pub target_device_pk: Pubkey,
+    pub sample_count: usize,
+    pub p50: f64,
+    pub p90: f64,
+    pub p95: f64,
+    pub p99: f64,
+    pub mean: f64,
+    pub min: f64,
+    pub max: f64,
+    pub stddev: f64,
+}
+
+pub fn calculate_stats(
+    epoch: u64,
+    link_pk: Pubkey,
+    link_code: Option<String>,
+    origin_device_pk: Pubkey,
+    target_device_pk: Pubkey,
+    samples: &[u32],
+) -> eyre::Result<LinkLatencyStats> {
+    if samples.is_empty() {
+        eyre::bail!("No samples available");
+    }
+
+    // Sort for percentiles
+    let mut sorted_samples: Vec<f64> = samples.iter().map(|&s| (s as f64) / 1000.0).collect();
+    sorted_samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let n = sorted_samples.len();
+
+    let p50 = percentile(&sorted_samples, 0.50);
+    let p90 = percentile(&sorted_samples, 0.90);
+    let p95 = percentile(&sorted_samples, 0.95);
+    let p99 = percentile(&sorted_samples, 0.99);
+
+    let sum: f64 = sorted_samples.iter().sum();
+    let mean = sum / n as f64;
+
+    let min = sorted_samples[0];
+    let max = sorted_samples[n - 1];
+
+    let variance: f64 = sorted_samples
+        .iter()
+        .map(|&x| {
+            let diff = x - mean;
+            diff * diff
+        })
+        .sum::<f64>()
+        / n as f64;
+    let stddev = variance.sqrt();
+
+    Ok(LinkLatencyStats {
+        epoch,
+        link_pk,
+        link_code,
+        origin_device_pk,
+        target_device_pk,
+        sample_count: n,
+        p50,
+        p90,
+        p95,
+        p99,
+        mean,
+        min,
+        max,
+        stddev,
+    })
+}
+
+fn percentile(sorted_samples: &[f64], p: f64) -> f64 {
+    let n = sorted_samples.len() as f64;
+    let index = (p * n).ceil() as usize - 1;
+    sorted_samples[index]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calculate_stats;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn calculate_stats_test() {
+        let epoch = 19500;
+        let link_pk = Pubkey::new_unique();
+        let origin_device_pk = Pubkey::new_unique();
+        let target_device_pk = Pubkey::new_unique();
+        let samples: &[u32] = &[10, 20, 30, 40, 50];
+
+        let stats = calculate_stats(
+            epoch,
+            link_pk,
+            None,
+            origin_device_pk,
+            target_device_pk,
+            samples,
+        )
+        .unwrap();
+
+        assert!((stats.p50 - 0.03).abs() < 1e-9);
+        assert!((stats.p90 - 0.05).abs() < 1e-9);
+        assert!((stats.p95 - 0.05).abs() < 1e-9);
+        assert!((stats.p99 - 0.05).abs() < 1e-9);
+
+        assert!((stats.mean - 0.03).abs() < 1e-9);
+        assert!((stats.min - 0.01).abs() < 1e-9);
+        assert!((stats.max - 0.05).abs() < 1e-9);
+
+        assert!((stats.stddev - 0.0141421356237).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
Resolves: #1942

## Summary of Changes
* Divided the latency command in two: latency (old functionality) and telemetry (new functionality)
* TelemetryClient and DeviceLatencySamples data structures for querying on-chain latency data
* Integrated latency commands into main CLI


## Testing Verification
* Unit tests - Serialization/deserialization tests for DeviceLatencySamples
* Test suite for TelemetryLatencyCliCommand with JSON/non-JSON output, mock integration, and error handling using TestFixture pattern
