### PR TITLE
Add signer checks for payer accounts across various processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
     - serviceability: add auto-assignment and validation for exchange.bgp_community
     - serviceability: prevent device interface name duplication
     - Update serviceability and telemetry program instruction args to use the `BorshDeserializeIncremental` derive macro incremental, backward-compatible, deserialization of structs.
+    - Add explicit signer checks for payer accounts across various processors to improve security and ensure correct transaction authorization.
 - CLI
     - Removed `--bgp-community` option from `doublezero exchange create` since these values are now assigned automatically
     - Add `--next-bgp-community` option to `doublezero global-config set` so authorized users can control which bgp_community will be assigned next

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/check_status.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/check_status.rs
@@ -38,6 +38,9 @@ pub fn process_check_status_access_pass(
     #[cfg(test)]
     msg!("process_check_status_access_pass({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if accesspass_account.data_is_empty() {
         return Err(DoubleZeroError::AccessPassNotFound.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/close.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/close.rs
@@ -36,6 +36,9 @@ pub fn process_close_access_pass(
     #[cfg(test)]
     msg!("process_close_accesspass({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if accesspass_account.data_is_empty() {
         return Err(DoubleZeroError::AccessPassNotFound.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -65,6 +65,9 @@ pub fn process_set_access_pass(
     #[cfg(test)]
     msg!("process_set_accesspass({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         *globalstate_account.owner,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/add.rs
@@ -41,6 +41,9 @@ pub fn process_add_device_allowlist_globalconfig(
     #[cfg(test)]
     msg!("process_add_device_allowlist_globalconfig({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/device/remove.rs
@@ -40,6 +40,9 @@ pub fn process_remove_device_allowlist_globalconfig(
     #[cfg(test)]
     msg!("process_remove_device_allowlist_globalconfig({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/add.rs
@@ -41,6 +41,9 @@ pub fn process_add_foundation_allowlist_globalconfig(
     #[cfg(test)]
     msg!("process_add_foundation_allowlist_globalconfig({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/foundation/remove.rs
@@ -43,6 +43,9 @@ pub fn process_remove_foundation_allowlist_globalconfig(
         value
     );
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/add.rs
@@ -41,6 +41,9 @@ pub fn process_add_user_allowlist(
     #[cfg(test)]
     msg!("process_add_user_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/user/remove.rs
@@ -40,6 +40,9 @@ pub fn process_remove_user_allowlist(
     #[cfg(test)]
     msg!("process_remove_user_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(pda_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
@@ -50,6 +50,9 @@ pub fn process_create_contributor(
     #[cfg(test)]
     msg!("process_create_contributor({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/delete.rs
@@ -36,6 +36,9 @@ pub fn process_delete_contributor(
     #[cfg(test)]
     msg!("process_delete_contributor({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         contributor_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/resume.rs
@@ -36,6 +36,9 @@ pub fn process_resume_contributor(
     #[cfg(test)]
     msg!("process_resume_contributor({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         contributor_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/suspend.rs
@@ -37,6 +37,9 @@ pub fn process_suspend_contributor(
     #[cfg(test)]
     msg!("process_suspend_contributor({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         contributor_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
@@ -39,6 +39,9 @@ pub fn process_update_contributor(
     #[cfg(test)]
     msg!("process_update_contributor({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         contributor_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/activate.rs
@@ -32,6 +32,9 @@ pub fn process_activate_device(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     #[cfg(test)]
     msg!("process_activate_device()");
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
@@ -43,6 +43,9 @@ pub fn process_closeaccount_device(
     #[cfg(test)]
     msg!("process_closeaccount_device({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -66,6 +66,9 @@ pub fn process_create_device(
     #[cfg(test)]
     msg!("process_create_device({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/delete.rs
@@ -40,6 +40,9 @@ pub fn process_delete_device(
     #[cfg(test)]
     msg!("process_delete_device({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
@@ -45,6 +45,9 @@ pub fn process_activate_device_interface(
     #[cfg(test)]
     msg!("process_activate_device_interface()");
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
@@ -50,6 +50,9 @@ pub fn process_create_device_interface(
     #[cfg(test)]
     msg!("process_create_device_interface({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
 
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/delete.rs
@@ -42,6 +42,9 @@ pub fn process_delete_device_interface(
     #[cfg(test)]
     msg!("process_delete_device_interface({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/reject.rs
@@ -38,6 +38,9 @@ pub fn process_reject_device_interface(
     #[cfg(test)]
     msg!("process_reject_device_interface()");
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/remove.rs
@@ -36,6 +36,9 @@ pub fn process_remove_device_interface(
     #[cfg(test)]
     msg!("process_remove_device_interface({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/unlink.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/unlink.rs
@@ -39,6 +39,9 @@ pub fn process_unlink_device_interface(
     #[cfg(test)]
     msg!("process_unlink_device_interface()");
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if device_account.owner != program_id {
         return Err(ProgramError::IncorrectProgramId);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
@@ -63,6 +63,9 @@ pub fn process_update_device_interface(
     #[cfg(test)]
     msg!("process_update_device_interface({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
@@ -37,6 +37,9 @@ pub fn process_reject_device(
     #[cfg(test)]
     msg!("process_activate_device({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/resume.rs
@@ -41,6 +41,9 @@ pub fn process_resume_device(
     #[cfg(test)]
     msg!("process_resume_device({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/suspend.rs
@@ -41,6 +41,9 @@ pub fn process_suspend_device(
     #[cfg(test)]
     msg!("process_suspend_device({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
@@ -78,6 +78,9 @@ pub fn process_update_device(
     #[cfg(test)]
     msg!("process_update_device({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         device_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/create.rs
@@ -59,6 +59,9 @@ pub fn process_create_exchange(
     #[cfg(test)]
     msg!("process_create_location({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/delete.rs
@@ -37,6 +37,9 @@ pub fn process_delete_exchange(
     #[cfg(test)]
     msg!("process_delete_exchange({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         exchange_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/resume.rs
@@ -40,6 +40,9 @@ pub fn process_resume_exchange(
     #[cfg(test)]
     msg!("process_resume_exchange({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         exchange_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/setdevice.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/setdevice.rs
@@ -56,9 +56,16 @@ pub fn process_setdevice_exchange(
     #[cfg(test)]
     msg!("process_setdevice_exchange({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         exchange_account.owner, program_id,
+        "Invalid PDA Account Owner"
+    );
+    assert_eq!(
+        device_account.owner, program_id,
         "Invalid PDA Account Owner"
     );
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/suspend.rs
@@ -34,6 +34,9 @@ pub fn process_suspend_exchange(
     #[cfg(test)]
     msg!("process_suspend_exchange({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         exchange_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/update.rs
@@ -53,6 +53,9 @@ pub fn process_update_exchange(
     #[cfg(test)]
     msg!("process_update_exchange({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         exchange_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
@@ -57,6 +57,15 @@ pub fn process_set_globalconfig(
     #[cfg(test)]
     msg!("process_set_global_config({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    // Check the owner of the accounts
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+
     let globalstate = globalstate_get(globalstate_account)?;
     if !globalstate.foundation_allowlist.contains(payer_account.key) {
         return Err(DoubleZeroError::NotAllowed.into());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -26,6 +26,9 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     #[cfg(test)]
     msg!("initialize_global_state()");
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     let (program_config_pda, program_config_bump_seed) = get_program_config_pda(program_id);
     assert_eq!(
         program_config_account.key, &program_config_pda,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setairdrop.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setairdrop.rs
@@ -45,6 +45,9 @@ pub fn process_set_airdrop(
     #[cfg(test)]
     msg!("process_set_airdrop({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         globalstate_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setauthority.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setauthority.rs
@@ -45,6 +45,9 @@ pub fn process_set_authority(
     #[cfg(test)]
     msg!("process_set_authority({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         globalstate_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
@@ -43,6 +43,9 @@ pub fn process_accept_link(
     #[cfg(test)]
     msg!("process_accept_link({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
@@ -49,6 +49,9 @@ pub fn process_activate_link(
     #[cfg(test)]
     msg!("process_activate_link({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
@@ -45,6 +45,9 @@ pub fn process_closeaccount_link(
     #[cfg(test)]
     msg!("process_closeaccount_link({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -58,6 +58,9 @@ pub fn process_create_link(
     #[cfg(test)]
     msg!("process_create_link({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
@@ -40,8 +40,16 @@ pub fn process_delete_link(
     #[cfg(test)]
     msg!("process_delete_link({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
+    assert_eq!(
+        contributor_account.owner, program_id,
+        "Invalid Contributor Account Owner"
+    );
+
     assert_eq!(
         globalstate_account.owner, program_id,
         "Invalid GlobalState Account Owner"

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
@@ -36,6 +36,9 @@ pub fn process_reject_link(
     #[cfg(test)]
     msg!("process_activate_link({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/resume.rs
@@ -39,8 +39,21 @@ pub fn process_resume_link(
     #[cfg(test)]
     msg!("process_resume_link({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
+    // Check the owner of the accounts
+    assert_eq!(
+        contributor_account.owner, program_id,
+        "Invalid Contributor Account Owner"
+    );
+
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
     assert_eq!(
         *system_program.unsigned_key(),
         solana_program::system_program::id(),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
@@ -39,8 +39,19 @@ pub fn process_suspend_link(
     #[cfg(test)]
     msg!("process_suspend_link({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        contributor_account.owner, program_id,
+        "Invalid Contributor Account Owner"
+    );
     assert_eq!(
         *system_program.unsigned_key(),
         solana_program::system_program::id(),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -53,6 +53,9 @@ pub fn process_update_link(
     #[cfg(test)]
     msg!("process_update_link({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/create.rs
@@ -63,6 +63,9 @@ pub fn process_create_location(
     #[cfg(test)]
     msg!("process_create_location({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/delete.rs
@@ -39,6 +39,9 @@ pub fn process_delete_location(
     #[cfg(test)]
     msg!("process_delete_location({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         location_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/resume.rs
@@ -34,6 +34,9 @@ pub fn process_resume_location(
     #[cfg(test)]
     msg!("process_resume_location({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         location_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/suspend.rs
@@ -35,6 +35,9 @@ pub fn process_suspend_location(
     #[cfg(test)]
     msg!("process_suspend_location({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         location_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/location/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/location/update.rs
@@ -45,6 +45,9 @@ pub fn process_update_location(
     #[cfg(test)]
     msg!("process_update_location({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         location_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/activate.rs
@@ -38,6 +38,9 @@ pub fn process_activate_multicastgroup(
     #[cfg(test)]
     msg!("process_activate_multicastgroup({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
@@ -55,6 +55,9 @@ pub fn process_add_multicastgroup_pub_allowlist(
     #[cfg(test)]
     msg!("process_add_multicastgroup_pub_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         mgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
@@ -49,6 +49,9 @@ pub fn process_remove_multicast_pub_allowlist(
     #[cfg(test)]
     msg!("process_remove_multicast_pub_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         mgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
@@ -55,6 +55,9 @@ pub fn process_add_multicastgroup_sub_allowlist(
     #[cfg(test)]
     msg!("process_add_multicastgroup_sub_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         mgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
@@ -49,6 +49,9 @@ pub fn process_remove_multicast_sub_allowlist(
     #[cfg(test)]
     msg!("process_remove_multicast_sub_allowlist({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         mgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/closeaccount.rs
@@ -38,6 +38,9 @@ pub fn process_deactivate_multicastgroup(
     #[cfg(test)]
     msg!("process_deactivate_multicastgroup({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/create.rs
@@ -53,6 +53,9 @@ pub fn process_create_multicastgroup(
     #[cfg(test)]
     msg!("process_create_multicastgroup({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Validate and normalize code
     let code =
         validate_account_code(&value.code).map_err(|_| DoubleZeroError::InvalidAccountCode)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/delete.rs
@@ -37,6 +37,9 @@ pub fn process_delete_multicastgroup(
     #[cfg(test)]
     msg!("process_delete_multicastgroup({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reactivate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reactivate.rs
@@ -36,6 +36,9 @@ pub fn process_reactivate_multicastgroup(
     #[cfg(test)]
     msg!("process_reactivate_multicastgroup({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
@@ -38,6 +38,9 @@ pub fn process_reject_multicastgroup(
     #[cfg(test)]
     msg!("process_activate_multicastgroup({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
@@ -51,6 +51,9 @@ pub fn process_subscribe_multicastgroup(
     #[cfg(test)]
     msg!("process_subscribe_multicastgroup({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         mgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/suspend.rs
@@ -37,6 +37,9 @@ pub fn process_suspend_multicastgroup(
     #[cfg(test)]
     msg!("process_suspend_multicastgroup({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
@@ -46,6 +46,9 @@ pub fn process_update_multicastgroup(
     #[cfg(test)]
     msg!("process_update_multicastgroup({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(
         multicastgroup_account.owner, program_id,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/activate.rs
@@ -54,6 +54,9 @@ pub fn process_activate_user(
     #[cfg(test)]
     msg!("process_activate_user({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid User Account Owner");
     if accesspass_account.data_is_empty() {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
@@ -34,6 +34,9 @@ pub fn process_ban_user(
     #[cfg(test)]
     msg!("process_banned_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
@@ -45,6 +45,9 @@ pub fn process_check_access_pass_user(
     #[cfg(test)]
     msg!("process_check_access_pass_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     if accesspass_account.data_is_empty() {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -41,6 +41,9 @@ pub fn process_closeaccount_user(
     #[cfg(test)]
     msg!("process_delete_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -60,6 +60,9 @@ pub fn process_create_user(
     #[cfg(test)]
     msg!("process_create_user({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if !user_account.data.borrow().is_empty() {
         return Err(ProgramError::AccountAlreadyInitialized);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -64,6 +64,9 @@ pub fn process_create_subscribe_user(
     #[cfg(test)]
     msg!("process_create_user({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     if !user_account.data.borrow().is_empty() {
         return Err(ProgramError::AccountAlreadyInitialized);
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
@@ -46,6 +46,9 @@ pub fn process_delete_user(
     #[cfg(test)]
     msg!("process_delete_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     if accesspass_account.data_is_empty() {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/reject.rs
@@ -36,6 +36,9 @@ pub fn process_reject_user(
     #[cfg(test)]
     msg!("process_reject_user({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
@@ -34,6 +34,9 @@ pub fn process_request_ban_user(
     #[cfg(test)]
     msg!("process_banning_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/resume.rs
@@ -38,6 +38,9 @@ pub fn process_resume_user(
     #[cfg(test)]
     msg!("process_resume_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid User Account Owner");
     if accesspass_account.data_is_empty() {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/suspend.rs
@@ -33,6 +33,9 @@ pub fn process_suspend_user(
     #[cfg(test)]
     msg!("process_suspend_user({:?})", _value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
@@ -52,6 +52,9 @@ pub fn process_update_user(
     #[cfg(test)]
     msg!("process_update_user({:?})", value);
 
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
     // Check the owner of the accounts
     assert_eq!(user_account.owner, program_id, "Invalid PDA Account Owner");
     assert_eq!(

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -28,14 +27,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_accesspass_allow_multiple_ip() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_user");

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::contributor::{create::*, delete::*, resume::*, suspend::*, update::*},
@@ -13,14 +12,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_contributor() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_contributor");

--- a/smartcontract/programs/doublezero-serviceability/tests/device_allowlist_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_allowlist_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::allowlist::device::{
@@ -15,14 +14,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn device_allowlist_test() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start device_allowlist_test");

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -21,14 +21,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_device() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_device");

--- a/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
@@ -1,6 +1,5 @@
 use device::activate::DeviceActivateArgs;
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -20,14 +19,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn exchange_setdevice() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_device");

--- a/smartcontract/programs/doublezero-serviceability/tests/exchange_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/exchange_test.rs
@@ -16,14 +16,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_exchange() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_exchange");

--- a/smartcontract/programs/doublezero-serviceability/tests/foundation_allowlist_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/foundation_allowlist_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::allowlist::foundation::{
@@ -15,14 +14,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn foundation_allowlist_test() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start foundation_allowlist_test");

--- a/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
@@ -1,6 +1,5 @@
 use doublezero_program_common::types::NetworkV4;
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -36,14 +35,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_doublezero_program() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start...");
@@ -639,7 +631,6 @@ async fn test_doublezero_program() {
             AccountMeta::new(device_la_pubkey, false),
             AccountMeta::new(device_ny_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
-            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )

--- a/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
@@ -1,6 +1,5 @@
 use device::activate::DeviceActivateArgs;
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -23,14 +22,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_device_interfaces() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_device_interfaces");

--- a/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -28,14 +27,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_dzx_link() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_link");

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -25,14 +24,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_wan_link() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_link");

--- a/smartcontract/programs/doublezero-serviceability/tests/location_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/location_test.rs
@@ -1,26 +1,18 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::location::{create::*, delete::*, resume::*, suspend::*, update::*},
     state::{accounttype::AccountType, location::*},
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_sdk::instruction::AccountMeta;
 
 mod test_helpers;
 use test_helpers::*;
 
 #[tokio::test]
 async fn test_location() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_location");

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -18,21 +17,14 @@ use doublezero_serviceability::{
     },
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, signer::Signer};
 
 mod test_helpers;
 use test_helpers::*;
 
 #[tokio::test]
 async fn test_multicast_publisher_allowlist() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢 1. Global Initialization...");

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -18,21 +17,14 @@ use doublezero_serviceability::{
     },
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, signer::Signer};
 
 mod test_helpers;
 use test_helpers::*;
 
 #[tokio::test]
 async fn test_multicast_subscriber_allowlist() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢 1. Global Initialization...");

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
@@ -1,7 +1,6 @@
 use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::multicastgroup::{
@@ -18,14 +17,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_multicastgroup() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_multicastgroup");

--- a/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
@@ -1,5 +1,6 @@
 use borsh::to_vec;
 use doublezero_serviceability::{
+    entrypoint::process_instruction,
     instructions::*,
     state::{accountdata::AccountData, accounttype::AccountType, globalstate::GlobalState},
 };
@@ -8,10 +9,45 @@ use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::{Keypair, Signer},
-    system_program,
+    system_instruction, system_program,
     transaction::Transaction,
 };
 use std::any::type_name;
+
+// Use a fixed byte array to create a constant Keypair for testing
+// This is safe for tests only; never use hardcoded keys in production!
+pub const TEST_PAYER_BYTES: [u8; 64] = [
+    169, 191, 120, 114, 135, 172, 221, 186, 245, 154, 139, 162, 103, 229, 16, 1, 170, 160, 159, 47,
+    224, 60, 179, 71, 245, 255, 116, 238, 144, 208, 19, 89, 13, 59, 115, 1, 186, 171, 180, 37, 165,
+    122, 75, 128, 161, 44, 98, 93, 190, 124, 25, 3, 175, 219, 173, 30, 195, 19, 111, 203, 78, 54,
+    241, 90,
+];
+
+pub fn test_payer() -> Keypair {
+    Keypair::from_bytes(&TEST_PAYER_BYTES).unwrap()
+}
+
+pub async fn init_test() -> (BanksClient, Pubkey, Keypair, solana_program::hash::Hash) {
+    let program_id = Pubkey::new_unique();
+
+    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    )
+    .start()
+    .await;
+
+    transfer(
+        &mut banks_client,
+        &payer,
+        &test_payer().pubkey(),
+        100_000_000,
+    )
+    .await;
+
+    (banks_client, program_id, payer, recent_blockhash)
+}
 
 #[allow(dead_code)]
 pub async fn get_globalstate(
@@ -65,9 +101,24 @@ pub async fn get_account_data(
     }
 }
 
+#[allow(dead_code)]
+pub async fn transfer(
+    banks_client: &mut BanksClient,
+    source: &Keypair,
+    destination: &Pubkey,
+    lamports: u64,
+) {
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let transfer_ix = system_instruction::transfer(&source.pubkey(), destination, lamports);
+    let mut tx = Transaction::new_with_payer(&[transfer_ix], Some(&source.pubkey()));
+    tx.sign(&[&source], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
+
 pub async fn execute_transaction(
     banks_client: &mut BanksClient,
-    recent_blockhash: solana_program::hash::Hash,
+    _recent_blockhash: solana_program::hash::Hash,
     program_id: Pubkey,
     instruction: DoubleZeroInstruction,
     accounts: Vec<AccountMeta>,
@@ -75,11 +126,78 @@ pub async fn execute_transaction(
 ) {
     print!("➡️  Transaction {instruction:?} ");
 
-    let mut transaction = create_transaction(program_id, instruction, accounts, payer);
-    transaction.sign(&[&payer], recent_blockhash);
+    // Test with a diferent signer
+    execute_transaction_tester(
+        banks_client,
+        program_id,
+        instruction.clone(),
+        accounts.clone(),
+        payer,
+    )
+    .await
+    .unwrap();
+
+    // Execute the transaction with the real payer
+    let recent_blockhash = banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+    println!("recent_blockhash: {recent_blockhash} ");
+    let mut transaction = create_transaction(program_id, &instruction, &accounts, payer);
+    transaction.try_sign(&[&payer], recent_blockhash).unwrap();
     banks_client.process_transaction(transaction).await.unwrap();
 
     println!("✅")
+}
+
+async fn execute_transaction_tester(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    instruction: DoubleZeroInstruction,
+    accounts: Vec<AccountMeta>,
+    payer: &Keypair,
+) -> Result<(), BanksClientError> {
+    let test_payer = Pubkey::new_unique();
+
+    let recent_blockhash = banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    println!("recent_blockhash: {recent_blockhash} ");
+
+    let recent_blockhash = banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    println!("➡️  Testing a transaction without the payer signing it...");
+    let mut transaction = Transaction::new_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &to_vec(&instruction).unwrap(),
+            [
+                accounts.clone(),
+                vec![
+                    AccountMeta::new(test_payer, false),
+                    AccountMeta::new(system_program::id(), false),
+                ],
+            ]
+            .concat(),
+        )],
+        Some(&payer.pubkey()),
+    );
+    transaction.try_sign(&[&payer], recent_blockhash).unwrap();
+    let res = banks_client.process_transaction(transaction).await;
+
+    assert!(
+        res.is_err(),
+        "Transaction should have failed (different signer)"
+    );
+
+    println!("🟢 Testing invalid payer - passed");
+
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -93,8 +211,8 @@ pub async fn try_execute_transaction(
 ) -> Result<(), BanksClientError> {
     print!("➡️  Transaction {instruction:?} ");
 
-    let mut transaction = create_transaction(program_id, instruction, accounts, payer);
-    transaction.sign(&[&payer], recent_blockhash);
+    let mut transaction = create_transaction(program_id, &instruction, &accounts, payer);
+    transaction.try_sign(&[&payer], recent_blockhash).unwrap();
     banks_client.process_transaction(transaction).await?;
 
     println!("✅");
@@ -104,16 +222,16 @@ pub async fn try_execute_transaction(
 
 pub fn create_transaction(
     program_id: Pubkey,
-    instruction: DoubleZeroInstruction,
-    accounts: Vec<AccountMeta>,
+    instruction: &DoubleZeroInstruction,
+    accounts: &Vec<AccountMeta>,
     payer: &Keypair,
 ) -> Transaction {
     Transaction::new_with_payer(
         &[Instruction::new_with_bytes(
             program_id,
-            &to_vec(&instruction).unwrap(),
+            &to_vec(instruction).unwrap(),
             [
-                accounts,
+                accounts.to_owned(),
                 vec![
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new(system_program::id(), false),

--- a/smartcontract/programs/doublezero-serviceability/tests/user_allowlist_stress_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_allowlist_stress_test.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::allowlist::user::{add::AddUserAllowlistArgs, remove::RemoveUserAllowlistArgs},
@@ -12,14 +11,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn user_allowlist_stress_test() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start user_allowlist_stress_test");

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -1,5 +1,4 @@
 use doublezero_serviceability::{
-    entrypoint::*,
     instructions::*,
     pda::*,
     processors::{
@@ -27,14 +26,7 @@ use test_helpers::*;
 
 #[tokio::test]
 async fn test_user() {
-    let program_id = Pubkey::new_unique();
-    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    )
-    .start()
-    .await;
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 
     /***********************************************************************************************************************************/
     println!("🟢  Start test_user");


### PR DESCRIPTION
- Implemented checks to ensure that the payer account is a signer in the following processors:
  - Device: reject, resume, suspend, update
  - Exchange: create, delete, resume, setdevice, suspend, update
  - GlobalConfig: set
  - GlobalState: initialize, setairdrop, setauthority
  - Link: accept, activate, closeaccount, create, delete, reject, resume, suspend, update
  - Location: create, delete, resume, suspend, update
  - MulticastGroup: activate, allowlist publisher add/remove, allowlist subscriber add/remove, closeaccount, create, delete, reactivate, reject, subscribe, suspend, update
  - User: activate, ban, check_access_pass, closeaccount, create, create_subscribe, delete, reject, requestban, resume, suspend, update

- Each processor now asserts that the payer account is a signer, improving security and ensuring proper authorization for account modifications.
