### PR TITLE
ci: fix go lint error from latest golangci-lint release

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,6 +74,9 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters: [govet]
+        text: 'buildtag: \+build line is no longer needed'
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
## Summary of Changes
- Fix Go [lint error](https://github.com/malbeclabs/doublezero/actions/runs/18972310051/job/54182918267?pr=2018) that started happening after the latest (v2.6.0) version of `golangci-lint` was released a couple days ago
- The error complains about the use of `// +build !linux` but even if you remove that it continues to complain about it, that so rule is excluded via `.golanci.yaml` instead
- This error is currently causing all CI runs or use of `make go-lint` to [fail](https://github.com/malbeclabs/doublezero/actions/runs/18972310051/job/54182918267?pr=2018)

## Testing Verification
- Error is reproduceable locally if you upgrade to latest golanci-lint version (or rebuild devcontainer) and run `make go-lint`, and no longer happens after this change
