### PR TITLE
Change error message when device is at cap or max users = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - Onchain programs
     - Check if `accesspass.owner` is equal to system program ([malbeclabs/doublezero#2088](https://github.com/malbeclabs/doublezero/pull/2088))
+- CLI
+    - Improve error message when connecting to a device that is at capacity or has max_users=0. Users now receive "Device is not accepting more users (at capacity or max_users=0)" instead of the confusing "Device not found" error when explicitly specifying an ineligible device.
 
 ### Breaking
 


### PR DESCRIPTION
Resolves: #1671

## Summary of Changes

### Problem
When a user explicitly connected to a device with `max_users=0` or at full capacity, they received a confusing "Device not found" error message, even though the device existed.

### Root Cause
The code was filtering out ineligible devices (those with `max_users=0` or at capacity) from the device list **before** looking up explicitly specified devices. When the lookup failed to find the device in the filtered list, it returned "Device not found".

### Solution
Modified the device selection logic to differentiate between two scenarios:

**Scenario 1: Auto-Selection (no `--device` flag)**
- Device list is filtered to only eligible devices **before** selection
- `best_latency()` automatically picks the best available device
- No eligibility check needed after selection (already filtered)

**Scenario 2: Explicit Device Selection (with `--device` flag)**
- Device list is **not filtered** before lookup
- Device is looked up in the full list (by code or pubkey)
- Eligibility check is performed **after** fetching the device
- Returns helpful error: `"Device is not accepting more users (at capacity or max_users=0)"` if ineligible

### Changes Made
1. Modified `find_or_create_user()` and `find_or_create_user_and_subscribe()` to conditionally filter devices only when auto-selecting
2. Added eligibility check in `find_or_create_device()` after fetching device data when user explicitly specifies a device
3. Added three new tests covering the explicit device selection scenarios

## Testing Verification

### New Tests Added
1. **`test_connect_to_device_at_max_users`** - Verifies proper error when device has `max_users=0`
2. **`test_connect_to_device_at_capacity`** - Verifies proper error when device is at full capacity  
3. **`test_connect_to_nonexistent_device`** - Ensures "Device not found" still works for non-existent devices