### PR TITLE
Bump cargo.toml to version 0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+## [v0.6.10](https://github.com/malbeclabs/doublezero/compare/client/v0.6.9...client/v0.6.10) – 2025-11-05
+
+### Breaking
+
+- None for this release
+
+### Changes
+
 - CI
     - Add automated compatibility tests in CI to validate all actual testnet and mainnet state against the current codebase, ensuring backward compatibility across protocol versions.
     - Add `--delay-override-ms` option to `doublezero link update`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "backon",
  "bitvec",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "backon",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "eyre",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.6.9"
+version = "0.6.10"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Bump cargo toml version to v0.6.10
- Update changelog for v0.6.10
- Related to https://github.com/malbeclabs/doublezero/issues/2080
