### PR TITLE
doublezero_monitor: add custom unit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist/
 dev/.deploy/
 
 # Ignore the directory used for checking out the monitor tool in CI
-doublezero_monitor/
+/doublezero_monitor/

--- a/release/.goreleaser.base.doublezero.monitor.tool.yaml
+++ b/release/.goreleaser.base.doublezero.monitor.tool.yaml
@@ -51,7 +51,7 @@ nfpms:
         dst: /opt/doublezero_monitor/ping.py
       - src: doublezero_monitor/task_group.py
         dst: /opt/doublezero_monitor/task_group.py
-      - src: doublezero_monitor/doublezero_monitor.service
+      - src: release/packaging/scripts/doublezero_monitor/systemd/doublezero_monitor.service
         dst: /etc/systemd/system/doublezero_monitor.service
     overrides:
       deb:

--- a/release/packaging/scripts/doublezero_monitor/systemd/doublezero_monitor.service
+++ b/release/packaging/scripts/doublezero_monitor/systemd/doublezero_monitor.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=DoubleZero IBRL monitor
+After=network.target
+
+[Service]
+Type=simple
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 /opt/doublezero_monitor/monitor_ibrl.py
+
+# Send stdout and stderr to systemd journal
+StandardOutput=journal
+StandardError=journal
+
+# Do not restart on crash/exit
+Restart=no
+
+[Install]
+WantedBy=doublezerod.service


### PR DESCRIPTION
## Summary of Changes
The unit file pulled from the upstream doublezero_monitor repo references a different install path than the package. This adds a custom unit file to replace the upstream one.

## Testing Verification
```
ubuntu@chi-dn-bm2:~$ sudo dpkg -i doublezero-monitor-tool_0.1.0-SNAPSHOT-48f869c4_linux_amd64.deb
(Reading database ... 226234 files and directories currently installed.)
Preparing to unpack doublezero-monitor-tool_0.1.0-SNAPSHOT-48f869c4_linux_amd64.deb ...
Creating directory /opt/doublezero_monitor...
Unpacking doublezero-monitor-tool (0.1.0~SNAPSHOT-48f869c4-1) over (0.1.0~SNAPSHOT-3a6b9f47-1) ...
Setting up doublezero-monitor-tool (0.1.0~SNAPSHOT-48f869c4-1) ...

ubuntu@chi-dn-bm2:~$ sudo systemctl status doublezero_monitor.service
○ doublezero_monitor.service - Doublezero IBRL monitor
     Loaded: loaded (/etc/systemd/system/doublezero_monitor.service; disabled; preset: enabled)
     Active: inactive (dead)
ubuntu@chi-dn-bm2:~$ sudo systemctl start doublezero_monitor.service
ubuntu@chi-dn-bm2:~$ sudo systemctl status doublezero_monitor.service
● doublezero_monitor.service - Doublezero IBRL monitor
     Loaded: loaded (/etc/systemd/system/doublezero_monitor.service; disabled; preset: enabled)
     Active: active (running) since Thu 2025-11-06 18:12:19 UTC; 1s ago
   Main PID: 31021 (python3)
      Tasks: 3 (limit: 9830)
     Memory: 15.8M (peak: 15.8M)
        CPU: 111ms
     CGroup: /system.slice/doublezero_monitor.service
             ├─31021 /usr/bin/python3 /opt/doublezero_monitor/monitor_ibrl.py
             └─31025 solana -utestnet gossip --output json

Nov 06 18:12:19 chi-dn-bm2 systemd[1]: Started doublezero_monitor.service - Doublezero IBRL monitor.
Nov 06 18:12:19 chi-dn-bm2 python3[31021]: Setting up nftables
Nov 06 18:12:19 chi-dn-bm2 python3[31021]: Refreshing staked nodes
```
