### PR TITLE
doublezero_monitor: hardcode upstream ref

### DIFF
--- a/.github/workflows/release.doublezero.monitor.tool.yml
+++ b/.github/workflows/release.doublezero.monitor.tool.yml
@@ -16,15 +16,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Extract version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF_NAME#doublezero-monitor-tool/}" >> $GITHUB_OUTPUT
       - name: Checkout doublezero_monitor repo
         uses: actions/checkout@v4
         with:
           repository: alexpyattaev/doublezero_monitor
           path: doublezero_monitor
-          ref: ${{ steps.get_version.outputs.VERSION }}
+          ref: v0.1.0
       - name: install dependencies for rpm packaging
         run: |
           sudo apt update


### PR DESCRIPTION
## Summary of Changes
In https://github.com/malbeclabs/doublezero/pull/1970, we set the upstream ref to match the pushed tag to this repo since the packaging depended on upstream assets. This is no longer true, so this hardcodes the upstream ref to v0.1.0 for the time being.

## Testing Verification
N/A
