### PR TITLE
feat(serviceability): add new interface types Cyoa and Dia to go SDK

### DIFF
--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -156,8 +156,8 @@ const (
 	InterfaceTypeInvalid InterfaceType = iota
 	InterfaceTypeLoopback
 	InterfaceTypePhysical
-	InterfaceTypeCyoa
-	InterfaceTypeDia
+	InterfaceTypeCYOA
+	InterfaceTypeDIA
 )
 
 func (i InterfaceType) String() string {


### PR DESCRIPTION
This pull request adds support for two new interface types to the `InterfaceType` enum in the `state.go` file. These changes expand the possible values that can be represented and handled by the codebase.

Enhancements to interface types:

* Added `InterfaceTypeCyoa` and `InterfaceTypeDia` to the `InterfaceType` enum and updated the `String()` method to support these new types.

## Testing Verification
* PASS
ok      github.com/malbeclabs/doublezero/smartcontract/sdk/go   0.005s