### PR TITLE
e2e: solana build use agave installer and bump to v2.3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 # Install goreleaser and gcc-x86-64-linux-gnu for building releases.
 RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list && \
     apt update -qq && \
-    apt install -y gcc-x86-64-linux-gnu goreleaser-pro && \
+    apt install -y goreleaser-pro && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -14,19 +14,10 @@ RUN curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && \
 
 # Install agave/solana tools
 # https://github.com/anza-xyz/agave/issues/1734
-ARG AGAVE_SOLANA_VERSION=2.2.17
-RUN ARCH=$(uname -m) && \
-    case "$ARCH" in \
-    x86_64) ARCH_TAG=x86_64 ;; \
-    aarch64) ARCH_TAG=aarch64 ;; \
-    *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
-    esac && \
-    mkdir -p /opt/agave && \
-    curl -sL "https://github.com/staratlasmeta/agave-dist/releases/download/v${AGAVE_SOLANA_VERSION}/solana-release-${ARCH_TAG}-unknown-linux-gnu.tar.bz2" -o /tmp/agave.tar.bz2 && \
-    tar -xjf /tmp/agave.tar.bz2 -C /opt/agave && \
-    mkdir -p /opt/solana/bin && \
-    cp -r /opt/agave/solana-release/bin/* /opt/solana/bin/ && \
-    rm -rf /tmp/agave.tar.bz2
+ARG SOLANA_VERSION=2.3.13
+RUN bash -c 'set -euo pipefail; curl -fsSL https://release.anza.xyz/v${SOLANA_VERSION}/install | sh'
+RUN mkdir -p /opt/solana/bin && \
+    mv /root/.local/share/solana/install/active_release/bin/* /opt/solana/bin/
 ENV PATH="/opt/solana/bin:${PATH}"
 
 # Alias to access the DinD container's published ports from inside the container,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
     "name": "DoubleZero Development",
     "build": {
         "dockerfile": "Dockerfile",
-        "context": "."
+        "context": ".",
+        "options": [
+            "--platform=linux/amd64"
+        ]
     },
     "runArgs": [
         "--name",

--- a/.github/workflows/release.devnet.smartcontract.daily.yml
+++ b/.github/workflows/release.devnet.smartcontract.daily.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install agave solana tools
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Set up keypairs
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install agave solana tools
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - run: make rust-build
   rust-lint:
@@ -34,7 +34,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install agave solana tools
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - run: make rust-test
   rust-validator-test:
@@ -45,6 +45,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install agave solana tools
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - run: make rust-validator-test

--- a/e2e/docker/base.dockerfile
+++ b/e2e/docker/base.dockerfile
@@ -7,20 +7,10 @@ RUN apt update -qq && \
     apt install --no-install-recommends -y ca-certificates curl bzip2
 
 # Install agave/solana tools
-# https://github.com/anza-xyz/agave/issues/1734
-ARG SOLANA_VERSION=2.3.6
-RUN ARCH=$(uname -m) && \
-    case "$ARCH" in \
-    x86_64) ARCH_TAG=x86_64 ;; \
-    aarch64) ARCH_TAG=aarch64 ;; \
-    *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
-    esac && \
-    mkdir -p /opt/agave && \
-    curl -sL "https://github.com/staratlasmeta/agave-dist/releases/download/v${SOLANA_VERSION}/solana-release-${ARCH_TAG}-unknown-linux-gnu.tar.bz2" -o /tmp/agave.tar.bz2 && \
-    tar -xjf /tmp/agave.tar.bz2 -C /opt/agave && \
-    mkdir -p /opt/solana/bin && \
-    cp -r /opt/agave/solana-release/bin/* /opt/solana/bin/ && \
-    rm -rf /tmp/agave.tar.bz2
+ARG SOLANA_VERSION=2.3.13
+RUN bash -c 'set -euo pipefail; curl -fsSL https://release.anza.xyz/v${SOLANA_VERSION}/install | sh'
+RUN mkdir -p /opt/solana/bin && \
+    mv /root/.local/share/solana/install/active_release/bin/* /opt/solana/bin/
 ENV PATH="/opt/solana/bin:${PATH}"
 
 # Force COPY in later stages to always copy the binaries, even if they appear to be the same.

--- a/e2e/internal/devnet/builder.go
+++ b/e2e/internal/devnet/builder.go
@@ -26,7 +26,8 @@ func BuildContainerImages(ctx context.Context, log *slog.Logger, workspaceDir st
 
 	// Build base image first
 	cacheBusterBuildArg := fmt.Sprintf("CACHE_BUSTER=%d", time.Now().Unix())
-	err := docker.Build(ctx, log, os.Getenv("DZ_BASE_IMAGE"), filepath.Join(dockerfilesDir, "base.dockerfile"), workspaceDir, verbose, "--build-arg", cacheBusterBuildArg)
+	extraArgs := []string{"--build-arg", cacheBusterBuildArg, "--platform", "linux/amd64"}
+	err := docker.Build(ctx, log, os.Getenv("DZ_BASE_IMAGE"), filepath.Join(dockerfilesDir, "base.dockerfile"), workspaceDir, verbose, extraArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to build base image: %w", err)
 	}
@@ -43,43 +44,43 @@ func BuildContainerImages(ctx context.Context, log *slog.Logger, workspaceDir st
 			name:       "activator",
 			image:      os.Getenv("DZ_ACTIVATOR_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "activator", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "activator"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "activator")}, extraArgs...),
 		},
 		{
 			name:       "client",
 			image:      os.Getenv("DZ_CLIENT_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "client", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "client"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "client")}, extraArgs...),
 		},
 		{
 			name:       "controller",
 			image:      os.Getenv("DZ_CONTROLLER_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "controller", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "controller"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "controller")}, extraArgs...),
 		},
 		{
 			name:       "device",
 			image:      os.Getenv("DZ_DEVICE_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "device", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "device"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "device")}, extraArgs...),
 		},
 		{
 			name:       "ledger",
 			image:      os.Getenv("DZ_LEDGER_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "ledger", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "ledger"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "ledger")}, extraArgs...),
 		},
 		{
 			name:       "manager",
 			image:      os.Getenv("DZ_MANAGER_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "manager", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "manager"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "manager")}, extraArgs...),
 		},
 		{
 			name:       "funder",
 			image:      os.Getenv("DZ_FUNDER_IMAGE"),
 			dockerfile: filepath.Join(dockerfilesDir, "funder", "Dockerfile"),
-			args:       []string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "funder"), "--build-arg", cacheBusterBuildArg},
+			args:       append([]string{"--build-arg", baseImageArg, "--build-arg", "DOCKERFILE_DIR=" + filepath.Join(dockerfilesDirRelativeToWorkspace, "funder")}, extraArgs...),
 		},
 	}
 


### PR DESCRIPTION
## Summary of Changes
- Solana program builds started failing in e2e, both locally and in the CI runner: https://github.com/malbeclabs/doublezero/actions/runs/19283274931/job/55138693417?pr=2092
- Switch to using the agave solana installer and bump to v2.3.13
- Make it work on Mac by specifying platform `linux/amd64`
- This will also make it easier to upgrade to agave v3 when ready

## Testing Verification
- https://github.com/malbeclabs/doublezero/actions/runs/19284500843/job/55142256818
