### PR TITLE
client/daemon: route liveness metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   - Validate AccessPass before client connection ([#1356](https://github.com/malbeclabs/doublezero/issues/1356))
 - Client
   - Add initial route liveness probing, initially disabled for rollout
+  - Add route liveness prometheus metrics
 
 ### Breaking
 

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -37,11 +37,12 @@ var (
 	routeConfigPath      = flag.String("route-config", "/var/lib/doublezerod/route-config.json", "path to route config file (unstable)")
 
 	// Route liveness configuration flags.
-	routeLivenessTxMin      = flag.Duration("route-liveness-tx-min", defaultRouteLivenessTxMin, "route liveness tx min")
-	routeLivenessRxMin      = flag.Duration("route-liveness-rx-min", defaultRouteLivenessRxMin, "route liveness rx min")
-	routeLivenessDetectMult = flag.Uint("route-liveness-detect-mult", defaultRouteLivenessDetectMult, "route liveness detect mult")
-	routeLivenessMinTxFloor = flag.Duration("route-liveness-min-tx-floor", defaultRouteLivenessMinTxFloor, "route liveness min tx floor")
-	routeLivenessMaxTxCeil  = flag.Duration("route-liveness-max-tx-ceil", defaultRouteLivenessMaxTxCeil, "route liveness max tx ceil")
+	routeLivenessTxMin       = flag.Duration("route-liveness-tx-min", defaultRouteLivenessTxMin, "route liveness tx min")
+	routeLivenessRxMin       = flag.Duration("route-liveness-rx-min", defaultRouteLivenessRxMin, "route liveness rx min")
+	routeLivenessDetectMult  = flag.Uint("route-liveness-detect-mult", defaultRouteLivenessDetectMult, "route liveness detect mult")
+	routeLivenessMinTxFloor  = flag.Duration("route-liveness-min-tx-floor", defaultRouteLivenessMinTxFloor, "route liveness min tx floor")
+	routeLivenessMaxTxCeil   = flag.Duration("route-liveness-max-tx-ceil", defaultRouteLivenessMaxTxCeil, "route liveness max tx ceil")
+	routeLivenessPeerMetrics = flag.Bool("route-liveness-peer-metrics", false, "enables per peer metrics for route liveness (high cardinality)")
 
 	// TODO(snormore): These flags are temporary for initial rollout testing.
 	// They will be superceded by a single `route-liveness-enable` flag, where false means
@@ -155,11 +156,12 @@ func main() {
 			// The manager only knows about passive mode, with the negation of it being active mode.
 			PassiveMode: !*routeLivenessEnableActive,
 
-			TxMin:      *routeLivenessTxMin,
-			RxMin:      *routeLivenessRxMin,
-			DetectMult: uint8(*routeLivenessDetectMult),
-			MinTxFloor: *routeLivenessMinTxFloor,
-			MaxTxCeil:  *routeLivenessMaxTxCeil,
+			TxMin:       *routeLivenessTxMin,
+			RxMin:       *routeLivenessRxMin,
+			DetectMult:  uint8(*routeLivenessDetectMult),
+			MinTxFloor:  *routeLivenessMinTxFloor,
+			MaxTxCeil:   *routeLivenessMaxTxCeil,
+			PeerMetrics: *routeLivenessPeerMetrics,
 		}
 	}
 

--- a/client/doublezerod/internal/liveness/metrics.go
+++ b/client/doublezerod/internal/liveness/metrics.go
@@ -1,0 +1,279 @@
+package liveness
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Labels.
+	LabelIface     = "iface"
+	LabelLocalIP   = "local_ip"
+	LabelPeerIP    = "peer_ip"
+	LabelState     = "state"
+	LabelStateTo   = "state_to"
+	LabelStateFrom = "state_from"
+	LabelReason    = "reason"
+	LabelOperation = "operation"
+)
+
+var (
+	serviceLabels = []string{LabelIface, LabelLocalIP}
+)
+
+func withServiceLabels(labels ...string) []string {
+	return append(serviceLabels, labels...)
+}
+
+var (
+	metricSessions = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_sessions",
+			Help: "Current number of sessions by FSM state",
+		},
+		withServiceLabels(LabelState),
+	)
+
+	metricSessionTransitions = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_session_transitions_total",
+			Help: "Count of session state transitions",
+		},
+		withServiceLabels(LabelStateFrom, LabelStateTo, LabelReason),
+	)
+
+	metricRoutesInstalled = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_routes_installed",
+			Help: "Number of routes installed",
+		},
+		serviceLabels,
+	)
+
+	metricRouteInstalls = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_route_installs_total",
+			Help: "Count of route installs",
+		},
+		serviceLabels,
+	)
+
+	metricRouteWithdraws = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_route_withdraws_total",
+			Help: "Count of route withdraws",
+		},
+		serviceLabels,
+	)
+
+	metricConvergenceToUp = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "doublezero_liveness_convergence_to_up_seconds",
+			Help: "Time from first successful control message while down until transition to up (includes detect threshold, scheduler delay, and kernel install).",
+		},
+		serviceLabels,
+	)
+
+	metricConvergenceToDown = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "doublezero_liveness_convergence_to_down_seconds",
+			Help: "Time from first failed or missing control message while up until transition to down (includes detect expiry, scheduler delay, and kernel delete).",
+		},
+		serviceLabels,
+	)
+
+	metricSchedulerServiceQueueLen = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_scheduler_service_queue_len",
+			Help: "Current number of pending events in the scheduler queue per service (iface, local_ip)",
+		},
+		serviceLabels,
+	)
+
+	metricSchedulerEventsDropped = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_scheduler_events_dropped_total",
+			Help: "Scheduler events dropped by type and reason.",
+		},
+		[]string{"type", "reason"},
+	)
+
+	metricSchedulerTotalQueueLen = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_scheduler_total_queue_len",
+			Help: "Total events currently in the scheduler queue.",
+		},
+	)
+
+	metricRouteInstallFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_route_install_failures_total",
+			Help: "Count of route kernel install failures",
+		},
+		serviceLabels,
+	)
+
+	metricRouteUninstallFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_route_uninstall_failures_total",
+			Help: "Count of route kernel uninstall failures",
+		},
+		serviceLabels,
+	)
+
+	metricHandleRxDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "doublezero_liveness_handle_rx_duration_seconds",
+			Help: "Distribution of time to handle a valid received packet.",
+		},
+		serviceLabels,
+	)
+
+	metricControlPacketsTX = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_control_packets_tx_total",
+			Help: "Total control packets sent.",
+		},
+		serviceLabels, // iface, local_ip
+	)
+
+	metricControlPacketsRX = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_control_packets_rx_total",
+			Help: "Total control packets received.",
+		},
+		serviceLabels,
+	)
+
+	metricControlPacketsRxInvalid = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_control_packets_rx_invalid_total",
+			Help: "Invalid control packets received (e.g. short, bad_version, bad_len, parse_error, not_ipv4, reserved_nonzero).",
+		},
+		withServiceLabels(LabelReason),
+	)
+
+	metricUnknownPeerPackets = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_unknown_peer_packets_total",
+			Help: "Packets received that didn’t match any known session.",
+		},
+		serviceLabels,
+	)
+
+	metricReadSocketErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_read_socket_errors_total",
+			Help: "Count of read socket errors.",
+		},
+		serviceLabels,
+	)
+
+	metricWriteSocketErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "doublezero_liveness_write_socket_errors_total",
+			Help: "Count of write socket errors.",
+		},
+		serviceLabels,
+	)
+
+	// Per peer metrics for route liveness (high cardinality).
+	metricRouteLivenessSessions = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_peer_sessions",
+			Help: "Current number of sessions by peer and FSM state",
+		},
+		withServiceLabels(LabelPeerIP, LabelState),
+	)
+
+	metricPeerDetectTime = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_liveness_peer_session_detect_time_seconds",
+			Help: "Current detect time by session (after clamping with peer value).",
+		},
+		withServiceLabels(LabelPeerIP),
+	)
+)
+
+func emitSessionStateMetrics(sess *Session, prevState *State, operation string, peerMetrics bool) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	var prevStateStr string
+	if prevState != nil {
+		prevStateStr = prevState.String()
+	} else {
+		prevStateStr = "NEW"
+	}
+	metricSessionTransitions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, prevStateStr, sess.state.String(), operation).Inc()
+	metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.state.String()).Inc()
+	if prevState != nil {
+		metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, prevStateStr).Dec()
+	}
+	if peerMetrics {
+		metricRouteLivenessSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, sess.state.String()).Inc()
+		if prevState != nil {
+			metricRouteLivenessSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, prevStateStr).Dec()
+		}
+	}
+}
+
+func emitRouteInstallMetrics(iface, localIP string) {
+	metricRoutesInstalled.WithLabelValues(iface, localIP).Inc()
+	metricRouteInstalls.WithLabelValues(iface, localIP).Inc()
+}
+
+func emitRouteWithdrawMetrics(iface, localIP string) {
+	metricRoutesInstalled.WithLabelValues(iface, localIP).Dec()
+	metricRouteWithdraws.WithLabelValues(iface, localIP).Inc()
+}
+
+func emitPeerDetectTimeGauge(sess *Session, dt time.Duration) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	metricPeerDetectTime.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP).Set(dt.Seconds())
+}
+
+func metricsCleanupOnWithdrawRoute(sess *Session, peerMetrics bool) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.state.String()).Dec()
+	if peerMetrics {
+		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateDown.String())
+		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateInit.String())
+		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateUp.String())
+		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateAdminDown.String())
+		metricPeerDetectTime.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP)
+	}
+}
+
+func emitConvergenceToUpMetrics(sess *Session, convergence time.Duration) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	metricConvergenceToUp.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP).Observe(convergence.Seconds())
+}
+
+func emitConvergenceToDownMetrics(sess *Session, convergence time.Duration) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	metricConvergenceToDown.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP).Observe(convergence.Seconds())
+}
+
+func emitSchedulerServiceQueueLengthGauge(eq *EventQueue, sess *Session) {
+	if sess == nil || sess.peer == nil {
+		return
+	}
+	iface, lip := sess.peer.Interface, sess.peer.LocalIP
+	cnt := eq.CountFor(iface, lip)
+	if cnt == 0 {
+		metricSchedulerServiceQueueLen.DeleteLabelValues(iface, lip)
+	} else {
+		metricSchedulerServiceQueueLen.WithLabelValues(iface, lip).Set(float64(cnt))
+	}
+}

--- a/client/doublezerod/internal/liveness/scheduler_test.go
+++ b/client/doublezerod/internal/liveness/scheduler_test.go
@@ -187,7 +187,7 @@ func TestClient_Liveness_Scheduler_Run_SendsAndReschedules(t *testing.T) {
 	}()
 
 	log := newTestLogger(t)
-	s := NewScheduler(log, w, func(*Session) {}, 0)
+	s := NewScheduler(log, w, func(*Session) {}, 0, false)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
@@ -401,7 +401,7 @@ func TestClient_Liveness_Scheduler_Run_CullsStaleDetectAndClearsMarker(t *testin
 	t.Parallel()
 
 	log := newTestLogger(t)
-	s := NewScheduler(log, nil, func(*Session) {}, 0)
+	s := NewScheduler(log, nil, func(*Session) {}, 0, false)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 

--- a/e2e/docker/client/entrypoint.sh
+++ b/e2e/docker/client/entrypoint.sh
@@ -77,4 +77,4 @@ for dev in $(ip -o link show | awk -F': ' '/^ *[0-9]+: eth[0-9]+/ {print $2}' | 
 done
 
 # Start doublezerod.
-doublezerod -program-id ${DZ_SERVICEABILITY_PROGRAM_ID} -solana-rpc-endpoint ${DZ_LEDGER_URL} -probe-interval 5 -cache-update-interval 3 ${DZ_CLIENT_EXTRA_ARGS}
+doublezerod -program-id ${DZ_SERVICEABILITY_PROGRAM_ID} -solana-rpc-endpoint ${DZ_LEDGER_URL} -probe-interval 5 -cache-update-interval 3 -metrics-enable -metrics-addr 0.0.0.0:8080 ${DZ_CLIENT_EXTRA_ARGS}

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -34,6 +34,10 @@ type ClientSpec struct {
 	// passive-mode, and true puts it in active-mode.
 	// RouteLivenessEnable bool
 
+	// RouteLivenessPeerMetrics is a flag to enable or disable per per-peer metrics for route
+	// liveness (high cardinality).
+	RouteLivenessPeerMetrics bool
+
 	// CYOANetworkIPHostID is the offset into the host portion of the subnet (must be < 2^(32 - prefixLen)).
 	CYOANetworkIPHostID uint32
 }
@@ -169,6 +173,9 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 	if c.Spec.RouteLivenessEnableActive {
 		extraArgs = append(extraArgs, "-route-liveness-enable-active")
+	}
+	if c.Spec.RouteLivenessPeerMetrics {
+		extraArgs = append(extraArgs, "-route-liveness-peer-metrics")
 	}
 
 	// Start the client container.

--- a/e2e/internal/devnet/cmd/add-client.go
+++ b/e2e/internal/devnet/cmd/add-client.go
@@ -19,6 +19,7 @@ func (c *AddClientCmd) Command() *cobra.Command {
 	var keypairPath string
 	var routeLivenessEnablePassive bool
 	var routeLivenessEnableActive bool
+	var routeLivenessPeerMetrics bool
 
 	cmd := &cobra.Command{
 		Use:   "add-client",
@@ -34,6 +35,7 @@ func (c *AddClientCmd) Command() *cobra.Command {
 				KeypairPath:                keypairPath,
 				RouteLivenessEnablePassive: routeLivenessEnablePassive,
 				RouteLivenessEnableActive:  routeLivenessEnableActive,
+				RouteLivenessPeerMetrics:   routeLivenessPeerMetrics,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to add client: %w", err)
@@ -49,6 +51,7 @@ func (c *AddClientCmd) Command() *cobra.Command {
 	cmd.Flags().StringVar(&keypairPath, "keypair-path", "", "Path to the keypair file (optional)")
 	cmd.Flags().BoolVar(&routeLivenessEnablePassive, "route-liveness-enable-passive", false, "Enable route liveness in passive mode (experimental)")
 	cmd.Flags().BoolVar(&routeLivenessEnableActive, "route-liveness-enable-active", false, "Enable route liveness in active mode (experimental)")
+	cmd.Flags().BoolVar(&routeLivenessPeerMetrics, "route-liveness-peer-metrics", false, "Enable per peer metrics for route liveness (high cardinality)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary of Changes
- Add prometheus metrics for the route liveness subsystem based on https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc7-client-route-liveness.md#metrics
- Includes a `--route-liveness-peer-metrics` flag for opting into higher cardinality per-peer metrics
- Closes https://github.com/malbeclabs/doublezero/issues/1964

## Testing Verification
- Verified in local devnet/e2e environment

```
root@client-6gRC1rfTDJP2KzKnBjbcG3LijaVs56fSAsCLyZBU6qa5:/# curl -s localhost:8080/metrics | grep doublezero_liveness
# HELP doublezero_liveness_control_packets_rx_total Total control packets received.
# TYPE doublezero_liveness_control_packets_rx_total counter
doublezero_liveness_control_packets_rx_total{iface="doublezero0",local_ip="9.169.90.110"} 44
# HELP doublezero_liveness_control_packets_tx_total Total control packets sent.
# TYPE doublezero_liveness_control_packets_tx_total counter
doublezero_liveness_control_packets_tx_total{iface="doublezero0",local_ip="9.169.90.110"} 62
# HELP doublezero_liveness_convergence_to_up_seconds Time from first successful control message while down until transition to up (includes detect threshold, scheduler delay, and kernel install).
# TYPE doublezero_liveness_convergence_to_up_seconds histogram
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.005"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.01"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.025"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.05"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.1"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.25"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.5"} 0
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="1"} 1
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="2.5"} 1
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="5"} 1
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="10"} 1
doublezero_liveness_convergence_to_up_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="+Inf"} 1
doublezero_liveness_convergence_to_up_seconds_sum{iface="doublezero0",local_ip="9.169.90.110"} 0.569091167
doublezero_liveness_convergence_to_up_seconds_count{iface="doublezero0",local_ip="9.169.90.110"} 1
# HELP doublezero_liveness_handle_rx_duration_seconds Distribution of time to handle a valid received packet.
# TYPE doublezero_liveness_handle_rx_duration_seconds histogram
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.005"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.01"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.025"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.05"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.1"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.25"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="0.5"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="1"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="2.5"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="5"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="10"} 44
doublezero_liveness_handle_rx_duration_seconds_bucket{iface="doublezero0",local_ip="9.169.90.110",le="+Inf"} 44
doublezero_liveness_handle_rx_duration_seconds_sum{iface="doublezero0",local_ip="9.169.90.110"} 0.0006427929999999999
doublezero_liveness_handle_rx_duration_seconds_count{iface="doublezero0",local_ip="9.169.90.110"} 44
# HELP doublezero_liveness_peer_session_detect_time_seconds Current detect time by session (after clamping with peer value).
# TYPE doublezero_liveness_peer_session_detect_time_seconds gauge
doublezero_liveness_peer_session_detect_time_seconds{iface="doublezero0",local_ip="9.169.90.110",peer_ip="8.8.8.8"} 0.9
doublezero_liveness_peer_session_detect_time_seconds{iface="doublezero0",local_ip="9.169.90.110",peer_ip="9.169.90.100"} 0.9
# HELP doublezero_liveness_peer_sessions Current number of sessions by peer and FSM state
# TYPE doublezero_liveness_peer_sessions gauge
doublezero_liveness_peer_sessions{iface="doublezero0",local_ip="9.169.90.110",peer_ip="8.8.8.8",state="DOWN"} 1
doublezero_liveness_peer_sessions{iface="doublezero0",local_ip="9.169.90.110",peer_ip="9.169.90.100",state="DOWN"} 0
doublezero_liveness_peer_sessions{iface="doublezero0",local_ip="9.169.90.110",peer_ip="9.169.90.100",state="INIT"} 0
doublezero_liveness_peer_sessions{iface="doublezero0",local_ip="9.169.90.110",peer_ip="9.169.90.100",state="UP"} 1
# HELP doublezero_liveness_route_installs_total Count of route installs
# TYPE doublezero_liveness_route_installs_total counter
doublezero_liveness_route_installs_total{iface="doublezero0",local_ip="9.169.90.110"} 1
# HELP doublezero_liveness_routes_installed Number of routes installed
# TYPE doublezero_liveness_routes_installed gauge
doublezero_liveness_routes_installed{iface="doublezero0",local_ip="9.169.90.110"} 1
# HELP doublezero_liveness_scheduler_events_dropped_total Scheduler events dropped by type and reason.
# TYPE doublezero_liveness_scheduler_events_dropped_total counter
doublezero_liveness_scheduler_events_dropped_total{reason="stale",type="detect"} 41
# HELP doublezero_liveness_scheduler_service_queue_len Current number of pending events in the scheduler queue per service (iface, local_ip)
# TYPE doublezero_liveness_scheduler_service_queue_len gauge
doublezero_liveness_scheduler_service_queue_len{iface="doublezero0",local_ip="9.169.90.110"} 5
# HELP doublezero_liveness_scheduler_total_queue_len Total events currently in the scheduler queue.
# TYPE doublezero_liveness_scheduler_total_queue_len gauge
doublezero_liveness_scheduler_total_queue_len 5
# HELP doublezero_liveness_session_transitions_total Count of session state transitions
# TYPE doublezero_liveness_session_transitions_total counter
doublezero_liveness_session_transitions_total{iface="doublezero0",local_ip="9.169.90.110",reason="handle_rx",state_from="DOWN",state_to="INIT"} 1
doublezero_liveness_session_transitions_total{iface="doublezero0",local_ip="9.169.90.110",reason="handle_rx",state_from="INIT",state_to="UP"} 1
doublezero_liveness_session_transitions_total{iface="doublezero0",local_ip="9.169.90.110",reason="register_route",state_from="NEW",state_to="DOWN"} 2
# HELP doublezero_liveness_sessions Current number of sessions by FSM state
# TYPE doublezero_liveness_sessions gauge
doublezero_liveness_sessions{iface="doublezero0",local_ip="9.169.90.110",state="DOWN"} 1
doublezero_liveness_sessions{iface="doublezero0",local_ip="9.169.90.110",state="INIT"} 0
doublezero_liveness_sessions{iface="doublezero0",local_ip="9.169.90.110",state="UP"} 1
```