### PR TITLE
fix(controlplane/s3-uploader): use correct cloudsmith repo

### DIFF
--- a/release/.goreleaser.testnet.s3-uploader.yaml
+++ b/release/.goreleaser.testnet.s3-uploader.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero-testnet
+    repository: doublezero
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"


### PR DESCRIPTION
# Summary

Small PR to fix the goreleaser workflow to use the correct repo for cloudsmith artifacts.
