### PR TITLE
ci: test deserialize existing state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ rust-fmt-check:
 rust-test:
 	cargo test --workspace --exclude doublezero-telemetry --exclude doublezero-serviceability --exclude doublezero-program-common --exclude doublezero-record --all-features
 	cd smartcontract && $(MAKE) test-programs
+	$(MAKE) rust-program-accounts-compat
 
 .PHONY: rust-test-programs
 rust-test-programs:
@@ -105,7 +106,7 @@ rust-validator-test:
 	bash smartcontract/test/run_record_test.sh
 
 .PHONY: rust-ci
-rust-ci: rust-build rust-lint rust-test rust-validator-test rust-program-accounts-compat
+rust-ci: rust-build rust-lint rust-test rust-validator-test
 
 .PHONY: rust-program-accounts-compat
 rust-program-accounts-compat:


### PR DESCRIPTION
## Summary of Changes
- Update `make test` target to run the `rust-program-accounts-compat` target so we attempt to deserialize all existing state in CI too
- @juan-malbeclabs already added this "deserialize all state" functionality a few weeks ago; this PR just makes it run in CI

## Testing Verification
- CI rust/test workflow is run on every PR, including this one
