### PR TITLE
Bump cargo.toml to version 0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
+- None for this release
+
+### Changes
+
+## [v0.6.11](https://github.com/malbeclabs/doublezero/compare/client/v0.6.10...client/v0.6.11) – 2025-11-13
+
+### Breaking
+
 ### Changes
 
 - Onchain programs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1539,7 +1539,7 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "indicatif",
- "mockall 0.13.1",
+ "mockall",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "backon",
  "bitvec",
@@ -1574,7 +1574,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
- "mockall 0.13.1",
+ "mockall",
  "solana-client",
  "solana-sdk",
  "tokio",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "backon",
@@ -1604,7 +1604,7 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "indicatif",
- "mockall 0.13.1",
+ "mockall",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "eyre",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1706,7 +1706,7 @@ dependencies = [
  "http 1.3.1",
  "indicatif",
  "ipnetwork",
- "mockall 0.13.1",
+ "mockall",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -1739,7 +1739,7 @@ dependencies = [
  "eyre",
  "futures",
  "log",
- "mockall 0.13.1",
+ "mockall",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3276,22 +3276,8 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive 0.11.4",
+ "mockall_derive",
  "predicates 2.1.5",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive 0.13.1",
- "predicates 3.1.3",
  "predicates-tree",
 ]
 
@@ -3305,18 +3291,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.102",
 ]
 
 [[package]]
@@ -6699,7 +6673,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2",
- "mockall 0.11.4",
+ "mockall",
  "modular-bitfield",
  "num-derive",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Bump `Cargo.toml` version to `v0.6.11`
- Move unreleased changelog items to v0.6.11
- Related to https://github.com/malbeclabs/doublezero/issues/2140
