### PR TITLE
docs: fix changelog non-breaking note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
-- None for this release
-
 ### Changes
 
 ## [v0.6.11](https://github.com/malbeclabs/doublezero/compare/client/v0.6.10...client/v0.6.11) – 2025-11-13
 
 ### Breaking
+
+- None for this release
 
 ### Changes
 


### PR DESCRIPTION
## Summary of Changes
- Move changelog non-breaking note to 0.6.11 release
