### PR TITLE
client/daemon: route liveness fix local/peer discriminator var names

### DIFF
--- a/client/doublezerod/internal/liveness/manager.go
+++ b/client/doublezerod/internal/liveness/manager.go
@@ -180,7 +180,7 @@ func NewManager(ctx context.Context, cfg *ManagerConfig) (*Manager, error) {
 	}
 
 	log := cfg.Logger
-	log.Info("liveness: manager starting", "localAddr", udp.LocalAddr().String(), "txMin", cfg.TxMin, "rxMin", cfg.RxMin, "detectMult", cfg.DetectMult, "passiveMode", cfg.PassiveMode, "peerMetrics", cfg.PeerMetrics)
+	log.Info("liveness: manager starting", "localAddr", udp.LocalAddr().String(), "txMin", cfg.TxMin.String(), "rxMin", cfg.RxMin.String(), "detectMult", cfg.DetectMult, "passiveMode", cfg.PassiveMode, "peerMetrics", cfg.PeerMetrics)
 
 	ctx, cancel := context.WithCancel(ctx)
 	m := &Manager{
@@ -412,7 +412,7 @@ func (m *Manager) HandleRx(ctrl *ControlPacket, peer Peer) {
 		m.unkownPeerErrWarnMu.Lock()
 		if m.unkownPeerErrWarnLast.IsZero() || time.Since(m.unkownPeerErrWarnLast) >= m.unkownPeerErrWarnEvery {
 			m.unkownPeerErrWarnLast = time.Now()
-			m.log.Warn("liveness: received control packet for unknown peer", "peer", peer.String(), "peerDiscrr", ctrl.peerDiscrr, "localDiscrr", ctrl.LocalDiscrr, "state", ctrl.State)
+			m.log.Warn("liveness: received control packet for unknown peer", "peer", peer.String(), "peerDiscr", ctrl.PeerDiscr, "localDiscr", ctrl.LocalDiscr, "state", ctrl.State)
 
 		}
 		m.unkownPeerErrWarnMu.Unlock()

--- a/client/doublezerod/internal/liveness/packet.go
+++ b/client/doublezerod/internal/liveness/packet.go
@@ -47,8 +47,8 @@ type ControlPacket struct {
 	State           State  // sender's current session state
 	DetectMult      uint8  // detection multiplier (used by peer for detect timeout)
 	Length          uint8  // total length, always 40 for this fixed-size implementation
-	LocalDiscrr     uint32 // sender's discriminator (unique session ID)
-	peerDiscrr      uint32 // discriminator of the remote session (echo back)
+	LocalDiscr      uint32 // sender's discriminator (unique session ID)
+	PeerDiscr       uint32 // discriminator of the remote session (echo back)
 	DesiredMinTxUs  uint32 // minimum TX interval desired by sender (microseconds)
 	RequiredMinRxUs uint32 // minimum RX interval the sender can handle (microseconds)
 }
@@ -61,8 +61,8 @@ type ControlPacket struct {
 //	1: State (2 high bits)   | 6 bits unused (zero)
 //	2: DetectMult
 //	3: Length (always 40)
-//	4–7:  LocalDiscrr
-//	8–11: peerDiscrr
+//	4–7:  LocalDiscr
+//	8–11: PeerDiscr
 //
 // 12–15: DesiredMinTxUs
 // 16–19: RequiredMinRxUs
@@ -77,8 +77,8 @@ func (c *ControlPacket) Marshal() []byte {
 	sf := (uint8(c.State) & 0x3) << 6
 	b[0], b[1], b[2], b[3] = vd, sf, c.DetectMult, 40
 	be := binary.BigEndian
-	be.PutUint32(b[4:8], c.LocalDiscrr)
-	be.PutUint32(b[8:12], c.peerDiscrr)
+	be.PutUint32(b[4:8], c.LocalDiscr)
+	be.PutUint32(b[8:12], c.PeerDiscr)
 	be.PutUint32(b[12:16], c.DesiredMinTxUs)
 	be.PutUint32(b[16:20], c.RequiredMinRxUs)
 	// Remaining bytes [20:40] are reserved/padding → left zeroed
@@ -109,8 +109,8 @@ func UnmarshalControlPacket(b []byte) (*ControlPacket, error) {
 	}
 
 	rd := func(off int) uint32 { return binary.BigEndian.Uint32(b[off : off+4]) }
-	c.LocalDiscrr = rd(4)
-	c.peerDiscrr = rd(8)
+	c.LocalDiscr = rd(4)
+	c.PeerDiscr = rd(8)
 	c.DesiredMinTxUs = rd(12)
 	c.RequiredMinRxUs = rd(16)
 	return c, nil

--- a/client/doublezerod/internal/liveness/packet_test.go
+++ b/client/doublezerod/internal/liveness/packet_test.go
@@ -14,8 +14,8 @@ func TestClient_Liveness_Packet_MarshalEncodesHeaderAndFields(t *testing.T) {
 		Version:         5,
 		State:           StateUp,
 		DetectMult:      3,
-		LocalDiscrr:     0x11223344,
-		peerDiscrr:      0x55667788,
+		LocalDiscr:      0x11223344,
+		PeerDiscr:       0x55667788,
 		DesiredMinTxUs:  0x01020304,
 		RequiredMinRxUs: 0x0A0B0C0D,
 	}
@@ -41,8 +41,8 @@ func TestClient_Liveness_Packet_UnmarshalRoundTrip(t *testing.T) {
 		Version:         1,
 		State:           StateInit,
 		DetectMult:      7,
-		LocalDiscrr:     1,
-		peerDiscrr:      2,
+		LocalDiscr:      1,
+		PeerDiscr:       2,
 		DesiredMinTxUs:  3,
 		RequiredMinRxUs: 4,
 	}
@@ -54,8 +54,8 @@ func TestClient_Liveness_Packet_UnmarshalRoundTrip(t *testing.T) {
 	require.Equal(t, StateInit, got.State)
 	require.Equal(t, uint8(7), got.DetectMult)
 	require.Equal(t, uint8(40), got.Length)
-	require.Equal(t, uint32(1), got.LocalDiscrr)
-	require.Equal(t, uint32(2), got.peerDiscrr)
+	require.Equal(t, uint32(1), got.LocalDiscr)
+	require.Equal(t, uint32(2), got.PeerDiscr)
 	require.Equal(t, uint32(3), got.DesiredMinTxUs)
 	require.Equal(t, uint32(4), got.RequiredMinRxUs)
 }

--- a/client/doublezerod/internal/liveness/scheduler.go
+++ b/client/doublezerod/internal/liveness/scheduler.go
@@ -333,8 +333,8 @@ func (s *Scheduler) doTX(sess *Session) {
 		State:           sess.state,
 		DetectMult:      sess.detectMult,
 		Length:          40,
-		LocalDiscrr:     sess.localDiscr,
-		peerDiscrr:      sess.peerDiscr,
+		LocalDiscr:      sess.localDiscr,
+		PeerDiscr:       sess.peerDiscr,
 		DesiredMinTxUs:  uint32(sess.localTxMin / time.Microsecond),
 		RequiredMinRxUs: uint32(sess.localRxMin / time.Microsecond),
 	}).Marshal()

--- a/client/doublezerod/internal/liveness/session.go
+++ b/client/doublezerod/internal/liveness/session.go
@@ -161,15 +161,15 @@ func (s *Session) HandleRx(now time.Time, ctrl *ControlPacket) (changed bool) {
 	if s.state == StateAdminDown {
 		return false
 	}
-	if ctrl.peerDiscrr != 0 && ctrl.peerDiscrr != s.localDiscr {
+	if ctrl.PeerDiscr != 0 && ctrl.PeerDiscr != s.localDiscr {
 		return false
 	}
 
 	prev := s.state
 
 	// Learn peer discriminator if not yet known.
-	if s.peerDiscr == 0 && ctrl.LocalDiscrr != 0 {
-		s.peerDiscr = ctrl.LocalDiscrr
+	if s.peerDiscr == 0 && ctrl.LocalDiscr != 0 {
+		s.peerDiscr = ctrl.LocalDiscr
 	}
 
 	// Update peer timing and clamp within floor/ceiling bounds.
@@ -198,7 +198,7 @@ func (s *Session) HandleRx(now time.Time, ctrl *ControlPacket) (changed bool) {
 
 		// Move to Init once peer identified; Up after echo confirmation.
 		if s.peerDiscr != 0 {
-			if ctrl.State >= StateInit && ctrl.peerDiscrr == s.localDiscr {
+			if ctrl.State >= StateInit && ctrl.PeerDiscr == s.localDiscr {
 				s.state = StateUp
 				s.backoffFactor = 1
 			} else {
@@ -209,7 +209,7 @@ func (s *Session) HandleRx(now time.Time, ctrl *ControlPacket) (changed bool) {
 
 	case StateInit:
 		// Promote to Up only after receiving echo referencing our localDiscr.
-		if s.peerDiscr != 0 && ctrl.State >= StateInit && ctrl.peerDiscrr == s.localDiscr {
+		if s.peerDiscr != 0 && ctrl.State >= StateInit && ctrl.PeerDiscr == s.localDiscr {
 			s.state = StateUp
 			s.backoffFactor = 1
 		}

--- a/client/doublezerod/internal/liveness/session_test.go
+++ b/client/doublezerod/internal/liveness/session_test.go
@@ -166,7 +166,7 @@ func TestClient_Liveness_Session_HandleRxIgnoresMismatchedpeerDiscrr(t *testing.
 	s := newSess()
 	s.localDiscr = 111
 	now := time.Now()
-	cp := &ControlPacket{peerDiscrr: 222, LocalDiscrr: 333, State: StateInit}
+	cp := &ControlPacket{PeerDiscr: 222, LocalDiscr: 333, State: StateInit}
 	changed := s.HandleRx(now, cp)
 	require.False(t, changed)
 	require.Equal(t, StateDown, s.state)
@@ -182,8 +182,8 @@ func TestClient_Liveness_Session_HandleRxFromDownToInitOrUpAndArmsDetect(t *test
 	now := time.Now()
 	// Peer Down -> go Init
 	cpDown := &ControlPacket{
-		peerDiscrr:      0,    // acceptable (we only check mismatch if nonzero)
-		LocalDiscrr:     1001, // learn peer discr
+		PeerDiscr:       0,    // acceptable (we only check mismatch if nonzero)
+		LocalDiscr:      1001, // learn peer discr
 		State:           StateDown,
 		DesiredMinTxUs:  30_000, // 30ms
 		RequiredMinRxUs: 40_000, // 40ms
@@ -197,8 +197,8 @@ func TestClient_Liveness_Session_HandleRxFromDownToInitOrUpAndArmsDetect(t *test
 
 	// Next packet peer Init -> go Up
 	cpInit := &ControlPacket{
-		peerDiscrr:      42, // matches our localDiscr (explicit echo required)
-		LocalDiscrr:     1001,
+		PeerDiscr:       42, // matches our localDiscr (explicit echo required)
+		LocalDiscr:      1001,
 		State:           StateInit,
 		DesiredMinTxUs:  20_000,
 		RequiredMinRxUs: 20_000,
@@ -216,14 +216,14 @@ func TestClient_Liveness_Session_HandleRxFromInitToUpOnPeerInitOrUp(t *testing.T
 	s.peerDiscr = 777 // already learned
 	now := time.Now()
 
-	// Without explicit echo (peerDiscrr != localDiscr), do NOT promote.
-	cpNoEcho := &ControlPacket{peerDiscrr: 0, LocalDiscrr: 777, State: StateUp}
+	// Without explicit echo (PeerDiscr != localDiscr), do NOT promote.
+	cpNoEcho := &ControlPacket{PeerDiscr: 0, LocalDiscr: 777, State: StateUp}
 	changed := s.HandleRx(now, cpNoEcho)
 	require.False(t, changed)
 	require.Equal(t, StateInit, s.state)
 
-	// With explicit echo (peerDiscrr == localDiscr), promote to Up.
-	cpEcho := &ControlPacket{peerDiscrr: s.localDiscr, LocalDiscrr: s.peerDiscr, State: StateUp}
+	// With explicit echo (PeerDiscr == localDiscr), promote to Up.
+	cpEcho := &ControlPacket{PeerDiscr: s.localDiscr, LocalDiscr: s.peerDiscr, State: StateUp}
 	changed = s.HandleRx(now, cpEcho)
 	require.True(t, changed)
 	require.Equal(t, StateUp, s.state)
@@ -237,7 +237,7 @@ func TestClient_Liveness_Session_HandleRxFromUpToDownWhenPeerReportsDownAndStopD
 	now := time.Now()
 	s.detectDeadline = now.Add(10 * time.Second)
 
-	cp := &ControlPacket{peerDiscrr: 0, LocalDiscrr: 1, State: StateDown}
+	cp := &ControlPacket{PeerDiscr: 0, LocalDiscr: 1, State: StateDown}
 	changed := s.HandleRx(now, cp)
 	require.True(t, changed)
 	require.Equal(t, StateDown, s.state)
@@ -250,8 +250,8 @@ func TestClient_Liveness_Session_HandleRxSetsPeerTimersAndDetectDeadline(t *test
 	s := newSess()
 	now := time.Now()
 	cp := &ControlPacket{
-		peerDiscrr:      0,
-		LocalDiscrr:     9,
+		PeerDiscr:       0,
+		LocalDiscr:      9,
 		State:           StateInit,
 		DesiredMinTxUs:  12_000,
 		RequiredMinRxUs: 34_000,
@@ -280,7 +280,7 @@ func TestClient_Liveness_Session_HandleRxIgnoredWhenAdminDown(t *testing.T) {
 	s := newSess()
 	s.state = StateAdminDown
 	now := time.Now()
-	cp := &ControlPacket{peerDiscrr: 0, LocalDiscrr: 9, State: StateUp, DesiredMinTxUs: 1000, RequiredMinRxUs: 2000}
+	cp := &ControlPacket{PeerDiscr: 0, LocalDiscr: 9, State: StateUp, DesiredMinTxUs: 1000, RequiredMinRxUs: 2000}
 	changed := s.HandleRx(now, cp)
 	require.False(t, changed)
 	require.Equal(t, StateAdminDown, s.state)
@@ -296,8 +296,8 @@ func TestClient_Liveness_Session_HandleRxClampsTimersAndDetectMultZero(t *testin
 	s.maxTxCeil = 40 * time.Millisecond
 
 	cp := &ControlPacket{
-		peerDiscrr:      0,
-		LocalDiscrr:     9,
+		PeerDiscr:       0,
+		LocalDiscr:      9,
 		State:           StateInit,
 		DetectMult:      0,         // invalid → clamp to 1 (internal)
 		DesiredMinTxUs:  1_000,     // 1ms  → clamp up to 7ms
@@ -327,8 +327,8 @@ func TestClient_Liveness_Session_HandleRx_NoChange_RearmsDetect(t *testing.T) {
 
 	callNow := now.Add(10 * time.Millisecond)
 	cp := &ControlPacket{
-		peerDiscrr:      s.localDiscr, // accepted (echo ok)
-		LocalDiscrr:     s.peerDiscr,  // may be 0; fine
+		PeerDiscr:       s.localDiscr, // accepted (echo ok)
+		LocalDiscr:      s.peerDiscr,  // may be 0; fine
 		State:           StateUp,
 		DesiredMinTxUs:  20000, // 20ms
 		RequiredMinRxUs: 20000,


### PR DESCRIPTION
## Summary of Changes
- Fix typos in a couple variable names (`s/PeerDiscrr/PeerDiscr` and `s/LocalDiscrr/LocalDiscr`)
- Log `TxMin` and `TxMax` durations on startup with `.String()`

## Testing Verification
- Variable name changes only; existing test coverage is sufficient
