### PR TITLE
doublezerod: return errors as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ All notable changes to this project will be documented in this file.
 ### Changes
 - RFCs
   - RFC9 Link Draining
-
-
 - Client
   - Switch to 64 byte latency probes instead of 32 bytes
+  - Fix two cases where errors returned by doublezerod to the local socket were not json-formatted
 
 ## [v0.7.0](https://github.com/malbeclabs/doublezero/compare/client/v0.6.11...client/v0.7.0) – 2025-11-14
 

--- a/client/doublezerod/internal/manager/http.go
+++ b/client/doublezerod/internal/manager/http.go
@@ -82,8 +82,9 @@ func (n *NetlinkManager) ServeStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	status, err := n.Status()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"status": "error", "description": "error while getting status: %v"}`, err)))
+		slog.Error("error while getting status", "error", err)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"doublezero_status": {"session_status": "error"}}]`))
 		return
 	}
 	if len(status) == 0 {
@@ -92,8 +93,9 @@ func (n *NetlinkManager) ServeStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err = json.NewEncoder(w).Encode(status); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"status": "error", "description": "error while encoding status: %v"}`, err)))
+		slog.Error("error while encoding status", "error", err)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"doublezero_status": {"session_status": "error"}}]`))
 		return
 	}
 }


### PR DESCRIPTION
## Summary of Changes
* Fixed a few cases where doublezerod returned errors that were not json-formatted
* This led to swallowing errors in failed QA tests, with the QA test logging `failed to unmarshal status response: invalid character 'E' looking for beginning of value`

## Testing Verification
* No tests were updated because the conditions leading to these error cases are difficult to reproduce under test
