### PR TITLE
qa: increase disconnect timeout

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	disconnectTimeout                = 30 * time.Second
+	disconnectTimeout                = 90 * time.Second
 	waitForStatusUpTimeout           = 60 * time.Second
 	waitForStatusDisconnectedTimeout = 30 * time.Second
 	waitForUserDeletionTimeout       = 60 * time.Second


### PR DESCRIPTION
## Summary of Changes
- Increase QA disconnect timeout to >60s to account for activator missing websocket events and catching up via 1m poll
