### PR TITLE
Use globalstate index instead of client-passed index multicast PDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to this project will be documented in this file.
 - E2E tests
   - Add GetLatency call to qaagent
   - The QA alldevices test now considers device location and connects hosts to nearby devices
+- Onchain programs
+  - Fix CreateMulticastGroup to use incremented globalstate.account_index for PDA derivation instead of client-provided index, to ensure the contract is the authoritative source for account indices
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -815,8 +815,6 @@ mod tests {
 
         test_instruction(
             DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
-                index: 123,
-                bump_seed: 255,
                 max_bandwidth: 1000,
                 code: "test".to_string(),
                 owner: Pubkey::new_unique(),

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -59,7 +59,7 @@ async fn test_multicast_publisher_allowlist() {
         .get_global_state()
         .unwrap();
 
-    let (multicastgroup_pubkey, bump_seed) =
+    let (multicastgroup_pubkey, _) =
         get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
 
     execute_transaction(
@@ -67,8 +67,6 @@ async fn test_multicast_publisher_allowlist() {
         recent_blockhash,
         program_id,
         DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
-            index: globalstate.account_index + 1,
-            bump_seed,
             code: "test".to_string(),
             max_bandwidth: 1_000_000_000,
             owner: payer.pubkey(),

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -59,7 +59,7 @@ async fn test_multicast_subscriber_allowlist() {
         .get_global_state()
         .unwrap();
 
-    let (multicastgroup_pubkey, bump_seed) =
+    let (multicastgroup_pubkey, _) =
         get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
 
     execute_transaction(
@@ -67,8 +67,6 @@ async fn test_multicast_subscriber_allowlist() {
         recent_blockhash,
         program_id,
         DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
-            index: globalstate.account_index + 1,
-            bump_seed,
             code: "test".to_string(),
             max_bandwidth: 100,
             owner: payer.pubkey(),

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/create.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/create.rs
@@ -23,13 +23,11 @@ impl CreateMulticastGroupCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        let (pda_pubkey, bump_seed) =
+        let (pda_pubkey, _) =
             get_multicastgroup_pda(&client.get_program_id(), globalstate.account_index + 1);
         client
             .execute_transaction(
                 DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
-                    index: globalstate.account_index + 1,
-                    bump_seed,
                     code,
                     max_bandwidth: self.max_bandwidth,
                     owner: self.owner,
@@ -62,15 +60,13 @@ mod tests {
         let mut client = create_test_client();
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
-        let (pda_pubkey, bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
+        let (pda_pubkey, _) = get_multicastgroup_pda(&client.get_program_id(), 1);
 
         client
             .expect_execute_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CreateMulticastGroup(
                     MulticastGroupCreateArgs {
-                        index: 1,
-                        bump_seed,
                         code: "test_group".to_string(),
                         max_bandwidth: 1000,
                         owner: globalstate_pubkey,


### PR DESCRIPTION
Resolves: #1996

## Summary of Changes

* Fixed `CreateMulticastGroup` to derive the PDA using the incremented `globalstate.account_index` instead of the client-provided `value.index`
* Ensures the smart contract is the authoritative source of truth for account indices, preventing clients from passing arbitrary index values that could cause PDA-to-index mismatches
* CHANGELOG.md update: Added entry under changes

## Testing Verification
* Existing test `test_multicastgroup` passes, validates that multicast groups are created with correct index values and all operations work properly
* Added `test_multicastgroup_create_with_wrong_index_fails` to verify that clients cannot pass incorrect index values