### PR TITLE
svc/cli: min compatible version

### DIFF
--- a/smartcontract/cli/src/checkversion.rs
+++ b/smartcontract/cli/src/checkversion.rs
@@ -7,16 +7,19 @@ pub fn check_version<C: CliCommand, W: Write>(
     out: &mut W,
     client_version: ProgramVersion,
 ) -> eyre::Result<()> {
-    // Check the program configuration version
     if let Ok((_, pconfig)) = client.get_program_config(GetProgramConfigCommand) {
-        // Compare the program version with the client version
-        // If the program version is incompatible, return an error
-        if pconfig.version.error(&client_version) {
-            eyre::bail!("Your client version is no longer up to date. Please update it before continuing to use the client.")
-        }
-        // If the program version is compatible, but the client version is behind, print a warning
-        if pconfig.version.warning(&client_version) {
-            writeln!(out, "A new version of the client is available: {} → {}\nWe recommend updating to the latest version for the best experience.", client_version, pconfig.version)?;
+        let program_version = pconfig.version;
+        if client_version < pconfig.min_compatible_version {
+            eyre::bail!(
+                "Your client version ({client_version}) is no longer compatible. \
+                 Please upgrade to {program_version} before continuing to use the client."
+            )
+        } else if client_version < program_version {
+            writeln!(
+                out,
+                "A new version of the client is available: {client_version} → {program_version}\n\
+                 We recommend upgrading to the latest version for the best experience."
+            )?;
         }
     }
 
@@ -36,6 +39,7 @@ mod tests {
     pub fn test_check_version(
         out: &mut Vec<u8>,
         contract_version: ProgramVersion,
+        contract_min_compatible_version: ProgramVersion,
         client_version: ProgramVersion,
     ) -> eyre::Result<()> {
         let mut client = MockCliCommand::new();
@@ -48,6 +52,7 @@ mod tests {
                     account_type: AccountType::ProgramConfig,
                     bump_seed: 1,
                     version: contract_version.clone(),
+                    min_compatible_version: contract_min_compatible_version.clone(),
                 };
                 Ok((Pubkey::new_unique(), program_config))
             });
@@ -56,12 +61,13 @@ mod tests {
     }
 
     #[test]
-    fn test_check_version_ok() {
+    fn test_check_version_same_versions_ok() {
         let mut output = Vec::new();
         let res = test_check_version(
             &mut output,
-            ProgramVersion::new(1, 0, 0),
-            ProgramVersion::new(1, 0, 0),
+            ProgramVersion::new(1, 0, 0), // program version
+            ProgramVersion::new(1, 0, 0), // min compatible
+            ProgramVersion::new(1, 0, 0), // client
         );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
@@ -69,12 +75,52 @@ mod tests {
     }
 
     #[test]
-    fn test_check_version_minor_ok() {
+    fn test_check_version_program_higher_patch_warning() {
+        // client == min_compatible < program → warning
         let mut output = Vec::new();
         let res = test_check_version(
             &mut output,
-            ProgramVersion::new(1, 1, 0),
-            ProgramVersion::new(1, 2, 0),
+            ProgramVersion::new(1, 0, 1), // program version
+            ProgramVersion::new(1, 0, 0), // min compatible
+            ProgramVersion::new(1, 0, 0), // client
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "A new version of the client is available: 1.0.0 → 1.0.1\n\
+We recommend upgrading to the latest version for the best experience.\n"
+        );
+    }
+
+    #[test]
+    fn test_check_version_program_higher_minor_warning() {
+        // client == min_compatible < program → warning
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 2, 0), // program version
+            ProgramVersion::new(1, 0, 0), // min compatible
+            ProgramVersion::new(1, 0, 0), // client
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "A new version of the client is available: 1.0.0 → 1.2.0\n\
+We recommend upgrading to the latest version for the best experience.\n"
+        );
+    }
+
+    #[test]
+    fn test_check_version_client_higher_minor_ok() {
+        // client > program >= min_compatible → no warning, no error
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(1, 1, 0), // program version
+            ProgramVersion::new(1, 0, 0), // min compatible
+            ProgramVersion::new(1, 2, 0), // client
         );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
@@ -82,12 +128,14 @@ mod tests {
     }
 
     #[test]
-    fn test_check_version_major_ok() {
+    fn test_check_version_client_higher_patch_ok() {
+        // client > program >= min_compatible → no warning, no error
         let mut output = Vec::new();
         let res = test_check_version(
             &mut output,
-            ProgramVersion::new(1, 0, 0),
-            ProgramVersion::new(2, 0, 0),
+            ProgramVersion::new(1, 2, 0), // program version
+            ProgramVersion::new(1, 2, 0), // min compatible
+            ProgramVersion::new(1, 2, 1), // client
         );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
@@ -95,15 +143,40 @@ mod tests {
     }
 
     #[test]
-    fn test_check_version_build_warning() {
+    fn test_check_version_client_below_min_compatible_error() {
+        // client < min_compatible <= program → error
         let mut output = Vec::new();
         let res = test_check_version(
             &mut output,
-            ProgramVersion::new(1, 2, 10),
-            ProgramVersion::new(1, 2, 0),
+            ProgramVersion::new(2, 0, 0), // program version
+            ProgramVersion::new(1, 1, 0), // min compatible
+            ProgramVersion::new(1, 0, 0), // client
         );
-        assert!(res.is_ok());
-        let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "A new version of the client is available: 1.2.0 → 1.2.10\nWe recommend updating to the latest version for the best experience.\n");
+        assert!(res.is_err());
+        let error_msg = res.unwrap_err().to_string();
+        assert_eq!(
+            error_msg,
+            "Your client version (1.0.0) is no longer compatible. \
+Please upgrade to 2.0.0 before continuing to use the client."
+        );
+    }
+
+    #[test]
+    fn test_check_version_client_much_older_major_error() {
+        // client << min_compatible == program → error
+        let mut output = Vec::new();
+        let res = test_check_version(
+            &mut output,
+            ProgramVersion::new(2, 0, 0), // program version
+            ProgramVersion::new(2, 0, 0), // min compatible
+            ProgramVersion::new(1, 0, 0), // client
+        );
+        assert!(res.is_err());
+        let error_msg = res.unwrap_err().to_string();
+        assert_eq!(
+            error_msg,
+            "Your client version (1.0.0) is no longer compatible. \
+Please upgrade to 2.0.0 before continuing to use the client."
+        );
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/lib.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod entrypoint;
 mod globalstate;
 mod helper;
+mod min_version;
 
 pub mod accounts;
 pub mod addresses;

--- a/smartcontract/programs/doublezero-serviceability/src/min_version.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/min_version.rs
@@ -1,0 +1,2 @@
+// Minimum compatible version of DoubleZero for the current version.
+pub const MIN_COMPATIBLE_VERSION: &str = "0.6.0";

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -14,6 +14,7 @@ use solana_program::{
     entrypoint::ProgramResult,
     pubkey::Pubkey,
 };
+use std::str::FromStr;
 
 pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -40,6 +41,10 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             account_type: AccountType::ProgramConfig,
             bump_seed: program_config_bump_seed, // This is not used in this context
             version: ProgramVersion::current(),  // Default version for initialization
+            min_compatible_version: ProgramVersion::from_str(
+                crate::min_version::MIN_COMPATIBLE_VERSION,
+            )
+            .unwrap(),
         },
         program_id,
         payer_account,

--- a/smartcontract/programs/doublezero-serviceability/src/programversion.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/programversion.rs
@@ -2,7 +2,7 @@ use borsh::BorshSerialize;
 use core::fmt;
 use std::str::FromStr;
 
-#[derive(BorshSerialize, Debug, PartialEq, Clone, Default)]
+#[derive(BorshSerialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProgramVersion {
     pub major: u32,
@@ -55,16 +55,6 @@ impl ProgramVersion {
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or_default(),
         }
     }
-
-    // Check if the current version is compatible with the required version
-    pub fn warning(&self, client: &ProgramVersion) -> bool {
-        self.major == client.major && self.minor == client.minor && self.patch > client.patch
-    }
-
-    // Check if the current version is incompatible with the required version
-    pub fn error(&self, client: &ProgramVersion) -> bool {
-        self.major > client.major || (self.major == client.major && self.minor > client.minor)
-    }
 }
 
 #[cfg(test)]
@@ -78,58 +68,19 @@ mod tests {
     }
 
     #[test]
-    fn test_program_version_warning1() {
-        let program = ProgramVersion::new(1, 1, 3);
-        let client = ProgramVersion::new(1, 2, 0);
-        assert!(!program.warning(&client));
-    }
+    fn test_program_version_ordering() {
+        let v1 = ProgramVersion::new(1, 2, 3);
+        let v2 = ProgramVersion::new(1, 2, 4);
+        let v3 = ProgramVersion::new(1, 3, 0);
+        let v4 = ProgramVersion::new(2, 0, 0);
 
-    #[test]
-    fn test_program_version_warning2() {
-        let program = ProgramVersion::new(1, 2, 2);
-        let client = ProgramVersion::new(1, 2, 3);
-        assert!(!program.warning(&client));
-    }
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+        assert!(v3 < v4);
 
-    #[test]
-    fn test_program_version_warning3() {
-        let program = ProgramVersion::new(1, 2, 3);
-        let client = ProgramVersion::new(1, 2, 3);
-        assert!(!program.warning(&client));
-    }
-
-    #[test]
-    fn test_program_version_warning4() {
-        let program = ProgramVersion::new(1, 2, 3);
-        let client = ProgramVersion::new(1, 2, 2);
-        assert!(program.warning(&client));
-    }
-
-    #[test]
-    fn test_program_version_error1() {
-        let program = ProgramVersion::new(1, 2, 3);
-        let client = ProgramVersion::new(1, 3, 0);
-        assert!(!program.error(&client));
-    }
-
-    #[test]
-    fn test_program_version_error2() {
-        let program = ProgramVersion::new(2, 0, 3);
-        let client = ProgramVersion::new(1, 2, 0);
-        assert!(program.error(&client));
-    }
-
-    #[test]
-    fn test_program_version_error3() {
-        let program = ProgramVersion::new(1, 3, 3);
-        let client = ProgramVersion::new(1, 2, 0);
-        assert!(program.error(&client));
-    }
-
-    #[test]
-    fn test_program_version_error4() {
-        let program = ProgramVersion::new(1, 0, 3);
-        let client = ProgramVersion::new(2, 2, 0);
-        assert!(!program.error(&client));
+        assert!(v4 > v1);
+        assert!(v2 >= v1);
+        assert!(v1 <= v2);
+        assert!(v1 <= v1);
     }
 }


### PR DESCRIPTION
## Summary of Changes
- Add `min_compatible_version` to serviceability `ProgramConfig` and store in `GlobalState` on `init`
- Update CLI `check_version` to error in client version is less than min compatible version and warn if less than program version
- Closes https://github.com/malbeclabs/doublezero/issues/2174
- Context https://github.com/malbeclabs/doublezero/pull/2175

## Testing Verification
- Updated existing test coverage to match the changes
