### PR TITLE
Bump cargo.toml to version 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,23 @@ All notable changes to this project will be documented in this file.
 ### Breaking
 
 ### Changes
+
+## [v0.7.1](https://github.com/malbeclabs/doublezero/compare/client/v0.7.0...client/v0.7.1) – 2025-11-18
+
+### Breaking
+
+- None for this release
+
+### Changes
+
 - RFCs
   - RFC9 Link Draining
-
 - Client
   - Switch to 64 byte latency probes instead of 32 bytes
   - Route liveness admin-down signalling and ignore stale remote-down messages
   - Added an on-chain minimum supported CLI version to allow multiple CLI versions to operate simultaneously.
-  
 - Smart contract
   - Delay V2 Interface Activation Until All Clients Support V2 Reading
-
 - Device controller
   - Now accepts the config agent's version in the grpc GetConfig call and includes it as a label in the controller_grpc_getconfig_requests_total metric
 - Device Agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "backon",
  "bitvec",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "eyre",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Bump `Cargo.toml` version to `v0.7.1` in prep for https://github.com/malbeclabs/doublezero/issues/2178
- Move unreleased changelog entries to `v0.7.1`
