### PR TITLE
qa: force stop grpc server and add logging

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -127,8 +127,9 @@ func (q *QAAgent) Start(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		q.log.Info("Stopping QA Agent...")
-		agent.GracefulStop()
+		q.log.Info("Stopping QA Agent gRPC server...")
+		agent.Stop()
+		q.log.Info("Stopping multicast listener...")
 		q.mcastListener.Stop()
 		return <-errChan
 	case err := <-errChan:


### PR DESCRIPTION
## Summary of Changes
QA agent is sometimes SIGKILL'd on shutdown. There isn't enough logging to know whether it's the graceful shutdown routine for the gRPC server or waiting for the multicast listener to close:
```
Nov 18 17:45:54 fra-tn-qa01 systemd[1]: Stopping doublezero-qaagent.service - DoubleZero QA Agent...
Nov 18 17:47:24 fra-tn-qa01 systemd[1]: doublezero-qaagent.service: State 'stop-sigterm' timed out. Killing.
Nov 18 17:47:24 fra-tn-qa01 systemd[1]: doublezero-qaagent.service: Killing process 1708272 (doublezero-qaag) with signal SIGKILL.
```
This moves the QA agent to force gRPC shutdown on close, since we don't need to cleanly end client connections, as well as adding logging if we're not blocking here.

## Testing Verification
```
ubuntu@chi-dn-bm2:~$ sudo systemctl stop doublezero-qaagent.service
ubuntu@chi-dn-bm2:~$ sudo systemctl status doublezero-qaagent.service
○ doublezero-qaagent.service - DoubleZero QA Agent
     Loaded: loaded (/etc/systemd/system/doublezero-qaagent.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/doublezero-qaagent.service.d
             └─override.conf
     Active: inactive (dead) since Tue 2025-11-18 18:38:16 UTC; 1s ago
   Duration: 10.710s
    Process: 31171 ExecStart=/usr/bin/doublezero-qaagent -server-addr 100.67.47.29:7009 (code=exited, status=0/SUCCESS)
   Main PID: 31171 (code=exited, status=0/SUCCESS)
        CPU: 14ms

Nov 18 18:38:05 chi-dn-bm2 systemd[1]: Started doublezero-qaagent.service - DoubleZero QA Agent.
Nov 18 18:38:05 chi-dn-bm2 doublezero-qaagent[31171]: time=2025-11-18T18:38:05.875Z level=INFO source=main.go:80 msg="Starting QA Agent..."
Nov 18 18:38:16 chi-dn-bm2 doublezero-qaagent[31171]: time=2025-11-18T18:38:16.575Z level=INFO source=agent.go:130 msg="Stopping QA Agent gRPC server..."
Nov 18 18:38:16 chi-dn-bm2 doublezero-qaagent[31171]: time=2025-11-18T18:38:16.575Z level=INFO source=agent.go:132 msg="Stopping multicast listener..."
Nov 18 18:38:16 chi-dn-bm2 systemd[1]: Stopping doublezero-qaagent.service - DoubleZero QA Agent...
Nov 18 18:38:16 chi-dn-bm2 systemd[1]: doublezero-qaagent.service: Deactivated successfully.
Nov 18 18:38:16 chi-dn-bm2 systemd[1]: Stopped doublezero-qaagent.service - DoubleZero QA Agent.
```
