### PR TITLE
qa: ping loss threshold and check if routes were uninstalled

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -169,6 +169,9 @@ func (q *QAAgent) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResult
 	}
 	stats := pinger.Statistics()
 	q.log.Info("Ping statistics", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv)
+	if stats.PacketsRecv < stats.PacketsSent {
+		q.log.Warn("Packet loss detected", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv)
+	}
 	return &pb.PingResult{PacketsSent: uint32(stats.PacketsSent), PacketsReceived: uint32(stats.PacketsRecv)}, nil
 }
 


### PR DESCRIPTION
## Summary of Changes
- Reduce per-probe ping timeout to 5s
- Add loss threshold where the test completely fails if over the threshold
- In QA agent, log if packet loss detected for visibility/tracking separate from full QA failures
- On ping failure, check installed routes and if target no longer there then log error for visibility
- Closes https://github.com/malbeclabs/infra/issues/379

## Testing Verification
- Executed these tests on devnet and testnet
