### PR TITLE
qa/agent: packet loss counter metric

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -170,7 +170,9 @@ func (q *QAAgent) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResult
 	stats := pinger.Statistics()
 	q.log.Info("Ping statistics", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv)
 	if stats.PacketsRecv < stats.PacketsSent {
-		q.log.Warn("Packet loss detected", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv)
+		packetsLost := stats.PacketsSent - stats.PacketsRecv
+		q.log.Warn("Packet loss detected", "target_ip", req.GetTargetIp(), "packets_sent", stats.PacketsSent, "packets_received", stats.PacketsRecv, "packets_lost", packetsLost)
+		PingPacketsLostTotal.WithLabelValues(req.GetSourceIp(), req.GetTargetIp()).Add(float64(packetsLost))
 	}
 	return &pb.PingResult{PacketsSent: uint32(stats.PacketsSent), PacketsReceived: uint32(stats.PacketsRecv)}, nil
 }

--- a/e2e/internal/rpc/metrics.go
+++ b/e2e/internal/rpc/metrics.go
@@ -13,8 +13,16 @@ var (
 	},
 		[]string{"version", "commit", "date"},
 	)
+
+	PingPacketsLostTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "doublezero_qaagent_ping_packets_lost_total",
+		Help: "Total number of packets lost during ping tests",
+	},
+		[]string{"source_ip", "target_ip"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(BuildInfo)
+	prometheus.MustRegister(PingPacketsLostTotal)
 }


### PR DESCRIPTION
## Summary of Changes
- Emit QA agent counter metric for total packets lost by (source, target)
