### PR TITLE
qa/agent: connect and disconnect duration metrics

### DIFF
--- a/e2e/internal/rpc/metrics.go
+++ b/e2e/internal/rpc/metrics.go
@@ -20,6 +20,21 @@ var (
 	},
 		[]string{"source_ip", "target_ip"},
 	)
+
+	ConnectUnicastDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "doublezero_qaagent_connect_unicast_duration_seconds",
+		Help: "Duration of unicast connect tests",
+	})
+
+	ConnectMulticastDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "doublezero_qaagent_connect_multicast_duration_seconds",
+		Help: "Duration of multicast connect tests",
+	})
+
+	DisconnectDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "doublezero_qaagent_disconnect_duration_seconds",
+		Help: "Duration of disconnect tests",
+	})
 )
 
 func init() {


### PR DESCRIPTION
## Summary of Changes
- Emit duration metrics for connect and disconnect operations for unicast and multicast in QA agent