### PR TITLE
qa: multicast better disconnect cleanup on connect timeout

### DIFF
--- a/e2e/qa_multicast_test.go
+++ b/e2e/qa_multicast_test.go
@@ -82,21 +82,11 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 		require.NotNil(t, group, "multicast group not found: %s", groupCode)
 	}
 
-	// Connect publisher to multicast group.
-	err = publisher.ConnectUserMulticast_Publisher_Wait(ctx, group.Code)
-	require.NoError(t, err, "failed to connect publisher to multicast group")
-
 	// Disconnect source client on cleanup.
 	t.Cleanup(func() {
 		err := publisher.DisconnectUser(context.Background(), true, true)
 		assert.NoError(t, err, "failed to disconnect user")
 	})
-
-	// Connect subscribers to multicast group.
-	for _, subscriber := range subscribers {
-		err = subscriber.ConnectUserMulticast_Subscriber_Wait(ctx, group.Code)
-		require.NoError(t, err, "failed to connect subscriber to multicast group")
-	}
 
 	// Disconnect subscribers on cleanup.
 	t.Cleanup(func() {
@@ -111,6 +101,16 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 		}
 		wg.Wait()
 	})
+
+	// Connect publisher to multicast group.
+	err = publisher.ConnectUserMulticast_Publisher_Wait(ctx, group.Code)
+	require.NoError(t, err, "failed to connect publisher to multicast group")
+
+	// Connect subscribers to multicast group.
+	for _, subscriber := range subscribers {
+		err = subscriber.ConnectUserMulticast_Subscriber_Wait(ctx, group.Code)
+		require.NoError(t, err, "failed to connect subscriber to multicast group")
+	}
 
 	// Wait for status of all clients to be up.
 	for _, client := range clients {


### PR DESCRIPTION
## Summary of Changes
- Update QA multicast test to configure disconnect cleanup _before_ connecting, so if there is a connect error/timeout the user will still be disconnected
- A case where the follow-on unicast test failed because multicast connect timed out but eventually did connect in the agent, causing unicast test to fail: https://github.com/malbeclabs/infra/actions/runs/19517954441/job/55874546538#logs

## Testing Verification
- Executed this on devnet and testnet
