### PR TITLE
qa: fix check for already disconnected

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -111,7 +111,7 @@ func (c *Client) DisconnectUser(ctx context.Context, waitForStatus bool, waitFor
 	if err != nil {
 		return fmt.Errorf("failed to get user status: %w", err)
 	}
-	if status.SessionStatus != UserStatusUp {
+	if status.SessionStatus == UserStatusDisconnected {
 		c.log.Debug("User already disconnected", "host", c.Host)
 	} else {
 		c.log.Info("Disconnecting user", "host", c.Host)


### PR DESCRIPTION
## Summary of Changes
- Fix check for already disconnected to look for `== UserStatusDisconnected` instead of `!= UserStatusUp`, since sometimes the connect may still be in pending (ie on activation timeout), and can cause racey failures if another test is queued up following it ([example](https://github.com/malbeclabs/infra/actions/runs/19527474150/job/55904470017))

## Testing Verification
- Executed QA on devnet and testnet
