### PR TITLE
Docs: update UDP port reachability reqs

### DIFF
--- a/client/INSTALL.md
+++ b/client/INSTALL.md
@@ -108,6 +108,10 @@ $ getcap bin/doublezerod
 doublezerod cap_net_admin,cap_net_raw=ep
 ```
 
+### Network requirements
+
+When running `doublezerod` with route liveness enabled, clients must be able to exchange liveness control traffic over UDP port `44880`. Ensure that host firewalls and any intervening network devices allow bidirectional UDP reachability on port `44880` between participating DoubleZero clients; otherwise, liveness sessions will be treated as down and associated routes may be withdrawn.
+
 ### Starting DoubleZero Client
 ```
 $ ./bin/doublezerod &


### PR DESCRIPTION
## Summary of Changes
* Updated  client/INSTALL.md to add a Network requirements section.
* Route liveness uses a shared UDP listener on port 44880.
* Making this requirement explicit helps users configure their networks correctly and avoid unexpected route withdrawals.
* None. This PR is documentation-only; it does not add or modify any metrics.
* Not necessary. This is a small documentation clarification with no behavior change.

## Testing Verification
* Documentation-only change; no code or behavior modified.

Fixes #2063 