### PR TITLE
fix(cli): update env error message

### DIFF
--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -59,7 +59,19 @@ async fn main() -> eyre::Result<()> {
     }
 
     let (url, ws, program_id) = if let Some(env) = app.env {
-        let config = env.parse::<Environment>()?.config()?;
+        let config = match env.parse::<Environment>() {
+            Ok(env) => match env.config() {
+                Ok(config) => config,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            },
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        };
         (
             Some(config.ledger_public_rpc_url),
             Some(config.ledger_public_ws_rpc_url),


### PR DESCRIPTION
## Summary of Changes
* Updated CLI environment handling in client/doublezero/src/main.rs by replacing ?-based error propagation with explicit match blocks.
* Invalid --env values now show a clean, user-friendly Error: <message> and exit with status 1, instead of printing eyre::Report with internal source locations.
* This improves UX by removing noisy Location: config/src/env.rs:... details and avoids exposing internal implementation paths.
* No metrics were added or changed.
* Behavior aligns with standard CLI UX (short, clear user-facing errors); no external docs introduced.

## Testing Verification
* make rust-test is green

fixes #1481 
