### PR TITLE
Add soft_drained and hard_drained link status values for traffic offloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,14 @@ All notable changes to this project will be documented in this file.
 - RFCs
   - RFC-10: Version Compatibility Windows
 - CLI
-  - IP address lookups via ifconfig.me are retried up to 3 times to minimize transient network errors.
-  - Added global `--no-version-warning` flag to the `doublezero` client and now emit version warnings to STDERR instead of STDOUT to improve scriptability and logging.
-  - Add the ability to update a Device’s location, managing the reference counters accordingly.
-- Client
-  - Add `/routes` daemon API endpoint providing a merged view of kernel routes and liveness-tracked routes.
-  - Route liveness scheduler avoid logging UDP send failure after shutdown
+    - IP address lookups via ifconfig.me are retried up to 3 times to minimize transient network errors.
+    - Added global `--no-version-warning` flag to the `doublezero` client and now emit version warnings to STDERR instead of STDOUT to improve scriptability and logging.
+    - Add the ability to update a Device’s location, managing the reference counters accordingly.
+    - Added support in the link update command to set a link’s status to soft_drained or hard_drained.
 - Funder: fund multicast group owners
 - Onchain programs
   - Serviceability Program: Updated the device update command to allow modifying a device’s location.
+  - Added new `soft_drained` and `hard_drained` link status values to serviceability to support traffic offloading as defined in RFC-9.
 
 
 ## [v0.7.1](https://github.com/malbeclabs/doublezero/compare/client/v0.7.0...client/v0.7.1) – 2025-11-18

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
@@ -71,6 +71,7 @@ pub fn process_delete_link(
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
+    // Any link can be deleted by its contributor or foundation allowlist on any status
     let mut link: Link = Link::try_from(link_account)?;
     link.status = LinkStatus::Deleting;
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/link.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/link.rs
@@ -61,6 +61,8 @@ pub enum LinkStatus {
     Deleting = 3,
     Rejected = 4,
     Requested = 5,
+    HardDrained = 6,
+    SoftDrained = 7,
 }
 
 impl From<u8> for LinkStatus {
@@ -72,6 +74,8 @@ impl From<u8> for LinkStatus {
             3 => LinkStatus::Deleting,
             4 => LinkStatus::Rejected,
             5 => LinkStatus::Requested,
+            6 => LinkStatus::HardDrained,
+            7 => LinkStatus::SoftDrained,
             _ => LinkStatus::Pending,
         }
     }
@@ -88,6 +92,8 @@ impl FromStr for LinkStatus {
             "deleting" => Ok(LinkStatus::Deleting),
             "rejected" => Ok(LinkStatus::Rejected),
             "requested" => Ok(LinkStatus::Requested),
+            "hard-drained" => Ok(LinkStatus::HardDrained),
+            "soft-drained" => Ok(LinkStatus::SoftDrained),
             _ => Err(format!("Invalid LinkStatus: {s}")),
         }
     }
@@ -102,6 +108,8 @@ impl fmt::Display for LinkStatus {
             LinkStatus::Deleting => write!(f, "deleting"),
             LinkStatus::Rejected => write!(f, "rejected"),
             LinkStatus::Requested => write!(f, "requested"),
+            LinkStatus::HardDrained => write!(f, "hard-drained"),
+            LinkStatus::SoftDrained => write!(f, "soft-drained"),
         }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -643,9 +643,92 @@ async fn test_wan_link() {
     assert_eq!(tunnel_la.status, LinkStatus::Activated);
 
     println!("✅ Link updated");
-
     /*****************************************************************************************************************************************************/
-    println!("🟢 12. Deleting Link...");
+    println!("🟢 12. Update Link to Soft Draining...");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
+            status: Some(LinkStatus::SoftDrained),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(tunnel_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_tunnel()
+        .unwrap();
+    assert_eq!(tunnel_la.account_type, AccountType::Link);
+    assert_eq!(tunnel_la.status, LinkStatus::SoftDrained);
+
+    println!("✅ Link updated to soft draining");
+    /*****************************************************************************************************************************************************/
+    println!("🟢 13. Update Link to Hard Draining...");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
+            status: Some(LinkStatus::HardDrained),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(tunnel_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_tunnel()
+        .unwrap();
+    assert_eq!(tunnel_la.account_type, AccountType::Link);
+    assert_eq!(tunnel_la.status, LinkStatus::HardDrained);
+
+    println!("✅ Link updated to hard draining");
+    /*****************************************************************************************************************************************************/
+    println!("🟢 14. Update Link to activated...");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
+            status: Some(LinkStatus::Activated),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(tunnel_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let tunnel_la = get_account_data(&mut banks_client, tunnel_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_tunnel()
+        .unwrap();
+    assert_eq!(tunnel_la.account_type, AccountType::Link);
+    assert_eq!(tunnel_la.status, LinkStatus::Activated);
+
+    println!("✅ Link updated to activated");
+    /*****************************************************************************************************************************************************/
+    println!("🟢 15. Deleting Link...");
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -675,7 +758,7 @@ async fn test_wan_link() {
     println!("✅ Link deleting");
 
     /*****************************************************************************************************************************************************/
-    println!("🟢 13. CloseAccount Link...");
+    println!("🟢 16. CloseAccount Link...");
     execute_transaction(
         &mut banks_client,
         recent_blockhash,

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -388,6 +388,8 @@ const (
 	LinkStatusDeleted
 	LinkStatusRejected
 	LinkStatusRequested
+	LinkStatusSoftDrained
+	LinkStatusHardDrained
 )
 
 func (l LinkStatus) String() string {


### PR DESCRIPTION
This pull request adds support for new link status values, `soft_drained` and `hard_drained`, to enable traffic offloading as defined in RFC-9. It updates the logic for who can set link statuses, allowing contributors to perform certain status transitions related to draining for maintenance purposes, and extends tests to cover these new behaviors.

**New Link Statuses and Status Transition Logic:**

* Added `HardDrained` and `SoftDrained` variants to the `LinkStatus` enum, including support for serialization, deserialization, and display formatting. [[1]](diffhunk://#diff-255c929d6c1f6d060a7c2a3dad9fb6f2911da3f5923ac99297d9e163a67eb619R64-R66) [[2]](diffhunk://#diff-255c929d6c1f6d060a7c2a3dad9fb6f2911da3f5923ac99297d9e163a67eb619R78-R79) [[3]](diffhunk://#diff-255c929d6c1f6d060a7c2a3dad9fb6f2911da3f5923ac99297d9e163a67eb619R96-R97) [[4]](diffhunk://#diff-255c929d6c1f6d060a7c2a3dad9fb6f2911da3f5923ac99297d9e163a67eb619R112-R113)
* Updated the link update logic so that:
  - Foundation members can set any status.
  - Contributors can transition links between `Activated`, `SoftDrained`, and `HardDrained` states, but cannot set arbitrary statuses.

**Command and Documentation Updates:**

* Updated the link update command to allow setting a link's status to `soft_drained` or `hard_drained`.
* Updated the changelog to document the new statuses and their intended use for traffic offloading.

**Testing Enhancements:**

* Extended integration tests (`link_dzx_test.rs` and `link_wan_test.rs`) to verify the correct behavior of the new status transitions, including both successful transitions and expected failures when attempting unauthorized transitions. [[1]](diffhunk://#diff-4faa5f93913fd25cf85cc39b77688f822dcdac64956b58397d593f60d88fb32aR719-R834) [[2]](diffhunk://#diff-cabf7c61e8e554a646c8b4949355a8b403a4a672a67d8e498031095786a216faR646-R731)

**Other Logic Updates:**

* Clarified that any link can be deleted by its contributor or the foundation allowlist, regardless of status.

## Testing Verification
* test result: ok. 92 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.01s
