### PR TITLE
qa/agent: include cli output in status unmarshal error

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -606,7 +606,7 @@ func (q *QAAgent) fetchStatus(ctx context.Context) ([]StatusResponse, error) {
 
 	var status []StatusResponse
 	if err := json.Unmarshal(output, &status); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal status response: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal status response: error: %w, output: %s", err, string(output))
 	}
 	return status, nil
 }


### PR DESCRIPTION
## Summary of Changes
- Update QA agent `fetchStatus` to include the CLI output in returned error when the status is not able to be unmarshalled as JSON
- Example QA failure with error unmarshalling status response: https://github.com/malbeclabs/infra/actions/runs/19598590148/job/56126761525

