### PR TITLE
fix: link validation logic

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/state/link.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/link.rs
@@ -270,6 +270,7 @@ impl Validate for Link {
         // Tunnel network must be private
         if self.status != LinkStatus::Requested
             && self.status != LinkStatus::Pending
+            && self.status != LinkStatus::Rejected
             && !self.tunnel_net.ip().is_private()
         {
             msg!("Invalid tunnel_net: {}", self.tunnel_net);
@@ -445,6 +446,34 @@ mod tests {
         let err = val.validate();
         assert!(err.is_err());
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidTunnelNet);
+    }
+
+    #[test]
+    fn test_state_link_validate_ok_rejected_ignores_tunnel_net() {
+        let val = Link {
+            account_type: AccountType::Link,
+            owner: Pubkey::new_unique(),
+            index: 123,
+            bump_seed: 1,
+            contributor_pk: Pubkey::new_unique(),
+            side_a_pk: Pubkey::new_unique(),
+            side_z_pk: Pubkey::new_unique(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 10_000_000_000,
+            mtu: 1566,
+            delay_ns: 1_000_000,
+            jitter_ns: 1_000_000,
+            tunnel_id: 1,
+            tunnel_net: "8.8.8.8/25".parse().unwrap(),
+            code: "test-123".to_string(),
+            status: LinkStatus::Rejected,
+            side_a_iface_name: "eth0".to_string(),
+            side_z_iface_name: "eth1".to_string(),
+            delay_override_ns: 0,
+        };
+
+        // For Rejected status, tunnel_net is not validated and should succeed
+        val.validate().unwrap();
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
@@ -175,7 +175,10 @@ impl Validate for MulticastGroup {
             return Err(DoubleZeroError::InvalidAccountType);
         }
         // Multicast IP must be in the range
-        if self.status != MulticastGroupStatus::Pending && !self.multicast_ip.is_multicast() {
+        if self.status != MulticastGroupStatus::Pending
+            && self.status != MulticastGroupStatus::Rejected
+            && !self.multicast_ip.is_multicast()
+        {
             msg!("Invalid multicast IP: {}", self.multicast_ip);
             return Err(DoubleZeroError::InvalidMulticastIp);
         }
@@ -245,6 +248,26 @@ mod tests {
         let err = val.validate();
         assert!(err.is_err());
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidAccountType);
+    }
+
+    #[test]
+    fn test_state_multicastgroup_validate_ok_rejected_ignores_multicast_ip() {
+        let val = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::new_unique(),
+            index: 123,
+            bump_seed: 1,
+            tenant_pk: Pubkey::new_unique(),
+            multicast_ip: Ipv4Addr::new(1, 1, 1, 1),
+            max_bandwidth: 1000,
+            status: MulticastGroupStatus::Rejected,
+            code: "test".to_string(),
+            publisher_count: 0,
+            subscriber_count: 0,
+        };
+
+        // For Rejected status, multicast_ip is not validated and should succeed
+        val.validate().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary of Changes
* Skip tunnel_net private Ip check when status is Rejected
* Skip multicast_ip range check when status is Rejected
* Added test_state_link_validate_ok_rejected_ignores_tunnel_net to verify rejected links ignore invalid tunnel_net.
* Added test_state_multicastgroup_validate_ok_rejected_ignores_multicast_ip to verify rejected groups ignore invalid multicast_ip.

## Testing Verification
* rust tests are all green!

fixes #2244 
