### PR TITLE
qa: fix up user connect/disconnect duration metrics

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -223,7 +223,7 @@ func (q *QAAgent) ConnectUnicast(ctx context.Context, req *pb.ConnectUnicastRequ
 		return res, fmt.Errorf("failed to connect unicast for client %s: %v", clientIP, err)
 	}
 	duration := time.Since(start)
-	ConnectUnicastDuration.Observe(duration.Seconds())
+	UserConnectDuration.WithLabelValues("unicast").Observe(duration.Seconds())
 	q.log.Info("Successfully connected IBRL mode tunnel", "duration", duration.String())
 	return res, nil
 }
@@ -253,7 +253,7 @@ func (q *QAAgent) Disconnect(ctx context.Context, req *emptypb.Empty) (*pb.Resul
 		res.Success = true
 		res.ReturnCode = 0
 		q.log.Info("Successfully disconnected", "duration", duration.String())
-		DisconnectDuration.Observe(duration.Seconds())
+		UserDisconnectDuration.Observe(duration.Seconds())
 	}
 
 	return res, nil
@@ -380,7 +380,7 @@ func (q *QAAgent) ConnectMulticast(ctx context.Context, req *pb.ConnectMulticast
 		return nil, err
 	}
 	duration := time.Since(start)
-	ConnectMulticastDuration.Observe(duration.Seconds())
+	UserConnectDuration.WithLabelValues("multicast").Observe(duration.Seconds())
 	q.log.Info("Successfully connected multicast tunnel", "duration", duration.String())
 	return result, nil
 }

--- a/e2e/internal/rpc/metrics.go
+++ b/e2e/internal/rpc/metrics.go
@@ -4,40 +4,33 @@ package rpc
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	BuildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "doublezero_qaagent_build_info",
 		Help: "Build information of the QA agent",
 	},
 		[]string{"version", "commit", "date"},
 	)
 
-	PingPacketsLostTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	PingPacketsLostTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "doublezero_qaagent_ping_packets_lost_total",
 		Help: "Total number of packets lost during ping tests",
 	},
 		[]string{"source_ip", "target_ip"},
 	)
 
-	ConnectUnicastDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "doublezero_qaagent_connect_unicast_duration_seconds",
-		Help: "Duration of unicast connect tests",
-	})
+	UserConnectDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "doublezero_qaagent_user_connect_duration_seconds",
+		Help:    "Duration of connect operations",
+		Buckets: prometheus.ExponentialBuckets(1, 1.5, 12), // 1s to 128s
+	}, []string{"user_type"})
 
-	ConnectMulticastDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "doublezero_qaagent_connect_multicast_duration_seconds",
-		Help: "Duration of multicast connect tests",
-	})
-
-	DisconnectDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "doublezero_qaagent_disconnect_duration_seconds",
-		Help: "Duration of disconnect tests",
+	UserDisconnectDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "doublezero_qaagent_user_disconnect_duration_seconds",
+		Help:    "Duration of disconnect operations",
+		Buckets: prometheus.ExponentialBuckets(1, 1.5, 12), // 1s to 128s
 	})
 )
-
-func init() {
-	prometheus.MustRegister(BuildInfo)
-	prometheus.MustRegister(PingPacketsLostTotal)
-}


### PR DESCRIPTION
## Summary of Changes
- Combine unicast/multicast connect duration into same metric with label to distinguish
- Add explicit histogram bucket configurations
- Use `promauto` so metrics are auto-registered

## Testing Verification
- Deployed to and verified on devnet QA nodes
