### PR TITLE
fix: strict equality comparison imposed

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
-use doublezero_program_common::types::NetworkV4;
+use doublezero_program_common::{types::NetworkV4, validate_iface};
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -67,8 +67,10 @@ pub fn process_activate_device_interface(
 
     let mut device: Device = Device::try_from(device_account)?;
 
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, iface) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
 
     if iface.status == InterfaceStatus::Deleting {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/delete.rs
@@ -9,6 +9,7 @@ use crate::{
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
 use core::fmt;
+use doublezero_program_common::validate_iface;
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -80,8 +81,10 @@ pub fn process_delete_device_interface(
 
     let mut device: Device = Device::try_from(device_account)?;
 
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, _) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
     let mut iface = device.interfaces[idx].into_current_version();
     iface.status = InterfaceStatus::Deleting;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/reject.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
+use doublezero_program_common::validate_iface;
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -60,8 +61,10 @@ pub fn process_reject_device_interface(
 
     let mut device: Device = Device::try_from(device_account)?;
 
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, mut iface) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
 
     iface.status = InterfaceStatus::Rejected;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/remove.rs
@@ -7,6 +7,7 @@ use crate::{
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
 use core::fmt;
+use doublezero_program_common::validate_iface;
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -62,8 +63,10 @@ pub fn process_remove_device_interface(
     }
 
     let mut device = Device::try_from(device_account)?;
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, iface) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
 
     if iface.status != InterfaceStatus::Deleting {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/unlink.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/unlink.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
-use doublezero_program_common::types::NetworkV4;
+use doublezero_program_common::{types::NetworkV4, validate_iface};
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -61,8 +61,10 @@ pub fn process_unlink_device_interface(
 
     let mut device: Device = Device::try_from(device_account)?;
 
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, mut iface) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
 
     if iface.status == InterfaceStatus::Deleting {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
@@ -11,7 +11,7 @@ use crate::{
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
 use core::fmt;
-use doublezero_program_common::types::NetworkV4;
+use doublezero_program_common::{types::NetworkV4, validate_iface};
 #[cfg(test)]
 use solana_program::msg;
 use solana_program::{
@@ -106,8 +106,10 @@ pub fn process_update_device_interface(
 
     let mut device: Device = Device::try_from(device_account)?;
 
+    let name = validate_iface(&value.name).map_err(|_| DoubleZeroError::InvalidInterfaceName)?;
+
     let (idx, _) = device
-        .find_interface(&value.name)
+        .find_interface(&name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
     let mut iface = device.interfaces[idx].into_current_version();
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -140,7 +140,7 @@ impl Device {
             .iter()
             .map(|iface| iface.into_current_version())
             .enumerate()
-            .find(|(_, iface)| iface.name.eq_ignore_ascii_case(name))
+            .find(|(_, iface)| iface.name == name)
             .ok_or_else(|| format!("Interface with name '{name}' not found"))
     }
 


### PR DESCRIPTION
## Summary of Changes
* Device::find_interface: Switched lookup from eq_ignore_ascii_case to strict iface.name == name comparison.
* ll interface-related processors now normalize value.name through validate_iface before calling find_interface, ensuring strict matching works consistently the codebase.
* Callers may still pass mixed-case names eg. ethernet1/1 because validate_iface canonicalizes them to the stored format eg. Ethernet1/1
* Prevents accidental case-insensitive matches while avoiding InterfaceNotFound for valid inputs.

## Testing Verification
* all rust tests green.
* all lint checks green.

Fixes #2235 
