### PR TITLE
tools: solana tpu quic connectivity testing with stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file.
   - Fix ProgramConfig resize during global state initialization.
 - QA
   - Traceroute when packet loss is detected
-
+- Tools
+  - Add `solana-tpu-quic-ping` tool for testing Solana TPU-QUIC connections with stats emitted periodically
 
 ## [v0.7.1](https://github.com/malbeclabs/doublezero/compare/client/v0.7.0...client/v0.7.1) – 2025-11-18
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.4
+	github.com/quic-go/quic-go v0.57.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/prometheus/common v0.67.4 h1:yR3NqWO1/UyO1w2PhUvXlGQs/PtFmoveVO0KZ4+L
 github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
+github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -337,6 +339,8 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/tools/solana/cmd/tpu-quic-ping/main.go
+++ b/tools/solana/cmd/tpu-quic-ping/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/lmittmann/tint"
+	tpuquic "github.com/malbeclabs/doublezero/tools/solana/pkg/tpu-quic"
+)
+
+func main() {
+	duration := flag.Duration("duration", tpuquic.DefaultDuration, "how long to keep the QUIC connection open")
+	interval := flag.Duration("interval", tpuquic.DefaultInterval, "how often to print connection stats")
+	timeout := flag.Duration("timeout", tpuquic.DefaultTimeout, "how long to wait for the connection to be established")
+	srcAddr := flag.String("src-addr", tpuquic.DefaultSrc.String(), "source address to bind (optional)")
+	quiet := flag.Bool("q", false, "quiet mode - only show errors")
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		fmt.Printf("Usage: %s [flags] <dst-ip>:<dst-port>\n", os.Args[0])
+		flag.PrintDefaults()
+		return
+	}
+	dstAddr := flag.Arg(0)
+
+	log := newLogger(*quiet)
+	cfg := tpuquic.PingConfig{
+		Logger: log,
+
+		Quiet:    *quiet,
+		Duration: *duration,
+		Interval: *interval,
+		Timeout:  *timeout,
+		Src:      *srcAddr,
+		Dst:      dstAddr,
+	}
+
+	result, err := tpuquic.Ping(cfg)
+	if err != nil {
+		if !*quiet {
+			log.Error("Failed to ping", "error", err)
+		}
+		os.Exit(1)
+	}
+	if result.Error != nil {
+		if !*quiet {
+			log.Error("Failed to ping", "error", result.Error)
+		}
+		os.Exit(1)
+	}
+}
+
+func newLogger(quiet bool) *slog.Logger {
+	var writer io.Writer
+	if quiet {
+		writer = io.Discard
+	} else {
+		writer = os.Stdout
+	}
+	return slog.New(tint.NewHandler(writer, &tint.Options{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				t := a.Value.Time().UTC()
+				a.Value = slog.StringValue(formatRFC3339Millis(t))
+			}
+			if s, ok := a.Value.Any().(string); ok && s == "" {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
+}
+
+func formatRFC3339Millis(t time.Time) string {
+	t = t.UTC()
+	base := t.Format("2006-01-02T15:04:05")
+	ms := t.Nanosecond() / 1_000_000
+	return fmt.Sprintf("%s.%03dZ", base, ms)
+}

--- a/tools/solana/pkg/tpu-quic/ping.go
+++ b/tools/solana/pkg/tpu-quic/ping.go
@@ -1,0 +1,245 @@
+package tpuquic
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"os"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+const (
+	DefaultDuration = 10 * time.Second
+	DefaultInterval = 3 * time.Second
+	DefaultTimeout  = 3 * time.Second
+
+	ALPNTPUProtocolID = "solana-tpu"
+	DefaultCommonName = "Solana node"
+)
+
+var (
+	DefaultSrc = net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 0}
+)
+
+type PingConfig struct {
+	Context context.Context
+	Logger  *slog.Logger
+
+	// StatsChan that results will be streamed to as they are available.
+	StatsChan chan *quic.ConnectionStats
+
+	Quiet    bool          `json:"quiet"`
+	Duration time.Duration `json:"duration"`
+	Interval time.Duration `json:"interval"`
+	Timeout  time.Duration `json:"timeout"`
+	Src      string        `json:"src"`
+	Dst      string        `json:"dst"`
+}
+
+type PingResult struct {
+	ConnectionStats []*quic.ConnectionStats `json:"connection_stats"`
+	Success         bool                    `json:"success"`
+	Error           error                   `json:"error"`
+}
+
+func (cfg *PingConfig) Validate() error {
+	if cfg.Context == nil {
+		cfg.Context = context.Background()
+	}
+	if cfg.Logger == nil {
+		var writer io.Writer
+		if cfg.Quiet {
+			writer = io.Discard
+		} else {
+			writer = os.Stdout
+		}
+		cfg.Logger = slog.New(slog.NewTextHandler(writer, nil))
+	}
+	if cfg.Duration == 0 {
+		cfg.Duration = DefaultDuration
+	}
+	if cfg.Interval == 0 {
+		cfg.Interval = DefaultInterval
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Src == "" {
+		cfg.Src = DefaultSrc.String()
+	}
+	if cfg.Dst == "" {
+		return fmt.Errorf("dst address is required")
+	}
+	return nil
+}
+
+func Ping(cfg PingConfig) (*PingResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate run config: %w", err)
+	}
+
+	log := cfg.Logger
+	ctx, cancel := context.WithTimeout(cfg.Context, cfg.Duration)
+	defer cancel()
+
+	// Resolve destination UDP address
+	dstAddr, err := net.ResolveUDPAddr("udp", cfg.Dst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve remote addr %s: %w", cfg.Dst, err)
+	}
+
+	// Resolve source UDP address
+	srcAddr, err := net.ResolveUDPAddr("udp", cfg.Src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve local addr %s: %w", cfg.Src, err)
+	}
+
+	// Bind our own UDP socket
+	srcConn, err := net.ListenUDP("udp", srcAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", srcAddr, err)
+	}
+	defer srcConn.Close()
+
+	if !cfg.Quiet {
+		log.Info("Connecting via QUIC", "src", srcConn.LocalAddr(), "dst", dstAddr)
+	}
+
+	quicConf := &quic.Config{
+		MaxIdleTimeout:  cfg.Timeout,
+		KeepAlivePeriod: cfg.Interval,
+	}
+
+	// Separate context for dial
+	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer dialCancel()
+
+	// Create TLS config
+	tlsConfig, err := createTlsConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS config: %w", err)
+	}
+
+	// Dial QUIC session
+	session, err := quic.Dial(dialCtx, srcConn, dstAddr, tlsConfig, quicConf)
+	if err != nil {
+		return &PingResult{
+			Error: fmt.Errorf("failed to connect to %s from %s: %w", dstAddr, srcAddr, err),
+		}, nil
+	}
+	defer func() {
+		_ = session.CloseWithError(0, "client done")
+	}()
+
+	// Start stats ticker loop
+	result := &PingResult{
+		ConnectionStats: make([]*quic.ConnectionStats, 0, cfg.Duration/cfg.Interval),
+		Success:         true,
+		Error:           nil,
+	}
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if !cfg.Quiet {
+				log.Info("Completed QUIC ping session", "duration", cfg.Duration)
+			}
+			return result, nil
+		case <-ticker.C:
+			stats := session.ConnectionStats()
+			result.ConnectionStats = append(result.ConnectionStats, &stats)
+			if cfg.StatsChan != nil {
+				select {
+				case cfg.StatsChan <- &stats:
+				default:
+				}
+			}
+			if !cfg.Quiet {
+				log.Info("QUIC stats",
+					"rttMin", stats.MinRTT,
+					"rttLatest", stats.LatestRTT,
+					"rttSmoothed", stats.SmoothedRTT,
+					"rttDev", stats.MeanDeviation,
+					"sentBytes", stats.BytesSent,
+					"sentPackets", stats.PacketsSent,
+					"recvBytes", stats.BytesReceived,
+					"recvPackets", stats.PacketsReceived,
+					"lostBytes", stats.BytesLost,
+					"lostPackets", stats.PacketsLost,
+				)
+			}
+		}
+	}
+}
+
+func createTlsConfig() (*tls.Config, error) {
+	certPem, privPem := newDummyX509Certificate()
+	cert, err := tls.X509KeyPair(certPem, privPem)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{ALPNTPUProtocolID},
+		Certificates:       []tls.Certificate{cert},
+		MinVersion:         tls.VersionTLS13,
+	}, nil
+}
+
+func newDummyX509Certificate() ([]byte, []byte) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
+	if err != nil {
+		return nil, nil
+	}
+
+	tmpl := x509.Certificate{
+		Version:            3,
+		SerialNumber:       serialNumber,
+		Subject:            pkix.Name{CommonName: DefaultCommonName},
+		Issuer:             pkix.Name{CommonName: DefaultCommonName},
+		SignatureAlgorithm: x509.PureEd25519,
+		NotBefore:          time.Date(1975, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:           time.Date(4096, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tmpl.ExtraExtensions = append(tmpl.ExtraExtensions, createSubjectAltNameExtension())
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, publicKey, privateKey)
+	if err != nil {
+		return nil, nil
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+}
+
+func createSubjectAltNameExtension() pkix.Extension {
+	return pkix.Extension{
+		Id:    asn1.ObjectIdentifier{2, 5, 29, 17},
+		Value: []byte{48, 6, 135, 4, 0, 0, 0, 0},
+	}
+}

--- a/tools/solana/pkg/tpu-quic/ping_test.go
+++ b/tools/solana/pkg/tpu-quic/ping_test.go
@@ -1,0 +1,255 @@
+package tpuquic
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTools_Solana_TPUQUICPing_ConfigValidateDefaults(t *testing.T) {
+	t.Parallel()
+	cfg := PingConfig{Dst: "127.0.0.1:1234"}
+	require.NoError(t, cfg.Validate())
+	require.NotNil(t, cfg.Context)
+	require.NotNil(t, cfg.Logger)
+	require.Equal(t, DefaultDuration, cfg.Duration)
+	require.Equal(t, DefaultInterval, cfg.Interval)
+	require.Equal(t, DefaultTimeout, cfg.Timeout)
+	require.Equal(t, DefaultSrc.String(), cfg.Src)
+	require.Equal(t, "127.0.0.1:1234", cfg.Dst)
+}
+
+func TestTools_Solana_TPUQUICPing_ConfigValidateRequiresDst(t *testing.T) {
+	t.Parallel()
+	cfg := PingConfig{}
+	require.Error(t, cfg.Validate())
+}
+
+func TestTools_Solana_TPUQUICPing_PingMissingDst(t *testing.T) {
+	t.Parallel()
+	cfg := PingConfig{Quiet: true}
+	res, err := Ping(cfg)
+	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestTools_Solana_TPUQUICPing_PingInvalidDst(t *testing.T) {
+	t.Parallel()
+	cfg := PingConfig{Dst: "not-a-valid-address", Quiet: true}
+	res, err := Ping(cfg)
+	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestTools_Solana_TPUQUICPing_PingInvalidSrc(t *testing.T) {
+	t.Parallel()
+	cfg := PingConfig{Dst: "127.0.0.1:1234", Src: "invalid-local", Quiet: true}
+	res, err := Ping(cfg)
+	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestTools_Solana_TPUQUICPing_DialFailure(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	cfg := PingConfig{
+		Context: ctx,
+		Dst:     "127.0.0.1:9",
+		Src:     "0.0.0.0:0",
+		Timeout: 50 * time.Millisecond,
+		Quiet:   true,
+	}
+
+	res, err := Ping(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.Success)
+	require.Error(t, res.Error)
+}
+
+func TestTools_Solana_TPUQUICPing_SuccessAgainstLocalQUICServer(t *testing.T) {
+	t.Parallel()
+
+	serverAddrCh := make(chan string, 1)
+	serverDone := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(serverDone)
+
+		tlsConf, err := createTlsConfig()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		tlsConf.ClientAuth = tls.NoClientCert
+
+		quicConf := &quic.Config{
+			MaxIdleTimeout:  time.Second,
+			KeepAlivePeriod: 100 * time.Millisecond,
+		}
+
+		l, err := quic.ListenAddr("127.0.0.1:0", tlsConf, quicConf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer l.Close()
+
+		serverAddrCh <- l.Addr().String()
+
+		sess, err := l.Accept(context.Background())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		<-sess.Context().Done()
+	}()
+
+	dst := <-serverAddrCh
+	statsCh := make(chan *quic.ConnectionStats, 10)
+
+	cfg := PingConfig{
+		Dst:       dst,
+		Src:       net.JoinHostPort("0.0.0.0", "0"),
+		Duration:  250 * time.Millisecond,
+		Interval:  50 * time.Millisecond,
+		Timeout:   500 * time.Millisecond,
+		StatsChan: statsCh,
+		Quiet:     true,
+	}
+
+	res, err := Ping(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.Success)
+	require.NotEmpty(t, res.ConnectionStats)
+	require.NotEmpty(t, statsCh)
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("server did not exit")
+	}
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+func TestTools_Solana_TPUQUICPing_FailureAgainstLocalQUICServer(t *testing.T) {
+	t.Parallel()
+
+	serverAddrCh := make(chan string, 1)
+	serverDone := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(serverDone)
+
+		tlsConf, err := createTlsConfig()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		tlsConf.ClientAuth = tls.NoClientCert
+		tlsConf.NextProtos = []string{"wrong-alpn"}
+
+		quicConf := &quic.Config{
+			MaxIdleTimeout:  time.Second,
+			KeepAlivePeriod: 100 * time.Millisecond,
+		}
+
+		l, err := quic.ListenAddr("127.0.0.1:0", tlsConf, quicConf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer l.Close()
+
+		serverAddrCh <- l.Addr().String()
+
+		time.Sleep(750 * time.Millisecond)
+	}()
+
+	dst := <-serverAddrCh
+
+	cfg := PingConfig{
+		Dst:     dst,
+		Src:     "0.0.0.0:0",
+		Timeout: 200 * time.Millisecond,
+		Quiet:   true,
+	}
+
+	res, err := Ping(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.Success)
+	require.Error(t, res.Error)
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("server did not exit")
+	}
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+func TestTools_Solana_TPUQUICPing_CreateTLSConfig(t *testing.T) {
+	t.Parallel()
+	cfg, err := createTlsConfig()
+	require.NoError(t, err)
+	require.True(t, cfg.InsecureSkipVerify)
+	require.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	require.Len(t, cfg.Certificates, 1)
+	require.Contains(t, cfg.NextProtos, ALPNTPUProtocolID)
+	require.NotEmpty(t, cfg.Certificates[0].Certificate)
+}
+
+func TestTools_Solana_TPUQUICPing_NewDummyCert(t *testing.T) {
+	t.Parallel()
+	certPEM, keyPEM := newDummyX509Certificate()
+	require.NotEmpty(t, certPEM)
+	require.NotEmpty(t, keyPEM)
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	require.Equal(t, DefaultCommonName, cert.Subject.CommonName)
+	require.Equal(t, DefaultCommonName, cert.Issuer.CommonName)
+	require.Equal(t, 1975, cert.NotBefore.Year())
+	require.Equal(t, 4096, cert.NotAfter.Year())
+
+	kb, _ := pem.Decode(keyPEM)
+	require.NotNil(t, kb)
+	priv, err := x509.ParsePKCS8PrivateKey(kb.Bytes)
+	require.NoError(t, err)
+	_, ok := priv.(ed25519.PrivateKey)
+	require.True(t, ok)
+}
+
+func TestTools_Solana_TPUQUICPing_SubjectAltNameExt(t *testing.T) {
+	t.Parallel()
+	ext := createSubjectAltNameExtension()
+	require.Equal(t, asn1.ObjectIdentifier{2, 5, 29, 17}, ext.Id)
+	require.NotEmpty(t, ext.Value)
+}


### PR DESCRIPTION
## Summary of Changes
- Add `solana-tpu-quic-ping` tool for testing Solana TPU-QUIC connections with stats emitted periodically
- In a follow-up PR this will be used to add TPU-QUIC connectivity checks in the QA tests
- Related to https://github.com/malbeclabs/doublezero/issues/2294

## Testing Verification
- Add unit tests for the tool

Example:
```
$ run tools/solana/cmd/tpu-quic-ping/main.go 185.92.120.157:9007
2025-11-25T13:46:56.205Z INF Connecting via QUIC src=[::]:50862 dst=185.92.120.157:9007
2025-11-25T13:46:59.459Z INF QUIC stats rttMin=120.634792ms rttLatest=128.680333ms rttSmoothed=122.519ms rttDev=37.195ms sentBytes=8107 sentPackets=15 recvBytes=1014 recvPackets=5 lostBytes=0 lostPackets=0
2025-11-25T13:47:02.458Z INF QUIC stats rttMin=120.634792ms rttLatest=128.680333ms rttSmoothed=122.519ms rttDev=37.195ms sentBytes=8223 sentPackets=19 recvBytes=1014 recvPackets=5 lostBytes=0 lostPackets=0
2025-11-25T13:47:05.459Z INF QUIC stats rttMin=120.634792ms rttLatest=128.680333ms rttSmoothed=122.519ms rttDev=37.195ms sentBytes=8223 sentPackets=19 recvBytes=1014 recvPackets=5 lostBytes=0 lostPackets=0
2025-11-25T13:47:06.206Z INF Completed QUIC ping session duration=10s

$ go run tools/solana/cmd/tpu-quic-ping/main.go 154.60.100.87:5010
2025-11-25T13:34:27.984Z INF Connecting via QUIC src=[::]:57350 dst=154.60.100.87:5010
2025-11-25T13:34:32.985Z ERR Failed to ping error="failed to connect to 154.60.100.87:5010 from 0.0.0.0:0: context deadline exceeded"
```
