### PR TITLE
The device interface list command is modified so that it shows all in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
     - Add support for updating `contributor.ops_manager_key`.
 - Client
   - Add route liveness fault-injection simulation tests.
+    - Updated the `interface list` command to display all interfaces when no device is specified.
 - Funder
   - Fund multicast group owners
 - Onchain programs


### PR DESCRIPTION
This pull request updates the device interface listing CLI command to support listing interfaces for all devices when no device is specified, and improves output clarity by including the device code in the display. The changes also update the tests to reflect the new output format.

### CLI Command Improvements

* The `device` argument in `ListDeviceInterfaceCliCommand` is now optional, allowing users to list interfaces for all devices if no device is specified.
* The command logic is updated to handle both single-device and all-devices listing, using `list_device` for the latter.

### Output Format Enhancements

* The `DeviceInterfaceDisplay` struct now includes a `device` field, so the output shows which device each interface belongs to. [[1]](diffhunk://#diff-1202e1ef0267b835d18d21f72877848420aea034a2e97b7a2012ef22c82e9833R30) [[2]](diffhunk://#diff-1202e1ef0267b835d18d21f72877848420aea034a2e97b7a2012ef22c82e9833R49-R62)
* Test assertions are updated to expect the new output format, which includes the device code in both table and JSON outputs.

### Dependency Updates

* Imports are updated to include `ListDeviceCommand` from the SDK, enabling listing interfaces for all devices.

## Testing Verification
* test result: ok. 102 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.01s
