### PR TITLE
tools: solana tpu quic bind to interface and fix timeout config

### DIFF
--- a/tools/solana/cmd/tpu-quic-ping/main.go
+++ b/tools/solana/cmd/tpu-quic-ping/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,14 +9,17 @@ import (
 
 	"github.com/lmittmann/tint"
 	tpuquic "github.com/malbeclabs/doublezero/tools/solana/pkg/tpu-quic"
+	flag "github.com/spf13/pflag"
 )
 
 func main() {
-	duration := flag.Duration("duration", tpuquic.DefaultDuration, "how long to keep the QUIC connection open")
-	interval := flag.Duration("interval", tpuquic.DefaultInterval, "how often to print connection stats")
-	timeout := flag.Duration("timeout", tpuquic.DefaultTimeout, "how long to wait for the connection to be established")
-	srcAddr := flag.String("src-addr", tpuquic.DefaultSrc.String(), "source address to bind (optional)")
-	quiet := flag.Bool("q", false, "quiet mode - only show errors")
+	count := flag.IntP("count", "c", tpuquic.DefaultCount, "how many intervals to ping for (optional)")
+	interval := flag.DurationP("interval", "i", tpuquic.DefaultInterval, "how often to print connection stats (optional)")
+	timeout := flag.DurationP("timeout", "t", tpuquic.DefaultTimeout, "how long to wait for the connection to be established (optional)")
+	srcAddr := flag.StringP("src", "S", tpuquic.DefaultSrc.String(), "source address to bind to (optional)")
+	iface := flag.StringP("interface", "I", "", "interface to bind to (optional)")
+	quiet := flag.BoolP("quiet", "q", false, "quiet mode - only show errors")
+
 	flag.Parse()
 
 	if flag.NArg() != 1 {
@@ -31,12 +33,13 @@ func main() {
 	cfg := tpuquic.PingConfig{
 		Logger: log,
 
-		Quiet:    *quiet,
-		Duration: *duration,
-		Interval: *interval,
-		Timeout:  *timeout,
-		Src:      *srcAddr,
-		Dst:      dstAddr,
+		Quiet:     *quiet,
+		Count:     *count,
+		Interval:  *interval,
+		Timeout:   *timeout,
+		Src:       *srcAddr,
+		Interface: *iface,
+		Dst:       dstAddr,
 	}
 
 	result, err := tpuquic.Ping(cfg)

--- a/tools/solana/pkg/tpu-quic/bind_darwin.go
+++ b/tools/solana/pkg/tpu-quic/bind_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package tpuquic
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func bindToDevice(c *net.UDPConn, ifaceName string) error {
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return fmt.Errorf("lookup interface %q: %w", ifaceName, err)
+	}
+	if iface.Index == 0 {
+		return fmt.Errorf("interface %q has index 0", ifaceName)
+	}
+
+	laddr := c.LocalAddr()
+	ua, ok := laddr.(*net.UDPAddr)
+	if !ok || ua.IP == nil {
+		return fmt.Errorf("unexpected LocalAddr type %T", laddr)
+	}
+
+	isV4 := ua.IP.To4() != nil
+
+	rc, err := c.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var serr error
+	err = rc.Control(func(fd uintptr) {
+		if isV4 {
+			serr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index)
+		} else {
+			serr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, iface.Index)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return serr
+}

--- a/tools/solana/pkg/tpu-quic/bind_linux.go
+++ b/tools/solana/pkg/tpu-quic/bind_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package tpuquic
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func bindToDevice(c *net.UDPConn, iface string) error {
+	rc, err := c.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var serr error
+	err = rc.Control(func(fd uintptr) {
+		serr = unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, iface)
+	})
+	if err != nil {
+		return err
+	}
+	return serr
+}

--- a/tools/solana/pkg/tpu-quic/bind_other.go
+++ b/tools/solana/pkg/tpu-quic/bind_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package tpuquic
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+func bindToDevice(c *net.UDPConn, iface string) error {
+	return fmt.Errorf("binding to device is not implemented for platform %s", runtime.GOOS)
+}


### PR DESCRIPTION
## Summary of Changes
- Update Solana TPU QUIC ping/stats tool to support binding to source interface
- Fix timeout/duration configuration and add count option instead of duration
- Related to https://github.com/malbeclabs/doublezero/issues/2294

## Testing Verification
- Add unit test coverage for new functionality
- Update existing unit test coverage for changed functionality
