### PR TITLE
client/daemon: route liveness fault tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
         ]
     },
     "runArgs": [
-        "--name",
-        "dz-dev-workspace-vsc"
+        "--name=dz-dev-workspace-vsc",
+        "--ulimit=nofile=65535"
     ],
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ All notable changes to this project will be documented in this file.
     - Add the ability to update a Device’s location, managing the reference counters accordingly.
     - Added support in the link update command to set a link’s status to soft_drained or hard_drained.
     - Add support for updating `contributor.ops_manager_key`.
-- Funder: fund multicast group owners
+- Client
+  - Add route liveness fault-injection simulation tests.
+- Funder
+  - Fund multicast group owners
 - Onchain programs
   - Serviceability Program: Updated the device update command to allow modifying a device’s location.
   - Added new `soft-drained` and `hard-drained` link status values to serviceability to support traffic offloading as defined in RFC9.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ go-test:
 	go test -exec "sudo -E" -race -v ./...
 	cd controlplane/s3-uploader && go test -race -v ./...
 	$(if $(findstring nocontainertest,$(MAKECMDGOALS)),,$(MAKE) go-container-test)
+	$(MAKE) -C client/doublezerod test-faults
 
 .PHONY: nocontainertest
 nocontainertest:

--- a/client/doublezerod/Makefile
+++ b/client/doublezerod/Makefile
@@ -6,10 +6,17 @@ LDFLAGS=-ldflags "-X=$(PREFIX)/build.Build=$(BUILD)"
 test:
 	go test -exec "sudo -E" -race -v ./...
 	$(MAKE) test-e2e
+	$(MAKE) test-faults
 
 .PHONY: test-e2e
 test-e2e:
 	go run ../../tools/container-test/main.go -v
+
+.PHONY: test-faults
+test-faults:
+	ulimit -n 65535
+	go clean -testcache
+	go test ./internal/liveness -v -run=TestClient_Liveness_Faults -clients=100 -stable-duration=10s
 
 .PHONY: lint
 lint:

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -165,12 +165,13 @@ func main() {
 			// The manager only knows about passive mode, with the negation of it being active mode.
 			PassiveMode: !*routeLivenessEnableActive,
 
-			TxMin:       *routeLivenessTxMin,
-			RxMin:       *routeLivenessRxMin,
-			DetectMult:  uint8(*routeLivenessDetectMult),
-			MinTxFloor:  *routeLivenessMinTxFloor,
-			MaxTxCeil:   *routeLivenessMaxTxCeil,
-			PeerMetrics: *routeLivenessPeerMetrics,
+			TxMin:      *routeLivenessTxMin,
+			RxMin:      *routeLivenessRxMin,
+			DetectMult: uint8(*routeLivenessDetectMult),
+			MinTxFloor: *routeLivenessMinTxFloor,
+			MaxTxCeil:  *routeLivenessMaxTxCeil,
+
+			EnablePeerMetrics: *routeLivenessPeerMetrics,
 		}
 	}
 

--- a/client/doublezerod/internal/liveness/faults_test.go
+++ b/client/doublezerod/internal/liveness/faults_test.go
@@ -1,0 +1,986 @@
+package liveness
+
+import (
+	"flag"
+	"math"
+	"math/rand"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	clientsFlag    = flag.Int("clients", 10, "number of clients")
+	txMinFlag      = flag.Duration("tx-min", 300*time.Millisecond, "tx min")
+	rxMinFlag      = flag.Duration("rx-min", 300*time.Millisecond, "rx min")
+	detectMultFlag = flag.Uint("detect-mult", 3, "detect mult")
+	backoffMaxFlag = flag.Duration("backoff-max", 1*time.Second, "backoff max")
+
+	stableDurationFlag  = flag.Duration("stable-duration", 2*time.Second, "stable duration")
+	bgpFlapCyclesFlag   = flag.Uint("bgp-flap-cycles", 3, "number of BGP flap cycles")
+	softLossPctFlag     = flag.Float64("soft-loss-pct", 0.01, "soft loss percentage")
+	softLossCyclesFlag  = flag.Int("soft-loss-cycles", 3, "number of soft-loss windows to run")
+	highSoftLossPctFlag = flag.Float64("soft-loss-high-pct", 0.8, "high soft loss percentage that should eventually cause timeout")
+
+	// Fractions of clients to involve in each scenario (0 = default behavior).
+	flapPairRatioFlag         = flag.Float64("flap-pair-ratio", 0, "fraction of clients to include in flap pairs (0 = single pair)")
+	softLossPairRatioFlag     = flag.Float64("soft-loss-pair-ratio", 0, "fraction of clients to include in soft-loss pairs (0 = single pair)")
+	highSoftLossPairRatioFlag = flag.Float64("soft-loss-high-pair-ratio", 0, "fraction of clients to include in high soft-loss pairs (0 = single pair)")
+	hardLossRatioFlag         = flag.Float64("hard-loss-ratio", 0.5, "fraction of clients to hard-fail (0–1)")
+
+	// Default to quiet logging.
+	notQuietFlag = flag.Bool("not-quiet", false, "do not quiet logging")
+)
+
+func TestClient_Liveness_Faults_FlapsOnConnectivityLoss(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping flapping test in short mode")
+	}
+
+	clients, sw, cfg := setupLivenessClients(t, 20000)
+	clientCount := cfg.clientCount
+	bgpFlapCycles := *bgpFlapCyclesFlag
+	flapRatio := *flapPairRatioFlag
+
+	if clientCount < 2 {
+		t.Skip("need at least 2 clients for flapping test")
+	}
+
+	nextHop := net.IPv4(10, 5, 0, 1)
+	registerFullMeshRoutes(t, clients, nextHop)
+	requireFullMeshUp(t, clients, clientCount-1, 30*time.Second)
+
+	pairs := selectPairs(clients, flapRatio)
+	if len(pairs) == 0 {
+		t.Skip("no pairs selected for flapping")
+	}
+
+	type pairState struct {
+		cA, cB   *testClient
+		ipA, ipB net.IP
+		peerAB   Peer
+		peerBA   Peer
+	}
+	ps := make([]pairState, len(pairs))
+	for i, p := range pairs {
+		ipA := p[0].mgr.LocalAddr().IP
+		ipB := p[1].mgr.LocalAddr().IP
+		ps[i] = pairState{
+			cA:  p[0],
+			cB:  p[1],
+			ipA: ipA,
+			ipB: ipB,
+			peerAB: Peer{
+				Interface: p[0].iface,
+				LocalIP:   ipA.To4().String(),
+				PeerIP:    ipB.To4().String(),
+			},
+			peerBA: Peer{
+				Interface: p[1].iface,
+				LocalIP:   ipB.To4().String(),
+				PeerIP:    ipA.To4().String(),
+			},
+		}
+	}
+
+	detectTime := cfg.rxMin * time.Duration(cfg.detectMult)
+	waitDown := 5 * detectTime
+
+	waitBothDown := func(p pairState) bool {
+		sessAB, okAB := p.cA.mgr.GetSession(p.peerAB)
+		sessBA, okBA := p.cB.mgr.GetSession(p.peerBA)
+		if !okAB || !okBA {
+			return false
+		}
+		snapAB := sessAB.Snapshot()
+		snapBA := sessBA.Snapshot()
+		return snapAB.State == StateDown && snapAB.LastDownReason == DownReasonTimeout &&
+			snapBA.State == StateDown && snapBA.LastDownReason == DownReasonTimeout
+	}
+
+	waitBothUp := func(p pairState) bool {
+		sessAB, okAB := p.cA.mgr.GetSession(p.peerAB)
+		sessBA, okBA := p.cB.mgr.GetSession(p.peerBA)
+		if !okAB || !okBA {
+			return false
+		}
+		snapAB := sessAB.Snapshot()
+		snapBA := sessBA.Snapshot()
+		return snapAB.State == StateUp && snapBA.State == StateUp
+	}
+
+	for _, p := range ps {
+		require.Eventually(t, func() bool { return waitBothUp(p) }, 10*time.Second, 200*time.Millisecond)
+	}
+
+	before := make(map[*testClient]float64)
+	for _, p := range ps {
+		if _, ok := before[p.cA]; !ok {
+			before[p.cA] = sessionUpToDownTransitions(t, p.cA)
+		}
+		if _, ok := before[p.cB]; !ok {
+			before[p.cB] = sessionUpToDownTransitions(t, p.cB)
+		}
+	}
+
+	for range bgpFlapCycles {
+		for _, p := range ps {
+			sw.SetHardLoss(p.ipA, p.ipB)
+		}
+
+		for _, p := range ps {
+			require.Eventually(t, func() bool { return waitBothDown(p) }, waitDown, 200*time.Millisecond)
+		}
+
+		for _, p := range ps {
+			sw.SetNoFault(p.ipA, p.ipB)
+		}
+
+		for _, p := range ps {
+			require.Eventually(t, func() bool { return waitBothUp(p) }, 30*time.Second, 500*time.Millisecond)
+		}
+	}
+
+	for c, v := range before {
+		after := sessionUpToDownTransitions(t, c)
+		require.Greaterf(t, after, v, "expected Up→Down transitions metric to increase for client %d", c.id)
+	}
+}
+
+func TestClient_Liveness_Faults_SoftLoss_PartialPacketLoss(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping soft-loss test in short mode")
+	}
+
+	clients, sw, cfg := setupLivenessClients(t, 21000)
+	clientCount := cfg.clientCount
+	softLossPct := *softLossPctFlag
+	softLossCycles := *softLossCyclesFlag
+	stableDuration := *stableDurationFlag
+	softRatio := *softLossPairRatioFlag
+
+	if clientCount < 2 {
+		t.Skip("need at least 2 clients for soft-loss test")
+	}
+
+	nextHop := net.IPv4(10, 5, 0, 1)
+	registerFullMeshRoutes(t, clients, nextHop)
+	requireFullMeshUp(t, clients, clientCount-1, 30*time.Second)
+
+	pairs := selectPairs(clients, softRatio)
+	if len(pairs) == 0 {
+		t.Skip("no pairs selected for soft-loss test")
+	}
+
+	type pairState struct {
+		cA, cB   *testClient
+		ipA, ipB net.IP
+		peerAB   Peer
+		peerBA   Peer
+	}
+	ps := make([]pairState, len(pairs))
+	for i, p := range pairs {
+		ipA := p[0].mgr.LocalAddr().IP
+		ipB := p[1].mgr.LocalAddr().IP
+		ps[i] = pairState{
+			cA:  p[0],
+			cB:  p[1],
+			ipA: ipA,
+			ipB: ipB,
+			peerAB: Peer{
+				Interface: p[0].iface,
+				LocalIP:   ipA.To4().String(),
+				PeerIP:    ipB.To4().String(),
+			},
+			peerBA: Peer{
+				Interface: p[1].iface,
+				LocalIP:   ipB.To4().String(),
+				PeerIP:    ipA.To4().String(),
+			},
+		}
+	}
+
+	waitBothUp := func(p pairState) bool {
+		sessAB, okAB := p.cA.mgr.GetSession(p.peerAB)
+		sessBA, okBA := p.cB.mgr.GetSession(p.peerBA)
+		if !okAB || !okBA {
+			return false
+		}
+		snapAB := sessAB.Snapshot()
+		snapBA := sessBA.Snapshot()
+		return snapAB.State == StateUp && snapBA.State == StateUp
+	}
+
+	for _, p := range ps {
+		require.Eventually(t, func() bool { return waitBothUp(p) }, 10*time.Second, 200*time.Millisecond)
+	}
+
+	for _, p := range ps {
+		sw.SetSoftLoss(p.ipA, p.ipB, softLossPct)
+	}
+
+	detectTime := cfg.rxMin * time.Duration(cfg.detectMult)
+
+	before := make(map[*testClient]float64)
+	for _, p := range ps {
+		if _, ok := before[p.cA]; !ok {
+			before[p.cA] = sessionUpToDownTransitions(t, p.cA)
+		}
+		if _, ok := before[p.cB]; !ok {
+			before[p.cB] = sessionUpToDownTransitions(t, p.cB)
+		}
+	}
+
+	for range softLossCycles {
+		stableDeadline := time.Now().Add(stableDuration)
+		for time.Now().Before(stableDeadline) {
+			for _, p := range ps {
+				require.Truef(t, waitBothUp(p),
+					"sessions between %v and %v should stay Up under soft loss", p.ipA, p.ipB)
+			}
+			time.Sleep(detectTime / 2)
+		}
+	}
+
+	for c, v := range before {
+		after := sessionUpToDownTransitions(t, c)
+		require.Equalf(t, v, after, "unexpected Up→Down transitions under mild soft loss for client %d", c.id)
+	}
+}
+
+func TestClient_Liveness_Faults_HardLoss_PermanentOutage(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping hard-loss test in short mode")
+	}
+
+	clients, sw, cfg := setupLivenessClients(t, 22000)
+	clientCount := cfg.clientCount
+	stableDuration := *stableDurationFlag
+
+	if clientCount < 2 {
+		t.Skip("need at least 2 clients for hard-loss test")
+	}
+
+	nextHop := net.IPv4(10, 5, 0, 1)
+	registerFullMeshRoutes(t, clients, nextHop)
+	requireFullMeshUp(t, clients, clientCount-1, 30*time.Second)
+
+	before := make(map[*testClient]float64, clientCount)
+	for _, c := range clients {
+		before[c] = sessionUpToDownTransitions(t, c)
+	}
+
+	ratio := *hardLossRatioFlag
+	if ratio <= 0 {
+		ratio = 0.5
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	failCount := int(math.Round(ratio * float64(clientCount)))
+	if failCount < 1 {
+		failCount = 1
+	}
+	if failCount > clientCount {
+		failCount = clientCount
+	}
+	failed := clients[:failCount]
+
+	failedIPs := make(map[string]struct{}, failCount)
+	for _, f := range failed {
+		ip := f.mgr.LocalAddr().IP.To4().String()
+		failedIPs[ip] = struct{}{}
+	}
+
+	for _, f := range failed {
+		ipF := f.mgr.LocalAddr().IP
+		for _, c := range clients {
+			if f == c {
+				continue
+			}
+			ipC := c.mgr.LocalAddr().IP
+			sw.SetHardLoss(ipF, ipC)
+		}
+	}
+
+	detectTime := cfg.rxMin * time.Duration(cfg.detectMult)
+	waitDown := 5 * detectTime
+
+	checkStates := func() bool {
+		for _, c := range clients {
+			sessions := c.mgr.GetSessions()
+			if len(sessions) != clientCount-1 {
+				return false
+			}
+			for _, s := range sessions {
+				_, localFailed := failedIPs[s.Peer.LocalIP]
+				_, remoteFailed := failedIPs[s.Peer.PeerIP]
+				if localFailed || remoteFailed {
+					if s.State != StateDown || s.LastDownReason != DownReasonTimeout {
+						return false
+					}
+				} else {
+					if s.State != StateUp {
+						return false
+					}
+				}
+			}
+		}
+		return true
+	}
+
+	require.Eventually(t, checkStates, waitDown, 200*time.Millisecond)
+
+	for c, v := range before {
+		after := sessionUpToDownTransitions(t, c)
+		require.Greaterf(t, after, v, "expected Up→Down transitions metric to increase for client %d under hard loss", c.id)
+	}
+
+	stableDeadline := time.Now().Add(stableDuration)
+	for time.Now().Before(stableDeadline) {
+		require.True(t, checkStates(), "session states should remain stable under hard loss")
+		time.Sleep(detectTime / 2)
+	}
+}
+
+func TestClient_Liveness_Faults_SoftLoss_TimeoutAtHighLoss(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping high soft-loss timeout test in short mode")
+	}
+
+	clients, sw, cfg := setupLivenessClients(t, 23000)
+	clientCount := cfg.clientCount
+	if clientCount < 2 {
+		t.Skip("need at least 2 clients for high soft-loss test")
+	}
+
+	highSoftLossPct := *highSoftLossPctFlag
+	highSoftRatio := *highSoftLossPairRatioFlag
+	stableDuration := *stableDurationFlag
+	nextHop := net.IPv4(10, 5, 0, 1)
+
+	registerFullMeshRoutes(t, clients, nextHop)
+	requireFullMeshUp(t, clients, clientCount-1, 30*time.Second)
+
+	pairs := selectPairs(clients, highSoftRatio)
+	if len(pairs) == 0 {
+		t.Skip("no pairs selected for high soft-loss test")
+	}
+
+	type pairState struct {
+		cA, cB   *testClient
+		ipA, ipB net.IP
+		peerAB   Peer
+		peerBA   Peer
+	}
+	ps := make([]pairState, len(pairs))
+	badIPs := make(map[string]struct{})
+	degradedClients := make(map[*testClient]struct{})
+
+	for i, p := range pairs {
+		ipA := p[0].mgr.LocalAddr().IP
+		ipB := p[1].mgr.LocalAddr().IP
+		ipA4 := ipA.To4().String()
+		ipB4 := ipB.To4().String()
+
+		ps[i] = pairState{
+			cA:  p[0],
+			cB:  p[1],
+			ipA: ipA,
+			ipB: ipB,
+			peerAB: Peer{
+				Interface: p[0].iface,
+				LocalIP:   ipA4,
+				PeerIP:    ipB4,
+			},
+			peerBA: Peer{
+				Interface: p[1].iface,
+				LocalIP:   ipB4,
+				PeerIP:    ipA4,
+			},
+		}
+		badIPs[ipA4] = struct{}{}
+		badIPs[ipB4] = struct{}{}
+		degradedClients[p[0]] = struct{}{}
+		degradedClients[p[1]] = struct{}{}
+	}
+
+	waitBothUp := func(p pairState) bool {
+		sessAB, okAB := p.cA.mgr.GetSession(p.peerAB)
+		sessBA, okBA := p.cB.mgr.GetSession(p.peerBA)
+		if !okAB || !okBA {
+			return false
+		}
+		snapAB := sessAB.Snapshot()
+		snapBA := sessBA.Snapshot()
+		return snapAB.State == StateUp && snapBA.State == StateUp
+	}
+	waitBothDown := func(p pairState) bool {
+		sessAB, okAB := p.cA.mgr.GetSession(p.peerAB)
+		sessBA, okBA := p.cB.mgr.GetSession(p.peerBA)
+		if !okAB || !okBA {
+			return false
+		}
+		snapAB := sessAB.Snapshot()
+		snapBA := sessBA.Snapshot()
+		return snapAB.State == StateDown && snapAB.LastDownReason == DownReasonTimeout &&
+			snapBA.State == StateDown && snapBA.LastDownReason == DownReasonTimeout
+	}
+
+	for _, p := range ps {
+		require.Eventually(t, func() bool { return waitBothUp(p) }, 10*time.Second, 200*time.Millisecond)
+	}
+
+	before := make(map[*testClient]float64)
+	for c := range degradedClients {
+		before[c] = sessionUpToDownTransitions(t, c)
+	}
+
+	for _, p := range ps {
+		sw.SetSoftLoss(p.ipA, p.ipB, highSoftLossPct)
+	}
+
+	detectTime := cfg.rxMin * time.Duration(cfg.detectMult)
+	waitDown := 30 * detectTime
+
+	for _, p := range ps {
+		require.Eventually(t, func() bool { return waitBothDown(p) }, waitDown, 200*time.Millisecond)
+	}
+
+	for c, v := range before {
+		after := sessionUpToDownTransitions(t, c)
+		require.Greaterf(t, after, v, "expected Up→Down transitions to increase for degraded client %d under high soft loss", c.id)
+	}
+
+	checkHealthy := func() bool {
+		for _, c := range clients {
+			sessions := c.mgr.GetSessions()
+			if len(sessions) != clientCount-1 {
+				return false
+			}
+			for _, s := range sessions {
+				_, localBad := badIPs[s.Peer.LocalIP]
+				_, remoteBad := badIPs[s.Peer.PeerIP]
+
+				if localBad && remoteBad {
+					if s.State == StateDown && s.LastDownReason != DownReasonTimeout {
+						return false
+					}
+					continue
+				}
+				if s.State != StateUp {
+					return false
+				}
+			}
+		}
+		return true
+	}
+
+	stableDeadline := time.Now().Add(stableDuration)
+	for time.Now().Before(stableDeadline) {
+		require.True(t, checkHealthy(), "non-degraded sessions must remain Up under high soft loss")
+		time.Sleep(detectTime / 2)
+	}
+}
+
+type livenessTestConfig struct {
+	clientCount int
+	txMin       time.Duration
+	rxMin       time.Duration
+	detectMult  uint8
+	backoffMax  time.Duration
+}
+
+// getLivenessTestConfig parses flags once and returns the shared config for all tests.
+func getLivenessTestConfig(t *testing.T) livenessTestConfig {
+	t.Helper()
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	return livenessTestConfig{
+		clientCount: *clientsFlag,
+		txMin:       *txMinFlag,
+		rxMin:       *rxMinFlag,
+		detectMult:  uint8(*detectMultFlag),
+		backoffMax:  *backoffMaxFlag,
+	}
+}
+
+type testClient struct {
+	id      uint32
+	mgr     *Manager
+	metrics *prometheus.Registry
+	nlr     RouteReaderWriter
+	iface   string
+}
+
+func (c *testClient) Close() error {
+	return c.mgr.Close()
+}
+
+// Shared setup for all three tests: builds N managers, wiring them to a common fake switch.
+func setupLivenessClients(t *testing.T, basePort int) ([]*testClient, *fakeUDPSwitch, livenessTestConfig) {
+	t.Helper()
+
+	cfg := getLivenessTestConfig(t)
+	log := newTestLoggerWith(t, !*notQuietFlag, *debugFlag)
+	sw := newFakeUDPSwitch()
+
+	clients := make([]*testClient, 0, cfg.clientCount)
+
+	for i := range cfg.clientCount {
+		cid := uint32(i + 1)
+
+		nlr := &MockRouteReaderWriter{
+			RouteAddFunc:        func(r *routing.Route) error { return nil },
+			RouteDeleteFunc:     func(r *routing.Route) error { return nil },
+			RouteByProtocolFunc: func(protocol int) ([]*routing.Route, error) { return nil, nil },
+		}
+
+		iface := "lo"
+		ip := nthTestIPv4(i)
+		udp := newFakeUDPConn(sw, ip.String(), basePort+i, iface)
+
+		reg := prometheus.NewRegistry()
+
+		lm, err := NewManager(t.Context(), &ManagerConfig{
+			Logger:          log.With("clientID", cid),
+			Netlinker:       nlr,
+			MetricsRegistry: reg,
+			UDP:             udp,
+			BindIP:          ip.String(),
+			Port:            udp.LocalAddr().(*net.UDPAddr).Port,
+			TxMin:           cfg.txMin,
+			RxMin:           cfg.rxMin,
+			DetectMult:      cfg.detectMult,
+			MinTxFloor:      cfg.txMin,
+			MaxTxCeil:       cfg.txMin,
+			BackoffMax:      cfg.backoffMax,
+		})
+		require.NoError(t, err)
+
+		tc := &testClient{
+			id:      cid,
+			mgr:     lm,
+			metrics: reg,
+			nlr:     nlr,
+			iface:   iface,
+		}
+		clients = append(clients, tc)
+
+		t.Cleanup(func() {
+			if err := lm.Close(); err != nil {
+				log.Warn("error closing manager", "error", err)
+			}
+		})
+	}
+
+	return clients, sw, cfg
+}
+
+// Registers a full mesh of routes between all clients.
+func registerFullMeshRoutes(t *testing.T, clients []*testClient, nextHop net.IP) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	for _, c1 := range clients {
+		for _, c2 := range clients {
+			if c1 == c2 {
+				continue
+			}
+			wg.Add(1)
+			go func(c1 *testClient, c2 *testClient) {
+				defer wg.Done()
+				err := c1.mgr.RegisterRoute(&routing.Route{
+					Table: 100,
+					Src:   c1.mgr.LocalAddr().IP,
+					Dst: &net.IPNet{
+						IP:   c2.mgr.LocalAddr().IP.To4(),
+						Mask: net.CIDRMask(32, 32),
+					},
+					NextHop:  nextHop,
+					Protocol: unix.RTPROT_BGP,
+				}, c1.iface, c1.mgr.LocalAddr().Port)
+				require.NoError(t, err)
+			}(c1, c2)
+		}
+	}
+	wg.Wait()
+}
+
+// Wait until all sessions are Up in the full mesh.
+func requireFullMeshUp(t *testing.T, clients []*testClient, expectedPerClient int, timeout time.Duration) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		for _, c := range clients {
+			sessions := c.mgr.GetSessions()
+			if len(sessions) != expectedPerClient {
+				return false
+			}
+			for _, sess := range sessions {
+				if sess.State != StateUp {
+					return false
+				}
+			}
+		}
+		return true
+	}, timeout, 500*time.Millisecond)
+}
+
+func nthTestIPv4(n int) net.IP {
+	if n < 0 {
+		return nil
+	}
+	base := uint32(10)<<24 | 0x00000001 // 10.0.0.1
+	addr := base + uint32(n)
+	// stop at 10.255.255.255
+	if addr > (uint32(10)<<24 | 0x00FFFFFF) {
+		return nil
+	}
+	b := []byte{
+		byte(addr >> 24),
+		byte(addr >> 16),
+		byte(addr >> 8),
+		byte(addr),
+	}
+	return net.IPv4(b[0], b[1], b[2], b[3])
+}
+
+type fakeUDPPacket struct {
+	data  []byte
+	src   *net.UDPAddr
+	iface string
+}
+
+type fakeUDPConn struct {
+	sw     *fakeUDPSwitch
+	local  *net.UDPAddr
+	ifname string
+
+	mu       sync.Mutex
+	deadline time.Time
+	closed   bool
+
+	in chan fakeUDPPacket
+}
+
+func newFakeUDPConn(sw *fakeUDPSwitch, ip string, port int, ifname string) *fakeUDPConn {
+	c := &fakeUDPConn{
+		sw:     sw,
+		local:  &net.UDPAddr{IP: net.ParseIP(ip), Port: port},
+		ifname: ifname,
+		in:     make(chan fakeUDPPacket, 1024),
+	}
+	sw.register(c)
+	return c
+}
+
+func (c *fakeUDPConn) WriteTo(pkt []byte, dst *net.UDPAddr, iface string, src net.IP) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, net.ErrClosed
+	}
+	c.mu.Unlock()
+
+	cp := make([]byte, len(pkt))
+	copy(cp, pkt)
+
+	c.sw.deliver(dst, fakeUDPPacket{
+		data:  cp,
+		src:   c.local, // sender addr
+		iface: iface,
+	})
+
+	return len(pkt), nil
+}
+
+func (c *fakeUDPConn) ReadFrom(buf []byte) (int, *net.UDPAddr, net.IP, string, error) {
+	c.mu.Lock()
+	deadline := c.deadline
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return 0, nil, nil, "", net.ErrClosed
+	}
+
+	var timeout <-chan time.Time
+	if !deadline.IsZero() {
+		timeout = time.After(time.Until(deadline))
+	}
+
+	select {
+	case pkt := <-c.in:
+		n := copy(buf, pkt.data)
+		// remoteAddr = sender; localIP = *this* conn's IP; iface = this conn's ifname
+		return n, pkt.src, c.local.IP, c.ifname, nil
+	case <-timeout:
+		return 0, nil, nil, "", os.ErrDeadlineExceeded
+	}
+}
+
+func (c *fakeUDPConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadline = t
+	return nil
+}
+
+func (c *fakeUDPConn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c *fakeUDPConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	close(c.in)
+	return nil
+}
+
+type faultMode int
+
+const (
+	faultModeNone faultMode = iota
+	faultModeDropAll
+	faultModeSoftDrop
+)
+
+type linkKey struct {
+	a, b string
+}
+
+func makeLinkKey(a, b net.IP) linkKey {
+	as, bs := a.String(), b.String()
+	if as < bs {
+		return linkKey{a: as, b: bs}
+	}
+	return linkKey{a: bs, b: as}
+}
+
+type linkFaultProfile struct {
+	mode    faultMode
+	lossPct float64 // 0–1 for soft-drop
+}
+
+type fakeUDPSwitch struct {
+	mu         sync.Mutex
+	conns      map[string]*fakeUDPConn
+	linkFaults map[linkKey]linkFaultProfile
+	rng        *rand.Rand
+}
+
+// fakeUDPSwitch routes purely by IP (port is ignored) because each test client
+// has a unique IP. This keeps the fake network simple while still matching the
+// liveness manager's behavior, which sends to dst.IP.
+func newFakeUDPSwitch() *fakeUDPSwitch {
+	return &fakeUDPSwitch{
+		conns:      make(map[string]*fakeUDPConn),
+		linkFaults: make(map[linkKey]linkFaultProfile),
+		rng:        rand.New(rand.NewSource(1)), // deterministic for tests
+	}
+}
+
+func (s *fakeUDPSwitch) register(c *fakeUDPConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conns[c.local.IP.String()] = c
+}
+
+// setFault is the unified injection API for link a<->b (unordered).
+// mode controls the basic behavior; lossPct is only used for faultModeSoftDrop.
+func (s *fakeUDPSwitch) setFault(a, b net.IP, mode faultMode, lossPct float64) {
+	if a == nil || b == nil {
+		return
+	}
+	lk := makeLinkKey(a, b)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch mode {
+	case faultModeNone:
+		delete(s.linkFaults, lk)
+		return
+	case faultModeSoftDrop:
+		if lossPct <= 0 {
+			// effect is equivalent to clearing the fault
+			delete(s.linkFaults, lk)
+			return
+		}
+		if lossPct > 1 {
+			lossPct = 1
+		}
+		s.linkFaults[lk] = linkFaultProfile{
+			mode:    faultModeSoftDrop,
+			lossPct: lossPct,
+		}
+	default: // faultModeDropAll or any future "hard" modes
+		s.linkFaults[lk] = linkFaultProfile{
+			mode:    mode,
+			lossPct: 0,
+		}
+	}
+}
+
+// SetNoFault clears any injected behavior for link a<->b.
+func (s *fakeUDPSwitch) SetNoFault(a, b net.IP) {
+	s.setFault(a, b, faultModeNone, 0)
+}
+
+// SetHardLoss configures a permanent drop-all fault for link a<->b.
+func (s *fakeUDPSwitch) SetHardLoss(a, b net.IP) {
+	s.setFault(a, b, faultModeDropAll, 0)
+}
+
+// SetSoftLoss configures probabilistic packet loss for link a<->b.
+// lossPct is 0–1 (e.g., 0.01 for 1% loss).
+func (s *fakeUDPSwitch) SetSoftLoss(a, b net.IP, lossPct float64) {
+	s.setFault(a, b, faultModeSoftDrop, lossPct)
+}
+
+func (s *fakeUDPSwitch) deliver(dst *net.UDPAddr, pkt fakeUDPPacket) {
+	if dst == nil || dst.IP == nil {
+		return
+	}
+	key := dst.IP.String()
+
+	s.mu.Lock()
+	if pkt.src != nil && pkt.src.IP != nil {
+		lk := makeLinkKey(pkt.src.IP, dst.IP)
+		if prof, ok := s.linkFaults[lk]; ok {
+			switch prof.mode {
+			case faultModeDropAll:
+				s.mu.Unlock()
+				return
+			case faultModeSoftDrop:
+				if prof.lossPct > 0 && s.rng.Float64() < prof.lossPct {
+					s.mu.Unlock()
+					return
+				}
+			}
+		}
+	}
+	c := s.conns[key]
+	s.mu.Unlock()
+
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	select {
+	case c.in <- pkt:
+	default:
+	}
+}
+
+// selectPairs deterministically picks disjoint pairs of clients from the front
+// of the slice, involving roughly ratio*len(clients) clients.
+// ratio:
+//   - <=0 → exactly one pair (clients[0], clients[1]) if possible
+//   - >=1 → all clients (rounded to an even count)
+//
+// For determinism and simplicity we don't randomize; we just walk the slice.
+func selectPairs(clients []*testClient, ratio float64) [][2]*testClient {
+	n := len(clients)
+	if n < 2 {
+		return nil
+	}
+
+	if ratio <= 0 {
+		return [][2]*testClient{{clients[0], clients[1]}}
+	}
+
+	if ratio > 1 {
+		ratio = 1
+	}
+
+	k := int(math.Round(ratio * float64(n)))
+	if k < 2 {
+		k = 2
+	}
+	if k > n {
+		k = n
+	}
+	if k%2 == 1 {
+		k--
+	}
+	if k < 2 {
+		// If we rounded down to 1, fall back to a single pair.
+		return [][2]*testClient{{clients[0], clients[1]}}
+	}
+
+	pairs := make([][2]*testClient, 0, k/2)
+	for i := 0; i+1 < k; i += 2 {
+		pairs = append(pairs, [2]*testClient{clients[i], clients[i+1]})
+	}
+	return pairs
+}
+
+func metricValueWithLabels(t *testing.T, reg *prometheus.Registry, name string, labelFilter map[string]string) float64 {
+	t.Helper()
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	var total float64
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			match := true
+			for _, lp := range m.GetLabel() {
+				want, ok := labelFilter[lp.GetName()]
+				if ok && lp.GetValue() != want {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+			if c := m.GetCounter(); c != nil {
+				total += c.GetValue()
+			} else if g := m.GetGauge(); g != nil {
+				total += g.GetValue()
+			}
+		}
+	}
+	return total
+}
+
+func sessionUpToDownTransitions(t *testing.T, c *testClient) float64 {
+	ip := c.mgr.LocalAddr().IP.To4().String()
+	return metricValueWithLabels(t, c.metrics, "doublezero_liveness_session_transitions_total", map[string]string{
+		LabelIface:     c.iface,
+		LabelLocalIP:   ip,
+		LabelStateFrom: StateUp.String(),
+		LabelStateTo:   StateDown.String(),
+		// LabelReason intentionally omitted: we sum across all reasons.
+	})
+}

--- a/client/doublezerod/internal/liveness/metrics.go
+++ b/client/doublezerod/internal/liveness/metrics.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -19,6 +18,30 @@ const (
 	LabelOperation = "operation"
 )
 
+type Metrics struct {
+	Sessions                 *prometheus.GaugeVec
+	SessionTransitions       *prometheus.CounterVec
+	RoutesInstalled          *prometheus.GaugeVec
+	RouteInstalls            *prometheus.CounterVec
+	RouteWithdraws           *prometheus.CounterVec
+	ConvergenceToUp          *prometheus.HistogramVec
+	ConvergenceToDown        *prometheus.HistogramVec
+	SchedulerServiceQueueLen *prometheus.GaugeVec
+	SchedulerEventsDropped   *prometheus.CounterVec
+	SchedulerTotalQueueLen   prometheus.Gauge
+	RouteInstallFailures     *prometheus.CounterVec
+	RouteUninstallFailures   *prometheus.CounterVec
+	HandleRxDuration         *prometheus.HistogramVec
+	ControlPacketsTX         *prometheus.CounterVec
+	ControlPacketsRX         *prometheus.CounterVec
+	ControlPacketsRxInvalid  *prometheus.CounterVec
+	UnknownPeerPackets       *prometheus.CounterVec
+	ReadSocketErrors         *prometheus.CounterVec
+	WriteSocketErrors        *prometheus.CounterVec
+	PeerSessions             *prometheus.GaugeVec
+	PeerDetectTime           *prometheus.GaugeVec
+}
+
 var (
 	serviceLabels = []string{LabelIface, LabelLocalIP}
 )
@@ -27,253 +50,244 @@ func withServiceLabels(labels ...string) []string {
 	return append(serviceLabels, labels...)
 }
 
-var (
-	metricSessions = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_sessions",
-			Help: "Current number of sessions by FSM state",
-		},
-		withServiceLabels(LabelState),
-	)
-
-	metricSessionTransitions = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_session_transitions_total",
-			Help: "Count of session state transitions",
-		},
-		withServiceLabels(LabelStateFrom, LabelStateTo, LabelReason),
-	)
-
-	metricRoutesInstalled = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_routes_installed",
-			Help: "Number of routes installed",
-		},
-		serviceLabels,
-	)
-
-	metricRouteInstalls = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_route_installs_total",
-			Help: "Count of route installs",
-		},
-		serviceLabels,
-	)
-
-	metricRouteWithdraws = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_route_withdraws_total",
-			Help: "Count of route withdraws",
-		},
-		serviceLabels,
-	)
-
-	metricConvergenceToUp = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "doublezero_liveness_convergence_to_up_seconds",
-			Help: "Time from first successful control message while down until transition to up (includes detect threshold, scheduler delay, and kernel install).",
-		},
-		serviceLabels,
-	)
-
-	metricConvergenceToDown = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "doublezero_liveness_convergence_to_down_seconds",
-			Help: "Time from first failed or missing control message while up until transition to down (includes detect expiry, scheduler delay, and kernel delete).",
-		},
-		serviceLabels,
-	)
-
-	metricSchedulerServiceQueueLen = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_scheduler_service_queue_len",
-			Help: "Current number of pending events in the scheduler queue per service (iface, local_ip)",
-		},
-		serviceLabels,
-	)
-
-	metricSchedulerEventsDropped = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_scheduler_events_dropped_total",
-			Help: "Scheduler events dropped by type and reason.",
-		},
-		[]string{"type", "reason"},
-	)
-
-	metricSchedulerTotalQueueLen = promauto.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_scheduler_total_queue_len",
-			Help: "Total events currently in the scheduler queue.",
-		},
-	)
-
-	metricRouteInstallFailures = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_route_install_failures_total",
-			Help: "Count of route kernel install failures",
-		},
-		serviceLabels,
-	)
-
-	metricRouteUninstallFailures = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_route_uninstall_failures_total",
-			Help: "Count of route kernel uninstall failures",
-		},
-		serviceLabels,
-	)
-
-	metricHandleRxDuration = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "doublezero_liveness_handle_rx_duration_seconds",
-			Help: "Distribution of time to handle a valid received packet.",
-		},
-		serviceLabels,
-	)
-
-	metricControlPacketsTX = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_control_packets_tx_total",
-			Help: "Total control packets sent.",
-		},
-		serviceLabels, // iface, local_ip
-	)
-
-	metricControlPacketsRX = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_control_packets_rx_total",
-			Help: "Total control packets received.",
-		},
-		serviceLabels,
-	)
-
-	metricControlPacketsRxInvalid = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_control_packets_rx_invalid_total",
-			Help: "Invalid control packets received (e.g. short, bad_version, bad_len, parse_error, not_ipv4, reserved_nonzero).",
-		},
-		withServiceLabels(LabelReason),
-	)
-
-	metricUnknownPeerPackets = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_unknown_peer_packets_total",
-			Help: "Packets received that didn’t match any known session.",
-		},
-		serviceLabels,
-	)
-
-	metricReadSocketErrors = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_read_socket_errors_total",
-			Help: "Count of read socket errors.",
-		},
-		serviceLabels,
-	)
-
-	metricWriteSocketErrors = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "doublezero_liveness_write_socket_errors_total",
-			Help: "Count of write socket errors.",
-		},
-		serviceLabels,
-	)
-
-	// Per peer metrics for route liveness (high cardinality).
-	metricRouteLivenessSessions = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_peer_sessions",
-			Help: "Current number of sessions by peer and FSM state",
-		},
-		withServiceLabels(LabelPeerIP, LabelState),
-	)
-
-	metricPeerDetectTime = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "doublezero_liveness_peer_session_detect_time_seconds",
-			Help: "Current detect time by session (after clamping with peer value).",
-		},
-		withServiceLabels(LabelPeerIP),
-	)
-)
-
-func emitSessionStateMetrics(sess *Session, prevState *State, operation string, peerMetrics bool) {
-	if sess == nil || sess.peer == nil {
-		return
+func newMetrics() *Metrics {
+	return &Metrics{
+		Sessions: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_sessions",
+				Help: "Current number of sessions by FSM state",
+			},
+			withServiceLabels(LabelState),
+		),
+		SessionTransitions: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_session_transitions_total",
+				Help: "Count of session state transitions",
+			},
+			withServiceLabels(LabelStateFrom, LabelStateTo, LabelReason),
+		),
+		RoutesInstalled: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_routes_installed",
+				Help: "Number of routes installed",
+			},
+			serviceLabels,
+		),
+		RouteInstalls: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_route_installs_total",
+				Help: "Count of route installs",
+			},
+			serviceLabels,
+		),
+		RouteWithdraws: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_route_withdraws_total",
+				Help: "Count of route withdraws",
+			},
+			serviceLabels,
+		),
+		ConvergenceToUp: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "doublezero_liveness_convergence_to_up_seconds",
+				Help: "Time from first successful control message while down until transition to up (includes detect threshold, scheduler delay, and kernel install).",
+			},
+			serviceLabels,
+		),
+		ConvergenceToDown: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "doublezero_liveness_convergence_to_down_seconds",
+				Help: "Time from first failed or missing control message while up until transition to down (includes detect expiry, scheduler delay, and kernel delete).",
+			},
+			serviceLabels,
+		),
+		SchedulerServiceQueueLen: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_scheduler_service_queue_len",
+				Help: "Current number of pending events in the scheduler queue per service (iface, local_ip)",
+			},
+			serviceLabels,
+		),
+		SchedulerEventsDropped: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_scheduler_events_dropped_total",
+				Help: "Count of events dropped by the scheduler",
+			},
+			serviceLabels,
+		),
+		SchedulerTotalQueueLen: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_scheduler_total_queue_len",
+				Help: "Total events currently in the scheduler queue.",
+			},
+		),
+		RouteInstallFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_route_install_failures_total",
+				Help: "Count of route kernel install failures",
+			},
+			serviceLabels,
+		),
+		RouteUninstallFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_route_uninstall_failures_total",
+				Help: "Count of route kernel uninstall failures",
+			},
+			serviceLabels,
+		),
+		HandleRxDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "doublezero_liveness_handle_rx_duration_seconds",
+				Help: "Distribution of time to handle a valid received packet.",
+			},
+			serviceLabels,
+		),
+		ControlPacketsTX: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_control_packets_tx_total",
+				Help: "Total control packets sent.",
+			},
+			serviceLabels, // iface, local_ip
+		),
+		ControlPacketsRX: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_control_packets_rx_total",
+				Help: "Total control packets received.",
+			},
+			serviceLabels,
+		),
+		ControlPacketsRxInvalid: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_control_packets_rx_invalid_total",
+				Help: "Invalid control packets received (e.g. short, bad_version, bad_len, parse_error, not_ipv4, reserved_nonzero).",
+			},
+			withServiceLabels(LabelReason),
+		),
+		UnknownPeerPackets: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_unknown_peer_packets_total",
+				Help: "Packets received that didn’t match any known session.",
+			},
+			serviceLabels,
+		),
+		ReadSocketErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_read_socket_errors_total",
+				Help: "Count of read socket errors.",
+			},
+			serviceLabels,
+		),
+		WriteSocketErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "doublezero_liveness_write_socket_errors_total",
+				Help: "Count of write socket errors.",
+			},
+			serviceLabels,
+		),
+		// Per peer metrics for route liveness (high cardinality).
+		PeerSessions: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_peer_sessions",
+				Help: "Current number of sessions by peer and FSM state",
+			},
+			withServiceLabels(LabelPeerIP, LabelState),
+		),
+		PeerDetectTime: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_peer_session_detect_time_seconds",
+				Help: "Current detect time by session (after clamping with peer value).",
+			},
+			withServiceLabels(LabelPeerIP),
+		),
 	}
+}
+
+// Register all metrics with the provided registry.
+func (m *Metrics) Register(r prometheus.Registerer) {
+	r.MustRegister(
+		m.Sessions,
+		m.SessionTransitions,
+		m.RoutesInstalled,
+		m.RouteInstalls,
+		m.RouteWithdraws,
+		m.ConvergenceToUp,
+		m.ConvergenceToDown,
+		m.SchedulerServiceQueueLen,
+		m.SchedulerEventsDropped,
+		m.SchedulerTotalQueueLen,
+		m.RouteInstallFailures,
+		m.RouteUninstallFailures,
+		m.HandleRxDuration,
+		m.ControlPacketsTX,
+		m.ControlPacketsRX,
+		m.ControlPacketsRxInvalid,
+		m.UnknownPeerPackets,
+		m.ReadSocketErrors,
+		m.WriteSocketErrors,
+		m.PeerSessions,
+		m.PeerDetectTime,
+	)
+}
+
+func (m *Metrics) sessionStateTransition(peer Peer, prevState *State, operation string, peerMetrics bool) {
 	var prevStateStr string
 	if prevState != nil {
 		prevStateStr = prevState.String()
 	} else {
 		prevStateStr = "new"
 	}
-	metricSessionTransitions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, prevStateStr, sess.state.String(), operation).Inc()
-	metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.state.String()).Inc()
+	m.SessionTransitions.WithLabelValues(peer.Interface, peer.LocalIP, prevStateStr, StateDown.String(), operation).Inc()
+	m.Sessions.WithLabelValues(peer.Interface, peer.LocalIP, StateDown.String()).Inc()
 	if prevState != nil {
-		metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, prevStateStr).Dec()
+		m.Sessions.WithLabelValues(peer.Interface, peer.LocalIP, prevStateStr).Dec()
 	}
 	if peerMetrics {
-		metricRouteLivenessSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, sess.state.String()).Inc()
+		m.PeerSessions.WithLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, StateDown.String()).Inc()
 		if prevState != nil {
-			metricRouteLivenessSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, prevStateStr).Dec()
+			m.PeerSessions.WithLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, prevStateStr).Dec()
 		}
 	}
 }
 
-func emitRouteInstallMetrics(iface, localIP string) {
-	metricRoutesInstalled.WithLabelValues(iface, localIP).Inc()
-	metricRouteInstalls.WithLabelValues(iface, localIP).Inc()
+func (m *Metrics) routeInstall(iface, localIP string) {
+	m.RoutesInstalled.WithLabelValues(iface, localIP).Inc()
+	m.RouteInstalls.WithLabelValues(iface, localIP).Inc()
 }
 
-func emitRouteWithdrawMetrics(iface, localIP string) {
-	metricRoutesInstalled.WithLabelValues(iface, localIP).Dec()
-	metricRouteWithdraws.WithLabelValues(iface, localIP).Inc()
+func (m *Metrics) routeWithdraw(iface, localIP string) {
+	m.RoutesInstalled.WithLabelValues(iface, localIP).Dec()
+	m.RouteWithdraws.WithLabelValues(iface, localIP).Inc()
 }
 
-func emitPeerDetectTimeGauge(sess *Session, dt time.Duration) {
-	if sess == nil || sess.peer == nil {
-		return
-	}
-	metricPeerDetectTime.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP).Set(dt.Seconds())
+func (m *Metrics) peerDetectTime(peer Peer, dt time.Duration) {
+	m.PeerDetectTime.WithLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP).Set(dt.Seconds())
 }
 
-func metricsCleanupOnWithdrawRoute(sess *Session, peerMetrics bool) {
-	if sess == nil || sess.peer == nil {
-		return
-	}
-	metricSessions.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.state.String()).Dec()
+func (m *Metrics) cleanupWithdrawRoute(peer Peer, peerMetrics bool) {
+	m.Sessions.WithLabelValues(peer.Interface, peer.LocalIP, StateDown.String()).Dec()
 	if peerMetrics {
-		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateDown.String())
-		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateInit.String())
-		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateUp.String())
-		metricRouteLivenessSessions.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP, StateAdminDown.String())
-		metricPeerDetectTime.DeleteLabelValues(sess.peer.Interface, sess.peer.LocalIP, sess.peer.PeerIP)
+		m.PeerSessions.DeleteLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, StateDown.String())
+		m.PeerSessions.DeleteLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, StateInit.String())
+		m.PeerSessions.DeleteLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, StateUp.String())
+		m.PeerSessions.DeleteLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP, StateAdminDown.String())
+		m.PeerDetectTime.DeleteLabelValues(peer.Interface, peer.LocalIP, peer.PeerIP)
 	}
 }
 
-func emitConvergenceToUpMetrics(sess *Session, convergence time.Duration) {
-	if sess == nil || sess.peer == nil {
-		return
-	}
-	metricConvergenceToUp.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP).Observe(convergence.Seconds())
+func (m *Metrics) convergenceToUp(peer Peer, convergence time.Duration) {
+	m.ConvergenceToUp.WithLabelValues(peer.Interface, peer.LocalIP).Observe(convergence.Seconds())
 }
 
-func emitConvergenceToDownMetrics(sess *Session, convergence time.Duration) {
-	if sess == nil || sess.peer == nil {
-		return
-	}
-	metricConvergenceToDown.WithLabelValues(sess.peer.Interface, sess.peer.LocalIP).Observe(convergence.Seconds())
+func (m *Metrics) convergenceToDown(peer Peer, convergence time.Duration) {
+	m.ConvergenceToDown.WithLabelValues(peer.Interface, peer.LocalIP).Observe(convergence.Seconds())
 }
 
-func emitSchedulerServiceQueueLengthGauge(eq *EventQueue, sess *Session) {
-	if sess == nil || sess.peer == nil {
-		return
-	}
-	iface, lip := sess.peer.Interface, sess.peer.LocalIP
+func (m *Metrics) schedulerServiceQueueLength(eq *EventQueue, peer Peer) {
+	iface, lip := peer.Interface, peer.LocalIP
 	cnt := eq.CountFor(iface, lip)
 	if cnt == 0 {
-		metricSchedulerServiceQueueLen.DeleteLabelValues(iface, lip)
+		m.SchedulerServiceQueueLen.DeleteLabelValues(iface, lip)
 	} else {
-		metricSchedulerServiceQueueLen.WithLabelValues(iface, lip).Set(float64(cnt))
+		m.SchedulerServiceQueueLen.WithLabelValues(iface, lip).Set(float64(cnt))
 	}
 }

--- a/client/doublezerod/internal/liveness/receiver_test.go
+++ b/client/doublezerod/internal/liveness/receiver_test.go
@@ -20,7 +20,7 @@ func TestClient_Liveness_Receiver_CancelStopsLoop(t *testing.T) {
 	require.NoError(t, err)
 	defer udp.Close()
 
-	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {})
+	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {}, newMetrics())
 
 	done := make(chan struct{})
 	go func() {
@@ -56,7 +56,7 @@ func TestClient_Liveness_Receiver_IgnoresMalformedPacket(t *testing.T) {
 	var calls int32
 	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {
 		atomic.AddInt32(&calls, 1)
-	})
+	}, newMetrics())
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
@@ -99,7 +99,7 @@ func TestClient_Liveness_Receiver_HandlerInvoked_WithPeerContext(t *testing.T) {
 
 	var got Peer
 	calls := int32(0)
-	rx := NewReceiver(newTestLogger(t), udp, func(cp *ControlPacket, p Peer) { got = p; atomic.AddInt32(&calls, 1) })
+	rx := NewReceiver(newTestLogger(t), udp, func(cp *ControlPacket, p Peer) { got = p; atomic.AddInt32(&calls, 1) }, newMetrics())
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -130,7 +130,7 @@ func TestClient_Liveness_Receiver_DeadlineTimeoutsAreSilent(t *testing.T) {
 	require.NoError(t, err)
 	defer udp.Close()
 
-	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {})
+	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {}, newMetrics())
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -150,7 +150,7 @@ func TestClient_Liveness_Receiver_SocketClosed_ReturnsError(t *testing.T) {
 	udp, err := ListenUDP("127.0.0.1", 0)
 	require.NoError(t, err)
 
-	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {})
+	rx := NewReceiver(newTestLogger(t), udp, func(*ControlPacket, Peer) {}, newMetrics())
 	errCh := make(chan error, 1)
 	go func() { errCh <- rx.Run(ctx) }()
 

--- a/client/doublezerod/internal/liveness/routerw.go
+++ b/client/doublezerod/internal/liveness/routerw.go
@@ -40,7 +40,7 @@ func NewRouteReaderWriter(lm *Manager, rrw RouteReaderWriter, iface string) *rou
 // RouteAdd registers the route with the liveness Manager for the given iface,
 // enabling the Manager to monitor reachability before installation.
 func (m *routeReaderWriter) RouteAdd(r *routing.Route) error {
-	return m.lm.RegisterRoute(r, m.iface)
+	return m.lm.RegisterRoute(r, m.iface, m.lm.cfg.Port)
 }
 
 // RouteDelete withdraws the route and removes it from liveness tracking for

--- a/client/doublezerod/internal/liveness/routerw_test.go
+++ b/client/doublezerod/internal/liveness/routerw_test.go
@@ -46,7 +46,7 @@ func TestClient_Liveness_RouteRW_RouteDelete_WithdrawsFromManager(t *testing.T) 
 
 	r := newTestRoute(nil)
 
-	require.NoError(t, m.RegisterRoute(r, "test-iface"))
+	require.NoError(t, m.RegisterRoute(r, "test-iface", 0))
 
 	require.Equal(t, 1, m.GetSessionsLen())
 	peer := Peer{Interface: "test-iface", LocalIP: r.Src.To4().String(), PeerIP: r.Dst.IP.To4().String()}
@@ -114,7 +114,7 @@ func TestClient_Liveness_RouteRW_RouteDelete_PassiveMode_PassesThroughToBackend(
 	r := newTestRoute(nil)
 
 	// Seed a session so WithdrawRoute has something to work with.
-	require.NoError(t, m.RegisterRoute(r, "lo"))
+	require.NoError(t, m.RegisterRoute(r, "lo", 0))
 
 	err = rrw.RouteDelete(r)
 	require.NoError(t, err)
@@ -179,8 +179,8 @@ func TestClient_Liveness_RouteRW_RouteByProtocol_BGP_UsesManagerSessions(t *test
 		}
 	})
 
-	require.NoError(t, m.RegisterRoute(r1, "lo"))
-	require.NoError(t, m.RegisterRoute(r2, "lo"))
+	require.NoError(t, m.RegisterRoute(r1, "lo", 0))
+	require.NoError(t, m.RegisterRoute(r2, "lo", 0))
 
 	routes, err := rrw.RouteByProtocol(unix.RTPROT_BGP)
 	require.NoError(t, err)

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/pim"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/runtime"
 	"github.com/malbeclabs/doublezero/config"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
@@ -2546,14 +2547,15 @@ func newTestNetworkConfig(t *testing.T) *config.NetworkConfig {
 
 func newTestLivenessManagerConfig() *liveness.ManagerConfig {
 	return &liveness.ManagerConfig{
-		Logger:      slog.Default(),
-		BindIP:      "0.0.0.0",
-		Port:        44880,
-		PassiveMode: true,
-		TxMin:       300 * time.Millisecond,
-		RxMin:       300 * time.Millisecond,
-		DetectMult:  3,
-		MinTxFloor:  50 * time.Millisecond,
-		MaxTxCeil:   1 * time.Second,
+		Logger:          slog.Default(),
+		BindIP:          "0.0.0.0",
+		Port:            44880,
+		PassiveMode:     true,
+		TxMin:           300 * time.Millisecond,
+		RxMin:           300 * time.Millisecond,
+		DetectMult:      3,
+		MinTxFloor:      50 * time.Millisecond,
+		MaxTxCeil:       1 * time.Second,
+		MetricsRegistry: prometheus.NewRegistry(),
 	}
 }


### PR DESCRIPTION
## Summary of Changes
- Adds route liveness fault-injection tests to simulate flaps, soft loss, high loss, and hard loss across a large subset of routes with many clients.
- Closes https://github.com/malbeclabs/doublezero/issues/2254

## Testing Verification
- Configured tests to run with `make test` and in CI
