### PR TITLE
programs/svc: contributor ops manager key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,20 @@ All notable changes to this project will be documented in this file.
     - IP address lookups via ifconfig.me are retried up to 3 times to minimize transient network errors.
     - Added global `--no-version-warning` flag to the `doublezero` client and now emit version warnings to STDERR instead of STDOUT to improve scriptability and logging.
     - Add the ability to update a Device’s location, managing the reference counters accordingly.
-    - Added support in the link update command to set a link’s status to soft-drained or hard-drained.
+    - Added support in the link update command to set a link’s status to soft_drained or hard_drained.
+    - Add support for updating `contributor.ops_manager_key`.
 - Funder: fund multicast group owners
 - Onchain programs
   - Serviceability Program: Updated the device update command to allow modifying a device’s location.
   - Added new `soft-drained` and `hard-drained` link status values to serviceability to support traffic offloading as defined in RFC9.
   - Fix ProgramConfig resize during global state initialization.
+  - Add `contributor.ops_manager_key` for authorizing incident management operations.
 - QA
   - Traceroute when packet loss is detected
 - Tools
   - Add `solana-tpu-quic-ping` tool for testing Solana TPU-QUIC connections with stats emitted periodically
 - Device controller
-  - Handle new link.status values (soft-drained and hard-drained) as per [RFC9](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc9-link-draining.md) 
+  - Handle new link.status values (soft-drained and hard-drained) as per [RFC9](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc9-link-draining.md)
 
 ## [v0.7.1](https://github.com/malbeclabs/doublezero/compare/client/v0.7.0...client/v0.7.1) – 2025-11-18
 

--- a/smartcontract/cli/src/contributor/create.rs
+++ b/smartcontract/cli/src/contributor/create.rs
@@ -93,6 +93,7 @@ mod tests {
                         code: "test2".to_string(),
                         status: ContributorStatus::Activated,
                         bump_seed: 0,
+                        ops_manager_pk: Pubkey::default(),
                     },
                 )]
                 .into_iter()

--- a/smartcontract/cli/src/contributor/delete.rs
+++ b/smartcontract/cli/src/contributor/delete.rs
@@ -66,6 +66,7 @@ mod tests {
             reference_count: 0,
             status: ContributorStatus::Activated,
             owner: Pubkey::default(),
+            ops_manager_pk: Pubkey::default(),
         };
 
         client

--- a/smartcontract/cli/src/contributor/get.rs
+++ b/smartcontract/cli/src/contributor/get.rs
@@ -18,8 +18,12 @@ impl GetContributorCliCommand {
 
         writeln!(
             out,
-            "account: {},\r\ncode: {}\r\nstatus: {}\r\nowner: {}",
-            pubkey, contributor.code, contributor.status, contributor.owner
+            "account: {},\r\ncode: {}\r\nstatus: {}\r\nowner: {}\r\nops_manager_key: {}",
+            pubkey,
+            contributor.code,
+            contributor.status,
+            contributor.owner,
+            contributor.ops_manager_pk
         )?;
 
         Ok(())
@@ -51,6 +55,7 @@ mod tests {
             reference_count: 0,
             status: ContributorStatus::Activated,
             owner: contributor1_pubkey,
+            ops_manager_pk: Pubkey::default(),
         };
 
         let contributor2 = contributor1.clone();
@@ -92,7 +97,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\nops_manager_key: 11111111111111111111111111111111\n");
 
         // Expected success
         let mut output = Vec::new();
@@ -102,6 +107,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB,\r\ncode: test\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\nops_manager_key: 11111111111111111111111111111111\n");
     }
 }

--- a/smartcontract/cli/src/contributor/list.rs
+++ b/smartcontract/cli/src/contributor/list.rs
@@ -87,6 +87,7 @@ mod tests {
             reference_count: 0,
             status: Activated,
             owner: contributor1_pubkey,
+            ops_manager_pk: Pubkey::default(),
         };
         client
             .expect_list_contributor()

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -216,6 +216,7 @@ mod tests {
             code: "test".to_string(),
             status: ContributorStatus::Activated,
             owner: contributor_pk,
+            ops_manager_pk: Pubkey::default(),
         };
 
         client

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -224,6 +224,7 @@ mod tests {
             code: "contributor1_code".to_string(),
             status: ContributorStatus::Activated,
             owner: contributor_pk,
+            ops_manager_pk: Pubkey::default(),
         };
 
         client.expect_list_contributor().returning(move |_| {

--- a/smartcontract/cli/src/link/accept.rs
+++ b/smartcontract/cli/src/link/accept.rs
@@ -123,6 +123,7 @@ mod tests {
             index: 1,
             status: ContributorStatus::Activated,
             code: "co01".to_string(),
+            ops_manager_pk: Pubkey::default(),
         };
         let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
         let signature = Signature::from([

--- a/smartcontract/cli/src/link/list.rs
+++ b/smartcontract/cli/src/link/list.rs
@@ -190,6 +190,7 @@ mod tests {
             code: "contributor1_code".to_string(),
             status: ContributorStatus::Activated,
             owner: contributor_pk,
+            ops_manager_pk: Pubkey::default(),
         };
 
         client.expect_list_contributor().returning(move |_| {
@@ -325,6 +326,7 @@ mod tests {
             code: "contributor1_code".to_string(),
             status: ContributorStatus::Activated,
             owner: contributor1_pk,
+            ops_manager_pk: Pubkey::default(),
         };
         let contributor2_pk = Pubkey::new_unique();
         let contributor2 = Contributor {
@@ -335,6 +337,7 @@ mod tests {
             code: "contributor2_code".to_string(),
             status: ContributorStatus::Activated,
             owner: contributor2_pk,
+            ops_manager_pk: Pubkey::default(),
         };
 
         let contributor1_for_list = contributor1.clone();

--- a/smartcontract/cli/src/link/update.rs
+++ b/smartcontract/cli/src/link/update.rs
@@ -156,6 +156,7 @@ mod tests {
             index: 1,
             status: ContributorStatus::Activated,
             code: "co01".to_string(),
+            ops_manager_pk: Pubkey::default(),
         };
         let (pda_pubkey, _bump_seed) = get_link_pda(&client.get_program_id(), 1);
         let (pda_pubkey2, _bump_seed) = get_link_pda(&client.get_program_id(), 2);

--- a/smartcontract/programs/doublezero-serviceability/README.md
+++ b/smartcontract/programs/doublezero-serviceability/README.md
@@ -61,6 +61,7 @@ classDiagram
         ContributorStatus status
         Pubkey ata_owner_pk
         String code
+        Pubkey ops_manager_pk
     }
     class Device {
         AccountType account_type
@@ -228,7 +229,7 @@ stateDiagram-v2
 
 ## Contributor
 
-Network Contributors are responsible for administering devices and tunnels in the DoubleZero network. These users expand and maintain the network by adding and managing hardware and connectivity. 
+Network Contributors are responsible for administering devices and tunnels in the DoubleZero network. These users expand and maintain the network by adding and managing hardware and connectivity.
 
 ```mermaid
 stateDiagram-v2

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -909,6 +909,7 @@ mod tests {
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code: Some("test".to_string()),
                 owner: Some(Pubkey::new_unique()),
+                ops_manager_pk: Some(Pubkey::new_unique()),
             }),
             "UpdateContributor",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
@@ -98,6 +98,7 @@ pub fn process_create_contributor(
         bump_seed,
         code,
         status: ContributorStatus::Activated,
+        ops_manager_pk: Pubkey::default(),
     };
 
     let deposit = Rent::get()

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
@@ -16,11 +16,16 @@ use std::fmt;
 pub struct ContributorUpdateArgs {
     pub code: Option<String>,
     pub owner: Option<Pubkey>,
+    pub ops_manager_pk: Option<Pubkey>,
 }
 
 impl fmt::Debug for ContributorUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "code: {:?}, owner: {:?}", self.code, self.owner)
+        write!(
+            f,
+            "code: {:?}, owner: {:?}, ops_manager_pk: {:?}",
+            self.code, self.owner, self.ops_manager_pk
+        )
     }
 }
 
@@ -76,7 +81,9 @@ pub fn process_update_contributor(
     if let Some(ref owner) = value.owner {
         contributor.owner = *owner;
     }
-
+    if let Some(ref ops_manager_pk) = value.ops_manager_pk {
+        contributor.ops_manager_pk = *ops_manager_pk;
+    }
     account_write(
         contributor_account,
         &contributor,

--- a/smartcontract/programs/doublezero-serviceability/src/state/contributor.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/contributor.rs
@@ -84,14 +84,20 @@ pub struct Contributor {
     pub status: ContributorStatus, // 1
     pub code: String,              // 4 + len
     pub reference_count: u32,      // 4
+    pub ops_manager_pk: Pubkey,    // 32
 }
 
 impl fmt::Display for Contributor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "account_type: {}, owner: {}, index: {}, bump_seed: {}, code: {}",
-            self.account_type, self.owner, self.index, self.bump_seed, self.code
+            "account_type: {}, owner: {}, index: {}, bump_seed: {}, code: {}, ops_manager_pk: {}",
+            self.account_type,
+            self.owner,
+            self.index,
+            self.bump_seed,
+            self.code,
+            self.ops_manager_pk
         )
     }
 }
@@ -101,7 +107,7 @@ impl AccountTypeInfo for Contributor {
         SEED_CONTRIBUTOR
     }
     fn size(&self) -> usize {
-        1 + 32 + 16 + 1 + 1 + 4 + self.code.len() + 4
+        1 + 32 + 16 + 1 + 1 + 4 + self.code.len() + 4 + 32
     }
     fn bump_seed(&self) -> u8 {
         self.bump_seed
@@ -126,6 +132,7 @@ impl TryFrom<&[u8]> for Contributor {
             status: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             code: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             reference_count: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            ops_manager_pk: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::Contributor {
@@ -198,6 +205,7 @@ mod tests {
         assert_eq!(val.status, ContributorStatus::None);
         assert_eq!(val.code, "");
         assert_eq!(val.reference_count, 0);
+        assert_eq!(val.ops_manager_pk, Pubkey::default());
     }
 
     #[test]
@@ -210,6 +218,7 @@ mod tests {
             reference_count: 0,
             status: ContributorStatus::Activated,
             code: "test".to_string(),
+            ops_manager_pk: Pubkey::new_unique(),
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -238,6 +247,7 @@ mod tests {
             reference_count: 0,
             status: ContributorStatus::Activated,
             code: "test".to_string(),
+            ops_manager_pk: Pubkey::new_unique(),
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -254,6 +264,7 @@ mod tests {
             reference_count: 0,
             status: ContributorStatus::Activated,
             code: "a".repeat(33), // More than 32
+            ops_manager_pk: Pubkey::new_unique(),
         };
         let err = val.validate();
         assert!(err.is_err());

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -72,6 +72,7 @@ async fn test_contributor() {
     assert_eq!(contributor_la.account_type, AccountType::Contributor);
     assert_eq!(contributor_la.code, "la".to_string());
     assert_eq!(contributor_la.status, ContributorStatus::Activated);
+    assert_eq!(contributor_la.ops_manager_pk, Pubkey::default());
 
     println!("✅ Contributor initialized successfully",);
     /*****************************************************************************************************************************************************/
@@ -124,6 +125,7 @@ async fn test_contributor() {
     println!("✅ Contributor resumed");
     /*****************************************************************************************************************************************************/
     println!("Testing Contributor update...");
+    let ops_manager_pk = Pubkey::new_unique();
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -131,6 +133,7 @@ async fn test_contributor() {
         DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
             code: Some("la2".to_string()),
             owner: Some(Pubkey::new_unique()),
+            ops_manager_pk: Some(ops_manager_pk),
         }),
         vec![
             AccountMeta::new(contributor_pubkey, false),
@@ -148,6 +151,7 @@ async fn test_contributor() {
     assert_eq!(contributor_la.account_type, AccountType::Contributor);
     assert_eq!(contributor_la.code, "la2".to_string());
     assert_eq!(contributor_la.status, ContributorStatus::Activated);
+    assert_eq!(contributor_la.ops_manager_pk, ops_manager_pk);
 
     println!("✅ Contributor updated");
     /*****************************************************************************************************************************************************/

--- a/smartcontract/sdk/rs/src/commands/contributor/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/delete.rs
@@ -74,6 +74,7 @@ mod tests {
             status: ContributorStatus::Activated,
             reference_count: 0,
             owner: Pubkey::default(),
+            ops_manager_pk: Pubkey::default(),
         };
 
         client

--- a/smartcontract/sdk/rs/src/commands/contributor/get.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/get.rs
@@ -59,6 +59,7 @@ mod tests {
         let mut client = create_test_client();
 
         let contributor_pubkey = Pubkey::new_unique();
+        let ops_manager_pk = Pubkey::new_unique();
         let contributor = Contributor {
             account_type: AccountType::Contributor,
             index: 1,
@@ -67,6 +68,7 @@ mod tests {
             code: "contributor_code".to_string(),
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
+            ops_manager_pk,
         };
 
         let contributor2 = contributor.clone();
@@ -93,7 +95,9 @@ mod tests {
         .execute(&client);
 
         assert!(res.is_ok());
-        assert_eq!(res.unwrap().1.code, "contributor_code".to_string());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "contributor_code".to_string());
+        assert_eq!(res.1.ops_manager_pk, ops_manager_pk);
 
         // Search by code
         let res = GetContributorCommand {
@@ -102,7 +106,9 @@ mod tests {
         .execute(&client);
 
         assert!(res.is_ok());
-        assert_eq!(res.unwrap().1.code, "contributor_code".to_string());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "contributor_code".to_string());
+        assert_eq!(res.1.ops_manager_pk, ops_manager_pk);
 
         // Invalid search
         let res = GetContributorCommand {

--- a/smartcontract/sdk/rs/src/commands/contributor/list.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/list.rs
@@ -45,6 +45,7 @@ mod tests {
         let mut client = create_test_client();
 
         let contributor1_pubkey = Pubkey::new_unique();
+        let ops_manager_pk1 = Pubkey::new_unique();
         let contributor1 = Contributor {
             account_type: AccountType::Contributor,
             index: 1,
@@ -53,9 +54,11 @@ mod tests {
             code: "contributor1_code".to_string(),
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
+            ops_manager_pk: ops_manager_pk1,
         };
 
         let contributor2_pubkey = Pubkey::new_unique();
+        let ops_manager_pk2 = Pubkey::new_unique();
         let contributor2 = Contributor {
             account_type: AccountType::Contributor,
             index: 1,
@@ -64,6 +67,7 @@ mod tests {
             code: "contributor2_code".to_string(),
             status: ContributorStatus::Activated,
             owner: Pubkey::new_unique(),
+            ops_manager_pk: ops_manager_pk2,
         };
 
         client
@@ -89,5 +93,13 @@ mod tests {
         let list = res.unwrap();
         assert!(list.len() == 2);
         assert!(list.contains_key(&contributor1_pubkey));
+        assert_eq!(
+            list.get(&contributor1_pubkey).unwrap().ops_manager_pk,
+            ops_manager_pk1
+        );
+        assert_eq!(
+            list.get(&contributor2_pubkey).unwrap().ops_manager_pk,
+            ops_manager_pk2
+        );
     }
 }

--- a/smartcontract/sdk/rs/src/commands/contributor/update.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/update.rs
@@ -10,6 +10,7 @@ pub struct UpdateContributorCommand {
     pub pubkey: Pubkey,
     pub code: Option<String>,
     pub owner: Option<Pubkey>,
+    pub ops_manager_pk: Option<Pubkey>,
 }
 
 impl UpdateContributorCommand {
@@ -28,6 +29,7 @@ impl UpdateContributorCommand {
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code,
                 owner: self.owner.to_owned(),
+                ops_manager_pk: self.ops_manager_pk.to_owned(),
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -65,6 +67,7 @@ mod tests {
                     ContributorUpdateArgs {
                         code: Some("test".to_string()),
                         owner: Some(Pubkey::default()),
+                        ops_manager_pk: Some(Pubkey::default()),
                     },
                 )),
                 predicate::eq(vec![
@@ -78,6 +81,7 @@ mod tests {
             pubkey: pda_pubkey,
             code: Some("test".to_string()),
             owner: Some(Pubkey::default()),
+            ops_manager_pk: Some(Pubkey::default()),
         }
         .execute(&client);
 


### PR DESCRIPTION
## Summary of Changes
- Add `contributor.ops_manager_key` for authorizing incident management operations.
- Add support for updating `contributor.ops_manager_key` via CLI.
- This key is only used by offchain processes to authorize incident management operations. It may be used for authorizing related onchain operations in the future.
- This addition is backward compatible and will default to an empty pubkey when deserializing previous versions of the state.
- Related to https://github.com/malbeclabs/doublezero/pull/2108

## Testing Verification
- Updated existing test coverage to include ops manager key expectations.
