### PR TITLE
feat(doublezero-cli): add support to load keypair via stdin

### DIFF
--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -39,7 +39,7 @@ use std::{
 
 use crate::{
     config::*, doublezeroclient::DoubleZeroClient, dztransaction::DZTransaction,
-    rpckeyedaccount_decode::rpckeyedaccount_decode, utils::*, AccountData,
+    keypair::load_keypair, rpckeyedaccount_decode::rpckeyedaccount_decode, AccountData,
 };
 
 pub struct DZClient {
@@ -65,7 +65,9 @@ impl DZClient {
             convert_ws_moniker(websocket_url.unwrap_or(config.websocket_url.unwrap_or(ws_url)));
 
         let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
-        let payer = read_keypair_from_file(keypair.unwrap_or(config.keypair_path)).ok();
+        let payer = load_keypair(keypair, None, config.keypair_path)
+            .ok()
+            .map(|r| r.keypair);
 
         let program_id = match program_id {
             None => match config.program_id.as_ref() {

--- a/smartcontract/sdk/rs/src/keypair/error.rs
+++ b/smartcontract/sdk/rs/src/keypair/error.rs
@@ -1,0 +1,59 @@
+use thiserror::Error;
+
+/// Error type for keypair loading operations.
+#[derive(Debug, Error)]
+pub enum KeypairLoadError {
+    /// No keypair source was available
+    #[error("No keypair source available. Tried:\n{}\n\nHint: Provide keypair via:\n  - doublezero --keypair /path/to/key.json\n  - cat key.json | doublezero ...\n  - export DOUBLEZERO_KEYPAIR=/path/to/key.json", format_attempted(.attempted))]
+    NoSourceAvailable {
+        /// List of sources that were attempted
+        attempted: Vec<String>,
+    },
+
+    /// Failed to read keypair from stdin
+    #[error("Failed to read keypair from stdin: {message}")]
+    StdinReadError {
+        /// Error message
+        message: String,
+    },
+
+    /// Failed to read keypair file
+    #[error("Failed to read keypair file '{path}': {message}")]
+    FileReadError {
+        /// Path that was attempted
+        path: String,
+        /// Error message
+        message: String,
+    },
+
+    /// Invalid JSON format in keypair data
+    #[error("Invalid keypair JSON format from {origin}: {message}")]
+    InvalidJsonFormat {
+        /// Source description
+        origin: String,
+        /// Error message
+        message: String,
+    },
+
+    /// Invalid keypair bytes (not 64 bytes)
+    #[error("Invalid keypair bytes from {origin}: expected 64 bytes")]
+    InvalidKeypairBytes {
+        /// Source description
+        origin: String,
+    },
+
+    /// Stdin is a TTY, cannot read interactively
+    #[error(
+        "Stdin is a TTY - cannot read keypair interactively. Pipe keypair JSON via stdin or use --keypair"
+    )]
+    StdinIsTty,
+}
+
+fn format_attempted(attempted: &[String]) -> String {
+    attempted
+        .iter()
+        .enumerate()
+        .map(|(i, s)| format!("  {}. {}", i + 1, s))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/smartcontract/sdk/rs/src/keypair/loader.rs
+++ b/smartcontract/sdk/rs/src/keypair/loader.rs
@@ -1,0 +1,295 @@
+use solana_sdk::signature::Keypair;
+use std::{
+    env, fs,
+    io::{IsTerminal, Read},
+    path::PathBuf,
+};
+
+use super::{error::KeypairLoadError, source::KeypairSource};
+
+/// Environment variable name for keypair (can be JSON content or file path)
+pub const ENV_KEYPAIR: &str = "DOUBLEZERO_KEYPAIR";
+
+/// Result of loading a keypair, including provenance information
+pub struct KeypairLoadResult {
+    /// The loaded keypair
+    pub keypair: Keypair,
+    /// The source from which the keypair was loaded
+    pub source: KeypairSource,
+}
+
+/// Check if a string value looks like JSON keypair content (starts with '[' and ends with ']')
+pub fn is_keypair_json_content(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.starts_with('[') && trimmed.ends_with(']')
+}
+
+/// Parse keypair from JSON string
+pub fn parse_keypair_json(json_str: &str, source_desc: &str) -> Result<Keypair, KeypairLoadError> {
+    let secret_key_bytes: Vec<u8> =
+        serde_json::from_str(json_str).map_err(|e| KeypairLoadError::InvalidJsonFormat {
+            origin: source_desc.to_string(),
+            message: e.to_string(),
+        })?;
+
+    Keypair::from_bytes(&secret_key_bytes).map_err(|_| KeypairLoadError::InvalidKeypairBytes {
+        origin: source_desc.to_string(),
+    })
+}
+
+/// Read keypair from a file path
+fn read_keypair_from_path(path: &PathBuf) -> Result<Keypair, KeypairLoadError> {
+    let content = fs::read_to_string(path).map_err(|e| KeypairLoadError::FileReadError {
+        path: path.display().to_string(),
+        message: e.to_string(),
+    })?;
+
+    parse_keypair_json(&content, &path.display().to_string())
+}
+
+/// Read keypair from stdin
+fn read_keypair_from_stdin() -> Result<Keypair, KeypairLoadError> {
+    if std::io::stdin().is_terminal() {
+        return Err(KeypairLoadError::StdinIsTty);
+    }
+
+    let mut buffer = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buffer)
+        .map_err(|e| KeypairLoadError::StdinReadError {
+            message: e.to_string(),
+        })?;
+
+    if buffer.trim().is_empty() {
+        return Err(KeypairLoadError::StdinReadError {
+            message: "stdin was empty".to_string(),
+        });
+    }
+
+    parse_keypair_json(&buffer, "stdin")
+}
+
+/// Read keypair from environment variable
+fn read_keypair_from_env() -> Result<(Keypair, bool), KeypairLoadError> {
+    let value = env::var(ENV_KEYPAIR).map_err(|_| KeypairLoadError::NoSourceAvailable {
+        attempted: vec![format!("Env {} not set", ENV_KEYPAIR)],
+    })?;
+
+    if is_keypair_json_content(&value) {
+        let keypair = parse_keypair_json(&value, &format!("{} (JSON)", ENV_KEYPAIR))?;
+        Ok((keypair, true))
+    } else {
+        let path = PathBuf::from(&value);
+        let keypair = read_keypair_from_path(&path)?;
+        Ok((keypair, false))
+    }
+}
+
+/// Load keypair following the precedence chain:
+/// 1. CLI argument (--keypair)
+/// 2. Environment variable (DOUBLEZERO_KEYPAIR)
+/// 3. Stdin (if not a TTY)
+/// 4. Config file keypair_path
+/// 5. Default path (~/.config/doublezero/id.json)
+///
+/// # Arguments
+/// * `cli_path` - Optional path from CLI --keypair argument
+/// * `config_path` - Optional path from config file
+/// * `default_path` - Default path if no other source available
+///
+/// # Returns
+/// * `Ok(KeypairLoadResult)` - Successfully loaded keypair with source
+/// * `Err(KeypairLoadError)` - Failed to load keypair from any source
+pub fn load_keypair(
+    cli_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+    default_path: PathBuf,
+) -> Result<KeypairLoadResult, KeypairLoadError> {
+    let mut attempted: Vec<String> = Vec::new();
+
+    // 1. Try CLI argument (highest precedence)
+    if let Some(path) = cli_path {
+        match read_keypair_from_path(&path) {
+            Ok(keypair) => {
+                return Ok(KeypairLoadResult {
+                    keypair,
+                    source: KeypairSource::CliArgument(path),
+                });
+            }
+            Err(e) => {
+                attempted.push(format!("CLI --keypair ({}): {}", path.display(), e));
+            }
+        }
+    } else {
+        attempted.push("CLI --keypair: not provided".to_string());
+    }
+
+    // 2. Try environment variable
+    match read_keypair_from_env() {
+        Ok((keypair, is_json)) => {
+            return Ok(KeypairLoadResult {
+                keypair,
+                source: KeypairSource::EnvVar { is_json },
+            });
+        }
+        Err(KeypairLoadError::NoSourceAvailable { .. }) => {
+            attempted.push(format!("Env {}: not set", ENV_KEYPAIR));
+        }
+        Err(e) => {
+            attempted.push(format!("Env {}: {}", ENV_KEYPAIR, e));
+        }
+    }
+
+    // 3. Try stdin (if not a TTY)
+    match read_keypair_from_stdin() {
+        Ok(keypair) => {
+            return Ok(KeypairLoadResult {
+                keypair,
+                source: KeypairSource::Stdin,
+            });
+        }
+        Err(KeypairLoadError::StdinIsTty) => {
+            attempted.push("Stdin: is a TTY (not piped)".to_string());
+        }
+        Err(e) => {
+            attempted.push(format!("Stdin: {}", e));
+        }
+    }
+
+    // 4. Try config file path
+    if let Some(path) = config_path {
+        match read_keypair_from_path(&path) {
+            Ok(keypair) => {
+                return Ok(KeypairLoadResult {
+                    keypair,
+                    source: KeypairSource::ConfigFile(path),
+                });
+            }
+            Err(e) => {
+                attempted.push(format!("Config keypair_path ({}): {}", path.display(), e));
+            }
+        }
+    }
+
+    // 5. Try default path
+    match read_keypair_from_path(&default_path) {
+        Ok(keypair) => {
+            return Ok(KeypairLoadResult {
+                keypair,
+                source: KeypairSource::DefaultPath(default_path),
+            });
+        }
+        Err(e) => {
+            attempted.push(format!("Default path ({}): {}", default_path.display(), e));
+        }
+    }
+
+    Err(KeypairLoadError::NoSourceAvailable { attempted })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::signer::Signer;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_test_keypair_file(dir: &TempDir) -> (PathBuf, Keypair) {
+        let keypair = Keypair::new();
+        let path = dir.path().join("test-keypair.json");
+        let json = serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap();
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+        (path, keypair)
+    }
+
+    #[test]
+    fn test_is_keypair_json_content() {
+        assert!(is_keypair_json_content("[1,2,3,4,5]"));
+        assert!(is_keypair_json_content("  [1,2,3,4,5]  "));
+        assert!(is_keypair_json_content("\n[1,2,3]\n"));
+        assert!(!is_keypair_json_content("/path/to/file.json"));
+        assert!(!is_keypair_json_content("~/.config/solana/id.json"));
+        assert!(!is_keypair_json_content(""));
+    }
+
+    #[test]
+    fn test_parse_keypair_json_valid() {
+        let keypair = Keypair::new();
+        let json = serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap();
+        let parsed = parse_keypair_json(&json, "test").unwrap();
+        assert_eq!(parsed.pubkey(), keypair.pubkey());
+    }
+
+    #[test]
+    fn test_parse_keypair_json_invalid() {
+        let result = parse_keypair_json("not json", "test");
+        assert!(matches!(
+            result,
+            Err(KeypairLoadError::InvalidJsonFormat { .. })
+        ));
+    }
+
+    #[test]
+    fn test_read_keypair_from_path() {
+        let tmp = TempDir::new().unwrap();
+        let (path, original) = create_test_keypair_file(&tmp);
+
+        let loaded = read_keypair_from_path(&path).unwrap();
+        assert_eq!(loaded.pubkey(), original.pubkey());
+    }
+
+    #[test]
+    fn test_read_keypair_from_path_not_found() {
+        let path = PathBuf::from("/nonexistent/path/keypair.json");
+        let result = read_keypair_from_path(&path);
+        assert!(matches!(
+            result,
+            Err(KeypairLoadError::FileReadError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_load_keypair_cli_path_precedence() {
+        let tmp = TempDir::new().unwrap();
+        let (cli_path, cli_keypair) = create_test_keypair_file(&tmp);
+
+        let config_path = tmp.path().join("config-keypair.json");
+        let default_path = tmp.path().join("default-keypair.json");
+
+        let result = load_keypair(Some(cli_path.clone()), Some(config_path), default_path).unwrap();
+
+        assert_eq!(result.keypair.pubkey(), cli_keypair.pubkey());
+        assert!(matches!(result.source, KeypairSource::CliArgument(_)));
+    }
+
+    #[test]
+    fn test_load_keypair_default_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let (default_path, default_keypair) = create_test_keypair_file(&tmp);
+
+        // Clear env var to ensure it doesn't interfere
+        env::remove_var(ENV_KEYPAIR);
+
+        let result = load_keypair(None, None, default_path).unwrap();
+
+        assert_eq!(result.keypair.pubkey(), default_keypair.pubkey());
+        assert!(matches!(result.source, KeypairSource::DefaultPath(_)));
+    }
+
+    #[test]
+    fn test_load_keypair_no_source_available() {
+        let tmp = TempDir::new().unwrap();
+
+        // Clear env var
+        env::remove_var(ENV_KEYPAIR);
+
+        let nonexistent = tmp.path().join("nonexistent.json");
+        let result = load_keypair(None, None, nonexistent);
+
+        assert!(matches!(
+            result,
+            Err(KeypairLoadError::NoSourceAvailable { .. })
+        ));
+    }
+}

--- a/smartcontract/sdk/rs/src/keypair/mod.rs
+++ b/smartcontract/sdk/rs/src/keypair/mod.rs
@@ -1,0 +1,46 @@
+//! Keypair loading module with support for multiple input sources.
+//!
+//! This module provides flexible keypair loading with the following precedence:
+//! 1. CLI argument (`--keypair /path/to/key.json`)
+//! 2. Environment variable (`DOUBLEZERO_KEYPAIR` - can be JSON or file path)
+//! 3. Stdin (if piped, not a TTY)
+//! 4. Config file `keypair_path`
+//! 5. Default path (`~/.config/doublezero/id.json`)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use doublezero_sdk::keypair::{load_keypair, KeypairSource, ENV_KEYPAIR};
+//! use std::path::PathBuf;
+//!
+//! let result = load_keypair(
+//!     Some(PathBuf::from("/path/from/cli")),
+//!     Some(PathBuf::from("/path/from/config")),
+//!     PathBuf::from("~/.config/doublezero/id.json"),
+//! );
+//!
+//! match result {
+//!     Ok(result) => {
+//!         println!("Loaded keypair from: {}", result.source);
+//!     }
+//!     Err(e) => eprintln!("Failed to load keypair: {}", e),
+//! }
+//! ```
+//!
+//! # Environment Variable
+//!
+//! The `DOUBLEZERO_KEYPAIR` environment variable can contain either:
+//! - A file path: `export DOUBLEZERO_KEYPAIR=/path/to/key.json`
+//! - Raw JSON: `export DOUBLEZERO_KEYPAIR='[1,2,3,...,64 bytes]'`
+//!
+//! The loader auto-detects which format is used.
+
+mod error;
+mod loader;
+mod source;
+
+pub use error::KeypairLoadError;
+pub use loader::{
+    is_keypair_json_content, load_keypair, parse_keypair_json, KeypairLoadResult, ENV_KEYPAIR,
+};
+pub use source::KeypairSource;

--- a/smartcontract/sdk/rs/src/keypair/source.rs
+++ b/smartcontract/sdk/rs/src/keypair/source.rs
@@ -1,0 +1,35 @@
+use std::{fmt, path::PathBuf};
+
+/// Represents the source from which a keypair was loaded.
+/// Used for provenance tracking and debugging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeypairSource {
+    /// Keypair loaded from CLI argument (highest precedence)
+    CliArgument(PathBuf),
+    /// Keypair loaded from DOUBLEZERO_KEYPAIR environment variable
+    EnvVar {
+        /// Whether the env var contained raw JSON or a file path
+        is_json: bool,
+    },
+    /// Keypair loaded from stdin (piped input)
+    Stdin,
+    /// Keypair loaded from config file keypair_path
+    ConfigFile(PathBuf),
+    /// Keypair loaded from default path
+    DefaultPath(PathBuf),
+}
+
+impl fmt::Display for KeypairSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CliArgument(path) => write!(f, "CLI argument ({})", path.display()),
+            Self::EnvVar { is_json: true } => {
+                write!(f, "DOUBLEZERO_KEYPAIR env var (JSON content)")
+            }
+            Self::EnvVar { is_json: false } => write!(f, "DOUBLEZERO_KEYPAIR env var (file path)"),
+            Self::Stdin => write!(f, "stdin"),
+            Self::ConfigFile(path) => write!(f, "config file ({})", path.display()),
+            Self::DefaultPath(path) => write!(f, "default path ({})", path.display()),
+        }
+    }
+}

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -37,6 +37,7 @@ mod errors;
 
 pub mod commands;
 pub mod doublezeroclient;
+pub mod keypair;
 pub mod record;
 pub mod rpckeyedaccount_decode;
 pub mod telemetry;

--- a/smartcontract/sdk/rs/src/utils.rs
+++ b/smartcontract/sdk/rs/src/utils.rs
@@ -1,11 +1,21 @@
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-use std::{error::Error, fs, path::PathBuf, str::FromStr};
+use std::{error::Error, path::PathBuf, str::FromStr};
 
+use crate::keypair::parse_keypair_json;
+
+/// Read a keypair from a JSON file.
+///
+/// # Deprecated
+/// Use [`crate::keypair::load_keypair`] instead, which supports stdin and
+/// environment variable input in addition to file paths.
+#[deprecated(
+    since = "0.8.0",
+    note = "Use crate::keypair::load_keypair instead for stdin/env var support"
+)]
 pub fn read_keypair_from_file(file: PathBuf) -> eyre::Result<Keypair, Box<dyn Error>> {
-    let file_content = fs::read_to_string(file)?;
-    let secret_key_bytes: Vec<u8> = serde_json::from_str(&file_content)?;
-    let keypair = Keypair::from_bytes(&secret_key_bytes)?;
-
+    let file_content = std::fs::read_to_string(&file)?;
+    let keypair = parse_keypair_json(&file_content, &file.display().to_string())
+        .map_err(|e| Box::new(e) as Box<dyn Error>)?;
     Ok(keypair)
 }
 


### PR DESCRIPTION
# Summary

Enables "keyless operations" for validators by supporting keypair input via stdin and environment variables, allowing integration with secret managers (Vault, AWS Secrets Manager) without storing keys on disk.

Fixes: https://github.com/malbeclabs/doublezero/issues/2305

## Changes

### New keypair module

- Add `load_keypair()` with 5-step precedence: CLI → env var → stdin → config → default
- Add `KeypairSource` enum for provenance tracking
- Add `KeypairLoadError` with detailed error messages
- Add `ENV_KEYPAIR` constant (`DOUBLEZERO_KEYPAIR`)

### SDK updates

- Update `DZClient::new()` to use `load_keypair()`
- Deprecate `read_keypair_from_file()` in `utils.rs`
- Export new keypair module from lib.rs

### CLI updates

- Rename `has_keypair_argument()` → `has_keypair_source()`
- Skip pre-flight file check when env var set or stdin piped
- Update error message to list all input options

## Usage

```
# Stdin
$ cat key.json | doublezero address

# Env var (file path)
$ export DOUBLEZERO_KEYPAIR=/path/to/key.json

# Env var (JSON content)
$ export DOUBLEZERO_KEYPAIR='[1,2,3,...64 bytes]'
```

## Examples

```bash
# Nothing set
$ cargo run -p doublezero -- address
warning: doublezero-telemetry@0.7.1: Environment: localnet
warning: doublezero-telemetry@0.7.1: Serviceability Program ID: 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/doublezero address`
DoubleZero keypair not found at default location (~/.config/doublezero/id.json)
Error: Provide keypair via:
  - doublezero --keypair /path/to/key.json
  - cat key.json | doublezero ...
  - export DOUBLEZERO_KEYPAIR=/path/to/key.json
  - doublezero keygen

# Env var exported
$ export DOUBLEZERO_KEYPAIR="/Users/rahul/.config/solana/id.json"
$ cargo run -p doublezero -- address
warning: doublezero-telemetry@0.7.1: Environment: localnet
warning: doublezero-telemetry@0.7.1: Serviceability Program ID: 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/doublezero address`
95erE5VsQDZdvCBSFPT4vJZaX62cxesFwDVeYmudAyXZ

# Unset env var (back to error)
$ unset DOUBLEZERO_KEYPAIR
$ echo $DOUBLEZERO_KEYPAIR
$ cargo run -p doublezero -- address
warning: doublezero-telemetry@0.7.1: Environment: localnet
warning: doublezero-telemetry@0.7.1: Serviceability Program ID: 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/doublezero address`
DoubleZero keypair not found at default location (~/.config/doublezero/id.json)
Error: Provide keypair via:
  - doublezero --keypair /path/to/key.json
  - cat key.json | doublezero ...
  - export DOUBLEZERO_KEYPAIR=/path/to/key.json
  - doublezero keygen

# stdin redirect (no env var set)
$ cat /Users/rahul/.config/solana/id.json | cargo run -p doublezero -- address
warning: doublezero-telemetry@0.7.1: Environment: localnet
warning: doublezero-telemetry@0.7.1: Serviceability Program ID: 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/doublezero address`
95erE5VsQDZdvCBSFPT4vJZaX62cxesFwDVeYmudAyXZ
```
