### PR TITLE
tools/solana: add tpu quic conn helper and use for ping tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/joho/godotenv v1.5.1
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/jwhited/corebgp v0.8.5
 	github.com/klauspost/compress v1.18.1
 	github.com/lmittmann/tint v1.1.2
@@ -34,6 +35,7 @@ require (
 	github.com/prometheus/common v0.67.4
 	github.com/quic-go/quic-go v0.57.0
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.40.0
@@ -122,7 +124,6 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=

--- a/tools/solana/pkg/tpu-quic/conn.go
+++ b/tools/solana/pkg/tpu-quic/conn.go
@@ -1,0 +1,205 @@
+package tpuquic
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+const (
+	ALPNTPUProtocolID = "solana-tpu"
+	DefaultCommonName = "Solana node"
+)
+
+var (
+	DefaultSrc = net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 0}
+)
+
+type DialConfig struct {
+	Interface string
+	Src       string
+
+	MaxIdleTimeout       time.Duration
+	HandshakeIdleTimeout time.Duration
+	KeepAlivePeriod      time.Duration
+}
+
+func (cfg *DialConfig) Validate() error {
+	if cfg.Src == "" {
+		cfg.Src = DefaultSrc.String()
+	}
+	return nil
+}
+
+type Conn struct {
+	srcConn  *net.UDPConn
+	dialConn *quic.Conn
+}
+
+func Dial(ctx context.Context, dst string, cfg *DialConfig) (*Conn, error) {
+	if cfg == nil {
+		cfg = &DialConfig{}
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate dial config: %w", err)
+	}
+
+	// Resolve destination UDP address
+	dstAddr, err := net.ResolveUDPAddr("udp", dst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve remote addr %s: %w", dst, err)
+	}
+
+	// Resolve source UDP address
+	srcAddr, err := net.ResolveUDPAddr("udp", cfg.Src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve local addr %s: %w", cfg.Src, err)
+	}
+
+	// Bind our own UDP socket
+	srcConn, err := net.ListenUDP("udp", srcAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", srcAddr, err)
+	}
+
+	// Bind to interface if specified
+	if cfg.Interface != "" {
+		if err := bindToDevice(srcConn, cfg.Interface); err != nil {
+			return nil, fmt.Errorf("failed to bind to device %s: %w", cfg.Interface, err)
+		}
+	}
+
+	// Create TLS config
+	tlsConfig, err := createTlsConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS config: %w", err)
+	}
+
+	// Dial QUIC session
+	conn, err := quic.Dial(ctx, srcConn, dstAddr, tlsConfig, &quic.Config{
+		MaxIdleTimeout:       cfg.MaxIdleTimeout,
+		HandshakeIdleTimeout: cfg.HandshakeIdleTimeout,
+		KeepAlivePeriod:      cfg.KeepAlivePeriod,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s from %s: %w", dstAddr, srcAddr, err)
+	}
+
+	return &Conn{
+		dialConn: conn,
+		srcConn:  srcConn,
+	}, nil
+}
+
+func (c *Conn) ConnectionStats() quic.ConnectionStats {
+	return c.dialConn.ConnectionStats()
+}
+
+func (c *Conn) IsClosed() bool {
+	select {
+	case <-c.dialConn.Context().Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Conn) Context() context.Context {
+	return c.dialConn.Context()
+}
+
+func (c *Conn) LocalAddr() net.Addr {
+	return c.dialConn.LocalAddr()
+}
+
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.dialConn.RemoteAddr()
+}
+
+func (c *Conn) Close() error {
+	if c.dialConn == nil {
+		if c.srcConn != nil {
+			return c.srcConn.Close()
+		}
+		return nil
+	}
+	err := c.dialConn.CloseWithError(0, "client done")
+	if c.srcConn != nil {
+		srcErr := c.srcConn.Close()
+		if srcErr != nil {
+			err = errors.Join(err, srcErr)
+		}
+	}
+	return err
+}
+
+func createTlsConfig() (*tls.Config, error) {
+	certPem, privPem := newDummyX509Certificate()
+	cert, err := tls.X509KeyPair(certPem, privPem)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{ALPNTPUProtocolID},
+		Certificates:       []tls.Certificate{cert},
+		MinVersion:         tls.VersionTLS13,
+	}, nil
+}
+
+func newDummyX509Certificate() ([]byte, []byte) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
+	if err != nil {
+		return nil, nil
+	}
+
+	tmpl := x509.Certificate{
+		Version:            3,
+		SerialNumber:       serialNumber,
+		Subject:            pkix.Name{CommonName: DefaultCommonName},
+		Issuer:             pkix.Name{CommonName: DefaultCommonName},
+		SignatureAlgorithm: x509.PureEd25519,
+		NotBefore:          time.Date(1975, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:           time.Date(4096, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tmpl.ExtraExtensions = append(tmpl.ExtraExtensions, createSubjectAltNameExtension())
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, publicKey, privateKey)
+	if err != nil {
+		return nil, nil
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+}
+
+func createSubjectAltNameExtension() pkix.Extension {
+	return pkix.Extension{
+		Id:    asn1.ObjectIdentifier{2, 5, 29, 17},
+		Value: []byte{48, 6, 135, 4, 0, 0, 0, 0},
+	}
+}

--- a/tools/solana/pkg/tpu-quic/conn_test.go
+++ b/tools/solana/pkg/tpu-quic/conn_test.go
@@ -1,0 +1,179 @@
+package tpuquic
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTools_Solana_TPUQUICConn_DialConfig_Validate_Defaults(t *testing.T) {
+	t.Parallel()
+
+	var cfg DialConfig
+	require.NoError(t, cfg.Validate())
+
+	require.Equal(t, DefaultSrc.String(), cfg.Src)
+	require.Zero(t, cfg.KeepAlivePeriod)
+}
+
+func TestTools_Solana_TPUQUICConn_Dial_InvalidDst(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "not-a-valid-address", nil)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}
+
+func TestTools_Solana_TPUQUICConn_Dial_InvalidSrc(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := &DialConfig{
+		Src: "invalid-local", // missing port -> net.ResolveUDPAddr should fail
+	}
+
+	conn, err := Dial(ctx, "127.0.0.1:1234", cfg)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}
+
+func TestTools_Solana_TPUQUICConn_Dial_NilConfig_UsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	serverAddrCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		tlsConf, err := createTlsConfig()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		tlsConf.ClientAuth = 0
+
+		quicConf := &quic.Config{
+			MaxIdleTimeout:  time.Second,
+			KeepAlivePeriod: 100 * time.Millisecond,
+		}
+
+		l, err := quic.ListenAddr("127.0.0.1:0", tlsConf, quicConf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer l.Close()
+
+		serverAddrCh <- l.Addr().String()
+
+		// Accept a single connection and then close it; don't wait on Context().
+		sess, err := l.Accept(context.Background())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		_ = sess.CloseWithError(0, "server done")
+	}()
+
+	dst := <-serverAddrCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, dst, nil) // nil cfg -> uses defaults
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// We should be using a UDP local addr and the remote addr should match dst.
+	_, ok := conn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok, "LocalAddr should be *net.UDPAddr")
+	require.Equal(t, dst, conn.RemoteAddr().String())
+
+	// ConnectionStats should be callable without panic.
+	_ = conn.ConnectionStats()
+
+	require.False(t, conn.IsClosed())
+
+	require.NoError(t, conn.Close())
+	require.Eventually(t, func() bool { return conn.IsClosed() }, time.Second, 10*time.Millisecond)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+func TestTools_Solana_TPUQUICConn_Dial_WithExplicitConfig_Success(t *testing.T) {
+	t.Parallel()
+
+	serverAddrCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		tlsConf, err := createTlsConfig()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		tlsConf.ClientAuth = 0
+
+		quicConf := &quic.Config{
+			MaxIdleTimeout:  time.Second,
+			KeepAlivePeriod: 100 * time.Millisecond,
+		}
+
+		l, err := quic.ListenAddr("127.0.0.1:0", tlsConf, quicConf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer l.Close()
+
+		serverAddrCh <- l.Addr().String()
+
+		sess, err := l.Accept(context.Background())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		_ = sess.CloseWithError(0, "server done")
+	}()
+
+	dst := <-serverAddrCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cfg := &DialConfig{
+		Src:                  "0.0.0.0:0",
+		MaxIdleTimeout:       2 * time.Second,
+		HandshakeIdleTimeout: time.Second,
+		KeepAlivePeriod:      200 * time.Millisecond,
+	}
+
+	conn, err := Dial(ctx, dst, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	stats := conn.ConnectionStats()
+	_ = stats
+
+	require.False(t, conn.IsClosed())
+	require.NoError(t, conn.Close())
+	require.Eventually(t, func() bool { return conn.IsClosed() }, time.Second, 10*time.Millisecond)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/tools/solana/pkg/tpu-quic/ping.go
+++ b/tools/solana/pkg/tpu-quic/ping.go
@@ -2,71 +2,42 @@ package tpuquic
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
-	"encoding/pem"
 	"fmt"
-	"io"
 	"log/slog"
-	"math/big"
-	"net"
-	"os"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/quic-go/quic-go"
 )
 
 const (
-	DefaultCount    = 3
-	DefaultInterval = 1 * time.Second
-	DefaultTimeout  = 5 * time.Second
-
-	ALPNTPUProtocolID = "solana-tpu"
-	DefaultCommonName = "Solana node"
-)
-
-var (
-	DefaultSrc = net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 0}
+	DefaultCount           = 3
+	DefaultInterval        = 3 * time.Second
+	DefaultKeepAlivePeriod = 500 * time.Millisecond
 )
 
 type PingConfig struct {
-	Context context.Context
-	Logger  *slog.Logger
+	DialConfig
 
-	// StatsChan that results will be streamed to as they are available.
-	StatsChan chan *quic.ConnectionStats
+	Count    int
+	Interval time.Duration
 
-	Quiet     bool          `json:"quiet"`
-	Count     int           `json:"count"`
-	Interval  time.Duration `json:"interval"`
-	Timeout   time.Duration `json:"timeout"`
-	Interface string        `json:"interface"`
-	Src       string        `json:"src"`
-	Dst       string        `json:"dst"`
+	Clock clockwork.Clock
 }
 
 type PingResult struct {
-	ConnectionStats []*quic.ConnectionStats `json:"connection_stats"`
-	Success         bool                    `json:"success"`
-	Error           error                   `json:"error"`
+	ConnectionStats []quic.ConnectionStats `json:"connection_stats"`
+	Success         bool                   `json:"success"`
+	Error           error                  `json:"error"`
 }
 
 func (cfg *PingConfig) Validate() error {
-	if cfg.Context == nil {
-		cfg.Context = context.Background()
+	if err := cfg.DialConfig.Validate(); err != nil {
+		return fmt.Errorf("failed to validate dial config: %w", err)
 	}
-	if cfg.Logger == nil {
-		var writer io.Writer
-		if cfg.Quiet {
-			writer = io.Discard
-		} else {
-			writer = os.Stdout
-		}
-		cfg.Logger = slog.New(slog.NewTextHandler(writer, nil))
+	if cfg.DialConfig.KeepAlivePeriod == 0 {
+		// This is necessary or else we won't see real stats on the connection.
+		cfg.DialConfig.KeepAlivePeriod = DefaultKeepAlivePeriod
 	}
 	if cfg.Count == 0 {
 		cfg.Count = DefaultCount
@@ -74,184 +45,84 @@ func (cfg *PingConfig) Validate() error {
 	if cfg.Interval == 0 {
 		cfg.Interval = DefaultInterval
 	}
-	if cfg.Timeout == 0 {
-		cfg.Timeout = DefaultTimeout
-	}
-	if cfg.Src == "" {
-		cfg.Src = DefaultSrc.String()
-	}
-	if cfg.Dst == "" {
-		return fmt.Errorf("dst address is required")
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
 	}
 	return nil
 }
 
-func Ping(cfg PingConfig) (*PingResult, error) {
+func Ping(ctx context.Context, log *slog.Logger, dst string, cfg PingConfig) (*PingResult, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate run config: %w", err)
 	}
 
-	log := cfg.Logger
-
-	// Resolve destination UDP address
-	dstAddr, err := net.ResolveUDPAddr("udp", cfg.Dst)
+	conn, err := Dial(ctx, dst, &cfg.DialConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve remote addr %s: %w", cfg.Dst, err)
+		return nil, fmt.Errorf("failed to dial TPU QUIC: %w", err)
 	}
+	defer conn.Close()
 
-	// Resolve source UDP address
-	srcAddr, err := net.ResolveUDPAddr("udp", cfg.Src)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve local addr %s: %w", cfg.Src, err)
-	}
-
-	// Bind our own UDP socket
-	srcConn, err := net.ListenUDP("udp", srcAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on %s: %w", srcAddr, err)
-	}
-	defer srcConn.Close()
-
-	// Bind to interface if specified
-	if cfg.Interface != "" {
-		if err := bindToDevice(srcConn, cfg.Interface); err != nil {
-			return nil, fmt.Errorf("failed to bind to device %s: %w", cfg.Interface, err)
-		}
-	}
-
-	if !cfg.Quiet {
-		log.Info("Connecting via QUIC", "src", srcConn.LocalAddr(), "dst", dstAddr)
-	}
-
-	// Separate context for dial based on configured timeout
-	dialCtx, dialCancel := context.WithTimeout(cfg.Context, cfg.Timeout)
-	defer dialCancel()
-
-	// Create TLS config
-	tlsConfig, err := createTlsConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create TLS config: %w", err)
-	}
-
-	// Dial QUIC session
-	session, err := quic.Dial(dialCtx, srcConn, dstAddr, tlsConfig, &quic.Config{
-		MaxIdleTimeout:       cfg.Timeout,
-		HandshakeIdleTimeout: cfg.Timeout,
-		KeepAlivePeriod:      cfg.Interval,
-	})
-	if err != nil {
-		return &PingResult{
-			Error: fmt.Errorf("failed to connect to %s from %s: %w", dstAddr, srcAddr, err),
-		}, nil
-	}
-	defer func() {
-		_ = session.CloseWithError(0, "client done")
-	}()
-
-	// Start stats ticker loop
-	result := &PingResult{
-		ConnectionStats: make([]*quic.ConnectionStats, 0, cfg.Count),
+	res := &PingResult{
+		ConnectionStats: make([]quic.ConnectionStats, 0, cfg.Count),
 		Success:         true,
 		Error:           nil,
 	}
-	ticker := time.NewTicker(cfg.Interval)
+
+	ticker := NewMaybeTick(cfg.Interval, cfg.Clock)
 	defer ticker.Stop()
-	for i := range cfg.Count {
+
+	for i := 0; i < cfg.Count; i++ {
 		select {
-		case <-cfg.Context.Done():
-			tickConnectionStats(log, i, session, result, &cfg)
-			if !cfg.Quiet {
-				log.Info("Completed QUIC ping session", "count", cfg.Count)
-			}
-			return result, nil
+		case <-ctx.Done():
+			log.Info("QUIC ping cancelled", "count", i+1)
+			stats := conn.ConnectionStats()
+			tick(log, i, stats)
+			res.ConnectionStats = append(res.ConnectionStats, stats)
+			return res, nil
 		case <-ticker.C:
-			tickConnectionStats(log, i, session, result, &cfg)
+			stats := conn.ConnectionStats()
+			tick(log, i, stats)
+			res.ConnectionStats = append(res.ConnectionStats, stats)
 		}
 	}
-	return result, nil
+
+	return res, nil
 }
 
-func tickConnectionStats(log *slog.Logger, i int, session *quic.Conn, result *PingResult, cfg *PingConfig) {
-	stats := session.ConnectionStats()
-	result.ConnectionStats = append(result.ConnectionStats, &stats)
-	if cfg.StatsChan != nil {
-		select {
-		case cfg.StatsChan <- &stats:
-		default:
-		}
+func tick(log *slog.Logger, i int, stats quic.ConnectionStats) {
+	log.Info("QUIC stats",
+		"interval", i+1,
+		"rttMin", stats.MinRTT,
+		"rttLatest", stats.LatestRTT,
+		"rttSmoothed", stats.SmoothedRTT,
+		"rttDev", stats.MeanDeviation,
+		"sentBytes", stats.BytesSent,
+		"sentPackets", stats.PacketsSent,
+		"recvBytes", stats.BytesReceived,
+		"recvPackets", stats.PacketsReceived,
+		"lostBytes", stats.BytesLost,
+		"lostPackets", stats.PacketsLost,
+	)
+}
+
+type MaybeTick struct {
+	C <-chan time.Time
+	t clockwork.Ticker
+}
+
+func NewMaybeTick(d time.Duration, clock clockwork.Clock) *MaybeTick {
+	if d == 0 {
+		return &MaybeTick{C: nil, t: nil}
 	}
-	if !cfg.Quiet {
-		log.Info("QUIC stats",
-			"interval", i+1,
-			"rttMin", stats.MinRTT,
-			"rttLatest", stats.LatestRTT,
-			"rttSmoothed", stats.SmoothedRTT,
-			"rttDev", stats.MeanDeviation,
-			"sentBytes", stats.BytesSent,
-			"sentPackets", stats.PacketsSent,
-			"recvBytes", stats.BytesReceived,
-			"recvPackets", stats.PacketsReceived,
-			"lostBytes", stats.BytesLost,
-			"lostPackets", stats.PacketsLost,
-		)
+	t := clock.NewTicker(d)
+	return &MaybeTick{
+		C: t.Chan(),
+		t: t,
 	}
 }
 
-func createTlsConfig() (*tls.Config, error) {
-	certPem, privPem := newDummyX509Certificate()
-	cert, err := tls.X509KeyPair(certPem, privPem)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tls.Config{
-		InsecureSkipVerify: true,
-		NextProtos:         []string{ALPNTPUProtocolID},
-		Certificates:       []tls.Certificate{cert},
-		MinVersion:         tls.VersionTLS13,
-	}, nil
-}
-
-func newDummyX509Certificate() ([]byte, []byte) {
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return nil, nil
-	}
-
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
-	if err != nil {
-		return nil, nil
-	}
-
-	tmpl := x509.Certificate{
-		Version:            3,
-		SerialNumber:       serialNumber,
-		Subject:            pkix.Name{CommonName: DefaultCommonName},
-		Issuer:             pkix.Name{CommonName: DefaultCommonName},
-		SignatureAlgorithm: x509.PureEd25519,
-		NotBefore:          time.Date(1975, time.January, 1, 0, 0, 0, 0, time.UTC),
-		NotAfter:           time.Date(4096, time.January, 1, 0, 0, 0, 0, time.UTC),
-	}
-
-	tmpl.ExtraExtensions = append(tmpl.ExtraExtensions, createSubjectAltNameExtension())
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, publicKey, privateKey)
-	if err != nil {
-		return nil, nil
-	}
-
-	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		return nil, nil
-	}
-
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
-		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
-}
-
-func createSubjectAltNameExtension() pkix.Extension {
-	return pkix.Extension{
-		Id:    asn1.ObjectIdentifier{2, 5, 29, 17},
-		Value: []byte{48, 6, 135, 4, 0, 0, 0, 0},
+func (m *MaybeTick) Stop() {
+	if m.t != nil {
+		m.t.Stop()
 	}
 }


### PR DESCRIPTION
## Summary of Changes
- Add a TPU-QUIC connection helper and use it for the ping tool. This better supports the use case of long running connections.

## Testing Verification
- Added test coverage for conn helper and updated pinger test coverage
