### PR TITLE
qa: traceroute on connectivity test error

### DIFF
--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -158,7 +158,6 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 							result, err := src.TestUnicastConnectivity(subCtx, target)
 							if err != nil {
 								log.Error("Connectivity test failed", "error", err, "source", src.Host, "target", target.Host, "sourceDevice", clientToDevice[src].Code, "targetDevice", clientToDevice[target].Code)
-								require.NoError(t, err)
 							}
 							if result.PacketsReceived < result.PacketsSent {
 								testsWithPartialLosses.Add(1)
@@ -168,6 +167,7 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 								require.NoError(t, err)
 								t.Logf("Traceroute for %s (device %s) -> %s (device %s): %s", src.Host, clientToDevice[src].Code, target.Host, clientToDevice[target].Code, res)
 							}
+							require.NoError(t, err, "failed to test connectivity")
 						}(srcClient, target)
 					}
 					wg.Wait()

--- a/e2e/qa_unicast_test.go
+++ b/e2e/qa_unicast_test.go
@@ -85,8 +85,9 @@ func TestQA_UnicastConnectivity(t *testing.T) {
 				subCtx := t.Context()
 
 				result, err := srcClient.TestUnicastConnectivity(subCtx, dstClient)
-				require.NoError(t, err, "failed to test connectivity")
-
+				if err != nil {
+					log.Error("Connectivity test failed", "error", err, "source", srcClient.Host, "target", dstClient.Host)
+				}
 				if result.PacketsReceived < result.PacketsSent {
 					testsWithPartialLosses.Add(1)
 
@@ -95,6 +96,7 @@ func TestQA_UnicastConnectivity(t *testing.T) {
 					require.NoError(t, err)
 					t.Logf("Traceroute for %s -> %s: %s", srcClient.Host, dstClient.Host, res)
 				}
+				require.NoError(t, err, "failed to test connectivity")
 			})
 		}
 	}


### PR DESCRIPTION
## Summary of Changes
- Update QA test to traceroute when connectivity test returns error too, which happens when there's sufficient or total packet loss

## Testing Verification
- Executed against devnet
