### PR TITLE
controller: add histogram for request duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle
+- Controller
+  - Add histogram metric for GetConfig request duration
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/controlplane/controller/internal/controller/metrics.go
+++ b/controlplane/controller/internal/controller/metrics.go
@@ -40,6 +40,12 @@ var (
 		Buckets: prometheus.ExponentialBucketsRange(16384, 1048576, 8),
 	})
 
+	getConfigDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "controller_grpc_getconfig_duration_seconds",
+		Help:    "The duration of GetConfig requests in seconds",
+		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5},
+	})
+
 	// cache update metrics
 	cacheUpdateErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "controller_cache_update_errors_total",
@@ -80,6 +86,7 @@ func init() {
 	prometheus.MustRegister(getConfigRenderErrors)
 	prometheus.MustRegister(getConfigOps)
 	prometheus.MustRegister(getConfigMsgSize)
+	prometheus.MustRegister(getConfigDuration)
 
 	// cache update metrics
 	prometheus.MustRegister(cacheUpdateErrors)

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -575,6 +575,7 @@ func (c *Controller) Run(ctx context.Context) error {
 
 // GetConfig renders the latest device configuration based on cached device data
 func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.ConfigResponse, error) {
+	reqStart := time.Now()
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	device, ok := c.cache.Devices[req.GetPubkey()]
@@ -690,6 +691,7 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 	}
 	resp := &pb.ConfigResponse{Config: config}
 	getConfigMsgSize.Observe(float64(proto.Size(resp)))
+	getConfigDuration.Observe(float64(time.Since(reqStart).Seconds()))
 	return resp, nil
 }
 


### PR DESCRIPTION
## Summary of Changes
We don't currently monitor the amount of time it takes to fulfill a GetConfig request from a DZD. This PR adds a histogram metric to track said time. 

## Testing Verification
```
$ while true; do ./bin/controller agent -controller-port 8080 -device-pubkey 8gisbwJnNhMNEWz587cAJMtSSFuWeNFtiufPuBTVqF2Z > /dev/null;done
^C

$ curl http://localhost:2112/metrics | grep controller
...
# HELP controller_grpc_getconfig_duration_seconds The duration of GetConfig requests in seconds
# TYPE controller_grpc_getconfig_duration_seconds histogram
controller_grpc_getconfig_duration_seconds_bucket{le="0.01"} 113
controller_grpc_getconfig_duration_seconds_bucket{le="0.025"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="0.05"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="0.1"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="0.25"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="0.5"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="1"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="5"} 114
controller_grpc_getconfig_duration_seconds_bucket{le="+Inf"} 114
controller_grpc_getconfig_duration_seconds_sum 0.4587458259999999
controller_grpc_getconfig_duration_seconds_count 114
```

closes #2339 