### PR TITLE
client/daemon: add metric for bgp session establish duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
   - Add `doublezero_bgp_routes_installed` gauge metric for number of installed BGP routes
   - Add route liveness gauges for in-memory maps
   - Route liveness sets set of routes configured as excluded to `AdminDown`.
+  - Add histogram metric for BGP session establishment duration
 - Release
   - Publish a Docker image for core components.
 

--- a/client/doublezerod/internal/bgp/metrics.go
+++ b/client/doublezerod/internal/bgp/metrics.go
@@ -9,12 +9,21 @@ var (
 	MetricSessionStatus = promauto.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "doublezero_session_is_up",
-			Help: "Status of session to doublezero",
+			Help: "Status of BGP session to DoubleZero",
 		},
 	)
 	MetricSessionStatusDesc = `
-# HELP doublezero_session_is_up Status of session to doublezero
+# HELP doublezero_session_is_up Status of BGP session to DoubleZero
 # TYPE doublezero_session_is_up gauge
 doublezero_session_is_up %d
 `
+
+	MetricSessionEstablishedDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "doublezero_session_established_duration_seconds",
+			Help:    "Duration of BGP session establishment to DoubleZero",
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12), // 1s to 128s
+		},
+		[]string{"peer_ip"},
+	)
 )


### PR DESCRIPTION
## Summary of Changes
- Add prometheus histogram metric for BGP session establishment duration in `doublezerod`
- Closes https://github.com/malbeclabs/doublezero/issues/2362

## Testing Verification
```
root@client-6gRC1rfTDJP2KzKnBjbcG3LijaVs56fSAsCLyZBU6qa5:/# curl -s localhost:8080/metrics | grep doublezero_session_established_duration_seconds
# HELP doublezero_session_established_duration_seconds Duration of BGP session establishment to DoubleZero
# TYPE doublezero_session_established_duration_seconds histogram
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="1"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="1.5"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="2.25"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="3.375"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="5.0625"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="7.59375"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="11.390625"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="17.0859375"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="25.62890625"} 0
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="38.443359375"} 1
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="57.6650390625"} 1
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="86.49755859375"} 1
doublezero_session_established_duration_seconds_bucket{peer_ip="169.254.0.0",le="+Inf"} 1
doublezero_session_established_duration_seconds_sum{peer_ip="169.254.0.0"} 29.113294722
doublezero_session_established_duration_seconds_count{peer_ip="169.254.0.0"} 1
```
