### PR TITLE
qa: increase timeout to wait for status up

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	disconnectTimeout                = 150 * time.Second
-	waitForStatusUpTimeout           = 90 * time.Second
+	waitForStatusUpTimeout           = 150 * time.Second
 	waitForStatusDisconnectedTimeout = 90 * time.Second
 	waitForUserDeletionTimeout       = 90 * time.Second
 


### PR DESCRIPTION
## Summary of Changes
- Increase "wait for status up" timeout in conjunction with https://github.com/malbeclabs/doublezero/pull/2363, so if BGP takes longer to be established the test doesn't fail but we maintain visibility

## Testing Verification
- Executed against devnet
