### PR TITLE
agent: increase default controller request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle
 - Controller
   - Add histogram metric for GetConfig request duration
+- Device agents
+  - Increase default controller request timeout in config agent
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/controlplane/agent/cmd/agent/main.go
+++ b/controlplane/agent/cmd/agent/main.go
@@ -24,7 +24,7 @@ var (
 	controllerAddress          = flag.String("controller", "18.116.166.35:7000", "The DoubleZero controller IP address and port to connect to")
 	device                     = flag.String("device", "127.0.0.1:9543", "IP Address and port of the Arist EOS API. Should always be the local switch at 127.0.0.1:9543.")
 	sleepIntervalInSeconds     = flag.Float64("sleep-interval-in-seconds", 5, "How long to sleep in between polls")
-	controllerTimeoutInSeconds = flag.Float64("controller-timeout-in-seconds", 2, "How long to wait for a response from the controller before giving up")
+	controllerTimeoutInSeconds = flag.Float64("controller-timeout-in-seconds", 30, "How long to wait for a response from the controller before giving up")
 	maxLockAge                 = flag.Int("max-lock-age-in-seconds", 3600, "If agent detects a config lock that older than the specified age, it will force unlock.")
 	verbose                    = flag.Bool("verbose", false, "Enable verbose logging")
 	showVersion                = flag.Bool("version", false, "Print the version of the doublezero-agent and exit")


### PR DESCRIPTION
## Summary of Changes
- Increase the default controller request timeout in the config agent to cover scenarios where there is internet instability nearby or on the path to the controller
- Related to https://malbeclabs.slack.com/archives/C07GHK0MU5C/p1764942988567259?thread_ts=1764774884.680929&cid=C07GHK0MU5C

## Testing Verification
- Existing E2E tests cover this CLI flag