### PR TITLE
ci: bigger runner for go tests

### DIFF
--- a/client/doublezerod/internal/liveness/faults_test.go
+++ b/client/doublezerod/internal/liveness/faults_test.go
@@ -39,14 +39,8 @@ var (
 	notQuietFlag = flag.Bool("not-quiet", false, "do not quiet logging")
 )
 
-func parallelIfNotCI(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Parallel()
-	}
-}
-
 func TestClient_Liveness_Faults_FlapsOnConnectivityLoss(t *testing.T) {
-	parallelIfNotCI(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Skip("Skipping flapping test in short mode")
@@ -163,7 +157,7 @@ func TestClient_Liveness_Faults_FlapsOnConnectivityLoss(t *testing.T) {
 }
 
 func TestClient_Liveness_Faults_SoftLoss_PartialPacketLoss(t *testing.T) {
-	parallelIfNotCI(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Skip("Skipping soft-loss test in short mode")
@@ -266,7 +260,7 @@ func TestClient_Liveness_Faults_SoftLoss_PartialPacketLoss(t *testing.T) {
 }
 
 func TestClient_Liveness_Faults_HardLoss_PermanentOutage(t *testing.T) {
-	parallelIfNotCI(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Skip("Skipping hard-loss test in short mode")
@@ -363,7 +357,7 @@ func TestClient_Liveness_Faults_HardLoss_PermanentOutage(t *testing.T) {
 }
 
 func TestClient_Liveness_Faults_SoftLoss_TimeoutAtHighLoss(t *testing.T) {
-	parallelIfNotCI(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Skip("Skipping high soft-loss timeout test in short mode")
@@ -505,7 +499,7 @@ func TestClient_Liveness_Faults_SoftLoss_TimeoutAtHighLoss(t *testing.T) {
 }
 
 func TestClient_Liveness_Faults_MixedPassiveConfigs_RemoteAdminAndTimeoutKeepRouteInstalled(t *testing.T) {
-	parallelIfNotCI(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Skip("Skipping mixed passive fault test in short mode")


### PR DESCRIPTION
## Summary of Changes
- The route liveness fault tests are pretty resource intensive and need more concurrency

## Testing Verification
- Ran the fault tests locally in a loop for a while without issue
- See CI checks for CI run
