### PR TITLE
qa: fix nil check during traceroute

### DIFF
--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -159,7 +159,7 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 							if err != nil {
 								log.Error("Connectivity test failed", "error", err, "source", src.Host, "target", target.Host, "sourceDevice", clientToDevice[src].Code, "targetDevice", clientToDevice[target].Code)
 							}
-							if result.PacketsReceived < result.PacketsSent {
+							if result != nil && result.PacketsReceived < result.PacketsSent {
 								testsWithPartialLosses.Add(1)
 
 								// If there are any losses, run a traceroute and dump the output for visibility.

--- a/e2e/qa_unicast_test.go
+++ b/e2e/qa_unicast_test.go
@@ -88,7 +88,7 @@ func TestQA_UnicastConnectivity(t *testing.T) {
 				if err != nil {
 					log.Error("Connectivity test failed", "error", err, "source", srcClient.Host, "target", dstClient.Host)
 				}
-				if result.PacketsReceived < result.PacketsSent {
+				if result != nil && result.PacketsReceived < result.PacketsSent {
 					testsWithPartialLosses.Add(1)
 
 					// If there are any losses, run a traceroute and dump the output for visibility.


### PR DESCRIPTION
## Summary of Changes
- Fix nil check in QA test when falling back to traceroute on packet loss

## Testing Verification
- Executed against devnet
