### PR TITLE
refactor: enforce lowercase for dzd and link naming

### DIFF
--- a/smartcontract/programs/common/src/validate_account_code.rs
+++ b/smartcontract/programs/common/src/validate_account_code.rs
@@ -4,7 +4,7 @@ pub fn validate_account_code(val: &str) -> Result<String, &'static str> {
     val.chars()
         .try_fold(String::with_capacity(val.len()), |mut code, char| {
             if char.is_alphanumeric() || char == ':' || char == '_' || char == '-' {
-                code.push(char)
+                code.push(char.to_ascii_lowercase());
             } else {
                 return Err("name must be alphanumeric, `_`, `-`, or `:` only");
             }
@@ -17,10 +17,17 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_valid_code() {
-        let input = "my_Device:-01".to_string();
+    fn test_valid_code_lowercased() {
+        let input = "my_device:-01".to_string();
         let output = validate_account_code(&input).unwrap();
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_valid_code_mixed_case_normalized() {
+        let input = "My_Device:-01".to_string();
+        let output = validate_account_code(&input).unwrap();
+        assert_eq!(output, "my_device:-01".to_string());
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
@@ -264,7 +264,7 @@ async fn test_dzx_link() {
         .get_device()
         .unwrap();
     assert_eq!(device_a.account_type, AccountType::Device);
-    assert_eq!(device_a.code, "A".to_string());
+    assert_eq!(device_a.code, "a".to_string());
     assert_eq!(device_a.status, DeviceStatus::Pending);
 
     // check reference counts
@@ -353,7 +353,7 @@ async fn test_dzx_link() {
         .get_device()
         .unwrap();
     assert_eq!(device_z.account_type, AccountType::Device);
-    assert_eq!(device_z.code, "Z".to_string());
+    assert_eq!(device_z.code, "z".to_string());
     assert_eq!(device_z.status, DeviceStatus::Pending);
 
     // check reference counts

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -225,7 +225,7 @@ async fn test_wan_link() {
         .get_device()
         .unwrap();
     assert_eq!(device_a.account_type, AccountType::Device);
-    assert_eq!(device_a.code, "A".to_string());
+    assert_eq!(device_a.code, "a".to_string());
     assert_eq!(device_a.status, DeviceStatus::Pending);
 
     let iface = device_a.interfaces.first().unwrap().into_current_version();
@@ -352,7 +352,7 @@ async fn test_wan_link() {
         .get_device()
         .unwrap();
     assert_eq!(device_z.account_type, AccountType::Device);
-    assert_eq!(device_z.code, "Z".to_string());
+    assert_eq!(device_z.code, "z".to_string());
     assert_eq!(device_z.status, DeviceStatus::Pending);
 
     let iface = device_z.interfaces.first().unwrap().into_current_version();


### PR DESCRIPTION
## Summary of Changes
* enforces lower-case for DZD and Link Naming.
* If a contributor creates either using uppercase, they shall be converted to lowercase automatically.

## Testing Verification
* rust checks pass
* fmt checks green too.

fixes #2331 
