### PR TITLE
client/daemon: route liveness admindown routes configured as excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
   - Advertise peer client version with route liveness control packets.
   - Add `doublezero_bgp_routes_installed` gauge metric for number of installed BGP routes
   - Add route liveness gauges for in-memory maps
+  - Route liveness sets set of routes configured as excluded to `AdminDown`.
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/client/doublezerod/internal/bgp/bgp_test.go
+++ b/client/doublezerod/internal/bgp/bgp_test.go
@@ -128,7 +128,7 @@ func TestBgpServer(t *testing.T) {
 		MinTxFloor:    50 * time.Millisecond,
 		MaxTxCeil:     1 * time.Second,
 		ClientVersion: "1.2.3-dev",
-	})
+	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = lm.Close() })
 	b, err := bgp.NewBgpServer(net.IP{1, 1, 1, 1}, nlr, lm)

--- a/client/doublezerod/internal/liveness/faults_test.go
+++ b/client/doublezerod/internal/liveness/faults_test.go
@@ -699,7 +699,7 @@ func setupLivenessClients(t *testing.T, basePort int) ([]*testClient, *fakeUDPSw
 			MaxTxCeil:       cfg.txMin,
 			BackoffMax:      cfg.backoffMax,
 			ClientVersion:   "1.2.3-dev",
-		})
+		}, nil)
 		require.NoError(t, err)
 
 		tc := &testClient{
@@ -772,7 +772,7 @@ func setupMixedPassiveLivenessClients(t *testing.T, basePort int) ([]*testClient
 			mcfg.PassiveMode = true
 		}
 
-		lm, err := NewManager(t.Context(), mcfg)
+		lm, err := NewManager(t.Context(), mcfg, nil)
 		require.NoError(t, err)
 
 		tc := &testClient{

--- a/client/doublezerod/internal/routing/config.go
+++ b/client/doublezerod/internal/routing/config.go
@@ -6,34 +6,58 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"sync"
 )
 
 type RouteConfig struct {
 	Exclude []string `json:"exclude"`
 }
 
-type ConfiguredRouteReaderWriter struct {
-	log     *slog.Logger
-	nlr     Netlinker
+type ConfiguredRoutes struct {
+	cfg     *RouteConfig
 	exclude map[string]struct{}
+	mu      sync.Mutex
 }
 
-func NewConfiguredRouteReaderWriter(log *slog.Logger, nlr Netlinker, path string) (*ConfiguredRouteReaderWriter, error) {
+func NewConfiguredRoutes(path string) (*ConfiguredRoutes, error) {
 	cfg, err := loadConfig(path)
 	if err != nil {
 		return nil, fmt.Errorf("error loading route config: %v", err)
 	}
-	log.Info("routes: loaded routes", "routes", len(cfg.Exclude))
-	return &ConfiguredRouteReaderWriter{
-		log:     log,
-		nlr:     nlr,
+	return &ConfiguredRoutes{
+		cfg:     cfg,
 		exclude: makeExcludeMap(cfg.Exclude),
 	}, nil
 }
 
+func (c *ConfiguredRoutes) GetExcluded() map[string]struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.exclude
+}
+
+func (c *ConfiguredRoutes) IsExcluded(ip string) bool {
+	_, ok := c.GetExcluded()[ip]
+	return ok
+}
+
+type ConfiguredRouteReaderWriter struct {
+	log *slog.Logger
+	nlr Netlinker
+	cfg *ConfiguredRoutes
+}
+
+func NewConfiguredRouteReaderWriter(log *slog.Logger, nlr Netlinker, cfg *ConfiguredRoutes) (*ConfiguredRouteReaderWriter, error) {
+	log.Info("routes: loaded routes", "excluded", len(cfg.GetExcluded()))
+	return &ConfiguredRouteReaderWriter{
+		log: log,
+		nlr: nlr,
+		cfg: cfg,
+	}, nil
+}
+
 func (c *ConfiguredRouteReaderWriter) RouteAdd(r *Route) error {
-	_, ok := c.exclude[r.Dst.IP.String()]
-	if ok {
+	if c.cfg.IsExcluded(r.Dst.IP.String()) {
 		c.log.Info("routes: excluding configured route from route add", "route", r.String())
 		return nil
 	}
@@ -41,8 +65,7 @@ func (c *ConfiguredRouteReaderWriter) RouteAdd(r *Route) error {
 }
 
 func (c *ConfiguredRouteReaderWriter) RouteDelete(r *Route) error {
-	_, ok := c.exclude[r.Dst.IP.String()]
-	if ok {
+	if c.cfg.IsExcluded(r.Dst.IP.String()) {
 		c.log.Info("routes: excluding configured route from route delete", "route", r.String())
 		return nil
 	}


### PR DESCRIPTION
## Summary of Changes
- Integrate routes config where routes can be excluded via static config with route liveness, so that excluded routes are marked as `AdminDown`
- Closes https://github.com/malbeclabs/doublezero/issues/2157

## Testing Verification
- Added test coverage for this functionality
