### PR TITLE
client/daemon: installed routes metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   - Route liveness treats peers that advertise passive mode as selectively passive; does not manage their routes directly.
   - Route liveness runs in passive mode for IBRL with allocated IP, if global passive mode is enabled.
   - Advertise peer client version with route liveness control packets.
+  - Add `doublezero_bgp_routes_installed` gauge metric for number of installed BGP routes
+  - Add route liveness gauges for in-memory maps
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/client/doublezerod/internal/liveness/manager.go
+++ b/client/doublezerod/internal/liveness/manager.go
@@ -324,6 +324,7 @@ func (m *manager) RegisterRoute(r *Route, iface string, port int) error {
 
 		m.mu.Lock()
 		m.installed[rk] = true
+		m.metrics.InstalledMapSize.Set(float64(len(m.installed)))
 		m.mu.Unlock()
 	}
 
@@ -337,6 +338,7 @@ func (m *manager) RegisterRoute(r *Route, iface string, port int) error {
 
 	m.mu.Lock()
 	m.desired[rk] = r
+	m.metrics.DesiredMapSize.Set(float64(len(m.desired)))
 	m.mu.Unlock()
 
 	peer := Peer{Interface: iface, LocalIP: srcIP, PeerIP: dstIP}
@@ -365,6 +367,7 @@ func (m *manager) RegisterRoute(r *Route, iface string, port int) error {
 		lastUpdated:   time.Now(),
 	}
 	m.sessions[peer] = sess
+	m.metrics.SessionsMapSize.Set(float64(len(m.sessions)))
 	m.metrics.sessionStateTransition(peer, nil, StateDown, "register_route", m.cfg.EnablePeerMetrics)
 	if m.cfg.EnablePeerMetrics {
 		// Set initial detect time based on current view (localRxMin until peer timers arrive)
@@ -407,8 +410,10 @@ func (m *manager) WithdrawRoute(r *Route, iface string) error {
 	rk := routeKeyFor(iface, r)
 	m.mu.Lock()
 	delete(m.desired, rk)
+	m.metrics.DesiredMapSize.Set(float64(len(m.desired)))
 	wasInstalled := m.installed[rk]
 	delete(m.installed, rk)
+	m.metrics.InstalledMapSize.Set(float64(len(m.installed)))
 	m.mu.Unlock()
 
 	peer := Peer{Interface: iface, LocalIP: srcIP, PeerIP: dstIP}
@@ -423,6 +428,7 @@ func (m *manager) WithdrawRoute(r *Route, iface string) error {
 		m.metrics.cleanupWithdrawRoute(peer, state, m.cfg.EnablePeerMetrics)
 	}
 	delete(m.sessions, peer)
+	m.metrics.SessionsMapSize.Set(float64(len(m.sessions)))
 	m.mu.Unlock()
 
 	// If we previously installed the route (and not in PassiveMode), remove it now.
@@ -434,6 +440,7 @@ func (m *manager) WithdrawRoute(r *Route, iface string) error {
 		}
 		m.metrics.routeWithdraw(iface, srcIP)
 	}
+
 	return nil
 }
 
@@ -686,6 +693,7 @@ func (m *manager) AdminDownRoute(r *Route, iface string) {
 		rk := routeKeyFor(iface, r)
 		m.mu.Lock()
 		m.installed[rk] = false
+		m.metrics.InstalledMapSize.Set(float64(len(m.installed)))
 		m.mu.Unlock()
 
 		// Ensure we send at least one AdminDown packet promptly.
@@ -729,6 +737,7 @@ func (m *manager) onSessionUp(sess *Session) {
 		}
 	} else {
 		m.installed[rk] = true
+		m.metrics.InstalledMapSize.Set(float64(len(m.installed)))
 		m.mu.Unlock()
 
 		if err := m.cfg.Netlinker.RouteAdd(&route.Route); err != nil {
@@ -779,6 +788,7 @@ func (m *manager) onSessionDown(sess *Session) {
 	} else {
 		if wasInstalled {
 			m.installed[rk] = false
+			m.metrics.InstalledMapSize.Set(float64(len(m.installed)))
 		}
 		m.mu.Unlock()
 	}

--- a/client/doublezerod/internal/liveness/metrics.go
+++ b/client/doublezerod/internal/liveness/metrics.go
@@ -21,7 +21,6 @@ const (
 type Metrics struct {
 	Sessions                 *prometheus.GaugeVec
 	SessionTransitions       *prometheus.CounterVec
-	RoutesInstalled          *prometheus.GaugeVec
 	RouteInstalls            *prometheus.CounterVec
 	RouteWithdraws           *prometheus.CounterVec
 	ConvergenceToUp          *prometheus.HistogramVec
@@ -38,6 +37,9 @@ type Metrics struct {
 	UnknownPeerPackets       *prometheus.CounterVec
 	ReadSocketErrors         *prometheus.CounterVec
 	WriteSocketErrors        *prometheus.CounterVec
+	SessionsMapSize          prometheus.Gauge
+	InstalledMapSize         prometheus.Gauge
+	DesiredMapSize           prometheus.Gauge
 	PeerSessions             *prometheus.GaugeVec
 	PeerDetectTime           *prometheus.GaugeVec
 }
@@ -65,13 +67,6 @@ func newMetrics() *Metrics {
 				Help: "Count of session state transitions",
 			},
 			withServiceLabels(LabelStateFrom, LabelStateTo, LabelReason),
-		),
-		RoutesInstalled: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "doublezero_liveness_routes_installed",
-				Help: "Number of routes installed",
-			},
-			serviceLabels,
 		),
 		RouteInstalls: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -184,6 +179,18 @@ func newMetrics() *Metrics {
 			},
 			serviceLabels,
 		),
+		SessionsMapSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_sessions_map_size",
+				Help: "Size of the sessions map",
+			},
+		),
+		InstalledMapSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_installed_map_size",
+				Help: "Size of the installed map",
+			},
+		),
 		// Per peer metrics for route liveness (high cardinality).
 		PeerSessions: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -199,6 +206,12 @@ func newMetrics() *Metrics {
 			},
 			withServiceLabels(LabelPeerIP),
 		),
+		DesiredMapSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "doublezero_liveness_desired_map_size",
+				Help: "Size of the desired map",
+			},
+		),
 	}
 }
 
@@ -207,7 +220,6 @@ func (m *Metrics) Register(r prometheus.Registerer) {
 	r.MustRegister(
 		m.Sessions,
 		m.SessionTransitions,
-		m.RoutesInstalled,
 		m.RouteInstalls,
 		m.RouteWithdraws,
 		m.ConvergenceToUp,
@@ -224,6 +236,9 @@ func (m *Metrics) Register(r prometheus.Registerer) {
 		m.UnknownPeerPackets,
 		m.ReadSocketErrors,
 		m.WriteSocketErrors,
+		m.SessionsMapSize,
+		m.InstalledMapSize,
+		m.DesiredMapSize,
 		m.PeerSessions,
 		m.PeerDetectTime,
 	)
@@ -256,12 +271,10 @@ func (m *Metrics) sessionStateTransition(peer Peer, prevState *State, newState S
 }
 
 func (m *Metrics) routeInstall(iface, localIP string) {
-	m.RoutesInstalled.WithLabelValues(iface, localIP).Inc()
 	m.RouteInstalls.WithLabelValues(iface, localIP).Inc()
 }
 
 func (m *Metrics) routeWithdraw(iface, localIP string) {
-	m.RoutesInstalled.WithLabelValues(iface, localIP).Dec()
 	m.RouteWithdraws.WithLabelValues(iface, localIP).Inc()
 }
 

--- a/client/doublezerod/internal/runtime/metrics.go
+++ b/client/doublezerod/internal/runtime/metrics.go
@@ -1,0 +1,22 @@
+package runtime
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Labels.
+	LabelRouteSrc     = "src"
+	LabelRouteNextHop = "next_hop"
+)
+
+var (
+	metricBGPRoutesInstalled = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "doublezero_bgp_routes_installed",
+			Help: "Number of BGP routes installed",
+		},
+		[]string{LabelRouteSrc, LabelRouteNextHop},
+	)
+)

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -21,6 +21,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	updateInstalledRoutesGaugeInterval = 10 * time.Second
+)
+
 func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLatencyProbing, enableLatencyMetrics bool, networkConfig *config.NetworkConfig, probeInterval, cacheUpdateInterval int, lmc *liveness.ManagerConfig) error {
 	nlr := routing.Netlink{}
 	var crw bgp.RouteReaderWriter
@@ -135,6 +139,8 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 		errCh <- err
 	}()
 
+	go updateInstalledRoutesGauge(ctx, nlr)
+
 	// The liveness manager can be nil if the liveness subsystem is disabled.
 	// TODO(snormore): The scenario where the liveness subsystem is completely disabled is
 	// temporary for initial rollout testing.
@@ -153,5 +159,50 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 		return err
 	case err := <-lmErrCh:
 		return err
+	}
+}
+
+func updateInstalledRoutesGauge(ctx context.Context, nlr routing.Netlinker) {
+	tick := func() {
+		routes, err := nlr.RouteByProtocol(unix.RTPROT_BGP)
+		if err != nil {
+			slog.Error("runtime: error listing kernel bgp routes", "error", err)
+			return
+		}
+
+		routesBySrcNextHop := make(map[string]map[string]int)
+		for _, route := range routes {
+			if route.Protocol != unix.RTPROT_BGP {
+				continue
+			}
+			if route.Src == nil || route.NextHop == nil || route.Src.To4() == nil || route.NextHop.To4() == nil {
+				continue
+			}
+			src := route.Src.To4().String()
+			nextHop := route.NextHop.To4().String()
+			if _, ok := routesBySrcNextHop[src]; !ok {
+				routesBySrcNextHop[src] = make(map[string]int)
+			}
+			routesBySrcNextHop[src][nextHop]++
+		}
+
+		metricBGPRoutesInstalled.Reset()
+		for src, nextHops := range routesBySrcNextHop {
+			for nextHop, count := range nextHops {
+				metricBGPRoutesInstalled.WithLabelValues(src, nextHop).Set(float64(count))
+			}
+		}
+	}
+
+	tick()
+	ticker := time.NewTicker(updateInstalledRoutesGaugeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tick()
+		}
 	}
 }


### PR DESCRIPTION
## Summary of Changes
- Replace route liveness "installed routes" metric with a daemon-level metric that updates more reliably via periodic netlink listing
- Add route liveness gauge metrics for size of the in-memory maps used in the manager (sessions, installed, desired) for better visibility

## Testing Verification
- Added test coverage for new route liveness metrics
