### PR TITLE
controller: use device.mgmt_vrf to apply the MAIN-CONTROL-PLANE-ACL to the correct vrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this project will be documented in this file.
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle
-- Controller
+- Device controller
   - Add histogram metric for GetConfig request duration
   - Add gRPC middleware for prometheus metrics
+  - Use device.mgmt_vrf to apply the MAIN-CONTROL-PLANE-ACL to the correct vrf
 - Device agents
   - Increase default controller request timeout in config agent
 - Client

--- a/controlplane/controller/internal/controller/fixtures/base.config.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.txt
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
@@ -61,8 +61,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf test-mgmt-vrf in
 !
 interface Loopback1000
    description RP Address

--- a/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/e2e.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/interfaces.txt
+++ b/controlplane/controller/internal/controller/fixtures/interfaces.txt
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/mixed.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/mixed.tunnel.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/multicast.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/multicast.tunnel.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.tmpl
@@ -54,6 +54,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/unicast.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unicast.tunnel.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
@@ -61,6 +61,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -77,8 +77,13 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP {{ .TelemetryTWAMPListenPort }})
    290 permit udp any any eq {{ .TelemetryTWAMPListenPort }}
 !
+no system control-plane
 system control-plane
+{{- if .Device.MgmtVrf }}
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf {{ .Device.MgmtVrf }} in
+{{- else }}
    ip access-group MAIN-CONTROL-PLANE-ACL in
+{{- end }}
 !
 {{- range .Device.Interfaces }}
 interface {{ .Name }}

--- a/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
@@ -54,8 +54,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
    280 remark Permit TWAMP (UDP 862)
    290 permit udp any any eq 862
 !
+no system control-plane
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL in
+   ip access-group MAIN-CONTROL-PLANE-ACL vrf mgmt in
 !
 interface Ethernet2
    mtu 2048

--- a/e2e/internal/devnet/device/startup-config.tmpl
+++ b/e2e/internal/devnet/device/startup-config.tmpl
@@ -11,10 +11,10 @@ vrf instance vrf1
 ip routing vrf vrf1
 !
 {{- if .ManagementNS }}
-vrf instance management
-ip routing vrf management
-ip route vrf management 0.0.0.0/0 {{.DefaultNetworkGateway}}
-ip name-server vrf management 8.8.8.8
+vrf instance mgmt
+ip routing vrf mgmt
+ip route vrf mgmt 0.0.0.0/0 {{.DefaultNetworkGateway}}
+ip name-server vrf mgmt 8.8.8.8
 !
 {{- end }}
 daemon doublezero-agent
@@ -37,21 +37,21 @@ management api http-commands
 {{- end }}
    no shutdown
 {{- if .ManagementNS }}
-   vrf management
+   vrf mgmt
       ip access-group allow-all
       no shutdown
 {{- end }}
 !
 management api eos-sdk-rpc
    transport grpc foo
-      localhost loopback {{ if .ManagementNS }}vrf management{{ end }}
+      localhost loopback {{ if .ManagementNS }}vrf mgmt{{ end }}
       service all
       no disabled
 !
 management api gnmi
    transport grpc gnmi
 {{- if .ManagementNS }}
-   vrf management
+   vrf mgmt
 {{- end }}
 !
 ip access-list MAIN-CONTROL-PLANE-ACL-MGMT
@@ -90,7 +90,7 @@ ip access-list MAIN-CONTROL-PLANE-ACL-MGMT
    {{- end }}
 !
 system control-plane
-   ip access-group MAIN-CONTROL-PLANE-ACL-MGMT vrf management in
+   ip access-group MAIN-CONTROL-PLANE-ACL-MGMT vrf mgmt in
 !
 no service interface inactive port-id allocation disabled
 !
@@ -123,7 +123,7 @@ interface Ethernet1
 !
 interface Management0
 {{- if .ManagementNS }}
-   vrf management
+   vrf mgmt
 {{- end }}
    no shutdown
    ip address {{.DefaultNetworkIP}}/{{.DefaultNetworkCIDRPrefix}}


### PR DESCRIPTION
## Summary of Changes
* controller: use device.mgmt_vrf to apply the MAIN-CONTROL-PLANE-ACL to the correct vrf
* After this change, devices with the mgmt_vrf no longer require manual configuration
* `no system control-plane` is necessary to handle the case when device.mgmt_vrf is changed
* Also updated e2e/internal/devnet/device/startup-config.tmpl, changing the name of the management vrf from `management` to `mgmt` to match the onchain device.mgmt_vrf

## Testing Verification
* Test fixtures updated
