### PR TITLE
devcontainer: fix gopls and rust-analyzer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/go:1.24
 
-# Install goreleaser and gcc-x86-64-linux-gnu for building releases.
+# Install goreleaser, mtr, docker.io
 RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list && \
     apt update -qq && \
-    apt install -y goreleaser-pro && \
+    apt install -y goreleaser-pro mtr docker.io && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -12,14 +12,6 @@ RUN curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && \
     chmod +x gotest && \
     mv gotest /usr/local/bin/gotest
 
-# Install agave/solana tools
-# https://github.com/anza-xyz/agave/issues/1734
-ARG SOLANA_VERSION=2.3.13
-RUN bash -c 'set -euo pipefail; curl -fsSL https://release.anza.xyz/v${SOLANA_VERSION}/install | sh'
-RUN mkdir -p /opt/solana/bin && \
-    mv /root/.local/share/solana/install/active_release/bin/* /opt/solana/bin/
-ENV PATH="/opt/solana/bin:${PATH}"
-
 # Alias to access the DinD container's published ports from inside the container,
 # since localhost does not route through NAT. Used in place of `localhost`.
 ENV DIND_LOCALHOST=host.docker.internal
@@ -27,9 +19,3 @@ ENV DIND_LOCALHOST=host.docker.internal
 # Tell Testcontainers to connect to the Docker daemon via host.docker.internal,
 # so sidecar containers like Ryuk can reach the DinD container hosting the daemon.
 ENV TESTCONTAINERS_HOST_OVERRIDE=${DIND_LOCALHOST}
-
-# Install mtr
-RUN apt update -qq && \
-    apt install -y mtr && \
-    apt clean -y && \
-    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,23 +2,24 @@
     "name": "DoubleZero Development",
     "build": {
         "dockerfile": "Dockerfile",
-        "context": ".",
-        "options": [
-            "--platform=linux/amd64"
-        ]
+        "context": "."
     },
     "runArgs": [
         "--name=dz-dev-workspace-vsc",
         "--ulimit",
         "nofile=1048576:1048576"
     ],
+    "containerEnv": {
+        "CARGO_TARGET_DIR": "/cargo-target"
+    },
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.24.3"
         },
-        "ghcr.io/devcontainers/features/rust:1": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "1.90.0"
+        },
     },
     "postCreateCommand": "rustup component add --toolchain nightly rustfmt",
     "customizations": {
@@ -57,7 +58,8 @@
     },
     "remoteUser": "root",
     "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+        "source=cargo-target-doublezero-devcontainer,target=/cargo-target,type=volume"
     ],
     "capAdd": [
         "NET_ADMIN",


### PR DESCRIPTION
## Summary of Changes
- Specify separate `CARGO_TARGET_DIR` for target dir in container
- Stop running devcontainer in `--platform=linux/amd64` and just let it run in `linux/arm64`
- Specify rust version so the right toolchain is installed during docker build
- Use go base docker image instead of generic base
- Remove docker-in-docker and just install the CLI instead since we share the socket from the host anyway

## Testing Verification
- Tested locally via rebuild without cache
