### PR TITLE
telemetry: initial flow-ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
   - Refactor flow enricher
   - Add metrics to flow enricher
   - Add serviceability data fetching to flow enricher
+  - Add flow-ingest service
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags "${GO_LDFLAGS}" -o ${BIN_DIR}/doublezero-telemetry-flow-enricher telemetry/flow-enricher/cmd/flow-enricher/main.go
 
+# Build the telemetry flow ingest server (golang)
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags "${GO_LDFLAGS}" -o ${BIN_DIR}/doublezero-telemetry-flow-ingest telemetry/flow-ingest/cmd/server/main.go
+
 # Force COPY in later stages to always copy the binaries, even if they appear to be the same.
 ARG CACHE_BUSTER=1
 RUN echo "$CACHE_BUSTER" > ${BIN_DIR}/.cache-buster && \

--- a/config/constants.go
+++ b/config/constants.go
@@ -9,6 +9,7 @@ const (
 	MainnetDeviceLocalASN             = 209321
 	MainnetTwoZOracleURL              = "https://sol-2z-oracle-api-v1.mainnet-beta.doublezero.xyz"
 	MainnetSolanaRPC                  = "https://api.mainnet-beta.solana.com"
+	MainnetTelemetryFlowIngestURL     = "http://telemetry-flow-in.mainnet-beta.doublezero.xyz"
 
 	// Testnet constants.
 	TestnetLedgerPublicRPCURL         = "https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16"
@@ -18,6 +19,7 @@ const (
 	TestnetDeviceLocalASN             = 65342
 	TestnetTwoZOracleURL              = "https://sol-2z-oracle-api-v1.testnet.doublezero.xyz"
 	TestnetSolanaRPC                  = "https://api.testnet.solana.com"
+	TestnetTelemetryFlowIngestURL     = "http://telemetry-flow-in.testnet.doublezero.xyz"
 
 	// Devnet constants.
 	DevnetLedgerPublicRPCURL         = "https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16"
@@ -26,6 +28,7 @@ const (
 	DevnetInternetLatencyCollectorPK = "3fXen9LP5JUAkaaDJtyLo1ohPiJ2LdzVqAnmhtGgAmwJ"
 	DevnetDeviceLocalASN             = 21682
 	DevnetTwoZOracleURL              = ""
+	DevnetTelemetryFlowIngestURL     = "http://telemetry-flow-in.devnet.doublezero.xyz"
 
 	// Localnet constants.
 	LocalnetLedgerPublicRPCURL         = "http://localhost:8899"
@@ -35,4 +38,5 @@ const (
 	LocalnetDeviceLocalASN             = 21682
 	LocalnetTwoZOracleURL              = ""
 	LocalnetSolanaRPC                  = "http://localhost:8899"
+	LocalnetTelemetryFlowIngestURL     = "http://localhost:8911"
 )

--- a/config/env.go
+++ b/config/env.go
@@ -24,6 +24,7 @@ type NetworkConfig struct {
 	DeviceLocalASN             uint32
 	TwoZOracleURL              string
 	SolanaRPCURL               string
+	TelemetryFlowIngestURL     string
 }
 
 func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
@@ -51,6 +52,7 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 			DeviceLocalASN:             MainnetDeviceLocalASN,
 			TwoZOracleURL:              MainnetTwoZOracleURL,
 			SolanaRPCURL:               MainnetSolanaRPC,
+			TelemetryFlowIngestURL:     MainnetTelemetryFlowIngestURL,
 		}
 	case EnvTestnet:
 		serviceabilityProgramID, err := solana.PublicKeyFromBase58(TestnetServiceabilityProgramID)
@@ -74,6 +76,7 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 			DeviceLocalASN:             TestnetDeviceLocalASN,
 			TwoZOracleURL:              TestnetTwoZOracleURL,
 			SolanaRPCURL:               TestnetSolanaRPC,
+			TelemetryFlowIngestURL:     TestnetTelemetryFlowIngestURL,
 		}
 	case EnvDevnet:
 		serviceabilityProgramID, err := solana.PublicKeyFromBase58(DevnetServiceabilityProgramID)
@@ -97,6 +100,7 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 			DeviceLocalASN:             DevnetDeviceLocalASN,
 			TwoZOracleURL:              DevnetTwoZOracleURL,
 			SolanaRPCURL:               TestnetSolanaRPC,
+			TelemetryFlowIngestURL:     DevnetTelemetryFlowIngestURL,
 		}
 	case EnvLocalnet:
 		serviceabilityProgramID, err := solana.PublicKeyFromBase58(LocalnetServiceabilityProgramID)
@@ -120,6 +124,7 @@ func NetworkConfigForEnv(env string) (*NetworkConfig, error) {
 			DeviceLocalASN:             LocalnetDeviceLocalASN,
 			TwoZOracleURL:              LocalnetTwoZOracleURL,
 			SolanaRPCURL:               LocalnetSolanaRPC,
+			TelemetryFlowIngestURL:     LocalnetTelemetryFlowIngestURL,
 		}
 	default:
 		// We intentionally do not include localnet in the error message.

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -27,6 +27,7 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 				DeviceLocalASN:             config.MainnetDeviceLocalASN,
 				TwoZOracleURL:              config.MainnetTwoZOracleURL,
 				SolanaRPCURL:               config.MainnetSolanaRPC,
+				TelemetryFlowIngestURL:     config.MainnetTelemetryFlowIngestURL,
 			},
 		},
 		{
@@ -40,6 +41,7 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 				DeviceLocalASN:             config.MainnetDeviceLocalASN,
 				TwoZOracleURL:              config.MainnetTwoZOracleURL,
 				SolanaRPCURL:               config.MainnetSolanaRPC,
+				TelemetryFlowIngestURL:     config.MainnetTelemetryFlowIngestURL,
 			},
 		},
 		{
@@ -53,6 +55,7 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 				DeviceLocalASN:             config.TestnetDeviceLocalASN,
 				TwoZOracleURL:              config.TestnetTwoZOracleURL,
 				SolanaRPCURL:               config.TestnetSolanaRPC,
+				TelemetryFlowIngestURL:     config.TestnetTelemetryFlowIngestURL,
 			},
 		},
 		{
@@ -66,6 +69,7 @@ func TestConfig_NetworkConfigForEnv(t *testing.T) {
 				DeviceLocalASN:             config.DevnetDeviceLocalASN,
 				TwoZOracleURL:              config.DevnetTwoZOracleURL,
 				SolanaRPCURL:               config.TestnetSolanaRPC,
+				TelemetryFlowIngestURL:     config.DevnetTelemetryFlowIngestURL,
 			},
 		},
 		{

--- a/telemetry/Makefile
+++ b/telemetry/Makefile
@@ -1,0 +1,4 @@
+.PHONY: proto
+proto:
+	docker pull namely/protoc-all
+	docker run -v $(PWD)/proto/flow:/defs namely/protoc-all --go-source-relative -f flow.proto -l go

--- a/telemetry/flow-ingest/cmd/server/main.go
+++ b/telemetry/flow-ingest/cmd/server/main.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lmittmann/tint"
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/kafka"
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/metrics"
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/server"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	flag "github.com/spf13/pflag"
+
+	_ "net/http/pprof"
+)
+
+var (
+	// Set by LDFLAGS
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+const (
+	defaultPort        = "6343"
+	defaultMetricsAddr = ":8080"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.ShowVersion {
+		fmt.Printf("version: %s, commit: %s, date: %s\n", version, commit, date)
+		return nil
+	}
+
+	log := newLogger(cfg.Verbose)
+
+	// Start pprof server
+	if cfg.EnablePprof {
+		go func() {
+			log.Info("starting pprof server", "address", "localhost:6060")
+			err := http.ListenAndServe("localhost:6060", nil)
+			if err != nil {
+				log.Error("failed to start pprof server", "error", err)
+			}
+		}()
+	}
+
+	// Start prometheus metrics server
+	if cfg.MetricsAddr != "" {
+		metrics.BuildInfo.WithLabelValues(version, commit, date).Set(1)
+		go func() {
+			listener, err := net.Listen("tcp", cfg.MetricsAddr)
+			if err != nil {
+				log.Error("Failed to start prometheus metrics server listener", "error", err)
+				os.Exit(1)
+			}
+			log.Info("Prometheus metrics server listening", "address", listener.Addr().String())
+			http.Handle("/metrics", promhttp.Handler())
+			if err := http.Serve(listener, nil); err != nil {
+				log.Error("Failed to start prometheus metrics server", "error", err)
+				os.Exit(1)
+			}
+		}()
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", ":"+cfg.Port)
+	if err != nil {
+		return fmt.Errorf("failed to resolve udp address: %w", err)
+	}
+
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen udp: %w", err)
+	}
+	log.Info("listening for UDP", "address", conn.LocalAddr())
+
+	healthListener, err := net.Listen("tcp", ":"+cfg.HealthPort)
+	if err != nil {
+		return fmt.Errorf("failed to listen tcp: %w", err)
+	}
+	log.Info("listening for TCP for health checks", "address", healthListener.Addr())
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		_ = healthListener.Close()
+	}()
+
+	kafkaClient, err := kafka.NewClient(ctx, &kafka.Config{
+		Brokers: cfg.KafkaBrokers,
+		AuthIAM: cfg.KafkaAuthIAMEnabled,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create kafka client: %w", err)
+	}
+
+	if err := kafkaClient.EnsureTopic(ctx, cfg.KafkaTopic, cfg.KafkaPartitions, cfg.KafkaReplicationFactor); err != nil {
+		return fmt.Errorf("failed to ensure topic exists: %w", err)
+	}
+
+	server, err := server.New(&server.Config{
+		Logger:         log,
+		FlowListener:   conn,
+		HealthListener: healthListener,
+		KafkaClient:    kafkaClient,
+		KafkaTopic:     cfg.KafkaTopic,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+	errCh := server.Start(ctx, cancel)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		log.Info("context cancelled, server stopped")
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+type Config struct {
+	ShowVersion bool
+	Verbose     bool
+	EnablePprof bool
+	MetricsAddr string
+
+	Port       string
+	HealthPort string
+
+	KafkaBrokers           []string
+	KafkaAuthIAMEnabled    bool
+	KafkaTopic             string
+	KafkaPartitions        int
+	KafkaReplicationFactor int
+}
+
+func getenv(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return def
+}
+func getenvBool(key string, def bool) bool {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+func getenvInt(key string, def int) (int, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s=%q: %w", key, v, err)
+	}
+	return i, nil
+}
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func loadConfig() (Config, error) {
+	var cfg Config
+	var kafkaBrokersCSV string
+
+	flag.BoolVar(&cfg.ShowVersion, "version", false, "show version and exit")
+	flag.BoolVar(&cfg.Verbose, "verbose", false, "verbose mode - show debug logs")
+	flag.BoolVar(&cfg.EnablePprof, "enable-pprof", false, "enable pprof server")
+
+	flag.StringVar(&cfg.MetricsAddr, "metrics-addr", getenv("METRICS_ADDR", defaultMetricsAddr), "address to listen on for prometheus metrics (env: METRICS_ADDR)")
+	flag.StringVar(&cfg.Port, "port", getenv("PORT", defaultPort), "udp listen port (env: PORT)")
+	flag.StringVar(&cfg.HealthPort, "health-port", getenv("HEALTH_PORT", ""), "health check port (env: HEALTH_PORT; default: port)")
+	flag.StringVar(&cfg.KafkaTopic, "kafka-topic", getenv("KAFKA_TOPIC", ""), "kafka topic (env: KAFKA_TOPIC)")
+	flag.BoolVar(&cfg.KafkaAuthIAMEnabled, "kafka-auth-iam-enabled", getenvBool("KAFKA_AUTH_IAM_ENABLED", false), "kafka IAM auth (env: KAFKA_AUTH_IAM_ENABLED)")
+	flag.StringVar(&kafkaBrokersCSV, "kafka-brokers", getenv("KAFKA_BROKERS", ""), "kafka brokers csv (env: KAFKA_BROKERS)")
+
+	flag.Parse()
+
+	if cfg.ShowVersion {
+		return cfg, nil
+	}
+
+	if cfg.HealthPort == "" {
+		cfg.HealthPort = cfg.Port
+	}
+	cfg.KafkaBrokers = splitCSV(kafkaBrokersCSV)
+
+	var err error
+	cfg.KafkaPartitions, err = getenvInt("KAFKA_TOPIC_PARTITIONS", 1)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.KafkaReplicationFactor, err = getenvInt("KAFKA_REPLICATION_FACTOR", 1)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if len(cfg.KafkaBrokers) == 0 {
+		return Config{}, fmt.Errorf("kafka brokers is empty (set KAFKA_BROKERS or --kafka-brokers)")
+	}
+
+	if cfg.KafkaTopic == "" {
+		return Config{}, fmt.Errorf("kafka topic is empty (set KAFKA_TOPIC or --kafka-topic)")
+	}
+
+	return cfg, nil
+}
+
+func newLogger(verbose bool) *slog.Logger {
+	logLevel := slog.LevelInfo
+	if verbose {
+		logLevel = slog.LevelDebug
+	}
+	return slog.New(tint.NewHandler(os.Stdout, &tint.Options{
+		Level: logLevel,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				t := a.Value.Time().UTC()
+				a.Value = slog.StringValue(formatRFC3339Millis(t))
+			}
+			if s, ok := a.Value.Any().(string); ok && s == "" {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
+}
+
+func formatRFC3339Millis(t time.Time) string {
+	t = t.UTC()
+	base := t.Format("2006-01-02T15:04:05")
+	ms := t.Nanosecond() / 1_000_000
+	return fmt.Sprintf("%s.%03dZ", base, ms)
+}

--- a/telemetry/flow-ingest/internal/e2e/server_test.go
+++ b/telemetry/flow-ingest/internal/e2e/server_test.go
@@ -1,0 +1,460 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	"github.com/twmb/franz-go/pkg/kgo"
+	goproto "google.golang.org/protobuf/proto"
+
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/kafka"
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/server"
+	flowproto "github.com/malbeclabs/doublezero/telemetry/proto/flow/gen/pb-go"
+)
+
+func TestTelemetry_FlowIngest_E2E_ProducesToKafka(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	brokers := startRedpanda(t, ctx)
+	topic := "flow-test-" + sanitizeTopicSuffix(t.Name())
+
+	kc := newKafkaClient(t, ctx, brokers)
+	requireTopic(t, ctx, kc, topic)
+
+	flowListener, healthListener := newListeners(t)
+	log := newTestLogger()
+
+	srv := newServer(t, log, flowListener, healthListener, kc, topic)
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	errCh := srv.Start(runCtx, runCancel)
+
+	consumer := newConsumerNoGroup(t, brokers, topic)
+	defer consumer.Close()
+
+	wantDatagram := buildSFlowV5DatagramWithFlowSample()
+	sendUDP(t, flowListener.LocalAddr().(*net.UDPAddr), wantDatagram)
+
+	var got flowproto.FlowSample
+	require.Eventually(t, func() bool {
+		v, ok := pollOneValue(ctx, consumer)
+		if !ok {
+			return false
+		}
+		require.NoError(t, goproto.Unmarshal(v, &got))
+		return true
+	}, 10*time.Second, 50*time.Millisecond)
+
+	require.NotNil(t, got.ReceiveTimestamp)
+	require.True(t, bytes.Equal(got.FlowPayload, wantDatagram))
+
+	runCancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not stop")
+	}
+}
+
+func TestTelemetry_FlowIngest_E2E_NoFlowSample_NoKafkaRecord(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	brokers := startRedpanda(t, ctx)
+	topic := "flow-test-" + sanitizeTopicSuffix(t.Name())
+
+	kc := newKafkaClient(t, ctx, brokers)
+	requireTopic(t, ctx, kc, topic)
+
+	flowListener, healthListener := newListeners(t)
+	srv := newServer(t, newTestLogger(), flowListener, healthListener, kc, topic)
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	_ = srv.Start(runCtx, runCancel)
+
+	consumer := newConsumerNoGroup(t, brokers, topic)
+	defer consumer.Close()
+
+	sendUDP(t, flowListener.LocalAddr().(*net.UDPAddr), buildSFlowV5DatagramWithNoSamples())
+
+	require.Never(t, func() bool {
+		_, ok := pollOneValue(ctx, consumer)
+		return ok
+	}, 1200*time.Millisecond, 50*time.Millisecond)
+}
+
+func TestTelemetry_FlowIngest_E2E_InvalidSFlow_NoKafkaRecord(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	brokers := startRedpanda(t, ctx)
+	topic := "flow-test-" + sanitizeTopicSuffix(t.Name())
+
+	kc := newKafkaClient(t, ctx, brokers)
+	requireTopic(t, ctx, kc, topic)
+
+	flowListener, healthListener := newListeners(t)
+	srv := newServer(t, newTestLogger(), flowListener, healthListener, kc, topic)
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	_ = srv.Start(runCtx, runCancel)
+
+	consumer := newConsumerNoGroup(t, brokers, topic)
+	defer consumer.Close()
+
+	sendUDP(t, flowListener.LocalAddr().(*net.UDPAddr), []byte{0x01, 0x02, 0x03})
+
+	require.Never(t, func() bool {
+		_, ok := pollOneValue(ctx, consumer)
+		return ok
+	}, 1200*time.Millisecond, 50*time.Millisecond)
+}
+
+func TestTelemetry_FlowIngest_E2E_HealthAcceptsAndCloses(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	brokers := startRedpanda(t, ctx)
+	kc := newKafkaClient(t, ctx, brokers)
+
+	flowListener, healthListener := newListeners(t)
+	srv := newServer(t, slog.New(slog.NewTextHandler(io.Discard, nil)), flowListener, healthListener, kc, "ignored")
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	_ = srv.Start(runCtx, runCancel)
+
+	c, err := net.Dial("tcp", healthListener.Addr().String())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var b [1]byte
+	_, rerr := c.Read(b[:])
+	require.Error(t, rerr)
+}
+
+func TestTelemetry_FlowIngest_E2E_NPackets_NRecords(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	brokers := startRedpanda(t, ctx)
+	topic := "flow-test-" + sanitizeTopicSuffix(t.Name())
+
+	kc := newKafkaClient(t, ctx, brokers)
+	requireTopic(t, ctx, kc, topic)
+
+	flowListener, healthListener := newListeners(t)
+	srv := newServer(t, newTestLogger(), flowListener, healthListener, kc, topic)
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	_ = srv.Start(runCtx, runCancel)
+
+	consumer := newConsumerNoGroup(t, brokers, topic)
+	defer consumer.Close()
+
+	dst := flowListener.LocalAddr().(*net.UDPAddr)
+
+	const N = 50
+	want := make(map[string]struct{}, N)
+
+	udpConn, err := net.DialUDP("udp", nil, dst)
+	require.NoError(t, err)
+	defer udpConn.Close()
+
+	for i := 0; i < N; i++ {
+		d := buildSFlowV5DatagramWithFlowSampleMarker(uint32(i + 1))
+		want[string(d)] = struct{}{}
+		_, err := udpConn.Write(d)
+		require.NoError(t, err)
+	}
+
+	got := make(map[string]struct{}, N)
+
+	require.Eventually(t, func() bool {
+		pctx, cancel := context.WithTimeout(ctx, 400*time.Millisecond)
+		defer cancel()
+
+		fetches := consumer.PollFetches(pctx)
+		for _, e := range fetches.Errors() {
+			if errors.Is(e.Err, context.DeadlineExceeded) || errors.Is(e.Err, context.Canceled) {
+				continue
+			}
+			t.Fatalf("consume error: %v", e)
+		}
+
+		iter := fetches.RecordIter()
+		for !iter.Done() {
+			r := iter.Next()
+			var fs flowproto.FlowSample
+			if err := goproto.Unmarshal(r.Value, &fs); err != nil {
+				t.Fatalf("unmarshal FlowSample: %v", err)
+			}
+			if fs.ReceiveTimestamp == nil {
+				t.Fatalf("ReceiveTimestamp is nil")
+			}
+			k := string(fs.FlowPayload)
+			if _, ok := want[k]; !ok {
+				t.Fatalf("unexpected FlowPayload (%d bytes)", len(fs.FlowPayload))
+			}
+			got[k] = struct{}{}
+		}
+		return len(got) == N
+	}, 45*time.Second, 25*time.Millisecond)
+
+	require.Equal(t, N, len(got))
+}
+
+func startRedpanda(t *testing.T, parent context.Context) []string {
+	t.Helper()
+
+	startCtx, cancel := context.WithTimeout(parent, 2*time.Minute)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		rp, err := redpanda.Run(startCtx, "docker.redpanda.com/redpandadata/redpanda:v24.2.6")
+		if err != nil {
+			lastErr = err
+			if isRetryableContainerStartErr(err) && attempt < 3 {
+				time.Sleep(time.Duration(attempt) * 750 * time.Millisecond)
+				continue
+			}
+			require.NoError(t, err)
+		}
+
+		t.Cleanup(func() { _ = rp.Terminate(context.Background()) })
+
+		broker, err := rp.KafkaSeedBroker(startCtx)
+		if err != nil {
+			lastErr = err
+			if isRetryableContainerStartErr(err) && attempt < 3 {
+				_ = rp.Terminate(context.Background())
+				time.Sleep(time.Duration(attempt) * 750 * time.Millisecond)
+				continue
+			}
+			require.NoError(t, err)
+		}
+
+		return []string{broker}
+	}
+
+	t.Fatalf("failed to start redpanda after retries: %v", lastErr)
+	return nil
+}
+
+func isRetryableContainerStartErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "wait until ready") ||
+		strings.Contains(s, "mapped port") ||
+		strings.Contains(s, "context deadline exceeded") ||
+		strings.Contains(s, "/containers/") && strings.Contains(s, "json") ||
+		strings.Contains(s, "Get \"http://%2Fvar%2Frun%2Fdocker.sock")
+}
+
+func newKafkaClient(t *testing.T, ctx context.Context, brokers []string) *kafka.Client {
+	t.Helper()
+	kc, err := kafka.NewClient(ctx, &kafka.Config{Brokers: brokers, AuthIAM: false})
+	require.NoError(t, err)
+	t.Cleanup(kc.Close)
+	return kc
+}
+
+func requireTopic(t *testing.T, ctx context.Context, kc *kafka.Client, topic string) {
+	t.Helper()
+	err := kc.EnsureTopic(ctx, topic, 1, 1)
+	if err != nil {
+		require.NoError(t, err)
+	}
+}
+
+func newListeners(t *testing.T) (*net.UDPConn, net.Listener) {
+	t.Helper()
+	flowListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = flowListener.Close() })
+
+	healthListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = healthListener.Close() })
+
+	return flowListener, healthListener
+}
+
+func newServer(t *testing.T, log *slog.Logger, flowListener *net.UDPConn, healthListener net.Listener, kc *kafka.Client, topic string) *server.Server {
+	t.Helper()
+	srv, err := server.New(&server.Config{
+		Logger:         log,
+		FlowListener:   flowListener,
+		HealthListener: healthListener,
+		KafkaClient:    kc,
+		KafkaTopic:     topic,
+		ReadTimeout:    100 * time.Millisecond,
+		WorkerCount:    1,
+	})
+	require.NoError(t, err)
+	return srv
+}
+
+func newConsumerNoGroup(t *testing.T, brokers []string, topic string) *kgo.Client {
+	t.Helper()
+	c, err := kgo.NewClient(
+		kgo.SeedBrokers(brokers...),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+	)
+	require.NoError(t, err)
+	return c
+}
+
+func pollOneValue(ctx context.Context, c *kgo.Client) ([]byte, bool) {
+	pctx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+
+	fetches := c.PollFetches(pctx)
+	if len(fetches.Errors()) > 0 {
+		return nil, false
+	}
+	iter := fetches.RecordIter()
+	if iter.Done() {
+		return nil, false
+	}
+	r := iter.Next()
+	v := make([]byte, len(r.Value))
+	copy(v, r.Value)
+	return v, true
+}
+
+func sendUDP(t *testing.T, dst *net.UDPAddr, payload []byte) {
+	t.Helper()
+	sender, err := net.DialUDP("udp", nil, dst)
+	require.NoError(t, err)
+	defer sender.Close()
+	_, err = sender.Write(payload)
+	require.NoError(t, err)
+}
+
+func newTestLogger() *slog.Logger {
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	if os.Getenv("TEST_LOG") != "" {
+		log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+	return log
+}
+
+func buildSFlowV5DatagramWithFlowSample() []byte {
+	return buildSFlowV5DatagramWithFlowSampleMarker(1)
+}
+
+func buildSFlowV5DatagramWithFlowSampleMarker(marker uint32) []byte {
+	var out bytes.Buffer
+	w32 := func(v uint32) { _ = binary.Write(&out, binary.BigEndian, v) }
+
+	w32(5)
+	w32(1)
+	out.Write([]byte{1, 2, 3, 4})
+	w32(0)
+	w32(marker) // datagram sequence
+	w32(100)
+	w32(1)
+
+	var sample bytes.Buffer
+	sw32 := func(v uint32) { _ = binary.Write(&sample, binary.BigEndian, v) }
+
+	sw32(marker) // sample sequence
+	sw32(0)
+	sw32(1000)
+	sw32(1)
+	sw32(0)
+	sw32(0)
+	sw32(0)
+	sw32(1)
+
+	var rec bytes.Buffer
+	rw32 := func(v uint32) { _ = binary.Write(&rec, binary.BigEndian, v) }
+
+	rw32(1)
+	rw32(64)
+	rw32(0)
+
+	ethIPv4UDP := []byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x08, 0x00,
+		0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00,
+		0x0a, 0x00, 0x00, 0x01,
+		0x0a, 0x00, 0x00, 0x02,
+		0x00, 0x35, 0x00, 0x35, 0x00, 0x08, 0x00, 0x00,
+	}
+	// Put marker into the last 4 bytes so each payload can be made unique.
+	binary.BigEndian.PutUint32(ethIPv4UDP[len(ethIPv4UDP)-4:], marker)
+
+	rw32(uint32(len(ethIPv4UDP)))
+	rec.Write(ethIPv4UDP)
+	for rec.Len()%4 != 0 {
+		rec.WriteByte(0)
+	}
+
+	sw32(1)                 // record header: format=1, enterprise=0
+	sw32(uint32(rec.Len())) // record length
+	sample.Write(rec.Bytes())
+
+	w32(1) // flow sample
+	w32(uint32(sample.Len()))
+	out.Write(sample.Bytes())
+
+	return out.Bytes()
+}
+
+func buildSFlowV5DatagramWithNoSamples() []byte {
+	var out bytes.Buffer
+	w32 := func(v uint32) { _ = binary.Write(&out, binary.BigEndian, v) }
+
+	w32(5)
+	w32(1)
+	out.Write([]byte{1, 2, 3, 4})
+	w32(0)
+	w32(1)
+	w32(100)
+	w32(0)
+
+	return out.Bytes()
+}
+
+func sanitizeTopicSuffix(s string) string {
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			b = append(b, c)
+		} else {
+			b = append(b, '-')
+		}
+	}
+	return string(b)
+}

--- a/telemetry/flow-ingest/internal/kafka/client.go
+++ b/telemetry/flow-ingest/internal/kafka/client.go
@@ -1,0 +1,107 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kversion"
+	"github.com/twmb/franz-go/pkg/sasl/aws"
+)
+
+type Config struct {
+	Brokers []string
+	AuthIAM bool
+}
+
+func (c *Config) Validate() error {
+	if len(c.Brokers) == 0 {
+		return errors.New("brokers are required")
+	}
+	return nil
+}
+
+type Client struct {
+	client *kgo.Client
+}
+
+func NewClient(ctx context.Context, cfg *Config) (*Client, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate config: %w", err)
+	}
+
+	seeds := kgo.SeedBrokers(cfg.Brokers...)
+	opts := []kgo.Opt{
+		seeds,
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.ProducerBatchCompression(kgo.SnappyCompression()),
+		kgo.ProducerLinger(1 * time.Second),
+		kgo.MaxVersions(kversion.V2_8_0()),
+	}
+
+	if cfg.AuthIAM {
+		awsCfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load aws config: %w", err)
+		}
+		opts = append(opts, kgo.SASL(aws.ManagedStreamingIAM(func(ctx context.Context) (aws.Auth, error) {
+			creds, err := awsCfg.Credentials.Retrieve(ctx)
+			if err != nil {
+				return aws.Auth{}, err
+			}
+			return aws.Auth{
+				AccessKey:    creds.AccessKeyID,
+				SecretKey:    creds.SecretAccessKey,
+				SessionToken: creds.SessionToken,
+			}, nil
+		})))
+		opts = append(opts, kgo.DialTLS())
+	}
+
+	client, err := kgo.NewClient(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kafka client: %w", err)
+	}
+
+	return &Client{client: client}, nil
+}
+
+func (k *Client) Close() {
+	k.client.Close()
+}
+
+func (k *Client) Produce(
+	ctx context.Context,
+	record *kgo.Record,
+	fn func(*kgo.Record, error),
+) {
+	k.client.Produce(ctx, record, fn)
+}
+
+func (k *Client) EnsureTopic(
+	ctx context.Context,
+	topic string,
+	partitions int,
+	replication int,
+) error {
+	adm := kadm.NewClient(k.client)
+	_, err := adm.CreateTopic(
+		ctx,
+		int32(partitions),
+		int16(replication),
+		nil,
+		topic,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "TOPIC_ALREADY_EXISTS") {
+			return nil // ignore error if topic already exists
+		}
+		return fmt.Errorf("create topic: %w", err)
+	}
+	return nil
+}

--- a/telemetry/flow-ingest/internal/metrics/metrics.go
+++ b/telemetry/flow-ingest/internal/metrics/metrics.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "doublezero_telemetry_flow_ingest_build_info",
+		Help: "Build information of the telemetry flow ingest",
+	}, []string{"version", "commit", "date"})
+
+	UDPPackets = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_udp_packets_total", Help: "Total UDP packets read from the flow listener.",
+	})
+	UDPBytes = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_udp_bytes_total", Help: "Total bytes read from the flow listener.",
+	})
+	UDPReadErrs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_udp_read_errors_total", Help: "Total UDP read errors.",
+	}, []string{"kind"})
+	UDPSetDeadlineErrs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_udp_set_deadline_errors_total", Help: "Total UDP SetReadDeadline errors.",
+	}, []string{"kind"})
+
+	PacketQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "doublezero_telemetry_flow_ingest_udp_queue_depth", Help: "Current depth of the packet channel.",
+	})
+
+	FlowDecodeErrs = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_decode_errors_total", Help: "Total sFlow decode errors.",
+	})
+	PacketsWithFlowSample = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_packets_with_flow_sample_total", Help: "Packets that contained at least one FlowSample.",
+	})
+	PacketsWithoutFlowSample = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_packets_without_flow_sample_total", Help: "Packets that contained no FlowSample.",
+	})
+
+	FlowKafkaProduceOutcomes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_flow_kafka_produce_outcomes_total", Help: "Flow produced to Kafka outcomes.",
+	}, []string{"result"})
+	FlowKafkaProduceInflight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "doublezero_telemetry_flow_ingest_flow_kafka_produce_callbacks_inflight", Help: "Flow produced to Kafka callbacks currently in flight.",
+	})
+
+	WorkersRunning = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "doublezero_telemetry_flow_ingest_workers_running", Help: "Number of ingest workers currently running.",
+	})
+
+	HealthAccept = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_health_accept_total", Help: "Total health accepts.",
+	})
+	HealthAcceptErrs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "doublezero_telemetry_flow_ingest_health_accept_errors_total", Help: "Total health accept errors.",
+	}, []string{"kind"})
+)

--- a/telemetry/flow-ingest/internal/server/config.go
+++ b/telemetry/flow-ingest/internal/server/config.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net"
+	"runtime"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type Config struct {
+	Logger         *slog.Logger
+	Clock          clockwork.Clock
+	FlowListener   *net.UDPConn
+	HealthListener net.Listener
+	KafkaClient    KafkaClient
+	KafkaTopic     string
+
+	// Optional with defaults.
+	ReadTimeout       time.Duration
+	WorkerCount       int
+	BufferSizePackets int
+	BufferSizeBytes   int
+}
+
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	if c.FlowListener == nil {
+		return errors.New("flow listener is required")
+	}
+	if c.HealthListener == nil {
+		return errors.New("health listener is required")
+	}
+	if c.KafkaClient == nil {
+		return errors.New("kafka client is required")
+	}
+	if c.KafkaTopic == "" {
+		return errors.New("kafka topic is required")
+	}
+
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = defaultReadTimeout
+	}
+	if c.ReadTimeout <= 0 {
+		return errors.New("read timeout must be > 0")
+	}
+
+	if c.WorkerCount == defaultWorkerCount {
+		c.WorkerCount = runtime.NumCPU()
+	}
+	if c.WorkerCount <= 0 {
+		return errors.New("worker count must be > 0")
+	}
+
+	if c.BufferSizePackets == 0 {
+		c.BufferSizePackets = defaultBufferSizePackets
+	}
+	if c.BufferSizePackets <= 0 {
+		return errors.New("buffer size packets must be > 0")
+	}
+
+	if c.BufferSizeBytes == 0 {
+		c.BufferSizeBytes = defaultBufferSizeBytes
+	}
+	if c.BufferSizeBytes <= 0 {
+		return errors.New("buffer size bytes must be > 0")
+	}
+
+	return nil
+}

--- a/telemetry/flow-ingest/internal/server/config_test.go
+++ b/telemetry/flow-ingest/internal/server/config_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestTelemetry_FlowIngest_Server_ConfigValidate_DefaultsAndErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing required fields", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "logger is required")
+	})
+
+	t.Run("defaults applied", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Logger:         newLogger(),
+			FlowListener:   newUDPConn(t),
+			HealthListener: newTCPListener(t),
+			KafkaClient: &mockKafkaClient{
+				ProduceFunc: func(context.Context, *kgo.Record, func(*kgo.Record, error)) {},
+			},
+			KafkaTopic: "topic",
+		}
+		require.NoError(t, cfg.Validate())
+		require.NotZero(t, cfg.ReadTimeout)
+		require.NotZero(t, cfg.WorkerCount)
+		require.NotZero(t, cfg.BufferSizePackets)
+		require.NotZero(t, cfg.BufferSizeBytes)
+	})
+}

--- a/telemetry/flow-ingest/internal/server/server.go
+++ b/telemetry/flow-ingest/internal/server/server.go
@@ -1,0 +1,304 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/malbeclabs/doublezero/telemetry/flow-ingest/internal/metrics"
+	flowproto "github.com/malbeclabs/doublezero/telemetry/proto/flow/gen/pb-go"
+	"github.com/netsampler/goflow2/v2/decoders/sflow"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	defaultReadTimeout       = 250 * time.Millisecond
+	defaultWorkerCount       = 0 // 0 => runtime.NumCPU()
+	defaultBufferSizePackets = 1024
+	defaultBufferSizeBytes   = 65535
+
+	// Health endpoint: best-effort backoff (does not kill ingest on transient failures).
+	healthBaseBackoff = 50 * time.Millisecond
+	healthMaxBackoff  = 2 * time.Second
+
+	// Non-timeout UDP read errors: keep running but avoid tight loops.
+	readErrBackoff = 10 * time.Millisecond
+)
+
+type KafkaClient interface {
+	Produce(ctx context.Context, record *kgo.Record, fn func(*kgo.Record, error))
+}
+
+type Server struct {
+	log *slog.Logger
+	cfg *Config
+}
+
+type packet struct {
+	addr *net.UDPAddr
+	data []byte
+}
+
+func New(cfg *Config) (*Server, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate config: %w", err)
+	}
+	return &Server{log: cfg.Logger, cfg: cfg}, nil
+}
+
+func (s *Server) Start(ctx context.Context, cancel context.CancelFunc) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		if err := s.Run(ctx); err != nil {
+			errCh <- err
+			cancel()
+		}
+	}()
+	return errCh
+}
+
+func (s *Server) Run(parentCtx context.Context) error {
+	s.log.Info("starting flow ingest server",
+		"flowListener", s.cfg.FlowListener.LocalAddr().String(),
+		"healthListener", s.cfg.HealthListener.Addr().String(),
+		"kafkaTopic", s.cfg.KafkaTopic,
+		"readTimeout", s.cfg.ReadTimeout,
+		"workerCount", s.cfg.WorkerCount,
+		"bufferSizePackets", s.cfg.BufferSizePackets,
+		"bufferSizeBytes", s.cfg.BufferSizeBytes,
+	)
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		if s.cfg.HealthListener != nil {
+			_ = s.cfg.HealthListener.Close()
+		}
+		if s.cfg.FlowListener != nil {
+			_ = s.cfg.FlowListener.Close()
+		}
+	}()
+
+	packets := make(chan packet, s.cfg.BufferSizePackets)
+
+	var workers sync.WaitGroup
+	for i := 0; i < s.cfg.WorkerCount; i++ {
+		workers.Add(1)
+		go func(id int) {
+			defer workers.Done()
+			s.ingestWorker(ctx, id, packets)
+		}(i)
+	}
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- s.healthLoop(ctx) }()
+	go func() { errCh <- s.readLoop(ctx, packets) }()
+
+	e1 := <-errCh
+	cancel()
+	e2 := <-errCh
+
+	close(packets)
+	workers.Wait()
+
+	if e1 != nil {
+		return e1
+	}
+	if e2 != nil {
+		return e2
+	}
+	s.log.Info("server stopped")
+	return nil
+}
+
+func (s *Server) readLoop(ctx context.Context, out chan<- packet) error {
+	buf := make([]byte, s.cfg.BufferSizeBytes)
+
+	for {
+		metrics.PacketQueueDepth.Set(float64(len(out)))
+
+		if err := s.cfg.FlowListener.SetReadDeadline(s.cfg.Clock.Now().Add(s.cfg.ReadTimeout)); err != nil {
+			if isClosedNetErr(err) {
+				metrics.UDPSetDeadlineErrs.WithLabelValues("closed").Inc()
+			} else {
+				metrics.UDPSetDeadlineErrs.WithLabelValues("other").Inc()
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			if isClosedNetErr(err) {
+				s.log.Debug("flow listener closed on set read deadline, exiting", "error", err)
+				return nil
+			}
+			return fmt.Errorf("set read deadline failed: %w", err)
+		}
+
+		n, remote, err := s.cfg.FlowListener.ReadFromUDP(buf)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if isClosedNetErr(err) {
+				s.log.Debug("flow listener closed on read from udp, exiting", "error", err)
+				metrics.UDPReadErrs.WithLabelValues("closed").Inc()
+				return nil
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				metrics.UDPReadErrs.WithLabelValues("timeout").Inc()
+				continue
+			}
+			metrics.UDPReadErrs.WithLabelValues("other").Inc()
+			s.log.Warn("read error", "error", err)
+			select {
+			case <-s.cfg.Clock.After(readErrBackoff):
+			case <-ctx.Done():
+				return nil
+			}
+			continue
+		}
+
+		metrics.UDPPackets.Inc()
+		metrics.UDPBytes.Add(float64(n))
+
+		data := make([]byte, n)
+		copy(data, buf[:n])
+
+		select {
+		case out <- packet{addr: remote, data: data}:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (s *Server) ingestWorker(ctx context.Context, id int, in <-chan packet) {
+	metrics.WorkersRunning.Inc()
+	defer metrics.WorkersRunning.Dec()
+
+	s.log.Info("worker started", "worker", id)
+	for {
+		select {
+		case <-ctx.Done():
+			s.log.Info("worker exiting on context cancel", "worker", id)
+			return
+		case p, ok := <-in:
+			if !ok {
+				s.log.Info("worker channel closed, exiting", "worker", id)
+				return
+			}
+			s.ingestPacket(ctx, id, p)
+		}
+	}
+}
+
+func (s *Server) ingestPacket(ctx context.Context, workerID int, p packet) {
+	var msg sflow.Packet
+	if err := sflow.DecodeMessageVersion(bytes.NewBuffer(p.data), &msg); err != nil {
+		metrics.FlowDecodeErrs.Inc()
+		s.log.Error("sflow decode error", "error", err, "worker", workerID)
+		return
+	}
+
+	hasFlowSample := false
+	for _, sample := range msg.Samples {
+		if _, ok := sample.(sflow.FlowSample); ok {
+			hasFlowSample = true
+			break
+		}
+	}
+	if !hasFlowSample {
+		metrics.PacketsWithoutFlowSample.Inc()
+		return
+	}
+	metrics.PacketsWithFlowSample.Inc()
+
+	now := s.cfg.Clock.Now().UTC()
+	sample := &flowproto.FlowSample{
+		ReceiveTimestamp: timestamppb.New(now),
+		FlowPayload:      p.data,
+	}
+
+	payload, err := proto.Marshal(sample)
+	if err != nil {
+		s.log.Error("proto marshal error", "error", err, "worker", workerID)
+		return
+	}
+
+	rec := &kgo.Record{Topic: s.cfg.KafkaTopic, Value: payload}
+	metrics.FlowKafkaProduceInflight.Inc()
+	s.cfg.KafkaClient.Produce(ctx, rec, func(r *kgo.Record, err error) {
+		defer metrics.FlowKafkaProduceInflight.Dec()
+		if err != nil {
+			metrics.FlowKafkaProduceOutcomes.WithLabelValues("error").Inc()
+			s.log.Error("failed to produce record",
+				"error", err, "worker", workerID,
+				"topic", r.Topic, "partition", r.Partition, "offset", r.Offset,
+			)
+			return
+		}
+		metrics.FlowKafkaProduceOutcomes.WithLabelValues("ok").Inc()
+		s.log.Debug("produced record",
+			"worker", workerID, "topic", r.Topic, "partition", r.Partition, "offset", r.Offset,
+		)
+	})
+
+	s.log.Debug("ingested sflow packet", "worker", workerID, "source", p.addr.String())
+}
+
+func (s *Server) healthLoop(ctx context.Context) error {
+	backoff := healthBaseBackoff
+	for {
+		c, err := s.cfg.HealthListener.Accept()
+		if err == nil {
+			metrics.HealthAccept.Inc()
+			backoff = healthBaseBackoff
+			_ = c.Close()
+			continue
+		}
+
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		closed := isClosedNetErr(err)
+		metrics.HealthAcceptErrs.WithLabelValues(map[bool]string{true: "closed", false: "other"}[closed]).Inc()
+		s.log.Warn("health accept error; continuing", "error", err, "closedClassified", closed, "backoff", backoff)
+
+		select {
+		case <-s.cfg.Clock.After(backoff):
+		case <-ctx.Done():
+			return nil
+		}
+		backoff *= 2
+		if backoff > healthMaxBackoff {
+			backoff = healthMaxBackoff
+		}
+	}
+}
+
+func isClosedNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "bad file descriptor")
+}

--- a/telemetry/flow-ingest/internal/server/server_test.go
+++ b/telemetry/flow-ingest/internal/server/server_test.go
@@ -1,0 +1,284 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestTelemetry_FlowIngest_Server_Run_StopsWorkersOnCancel(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.KafkaClient = &mockKafkaClient{
+			ProduceFunc: func(context.Context, *kgo.Record, func(*kgo.Record, error)) {},
+		}
+		c.HealthListener = &errListener{addr: dummyAddr("health"), err: errors.New("accept failed")}
+		c.WorkerCount = 4
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = s.Run(ctx)
+	require.NoError(t, err)
+}
+
+func TestTelemetry_FlowIngest_Server_ReadLoop_ForwardsPackets(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.ReadTimeout = 25 * time.Millisecond
+		c.BufferSizeBytes = 4096
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	out := make(chan packet, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.readLoop(ctx, out) }()
+
+	dst := cfg.FlowListener.LocalAddr().(*net.UDPAddr)
+	src, err := net.DialUDP("udp", nil, dst)
+	require.NoError(t, err)
+	_, err = src.Write([]byte("hello"))
+	require.NoError(t, err)
+	_ = src.Close()
+
+	select {
+	case p := <-out:
+		require.NotNil(t, p.addr)
+		require.Equal(t, []byte("hello"), p.data)
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for packet")
+	}
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestTelemetry_FlowIngest_Server_ReadLoop_IgnoresTimeouts(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.ReadTimeout = 5 * time.Millisecond
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	out := make(chan packet, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.readLoop(ctx, out) }()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestTelemetry_FlowIngest_Server_HealthLoop_AcceptThenCancel(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t)
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.healthLoop(ctx) }()
+
+	conn, err := net.Dial("tcp", cfg.HealthListener.Addr().String())
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	cancel()
+	_ = cfg.HealthListener.Close()
+
+	require.NoError(t, <-done)
+}
+
+func TestTelemetry_FlowIngest_Server_HealthLoop_DoesNotFailOnTransientErrors(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.HealthListener = &errListener{addr: dummyAddr("health"), err: errors.New("boom")}
+	})
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.healthLoop(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestTelemetry_FlowIngest_Server_Ingest_InvalidDoesNotProduce(t *testing.T) {
+	t.Parallel()
+
+	var produced int32
+	mk := &mockKafkaClient{
+		ProduceFunc: func(ctx context.Context, rec *kgo.Record, fn func(*kgo.Record, error)) {
+			atomic.AddInt32(&produced, 1)
+			fn(rec, nil)
+		},
+	}
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.KafkaClient = mk
+		c.WorkerCount = 1
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	s.ingestPacket(context.Background(), 0, packet{
+		addr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234},
+		data: []byte("not sflow"),
+	})
+
+	require.Equal(t, int32(0), atomic.LoadInt32(&produced))
+}
+
+func TestTelemetry_FlowIngest_Server_isClosedNetErr(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isClosedNetErr(net.ErrClosed))
+	require.False(t, isClosedNetErr(errors.New("some other error")))
+	require.True(t, isClosedNetErr(errors.New("use of closed network connection")))
+	require.True(t, isClosedNetErr(errors.New("bad file descriptor")))
+	require.False(t, isClosedNetErr(errors.New("timeout")))
+}
+
+func TestTelemetry_FlowIngest_Server_ReadLoop_PermanentErrorExits(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t)
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	_ = cfg.FlowListener.Close()
+
+	out := make(chan packet, 1)
+	err = s.readLoop(context.Background(), out)
+	require.NoError(t, err)
+}
+
+func TestTelemetry_FlowIngest_Server_ReadLoop_SetDeadlineFailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t)
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	_ = cfg.FlowListener.Close()
+
+	out := make(chan packet, 1)
+	err = s.readLoop(context.Background(), out)
+	require.NoError(t, err)
+}
+
+func TestTelemetry_FlowIngest_Server_Run_ReturnsFirstNonNilError(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.HealthListener = &errListener{addr: dummyAddr("health"), err: errors.New("health down")}
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = s.Run(ctx)
+	require.NoError(t, err)
+}
+
+type mockKafkaClient struct {
+	ProduceFunc func(ctx context.Context, record *kgo.Record, fn func(*kgo.Record, error))
+}
+
+func (m *mockKafkaClient) Produce(ctx context.Context, record *kgo.Record, fn func(*kgo.Record, error)) {
+	m.ProduceFunc(ctx, record, fn)
+}
+
+func newLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+}
+
+func newUDPConn(t *testing.T) *net.UDPConn {
+	t.Helper()
+	c, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func newTCPListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+func newTestConfig(t *testing.T, mutate ...func(*Config)) *Config {
+	t.Helper()
+
+	cfg := &Config{
+		Logger:         newLogger(),
+		FlowListener:   newUDPConn(t),
+		HealthListener: newTCPListener(t),
+
+		KafkaClient: &mockKafkaClient{
+			ProduceFunc: func(context.Context, *kgo.Record, func(*kgo.Record, error)) {},
+		},
+		KafkaTopic: "topic",
+
+		ReadTimeout:       10 * time.Millisecond,
+		WorkerCount:       1,
+		BufferSizePackets: 8,
+		BufferSizeBytes:   2048,
+	}
+
+	for _, m := range mutate {
+		m(cfg)
+	}
+	require.NoError(t, cfg.Validate())
+	return cfg
+}
+
+type errListener struct {
+	addr net.Addr
+	err  error
+}
+
+func (e *errListener) Accept() (net.Conn, error) { return nil, e.err }
+func (e *errListener) Close() error              { return nil }
+func (e *errListener) Addr() net.Addr            { return e.addr }
+
+type dummyAddr string
+
+func (d dummyAddr) Network() string { return "dummy" }
+func (d dummyAddr) String() string  { return string(d) }


### PR DESCRIPTION
## Summary of Changes
- Add `telemetry/flow-ingest` component that exposes UDP port for consuming sflow data from devices, and pushes it onto a Kafka topic
- Includes some baseline prometheus metrics
- Packaged in and released with `doublezero-core` docker image
- Related to https://github.com/malbeclabs/doublezero/issues/2417
- Closes https://github.com/malbeclabs/doublezero/issues/2423
- Closes https://github.com/malbeclabs/doublezero/issues/2419

## Testing Verification
- Add unit tests for server
- Add integration tests for server using testcontainers with real (containerized) kafka
