### PR TITLE
Update contributor, device, exchange, link, location, and multicast g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle
+  - Update contributor, device, exchange, link, location, and multicast group commands to ignore case when matching codes
 - Device controller
   - Add histogram metric for GetConfig request duration
   - Add gRPC middleware for prometheus metrics

--- a/smartcontract/programs/doublezero-serviceability/src/state/link.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/link.rs
@@ -176,6 +176,32 @@ impl fmt::Display for Link {
     }
 }
 
+impl Default for Link {
+    fn default() -> Self {
+        Self {
+            account_type: AccountType::Link,
+            owner: Pubkey::default(),
+            index: 0,
+            bump_seed: 0,
+            side_a_pk: Pubkey::default(),
+            side_z_pk: Pubkey::default(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 0,
+            mtu: 0,
+            delay_ns: 0,
+            jitter_ns: 0,
+            tunnel_id: 0,
+            tunnel_net: NetworkV4::default(),
+            status: LinkStatus::Pending,
+            code: String::new(),
+            contributor_pk: Pubkey::default(),
+            side_a_iface_name: String::new(),
+            side_z_iface_name: String::new(),
+            delay_override_ns: 0,
+        }
+    }
+}
+
 impl AccountTypeInfo for Link {
     fn seed(&self) -> &[u8] {
         SEED_LINK

--- a/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
@@ -107,6 +107,24 @@ impl fmt::Display for MulticastGroup {
     }
 }
 
+impl Default for MulticastGroup {
+    fn default() -> Self {
+        Self {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::default(),
+            index: 0,
+            bump_seed: 0,
+            tenant_pk: Pubkey::default(),
+            multicast_ip: Ipv4Addr::new(0, 0, 0, 0),
+            max_bandwidth: 0,
+            status: MulticastGroupStatus::Pending,
+            code: String::new(),
+            publisher_count: 0,
+            subscriber_count: 0,
+        }
+    }
+}
+
 impl AccountTypeInfo for MulticastGroup {
     fn seed(&self) -> &[u8] {
         SEED_MULTICAST_GROUP

--- a/smartcontract/sdk/rs/src/commands/contributor/get.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/get.rs
@@ -21,7 +21,7 @@ impl GetContributorCommand {
                 .into_iter()
                 .find(|(_, v)| match v {
                     AccountData::Contributor(contributor) => {
-                        contributor.code == self.pubkey_or_code
+                        contributor.code.eq_ignore_ascii_case(&self.pubkey_or_code)
                     }
                     _ => false,
                 })
@@ -102,6 +102,17 @@ mod tests {
         // Search by code
         let res = GetContributorCommand {
             pubkey_or_code: "contributor_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "contributor_code".to_string());
+        assert_eq!(res.1.ops_manager_pk, ops_manager_pk);
+
+        // Search by code UPPERCASE
+        let res = GetContributorCommand {
+            pubkey_or_code: "CONTRIBUTOR_CODE".to_string(),
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/device/get.rs
+++ b/smartcontract/sdk/rs/src/commands/device/get.rs
@@ -20,7 +20,9 @@ impl GetDeviceCommand {
                 .gets(AccountType::Device)?
                 .into_iter()
                 .find(|(_, v)| match v {
-                    AccountData::Device(device) => device.code == self.pubkey_or_code,
+                    AccountData::Device(device) => {
+                        device.code.eq_ignore_ascii_case(&self.pubkey_or_code)
+                    }
                     _ => false,
                 })
                 .map(|(pk, v)| match v {
@@ -34,5 +36,99 @@ impl GetDeviceCommand {
                     ))
                 }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{commands::device::get::GetDeviceCommand, tests::utils::create_test_client};
+    use doublezero_serviceability::state::{
+        accountdata::AccountData, accounttype::AccountType, device::Device,
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_device_get_command() {
+        let mut client = create_test_client();
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 2,
+            reference_count: 0,
+            code: "device_code".to_string(),
+            owner: Pubkey::new_unique(),
+            ..Default::default()
+        };
+
+        let device2 = device.clone();
+        client
+            .expect_get()
+            .with(predicate::eq(device_pubkey))
+            .returning(move |_| Ok(AccountData::Device(device2.clone())));
+
+        let device2 = device.clone();
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Device))
+            .returning(move |_| {
+                Ok(HashMap::from([(
+                    device_pubkey,
+                    AccountData::Device(device2.clone()),
+                )]))
+            });
+
+        // Search by pubkey
+        let res = GetDeviceCommand {
+            pubkey_or_code: device_pubkey.to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "device_code".to_string());
+        assert_eq!(res.1.owner, device.owner);
+
+        // Search by code
+        let res = GetDeviceCommand {
+            pubkey_or_code: "device_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "device_code".to_string());
+        assert_eq!(res.1.owner, device.owner);
+
+        // Search by code UPPERCASE
+        let res = GetDeviceCommand {
+            pubkey_or_code: "DEVICE_CODE".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "device_code".to_string());
+        assert_eq!(res.1.owner, device.owner);
+
+        // Invalid search
+        let res = GetDeviceCommand {
+            pubkey_or_code: "ssssssssssss".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
+
+        // Search by invalid code
+        let res = GetDeviceCommand {
+            pubkey_or_code: "s(%".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
     }
 }

--- a/smartcontract/sdk/rs/src/commands/exchange/get.rs
+++ b/smartcontract/sdk/rs/src/commands/exchange/get.rs
@@ -20,7 +20,9 @@ impl GetExchangeCommand {
                 .gets(AccountType::Exchange)?
                 .into_iter()
                 .find(|(_, v)| match v {
-                    AccountData::Exchange(exchange) => exchange.code == self.pubkey_or_code,
+                    AccountData::Exchange(exchange) => {
+                        exchange.code.eq_ignore_ascii_case(&self.pubkey_or_code)
+                    }
                     _ => false,
                 })
                 .map(|(pk, v)| match v {
@@ -100,6 +102,15 @@ mod tests {
         // Search by code
         let res = GetExchangeCommand {
             pubkey_or_code: "exchange_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().1.code, "exchange_code".to_string());
+
+        // Search by code UPPERCASE
+        let res = GetExchangeCommand {
+            pubkey_or_code: "EXCHANGE_CODE".to_string(),
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/link/get.rs
+++ b/smartcontract/sdk/rs/src/commands/link/get.rs
@@ -20,7 +20,9 @@ impl GetLinkCommand {
                 .gets(AccountType::Link)?
                 .into_iter()
                 .find(|(_, v)| match v {
-                    AccountData::Link(tunnel) => tunnel.code == self.pubkey_or_code,
+                    AccountData::Link(tunnel) => {
+                        tunnel.code.eq_ignore_ascii_case(&self.pubkey_or_code)
+                    }
                     _ => false,
                 })
                 .map(|(pk, v)| match v {
@@ -34,5 +36,98 @@ impl GetLinkCommand {
                     ))
                 }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{commands::link::get::GetLinkCommand, tests::utils::create_test_client};
+    use doublezero_serviceability::state::{
+        accountdata::AccountData, accounttype::AccountType, link::Link,
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_link_get_command() {
+        let mut client = create_test_client();
+
+        let link_pubkey = Pubkey::new_unique();
+        let link = Link {
+            account_type: AccountType::Link,
+            index: 1,
+            bump_seed: 2,
+            code: "link_code".to_string(),
+            owner: Pubkey::new_unique(),
+            ..Default::default()
+        };
+
+        let link2 = link.clone();
+        client
+            .expect_get()
+            .with(predicate::eq(link_pubkey))
+            .returning(move |_| Ok(AccountData::Link(link2.clone())));
+
+        let link2 = link.clone();
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Link))
+            .returning(move |_| {
+                Ok(HashMap::from([(
+                    link_pubkey,
+                    AccountData::Link(link2.clone()),
+                )]))
+            });
+
+        // Search by pubkey
+        let res = GetLinkCommand {
+            pubkey_or_code: link_pubkey.to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "link_code".to_string());
+        assert_eq!(res.1.owner, link.owner);
+
+        // Search by code
+        let res = GetLinkCommand {
+            pubkey_or_code: "link_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "link_code".to_string());
+        assert_eq!(res.1.owner, link.owner);
+
+        // Search by code UPPERCASE
+        let res = GetLinkCommand {
+            pubkey_or_code: "LINK_CODE".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "link_code".to_string());
+        assert_eq!(res.1.owner, link.owner);
+
+        // Invalid search
+        let res = GetLinkCommand {
+            pubkey_or_code: "ssssssssssss".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
+
+        // Search by invalid code
+        let res = GetLinkCommand {
+            pubkey_or_code: "s(%".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
     }
 }

--- a/smartcontract/sdk/rs/src/commands/location/get.rs
+++ b/smartcontract/sdk/rs/src/commands/location/get.rs
@@ -20,7 +20,9 @@ impl GetLocationCommand {
                 .gets(AccountType::Location)?
                 .into_iter()
                 .find(|(_, v)| match v {
-                    AccountData::Location(location) => location.code == self.pubkey_or_code,
+                    AccountData::Location(location) => {
+                        location.code.eq_ignore_ascii_case(&self.pubkey_or_code)
+                    }
                     _ => false,
                 })
                 .map(|(pk, v)| match v {
@@ -98,6 +100,15 @@ mod tests {
         // Search by code
         let res = GetLocationCommand {
             pubkey_or_code: "location_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().1.code, "location_code".to_string());
+
+        // Search by code UPPERCASE
+        let res = GetLocationCommand {
+            pubkey_or_code: "LOCATION_CODE".to_string(),
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/get.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/get.rs
@@ -20,9 +20,9 @@ impl GetMulticastGroupCommand {
                 .gets(AccountType::MulticastGroup)?
                 .into_iter()
                 .find(|(_, v)| match v {
-                    AccountData::MulticastGroup(multicastgroup) => {
-                        multicastgroup.code == self.pubkey_or_code
-                    }
+                    AccountData::MulticastGroup(multicastgroup) => multicastgroup
+                        .code
+                        .eq_ignore_ascii_case(&self.pubkey_or_code),
                     _ => false,
                 })
                 .map(|(pk, v)| match v {
@@ -36,5 +36,100 @@ impl GetMulticastGroupCommand {
                     ))
                 }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        commands::multicastgroup::get::GetMulticastGroupCommand, tests::utils::create_test_client,
+    };
+    use doublezero_serviceability::state::{
+        accountdata::AccountData, accounttype::AccountType, multicastgroup::MulticastGroup,
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_multicastgroup_get_command() {
+        let mut client = create_test_client();
+
+        let multicastgroup_pubkey = Pubkey::new_unique();
+        let multicastgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 2,
+            code: "multicastgroup_code".to_string(),
+            owner: Pubkey::new_unique(),
+            ..Default::default()
+        };
+
+        let multicastgroup2 = multicastgroup.clone();
+        client
+            .expect_get()
+            .with(predicate::eq(multicastgroup_pubkey))
+            .returning(move |_| Ok(AccountData::MulticastGroup(multicastgroup2.clone())));
+
+        let multicastgroup2 = multicastgroup.clone();
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::MulticastGroup))
+            .returning(move |_| {
+                Ok(HashMap::from([(
+                    multicastgroup_pubkey,
+                    AccountData::MulticastGroup(multicastgroup2.clone()),
+                )]))
+            });
+
+        // Search by pubkey
+        let res = GetMulticastGroupCommand {
+            pubkey_or_code: multicastgroup_pubkey.to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "multicastgroup_code".to_string());
+        assert_eq!(res.1.owner, multicastgroup.owner);
+
+        // Search by code
+        let res = GetMulticastGroupCommand {
+            pubkey_or_code: "multicastgroup_code".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "multicastgroup_code".to_string());
+        assert_eq!(res.1.owner, multicastgroup.owner);
+
+        // Search by code UPPERCASE
+        let res = GetMulticastGroupCommand {
+            pubkey_or_code: "MULTICASTGROUP_CODE".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.code, "multicastgroup_code".to_string());
+        assert_eq!(res.1.owner, multicastgroup.owner);
+
+        // Invalid search
+        let res = GetMulticastGroupCommand {
+            pubkey_or_code: "ssssssssssss".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
+
+        // Search by invalid code
+        let res = GetMulticastGroupCommand {
+            pubkey_or_code: "s(%".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
This pull request updates several account-related commands to make code matching case-insensitive, improving usability when searching for contributors, devices, exchanges, links, locations, and multicast groups by their codes. It also adds corresponding test coverage to ensure this behavior works as expected.

### Case-insensitive code matching improvements

* Updated the `GetContributorCommand`, `GetDeviceCommand`, `GetExchangeCommand`, `GetLinkCommand`, `GetLocationCommand`, and `GetMulticastGroupCommand` implementations to use case-insensitive comparison (`eq_ignore_ascii_case`) when matching account codes. [[1]](diffhunk://#diff-313d12ca7e0979e9d5fa4564551e17e32c9920e287ac8243c06b89cc432cd5d7L24-R24) [[2]](diffhunk://#diff-b7e2be8a45451a33dacf623399e1c6229536565762998c523ecc0c1308421b39L23-R23) [[3]](diffhunk://#diff-3dacafe27c3f728c7c156412560a52d9fbdfbcb59667b1514221d62a897c6ff8L23-R25) [[4]](diffhunk://#diff-04826155876e85151e671cc3af7cd677d987de667051e093bcbf4e80357c8e61L23-R25) [[5]](diffhunk://#diff-8af8b08ba31cf181971b5164727efa3fafabb76699e373def3b11b6004724fbfL23-R25) [[6]](diffhunk://#diff-0add70093e942a4cf423f30dbe820afa7136757fb765d670881a38e9b6a36e24L23-R25)
* Added new tests in the contributor, exchange, and location command modules to verify that searching by uppercase codes returns the correct results. [[1]](diffhunk://#diff-313d12ca7e0979e9d5fa4564551e17e32c9920e287ac8243c06b89cc432cd5d7R113-R123) [[2]](diffhunk://#diff-3dacafe27c3f728c7c156412560a52d9fbdfbcb59667b1514221d62a897c6ff8R111-R119) [[3]](diffhunk://#diff-8af8b08ba31cf181971b5164727efa3fafabb76699e373def3b11b6004724fbfR109-R117)

### Documentation

* Updated the `CHANGELOG.md` to document that contributor, device, exchange, link, location, and multicast group commands now ignore case when matching codes.

## Testing Verification
* make ci runs
