### PR TITLE
actions: cancel existing e2e run on new trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this project will be documented in this file.
   - Add serviceability data fetching to flow enricher
   - Add flow-ingest service
   - Add annotation of flow records with serviceability data
+- CI
+  - Cancel existing e2e test runs on the push of new commits
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 


### PR DESCRIPTION
## Summary of Changes
This causes e2e workflows to be cancelled if an existing PR or branch triggers a second run of the workflow. If you push new commits to an open PR, it can create a backlog of e2e tests to run on old commits, which is useless.

## Testing Verification
This change was pushed without updating the changelog but still kicked off an e2e run. When pushing to this branch with the updated changelog, the old e2e run was immediately cancelled: https://github.com/malbeclabs/doublezero/actions/runs/20343856767
