### PR TITLE
rfcs: update statuses of existing rfcs to match template updates

### DIFF
--- a/rfcs/rfc1-change-management.md
+++ b/rfcs/rfc1-change-management.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-**Status: Active**
+**Status: Implemented**
 
 This RFC provides a framework to manage software configuration and compatibility through semantic versioning, feature flags, and well-formed and intentional commits. Standardization unlocks automation and should keep human involvement with deployment and verification to a minimum.
 

--- a/rfcs/rfc10-version-compatibility-windows.md
+++ b/rfcs/rfc10-version-compatibility-windows.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-**Status: Active**
+**Status: Implemented**
 
 This document proposes a windowed version-compatibility model for DoubleZero. The serviceability program will store both:
 

--- a/rfcs/rfc4-telemetry-for-contributor-rewards.md
+++ b/rfcs/rfc4-telemetry-for-contributor-rewards.md
@@ -2,7 +2,7 @@
 
 # Summary
 
-**Status: Active**
+**Status: Implemented**
 
 This document defines a decentralized process for collecting, storing, and evaluating network telemetry data on the DZ Serviceability sidechain. Telemetry is accumulated on-chain via a dedicated smart contract, with requirements defined in this document. Telemetry enables transparent and tamper-resistant tracking of network performance and resource utilization. This data is then used to assess each contributor's participation in the network and to verify that they have met their agreed-upon commitments. The approach ensures accountability, incentivizes high-quality service, and provides a foundation for automated rewards or penalties based on objective, on-chain evidence.
 

--- a/rfcs/rfc5-rewards-division.md
+++ b/rfcs/rfc5-rewards-division.md
@@ -1,6 +1,6 @@
 # **Summary**
 
-**Status: Active**
+**Status: Implemented**
 
 This document specifies the architecture for the `rewards-calculator`, a stateless off-chain service responsible for calculating contributor reward proportions and the epoch-specific burn rate for the DoubleZero network. The design prioritizes correctness, verifiability, and a clean separation of concerns between off-chain computation and on-chain settlement.
 

--- a/rfcs/rfc6-metro-routing-policy.md
+++ b/rfcs/rfc6-metro-routing-policy.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-**Status: Active**
+**Status: Implemented**
 
 This rfc proposes an optimization to network traffic flow within each DoubleZero exchange. Currently, DoubleZero sends /32 routes representing the `dz_ip`s of all connected users, regardless of where they are physically located. After this change, DoubleZero will only send /32 routes representing users who are NOT connected to the same DoubleZero exchange. For example, after this change, traffic between users connected to devices in the Frankfurt exchange will no longer traverse the DoubleZero network, and will instead traverse the local internet infrastructure in Frankfurt.
 

--- a/rfcs/rfc7-client-route-liveness.md
+++ b/rfcs/rfc7-client-route-liveness.md
@@ -1,6 +1,6 @@
 # DoubleZero Client Route Liveness
 
-**Status: Active**
+**Status: Approved**
 
 ## Summary
 

--- a/rfcs/rfc8-contributor-incident-maintenance-logging.md
+++ b/rfcs/rfc8-contributor-incident-maintenance-logging.md
@@ -2,7 +2,7 @@
 
 # Summary
 
-**Status: Draft**
+**Status: Approved**
 
 This RFC proposes a gateway-first mechanism for creating and updating incidents and planned maintenance across the DoubleZero network. Contributors use a single, versioned API to publish operational events while retaining their internal tools. The gateway validates identity (API key bound to contributor), enforces enumerations, normalizes payloads, stores them in a  datastore, and notifies coordination channels in Slack.
 

--- a/rfcs/rfc9-link-draining.md
+++ b/rfcs/rfc9-link-draining.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-**Status: Active**
+**Status: Implemented**
 
 A frequent requirement of operating a physical network is the ability to remove a link from being an active part of the network topology.  This is often referred to as draining, where traffic is rerouted to alternative options or, in the case of provisioning, prevented from being actively used until formally declared Ready for Service (RFS).
  


### PR DESCRIPTION
## Summary of Changes
* Update existing RFC statuses to match the recent update to rfcs/rfc0-template.md 

