### PR TITLE
Update CLI command arguments to be visible in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
   - IP address lookup responses that do not contain a valid IPv4 address (such as upstream timeout messages) are now treated as retryable errors instead of being parsed as IPs.
 - Onchain programs
   - Allow contributor owner to update ops manager key
+  - Add new arguments on create interface cli command
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle

--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -24,22 +24,22 @@ pub struct CreateDeviceInterfaceCliCommand {
     #[arg(long)]
     pub loopback_type: Option<types::LoopbackType>,
     /// Interface CYOA (for CYOA interfaces)
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub interface_cyoa: Option<types::InterfaceCYOA>,
     /// DIA Port (for DIA interfaces)
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub interface_dia: Option<types::InterfaceDIA>,
     /// Bandwidth in Mbps
-    #[arg(long, value_parser = validate_parse_bandwidth, default_value = "0", hide = true)]
+    #[arg(long, value_parser = validate_parse_bandwidth, default_value = "0")]
     pub bandwidth: u64,
     /// Committed Information Rate in Mbps
     #[arg(long, value_parser = validate_parse_bandwidth, default_value = "0")]
     pub cir: u64,
     /// MTU
-    #[arg(long, default_value = "1500", hide = true)]
+    #[arg(long, default_value = "1500")]
     pub mtu: u16,
     /// Routing mode
-    #[arg(long, default_value = "static", hide = true)]
+    #[arg(long, default_value = "static")]
     pub routing_mode: types::RoutingMode,
     /// VLAN ID (default: 0, i.e. not set)
     #[arg(long, default_value = "0")]

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -24,22 +24,22 @@ pub struct UpdateDeviceInterfaceCliCommand {
     #[arg(long)]
     pub loopback_type: Option<types::LoopbackType>,
     /// Interface CYOA
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub interface_cyoa: Option<types::InterfaceCYOA>,
     /// DIA Port (for DIA interfaces)
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub interface_dia: Option<types::InterfaceDIA>,
     /// Bandwidth in Mbps
-    #[arg(long, value_parser = validate_parse_bandwidth, hide = true)]
+    #[arg(long, value_parser = validate_parse_bandwidth)]
     pub bandwidth: Option<u64>,
     /// Committed Information Rate in Mbps
-    #[arg(long, value_parser = validate_parse_bandwidth, hide = true)]
+    #[arg(long, value_parser = validate_parse_bandwidth)]
     pub cir: Option<u64>,
     /// MTU
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub mtu: Option<u16>,
     /// Routing mode
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub routing_mode: Option<types::RoutingMode>,
     /// VLAN ID (default: 0, i.e. not set)
     #[arg(long)]


### PR DESCRIPTION
This pull request makes several improvements to the device interface CLI commands by exposing previously hidden arguments, allowing users to specify more interface parameters directly from the command line. The changelog is also updated to reflect these new arguments.

**CLI improvements:**

* Exposed the previously hidden arguments `interface_cyoa`, `interface_dia`, `bandwidth`, `mtu`, and `routing_mode` in the `CreateDeviceInterfaceCliCommand` struct, making them available as standard CLI options.
* Similarly, exposed the same set of arguments in the `UpdateDeviceInterfaceCliCommand` struct, so users can update these fields via the CLI.

**Documentation:**

* Updated the `CHANGELOG.md` to note the addition of new arguments to the create interface CLI command.

## Testing Verification
* Show evidence of testing the change
