### PR TITLE
monitor: add link status to device-telemetry metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ All notable changes to this project will be documented in this file.
   - Cancel existing e2e test runs on the push of new commits
 - RFCs
   - RFC - Network Provisioning
+- Monitor
+  - Add link status to device-telemetry metrics to enable Grafana alerts to filter out links that are not in activated status
 
 ## [v0.8.0](https://github.com/malbeclabs/doublezero/compare/client/v0.7.1...client/v0.8.0) – 2025-12-02
 

--- a/controlplane/monitor/internal/device-telemetry/metrics.go
+++ b/controlplane/monitor/internal/device-telemetry/metrics.go
@@ -13,8 +13,9 @@ const (
 	MetricNameAccountNotFound = "doublezero_monitor_device_telemetry_account_not_found_total"
 
 	// Labels.
-	MetricLabelErrorType = "error_type"
-	MetricLabelCircuit   = "circuit"
+	MetricLabelErrorType  = "error_type"
+	MetricLabelCircuit    = "circuit"
+	MetricLabelLinkStatus = "link_status"
 
 	// Error types.
 	MetricErrorTypeGetCircuits       = "get_circuits"
@@ -45,28 +46,28 @@ func NewMetrics() *Metrics {
 				Name: MetricNameSamples,
 				Help: "Number of samples",
 			},
-			[]string{MetricLabelCircuit},
+			[]string{MetricLabelCircuit, MetricLabelLinkStatus},
 		),
 		Successes: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: MetricNameSuccesses,
 				Help: "Number of successes",
 			},
-			[]string{MetricLabelCircuit},
+			[]string{MetricLabelCircuit, MetricLabelLinkStatus},
 		),
 		Losses: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: MetricNameLosses,
 				Help: "Number of losses",
 			},
-			[]string{MetricLabelCircuit},
+			[]string{MetricLabelCircuit, MetricLabelLinkStatus},
 		),
 		AccountNotFound: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: MetricNameAccountNotFound,
 				Help: "Number of account not found",
 			},
-			[]string{MetricLabelCircuit},
+			[]string{MetricLabelCircuit, MetricLabelLinkStatus},
 		),
 	}
 }

--- a/controlplane/monitor/internal/device-telemetry/watcher_test.go
+++ b/controlplane/monitor/internal/device-telemetry/watcher_test.go
@@ -414,7 +414,7 @@ func TestWatcher_Tick_AccountNotFound_IncrementsAccountNotFoundMetric(t *testing
 	require.NoError(t, w.Tick(context.Background()))
 
 	circuitKey := circuitKey("A", "B", link)
-	require.Equal(t, 1.0, testutil.ToFloat64(cfg.Metrics.AccountNotFound.WithLabelValues(circuitKey)))
+	require.Equal(t, 1.0, testutil.ToFloat64(cfg.Metrics.AccountNotFound.WithLabelValues(circuitKey, "pending")))
 }
 
 func TestWatcher_Tick_DeletesMetrics_WhenCircuitDisappears(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes
* monitor: add link status to device-telemetry metrics
* This label enables Grafana alerts to filter out links that are not in activated status

## Testing Verification
* Tested in devnet:
```
$ curl -s http://localhost:8080/metrics | grep link_status
doublezero_monitor_device_telemetry_account_not_found_total{circuit="test123 → test456 (CxCYKLN)",link_status="requested"} 2
doublezero_monitor_device_telemetry_account_not_found_total{circuit="test123 → test456 (ii4af4v)",link_status="activated"} 2
doublezero_monitor_device_telemetry_account_not_found_total{circuit="test456 → test123 (CxCYKLN)",link_status="requested"} 2
doublezero_monitor_device_telemetry_account_not_found_total{circuit="test456 → test123 (ii4af4v)",link_status="activated"} 2
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd1 → chi-dn-dzd2 (SR5tEcc)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd1 → chi-dn-dzd3 (RtnNABY)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd2 → chi-dn-dzd1 (SR5tEcc)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd2 → chi-dn-dzd4 (tZ4NwFC)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd3 → chi-dn-dzd1 (RtnNABY)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd3 → chi-dn-dzd4 (2XudbVt)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd4 → chi-dn-dzd2 (tZ4NwFC)",link_status="activated"} 6
doublezero_monitor_device_telemetry_samples_total{circuit="chi-dn-dzd4 → chi-dn-dzd3 (2XudbVt)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd1 → chi-dn-dzd2 (SR5tEcc)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd1 → chi-dn-dzd3 (RtnNABY)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd2 → chi-dn-dzd1 (SR5tEcc)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd2 → chi-dn-dzd4 (tZ4NwFC)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd3 → chi-dn-dzd1 (RtnNABY)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd3 → chi-dn-dzd4 (2XudbVt)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd4 → chi-dn-dzd2 (tZ4NwFC)",link_status="activated"} 6
doublezero_monitor_device_telemetry_successes_total{circuit="chi-dn-dzd4 → chi-dn-dzd3 (2XudbVt)",link_status="activated"} 6
```
