### PR TITLE
client: resolve tunnel source IP from routing table for IBRL with allocated IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
   - Add route liveness gauges for in-memory maps
   - Route liveness sets set of routes configured as excluded to `AdminDown`.
   - Add histogram metric for BGP session establishment duration
+  - For IBRL with allocated IP mode, resolve tunnel source IP from routing table via resolve-route API endpoint instead of using client IP to support clients behind NAT
 - Global monitor
   - Initial implementation
 - Release

--- a/client/doublezero/src/routes.rs
+++ b/client/doublezero/src/routes.rs
@@ -1,4 +1,18 @@
-use crate::servicecontroller::{RouteRecord, ServiceController};
+use crate::servicecontroller::{
+    ResolveRouteRequest, ResolveRouteResponse, RouteRecord, ServiceController,
+};
+
+pub async fn resolve_route<T: ServiceController>(
+    controller: &T,
+    _spinner: Option<&indicatif::ProgressBar>,
+    args: ResolveRouteRequest,
+) -> eyre::Result<ResolveRouteResponse> {
+    let response = controller
+        .resolve_route(args)
+        .await
+        .map_err(|e| eyre::eyre!(e))?;
+    Ok(response)
+}
 
 pub async fn retrieve_routes<T: ServiceController>(
     controller: &T,

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -1,13 +1,14 @@
 use chrono::DateTime;
 use doublezero_config::Environment;
 use eyre::eyre;
+use http::StatusCode;
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::{body::Bytes, Method, Request};
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use hyperlocal::{UnixConnector, Uri};
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use std::{fmt, fs::File, path::Path};
+use std::{fmt, fs::File, net::Ipv4Addr, path::Path};
 use tabled::{derive::display, Tabled};
 
 const NANOS_TO_MS: f32 = 1000000.0;
@@ -138,6 +139,27 @@ impl fmt::Display for RouteRecord {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ResolveRouteRequest {
+    pub dst: Ipv4Addr,
+}
+impl fmt::Display for ResolveRouteRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dst: {}", self.dst)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ResolveRouteResponse {
+    pub src: Option<Ipv4Addr>,
+}
+
+impl fmt::Display for ResolveRouteResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "src: {:?}", self.src)
+    }
+}
+
 fn maybe_i64_to_dt_str(maybe_i64_dt: &Option<i64>) -> String {
     maybe_i64_dt.as_ref().map_or_else(
         || "no session data".to_string(),
@@ -166,6 +188,7 @@ pub trait ServiceController {
     async fn remove(&self, args: RemoveTunnelCliCommand) -> eyre::Result<RemoveResponse>;
     async fn status(&self) -> eyre::Result<Vec<StatusResponse>>;
     async fn routes(&self) -> eyre::Result<Vec<RouteRecord>>;
+    async fn resolve_route(&self, args: ResolveRouteRequest) -> eyre::Result<ResolveRouteResponse>;
 }
 
 pub struct ServiceControllerImpl {
@@ -371,6 +394,29 @@ impl ServiceController for ServiceControllerImpl {
         let res = client.request(req).await?;
         let data = res.into_body().collect().await?.to_bytes();
         let response = serde_json::from_slice::<Vec<RouteRecord>>(&data)?;
+        Ok(response)
+    }
+
+    async fn resolve_route(&self, args: ResolveRouteRequest) -> eyre::Result<ResolveRouteResponse> {
+        let client = Client::builder(TokioExecutor::new()).build(UnixConnector);
+        let body_bytes =
+            serde_json::to_vec(&args).map_err(|e| eyre!("Unable to serialize request: {e}"))?;
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(Uri::new(&self.socket_path, "/resolve-route"))
+            .body(Full::new(Bytes::from(body_bytes)))?;
+        let res = client.request(req).await?;
+
+        println!("resolve-route: res: {:?}", res);
+
+        // If route not found (404) or API error, return src=None instead of error
+        if res.status() == StatusCode::NOT_FOUND || !res.status().is_success() {
+            return Ok(ResolveRouteResponse { src: None });
+        }
+
+        let data = res.into_body().collect().await?.to_bytes();
+        let response = serde_json::from_slice::<ResolveRouteResponse>(&data)?;
+        println!("resolve-route: response: {:?}", response);
         Ok(response)
     }
 }

--- a/client/doublezerod/internal/api/resolve_route.go
+++ b/client/doublezerod/internal/api/resolve_route.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
+	"github.com/malbeclabs/doublezero/config"
+)
+
+type ResolveRouteRequest struct {
+	Dst net.IP `json:"dst"`
+}
+
+type ResolveRouteResponse struct {
+	Src net.IP `json:"src"`
+}
+
+func (r *ResolveRouteRequest) Validate() error {
+	if r.Dst == nil {
+		return errors.New("dst is required")
+	}
+	return nil
+}
+
+func ServeResolveRouteHandler(nlr routing.Netlinker, networkConfig *config.NetworkConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req ResolveRouteRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			http.Error(w, "malformed request", http.StatusBadRequest)
+			return
+		}
+		if err = req.Validate(); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		routes, err := nlr.RouteGet(req.Dst)
+		if err != nil {
+			http.Error(w, "failed to resolve route", http.StatusInternalServerError)
+			return
+		}
+		for _, route := range routes {
+			if route.Dst.IP.Equal(req.Dst) {
+				if err := json.NewEncoder(w).Encode(ResolveRouteResponse{Src: route.Src}); err != nil {
+					http.Error(w, "failed to encode response", http.StatusInternalServerError)
+					return
+				}
+				return
+			}
+		}
+		http.Error(w, "route not found", http.StatusNotFound)
+	}
+}

--- a/client/doublezerod/internal/api/resolve_route_test.go
+++ b/client/doublezerod/internal/api/resolve_route_test.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
+	"github.com/malbeclabs/doublezero/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockNetlinker struct {
+	RouteGetFunc func(net.IP) ([]*routing.Route, error)
+	mu           sync.Mutex
+}
+
+func (m *mockNetlinker) TunnelAdd(*routing.Tunnel) error               { return nil }
+func (m *mockNetlinker) TunnelDelete(*routing.Tunnel) error            { return nil }
+func (m *mockNetlinker) TunnelAddrAdd(*routing.Tunnel, string) error   { return nil }
+func (m *mockNetlinker) TunnelUp(*routing.Tunnel) error                { return nil }
+func (m *mockNetlinker) RouteAdd(*routing.Route) error                 { return nil }
+func (m *mockNetlinker) RouteDelete(*routing.Route) error              { return nil }
+func (m *mockNetlinker) RuleAdd(*routing.IPRule) error                 { return nil }
+func (m *mockNetlinker) RuleDel(*routing.IPRule) error                 { return nil }
+func (m *mockNetlinker) RouteByProtocol(int) ([]*routing.Route, error) { return nil, nil }
+
+func (m *mockNetlinker) RouteGet(ip net.IP) ([]*routing.Route, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.RouteGetFunc == nil {
+		return nil, nil
+	}
+	return m.RouteGetFunc(ip)
+}
+
+func TestServeResolveRouteHandler_Success(t *testing.T) {
+	t.Parallel()
+
+	dstIP := net.ParseIP("192.0.2.1")
+	srcIP := net.ParseIP("10.0.0.1")
+	nextHop := net.ParseIP("203.0.113.1")
+
+	nlr := &mockNetlinker{
+		RouteGetFunc: func(ip net.IP) ([]*routing.Route, error) {
+			require.Equal(t, dstIP, ip)
+			return []*routing.Route{
+				{
+					Dst:     &net.IPNet{IP: dstIP, Mask: net.CIDRMask(32, 32)},
+					Src:     srcIP,
+					NextHop: nextHop,
+				},
+			}, nil
+		},
+	}
+
+	reqBody := ResolveRouteRequest{Dst: dstIP}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var got ResolveRouteResponse
+	err = json.NewDecoder(rr.Body).Decode(&got)
+	require.NoError(t, err)
+	require.Equal(t, srcIP, got.Src)
+}
+
+func TestServeResolveRouteHandler_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dstIP := net.ParseIP("192.0.2.1")
+	otherIP := net.ParseIP("192.0.2.2")
+
+	nlr := &mockNetlinker{
+		RouteGetFunc: func(ip net.IP) ([]*routing.Route, error) {
+			require.Equal(t, dstIP, ip)
+			return []*routing.Route{
+				{
+					Dst: &net.IPNet{IP: otherIP, Mask: net.CIDRMask(32, 32)},
+					Src: net.ParseIP("10.0.0.1"),
+				},
+			}, nil
+		},
+	}
+
+	reqBody := ResolveRouteRequest{Dst: dstIP}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "route not found")
+}
+
+func TestServeResolveRouteHandler_EmptyRoutes(t *testing.T) {
+	t.Parallel()
+
+	dstIP := net.ParseIP("192.0.2.1")
+
+	nlr := &mockNetlinker{
+		RouteGetFunc: func(ip net.IP) ([]*routing.Route, error) {
+			require.Equal(t, dstIP, ip)
+			return nil, nil
+		},
+	}
+
+	reqBody := ResolveRouteRequest{Dst: dstIP}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "route not found")
+}
+
+func TestServeResolveRouteHandler_RouteGetError(t *testing.T) {
+	t.Parallel()
+
+	dstIP := net.ParseIP("192.0.2.1")
+
+	nlr := &mockNetlinker{
+		RouteGetFunc: func(ip net.IP) ([]*routing.Route, error) {
+			require.Equal(t, dstIP, ip)
+			return nil, errors.New("netlink error")
+		},
+	}
+
+	reqBody := ResolveRouteRequest{Dst: dstIP}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.Contains(t, rr.Body.String(), "failed to resolve route")
+}
+
+func TestServeResolveRouteHandler_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	nlr := &mockNetlinker{}
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "malformed request")
+}
+
+func TestServeResolveRouteHandler_MissingDst(t *testing.T) {
+	t.Parallel()
+
+	nlr := &mockNetlinker{}
+
+	reqBody := ResolveRouteRequest{Dst: nil}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "invalid request")
+}
+
+func TestServeResolveRouteHandler_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	nlr := &mockNetlinker{}
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(nil))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "malformed request")
+}
+
+func TestServeResolveRouteHandler_MultipleRoutes_FirstMatch(t *testing.T) {
+	t.Parallel()
+
+	dstIP := net.ParseIP("192.0.2.1")
+	srcIP1 := net.ParseIP("10.0.0.1")
+	srcIP2 := net.ParseIP("10.0.0.2")
+
+	nlr := &mockNetlinker{
+		RouteGetFunc: func(ip net.IP) ([]*routing.Route, error) {
+			require.Equal(t, dstIP, ip)
+			return []*routing.Route{
+				{
+					Dst: &net.IPNet{IP: dstIP, Mask: net.CIDRMask(32, 32)},
+					Src: srcIP1,
+				},
+				{
+					Dst: &net.IPNet{IP: dstIP, Mask: net.CIDRMask(32, 32)},
+					Src: srcIP2,
+				},
+			}, nil
+		},
+	}
+
+	reqBody := ResolveRouteRequest{Dst: dstIP}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/resolve-route", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler := ServeResolveRouteHandler(nlr, &config.NetworkConfig{})
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var got ResolveRouteResponse
+	err = json.NewDecoder(rr.Body).Decode(&got)
+	require.NoError(t, err)
+	require.Equal(t, srcIP1, got.Src)
+}

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -84,6 +84,7 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 	mux.HandleFunc("POST /remove", nlm.ServeRemove)
 	mux.HandleFunc("GET /status", nlm.ServeStatus)
 	mux.HandleFunc("GET /routes", api.ServeRoutesHandler(nlr, lm, db, networkConfig))
+	mux.HandleFunc("POST /resolve-route", api.ServeResolveRouteHandler(nlr, networkConfig))
 
 	if enableLatencyProbing {
 		latencyManager := latency.NewLatencyManager(


### PR DESCRIPTION
## Summary of Changes
- Support clients connecting behind NAT in IBRL-with-allocated-IP mode
- Connect command resolves tunnel source IP from routing table, which when behind NAT is not the client's public IP
- Add resolve-route API endpoint to daemon
- Closes https://github.com/malbeclabs/doublezero/issues/2441 

## Testing Verification
- Added CLI tests for connect command workflow
- Added daemon tests for resolve-route API handler
- Deployed snapshot to NAT'd client, connected in `-a` mode, confirmed BGP up, tested connectivity