### PR TITLE
devcontainer: fix rust component snapshot builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,6 @@
         "--ulimit",
         "nofile=1048576:1048576"
     ],
-    "containerEnv": {
-        "CARGO_TARGET_DIR": "/cargo-target"
-    },
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
         "ghcr.io/devcontainers/features/go:1": {
@@ -59,7 +56,7 @@
     "remoteUser": "root",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-        "source=cargo-target-doublezero-devcontainer,target=/cargo-target,type=volume"
+        "source=devcontainer-target,target=/workspaces/doublezero/target,type=volume"
     ],
     "capAdd": [
         "NET_ADMIN",


### PR DESCRIPTION
## Summary of Changes
- Using a custom `CARGO_TARGET_DIR` breaks goreleaser rust builder expectations, and overriding doesn't work. So use the standard target dir but define a volume mount on top of the hosts so we still use a separate one inside the devcontainer

## Testing Verification
- Rebuilt devcontainer locally, built snapshot of client, confirmed hosts target dir does not contain containers contents
