### PR TITLE
flow-ingest: accept expanded flow samples

### DIFF
--- a/telemetry/flow-ingest/internal/server/server.go
+++ b/telemetry/flow-ingest/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -211,13 +212,13 @@ func (s *Server) ingestPacket(ctx context.Context, workerID int, p packet) {
 		return
 	}
 
-	hasFlowSample := false
-	for _, sample := range msg.Samples {
-		if _, ok := sample.(sflow.FlowSample); ok {
-			hasFlowSample = true
-			break
+	hasFlowSample := slices.ContainsFunc(msg.Samples, func(s any) bool {
+		switch s.(type) {
+		case sflow.FlowSample, sflow.ExpandedFlowSample:
+			return true
 		}
-	}
+		return false
+	})
 	if !hasFlowSample {
 		metrics.PacketsWithoutFlowSample.Inc()
 		return

--- a/telemetry/flow-ingest/internal/server/server_test.go
+++ b/telemetry/flow-ingest/internal/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"log/slog"
@@ -282,3 +284,196 @@ type dummyAddr string
 
 func (d dummyAddr) Network() string { return "dummy" }
 func (d dummyAddr) String() string  { return string(d) }
+
+func TestTelemetry_FlowIngest_Server_Ingest_AcceptsFlowSample(t *testing.T) {
+	t.Parallel()
+
+	var produced int32
+	mk := &mockKafkaClient{
+		ProduceFunc: func(ctx context.Context, rec *kgo.Record, fn func(*kgo.Record, error)) {
+			atomic.AddInt32(&produced, 1)
+			fn(rec, nil)
+		},
+	}
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.KafkaClient = mk
+		c.WorkerCount = 1
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	s.ingestPacket(context.Background(), 0, packet{
+		addr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234},
+		data: buildSFlowV5DatagramWithFlowSample(),
+	})
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&produced))
+}
+
+func TestTelemetry_FlowIngest_Server_Ingest_AcceptsExpandedFlowSample(t *testing.T) {
+	t.Parallel()
+
+	var produced int32
+	mk := &mockKafkaClient{
+		ProduceFunc: func(ctx context.Context, rec *kgo.Record, fn func(*kgo.Record, error)) {
+			atomic.AddInt32(&produced, 1)
+			fn(rec, nil)
+		},
+	}
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.KafkaClient = mk
+		c.WorkerCount = 1
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	s.ingestPacket(context.Background(), 0, packet{
+		addr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234},
+		data: buildSFlowV5DatagramWithExpandedFlowSample(),
+	})
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&produced))
+}
+
+func TestTelemetry_FlowIngest_Server_Ingest_RejectsNoFlowSample(t *testing.T) {
+	t.Parallel()
+
+	var produced int32
+	mk := &mockKafkaClient{
+		ProduceFunc: func(ctx context.Context, rec *kgo.Record, fn func(*kgo.Record, error)) {
+			atomic.AddInt32(&produced, 1)
+			fn(rec, nil)
+		},
+	}
+
+	cfg := newTestConfig(t, func(c *Config) {
+		c.KafkaClient = mk
+		c.WorkerCount = 1
+	})
+
+	s, err := New(cfg)
+	require.NoError(t, err)
+
+	s.ingestPacket(context.Background(), 0, packet{
+		addr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234},
+		data: buildSFlowV5DatagramWithCounterSample(),
+	})
+
+	require.Equal(t, int32(0), atomic.LoadInt32(&produced))
+}
+
+// buildSFlowV5DatagramWithFlowSample builds a minimal sFlow v5 datagram containing a FlowSample (type 1).
+func buildSFlowV5DatagramWithFlowSample() []byte {
+	return buildSFlowV5Datagram(1) // FlowSample
+}
+
+// buildSFlowV5DatagramWithExpandedFlowSample builds a minimal sFlow v5 datagram containing an ExpandedFlowSample (type 3).
+func buildSFlowV5DatagramWithExpandedFlowSample() []byte {
+	return buildSFlowV5Datagram(3) // ExpandedFlowSample
+}
+
+// buildSFlowV5DatagramWithCounterSample builds a minimal sFlow v5 datagram containing a CounterSample (type 2).
+func buildSFlowV5DatagramWithCounterSample() []byte {
+	return buildSFlowV5Datagram(2) // CounterSample
+}
+
+// buildSFlowV5Datagram builds a minimal sFlow v5 datagram with the specified sample type.
+func buildSFlowV5Datagram(sampleType uint32) []byte {
+	var out bytes.Buffer
+	w32 := func(v uint32) { _ = binary.Write(&out, binary.BigEndian, v) }
+
+	// sFlow v5 header
+	w32(5)                        // version
+	w32(1)                        // address type (IPv4)
+	out.Write([]byte{1, 2, 3, 4}) // agent address
+	w32(0)                        // sub-agent ID
+	w32(1)                        // sequence number
+	w32(100)                      // uptime
+	w32(1)                        // number of samples
+
+	// Build sample based on type
+	var sample bytes.Buffer
+	sw32 := func(v uint32) { _ = binary.Write(&sample, binary.BigEndian, v) }
+
+	switch sampleType {
+	case 1: // FlowSample
+		sw32(1)    // sample sequence
+		sw32(0)    // source ID
+		sw32(1000) // sampling rate
+		sw32(1)    // sample pool
+		sw32(0)    // drops
+		sw32(0)    // input
+		sw32(0)    // output
+		sw32(1)    // number of records
+	case 3: // ExpandedFlowSample
+		sw32(1)    // sample sequence
+		sw32(0)    // source ID type
+		sw32(0)    // source ID index
+		sw32(1000) // sampling rate
+		sw32(1)    // sample pool
+		sw32(0)    // drops
+		sw32(0)    // input format
+		sw32(0)    // input value
+		sw32(0)    // output format
+		sw32(0)    // output value
+		sw32(1)    // number of records
+	default: // CounterSample (type 2)
+		sw32(1) // sample sequence
+		sw32(0) // source ID
+		sw32(1) // number of records
+
+		// Add a minimal counter record
+		var rec bytes.Buffer
+		rw32 := func(v uint32) { _ = binary.Write(&rec, binary.BigEndian, v) }
+		rw32(1) // counter format (generic interface)
+		rw32(0) // counter length (empty for simplicity)
+
+		sw32(1)                 // record format
+		sw32(uint32(rec.Len())) // record length
+		sample.Write(rec.Bytes())
+
+		w32(sampleType)
+		w32(uint32(sample.Len()))
+		out.Write(sample.Bytes())
+		return out.Bytes()
+	}
+
+	// Add a raw packet record for flow samples
+	var rec bytes.Buffer
+	rw32 := func(v uint32) { _ = binary.Write(&rec, binary.BigEndian, v) }
+
+	rw32(1)  // protocol (ethernet)
+	rw32(64) // frame length
+	rw32(0)  // stripped
+
+	// Minimal Ethernet + IPv4 + UDP packet
+	ethIPv4UDP := []byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst mac
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // src mac
+		0x08, 0x00, // ethertype IPv4
+		0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00, // IPv4 header
+		0x0a, 0x00, 0x00, 0x01, // src IP
+		0x0a, 0x00, 0x00, 0x02, // dst IP
+		0x00, 0x35, 0x00, 0x35, 0x00, 0x08, 0x00, 0x00, // UDP header
+	}
+
+	rw32(uint32(len(ethIPv4UDP)))
+	rec.Write(ethIPv4UDP)
+	for rec.Len()%4 != 0 {
+		rec.WriteByte(0)
+	}
+
+	sw32(1)                 // record header: format=1 (raw packet), enterprise=0
+	sw32(uint32(rec.Len())) // record length
+	sample.Write(rec.Bytes())
+
+	w32(sampleType)
+	w32(uint32(sample.Len()))
+	out.Write(sample.Bytes())
+
+	return out.Bytes()
+}


### PR DESCRIPTION
## Summary of Changes
This adds support for accepting expanded flow samples to flow ingestion. We currently only accept standard flow sample packets but testnet devices use subinterfaces which causes devices to wrap samples in a modified frame format.

## Testing Verification
The tests added exercise standard, expanded and missing flow samples into packet ingestion.
