### PR TITLE
telemetry/flow-ingest: fix flake in integration test

### DIFF
--- a/telemetry/flow-ingest/internal/e2e/server_test.go
+++ b/telemetry/flow-ingest/internal/e2e/server_test.go
@@ -272,6 +272,7 @@ func isRetryableContainerStartErr(err error) bool {
 	s := err.Error()
 	return strings.Contains(s, "wait until ready") ||
 		strings.Contains(s, "mapped port") ||
+		strings.Contains(s, "timeout") ||
 		strings.Contains(s, "context deadline exceeded") ||
 		strings.Contains(s, "/containers/") && strings.Contains(s, "json") ||
 		strings.Contains(s, "Get \"http://%2Fvar%2Frun%2Fdocker.sock")


### PR DESCRIPTION
## Summary of Changes
- Add a missing testcontainer retryable case that we ran into on this run: https://github.com/malbeclabs/doublezero/actions/runs/20397355481/job/58614750657#logs
