### PR TITLE
telemetry: add gnmi tunnel proxy tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,8 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oapi-codegen/runtime v1.0.0 // indirect
+	github.com/openconfig/gnmi v0.10.0 // indirect
+	github.com/openconfig/grpctunnel v0.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/oschwald/maxminddb-golang v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,10 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/openconfig/gnmi v0.10.0 h1:kQEZ/9ek3Vp2Y5IVuV2L/ba8/77TgjdXg505QXvYmg8=
+github.com/openconfig/gnmi v0.10.0/go.mod h1:Y9os75GmSkhHw2wX8sMsxfI7qRGAEcDh8NTa5a8vj6E=
+github.com/openconfig/grpctunnel v0.1.0 h1:EN99qtlExZczgQgp5ANnHRC/Rs62cAG+Tz2BQ5m/maM=
+github.com/openconfig/grpctunnel v0.1.0/go.mod h1:G04Pdu0pml98tdvXrvLaU+EBo3PxYfI9MYqpvdaEHLo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/telemetry/state-ingest/cmd/gnmi_tunnel/main.go
+++ b/telemetry/state-ingest/cmd/gnmi_tunnel/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/openconfig/grpctunnel/bidi"
+	"github.com/openconfig/grpctunnel/tunnel"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	tpb "github.com/openconfig/grpctunnel/proto/tunnel"
+)
+
+var (
+	target        = flag.String("target", "dzd01", "Target name to use when registering with the tunnel server")
+	targetType    = flag.String("target-type", "GNMI_GNOI", "The target type to register")
+	localDialAddr = flag.String("local-dial-addr", "/var/run/gnmiServer.sock", "The local dial address to connect to")
+	tunServerAddr = flag.String("tunnel-server-addr", "localhost:10000", "The tunnel server address to connect to")
+)
+
+func main() {
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	go func() {
+		bo := backoff.NewExponentialBackOff()
+		bo.MaxElapsedTime = 0
+		bo.InitialInterval = 1 * time.Second
+		bo.MaxInterval = 1 * time.Minute
+		bo.RandomizationFactor = 0.5
+		var err error
+		for {
+			if err = run(ctx, logger); err != nil {
+				logger.Error("tunnel client error", "error", err)
+				wait := bo.NextBackOff()
+				logger.Info("reconnecting", "in", wait)
+				time.Sleep(wait)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+	}()
+
+	<-ctx.Done()
+}
+
+func run(ctx context.Context, logger *slog.Logger) error {
+	clientConn, err := grpc.NewClient(*tunServerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("grpc dial error: %w", err)
+	}
+	defer clientConn.Close()
+
+	logger.Info("tunnel client connected to", "address", *tunServerAddr)
+
+	registerHandler := func(t tunnel.Target) error {
+		if t.ID == *target {
+			return nil
+		}
+		return fmt.Errorf("could not register handler for target: %s", t.ID)
+	}
+
+	handler := func(t tunnel.Target, i io.ReadWriteCloser) error {
+		var dialAddr string
+		if t.ID == *target && t.Type == *targetType {
+			dialAddr = *localDialAddr
+		}
+		if len(dialAddr) == 0 {
+			return fmt.Errorf("no local port found for target: %s", t.ID)
+		}
+
+		conn, err := net.Dial("unix", dialAddr)
+		if err != nil {
+			return fmt.Errorf("failed to dial %s: %v", dialAddr, err)
+		}
+
+		logger.Info("new session established for target", "target", t)
+		if err = bidi.Copy(i, conn); err != nil {
+			return fmt.Errorf("error while copying between connections: %v", err)
+		}
+		return nil
+	}
+
+	ts := make(map[tunnel.Target]struct{})
+	t := tunnel.Target{ID: *target, Type: *targetType}
+	ts[t] = struct{}{}
+
+	client, err := tunnel.NewClient(tpb.NewTunnelClient(clientConn), tunnel.ClientConfig{
+		RegisterHandler: registerHandler,
+		Handler:         handler,
+	}, ts)
+
+	if err != nil {
+		return fmt.Errorf("failed to create tunnel client: %w", err)
+	}
+
+	if err := client.Register(ctx); err != nil {
+		return fmt.Errorf("failed to register tunnel client: %w", err)
+	}
+	logger.Info("tunnel client registered to", "address", *tunServerAddr)
+
+	client.Start(ctx)
+	return client.Error()
+}


### PR DESCRIPTION
## Summary of Changes
This adds an example of a gRPC tunnel proxy for DZDs which enables the ability to subscribe to gNMI streaming telemetry samples without the requirement of dialing into devices. The tunnel proxy initiates a gRPC tunnel towards a collector, which then can be used to accept telemetry subscriptions over said tunnel. Subscription requests are then forwarded to the locally running gNMI server via a unix domain socket.

## Testing Verification
Start collector instance with configuration to ask for the input pkt counter of Ethernet1 every 10s:
```
➜  cat config.yaml
insecure: true
username: admin
password: ""

subscriptions:
  sub1:
    stream-mode: SAMPLE
    paths:
      - /interfaces/interface[name=Ethernet1]/state/counters/in-pkts
    sample-interval: 10s

tunnel-server:
  address: :10000
  targets:
    - id: .*
      type: GNMI_GNOI
      config:
        subscriptions:
          - sub1
          - 
➜  gnmic --config ./config.yaml --use-tunnel-server subscribe
...
```

Start tunnel proxy on device which dials out to collector:
```
[root@e76554a34f51 app]# ./gnmi_tunnel -tunnel-server-addr 10.0.0.176:10000
time=2025-12-23T01:53:17.761Z level=INFO msg="tunnel client connected to" address=10.0.0.176:10000
time=2025-12-23T01:53:17.770Z level=INFO msg="tunnel client registered to" address=10.0.0.176:10000
time=2025-12-23T01:53:17.774Z level=INFO msg="new session established for target" target="{ID:dzd01 Type:GNMI_GNOI}"
```

Subscription responses begin to magically show up on the collector:
```
➜  gnmic --config ./config.yaml --use-tunnel-server subscribe
{
  "source": "dzd01",
  "subscription-name": "sub1",
  "timestamp": 1766454796083385625,
  "time": "2025-12-22T20:53:16.083385625-05:00",
  "updates": [
    {
      "Path": "interfaces/interface[name=Ethernet1]/state/counters/in-pkts",
      "values": {
        "interfaces/interface/state/counters/in-pkts": 9337
      }
    }
  ]
}
{
  "sync-response": true
}
```