### PR TITLE
Network Provisioning [1/3] Add health management framework for devices and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - CLI
   - IP address lookup responses that do not contain a valid IPv4 address (such as upstream timeout messages) are now treated as retryable errors instead of being parsed as IPs.
   - `doublezero resource` commands added for managing ResourceExtension accounts.
+  - Added health_oracle to the smart contract global configuration to manage and authorize health-related operations.
 - Onchain programs
   - Allow contributor owner to update ops manager key
   - Add new arguments on create interface cli command
@@ -19,6 +20,7 @@ All notable changes to this project will be documented in this file.
   - Enforce best practices for instruction implementation across onchain programs
   - Add missing system program account owner checks in multiple instructions
   - Refactor codebase for improved maintainability and future development
+  - Introduced health management for Devices and Links, adding explicit health states, authorized health updates, and related state, processor, and test enhancements.
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle

--- a/activator/src/activator_metrics.rs
+++ b/activator/src/activator_metrics.rs
@@ -45,6 +45,7 @@ fn ip_count(device: &DeviceState) -> (u32, u32) {
 mod tests {
     use super::*;
     use doublezero_sdk::{AccountType, Device, DeviceStatus, DeviceType};
+    use doublezero_serviceability::state::device::DeviceHealth;
     use solana_sdk::pubkey::Pubkey;
 
     #[test]
@@ -68,6 +69,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         let mut device = DeviceState::new(&device);

--- a/activator/src/process/device.rs
+++ b/activator/src/process/device.rs
@@ -179,6 +179,8 @@ mod tests {
                 ],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             let mut expected_interfaces = [
@@ -361,6 +363,7 @@ mod tests {
             ],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let mut ip_block_allocator = IPBlockAllocator::new("1.1.1.0/24".parse().unwrap());

--- a/activator/src/process/link.rs
+++ b/activator/src/process/link.rs
@@ -190,6 +190,7 @@ mod tests {
                 code: "TestLink".to_string(),
                 side_a_iface_name: "Ethernet0".to_string(),
                 side_z_iface_name: "Ethernet1".to_string(),
+                link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
             };
 
             let tunnel_cloned = tunnel.clone();
@@ -311,6 +312,7 @@ mod tests {
             code: "TestLink".to_string(),
             side_a_iface_name: "Ethernet0".to_string(),
             side_z_iface_name: "Ethernet1".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
         };
 
         let link_cloned = link.clone();
@@ -367,6 +369,7 @@ mod tests {
                 code: "TestLink".to_string(),
                 side_a_iface_name: "Ethernet0".to_string(),
                 side_z_iface_name: "Ethernet1".to_string(),
+                link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
             };
 
             let _ = link_ips.next_available_block(0, 2);

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -452,6 +452,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -642,6 +644,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -887,6 +891,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -993,6 +999,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -1124,6 +1132,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
 
             devices.insert(device_pubkey, DeviceState::new(&device));

--- a/activator/src/tests.rs
+++ b/activator/src/tests.rs
@@ -30,6 +30,7 @@ pub mod utils {
             sentinel_authority_pk: payer,
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
+            health_oracle_pk: payer,
         };
 
         client.expect_get_payer().returning(move || payer);

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -940,6 +940,8 @@ mod tests {
                 interfaces: vec![],
                 max_users: 255,
                 users_count: 0,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             };
             devices.insert(pk, device.clone());
             (pk, device)

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -180,6 +180,8 @@ mod tests {
                 reference_count: 0,
                 users_count: 64,
                 max_users: 128,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             },
         );
 
@@ -205,6 +207,8 @@ mod tests {
                 reference_count: 0,
                 users_count: 64,
                 max_users: 128,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             },
         );
 
@@ -367,6 +371,8 @@ mod tests {
                 reference_count: 0,
                 users_count: 64,
                 max_users: 128,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             },
         );
 
@@ -392,6 +398,8 @@ mod tests {
                 reference_count: 0,
                 users_count: 64,
                 max_users: 128,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             },
         );
 

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -141,6 +141,8 @@ mod tests {
                 reference_count: 0,
                 users_count,
                 max_users: 1,
+                device_health:
+                    doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
             },
         )
     }

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_device_list.tmpl
@@ -1,9 +1,9 @@
-account     | code        | contributor | location | exchange | device_type | public_ip        | dz_prefixes                              | users | max_users | status    | owner              | mgmt_vrf
-IGNORED     | la2-dz01    | co01        | lax      | xlax     | hybrid      | 207.45.216.134   | 207.45.216.136/30, 200.12.12.12/29       | 5     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ty2-dz01    | co01        | tyo      | xtyo     | hybrid      | 180.87.154.112   | 180.87.154.120/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ams-dz001   | co01        | ams      | xams     | hybrid      | 195.219.138.50   | 195.219.138.56/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | pit-dzd01   | co01        | pit      | xpit     | hybrid      | 204.16.241.243   | 204.16.243.243/32                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | frk-dz01    | co01        | fra      | xfra     | hybrid      | 195.219.220.88   | 195.219.220.96/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | sg1-dz01    | co01        | sin      | xsin     | hybrid      | 180.87.102.104   | 180.87.102.112/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ny5-dz01    | co01        | ewr      | xewr     | hybrid      | {{.DeviceIP}}    | {{.DeviceDZPrefix}}                      | 1     | 128       | activated | {{.ManagerPubkey}} | mgmt
-IGNORED     | ld4-dz01    | co01        | lhr      | xlhr     | hybrid      | 195.219.120.72   | 195.219.120.80/29                        | 0     | 128       | activated | {{.ManagerPubkey}} | mgmt
+account     | code        | contributor | location | exchange | device_type | public_ip        | dz_prefixes                              | users | max_users | status    | health  | owner              | mgmt_vrf
+IGNORED     | la2-dz01    | co01        | lax      | xlax     | hybrid      | 207.45.216.134   | 207.45.216.136/30, 200.12.12.12/29       | 5     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | ty2-dz01    | co01        | tyo      | xtyo     | hybrid      | 180.87.154.112   | 180.87.154.120/29                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | ams-dz001   | co01        | ams      | xams     | hybrid      | 195.219.138.50   | 195.219.138.56/29                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | pit-dzd01   | co01        | pit      | xpit     | hybrid      | 204.16.241.243   | 204.16.243.243/32                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | frk-dz01    | co01        | fra      | xfra     | hybrid      | 195.219.220.88   | 195.219.220.96/29                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | sg1-dz01    | co01        | sin      | xsin     | hybrid      | 180.87.102.104   | 180.87.102.112/29                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | ny5-dz01    | co01        | ewr      | xewr     | hybrid      | {{.DeviceIP}}    | {{.DeviceDZPrefix}}                      | 1     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt
+IGNORED     | ld4-dz01    | co01        | lhr      | xlhr     | hybrid      | 195.219.120.72   | 195.219.120.80/29                        | 0     | 128       | activated | pending | {{.ManagerPubkey}} | mgmt

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -340,6 +340,7 @@ mod tests {
             users_count: 0,
             max_users: 100,
             owner: Pubkey::default(),
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let mut devices = HashMap::new();

--- a/smartcontract/cli/src/device/delete.rs
+++ b/smartcontract/cli/src/device/delete.rs
@@ -117,6 +117,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/get.rs
+++ b/smartcontract/cli/src/device/get.rs
@@ -32,6 +32,7 @@ interfaces: {:?}\r\n\
 max_users: {}\r\n\
 users_count: {}\r\n\
 status: {}\r\n\
+health: {}\r\n\
 owner: {}",
             pubkey,
             device.code,
@@ -47,6 +48,7 @@ owner: {}",
             device.max_users,
             device.users_count,
             device.status,
+            device.device_health,
             device.owner
         )?;
 
@@ -94,6 +96,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client
@@ -122,6 +125,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\nstatus: activated\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\nstatus: activated\r\nhealth: ready-for-users\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }
 }

--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -154,6 +154,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/delete.rs
+++ b/smartcontract/cli/src/device/interface/delete.rs
@@ -131,6 +131,7 @@ mod tests {
             ],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/get.rs
+++ b/smartcontract/cli/src/device/interface/get.rs
@@ -120,6 +120,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/list.rs
+++ b/smartcontract/cli/src/device/interface/list.rs
@@ -185,6 +185,7 @@ mod tests {
             ],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -202,6 +202,7 @@ mod tests {
             ],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -10,6 +10,7 @@ use doublezero_sdk::{
     },
     DeviceStatus, DeviceType,
 };
+use doublezero_serviceability::state::device::DeviceHealth;
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr};
@@ -59,6 +60,7 @@ pub struct DeviceDisplay {
     pub users: u16,
     pub max_users: u16,
     pub status: DeviceStatus,
+    pub health: DeviceHealth,
     pub mgmt_vrf: String,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
@@ -127,6 +129,7 @@ impl ListDeviceCliCommand {
                     mgmt_vrf: device.mgmt_vrf.clone(),
                     users: device.users_count,
                     max_users: device.max_users,
+                    health: device.device_health,
                     owner: device.owner,
                 }
             })
@@ -253,6 +256,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client.expect_list_device().returning(move |_| {
@@ -270,7 +274,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, " account                                   | code         | contributor       | location       | exchange       | device_type | public_ip | dz_prefixes | users | max_users | status    | mgmt_vrf | owner                                     \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB | device1_code | contributor1_code | location1_code | exchange1_code | hybrid      | 1.2.3.4   | 1.2.3.4/32  | 0     | 255       | activated | default  | 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB \n");
+        assert_eq!(output_str, " account                                   | code         | contributor       | location       | exchange       | device_type | public_ip | dz_prefixes | users | max_users | status    | health          | mgmt_vrf | owner                                     \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB | device1_code | contributor1_code | location1_code | exchange1_code | hybrid      | 1.2.3.4   | 1.2.3.4/32  | 0     | 255       | activated | ready-for-users | default  | 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB \n");
 
         let mut output = Vec::new();
         let res = ListDeviceCliCommand {
@@ -281,6 +285,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\",\"code\":\"device1_code\",\"bump_seed\":2,\"location_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"contributor_code\":\"contributor1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"exchange_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPA\",\"exchange_code\":\"exchange1_code\",\"exchange_name\":\"exchange1_name\",\"device_type\":\"Hybrid\",\"public_ip\":\"1.2.3.4\",\"dz_prefixes\":\"1.2.3.4/32\",\"users\":0,\"max_users\":255,\"status\":\"Activated\",\"mgmt_vrf\":\"default\",\"owner\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\",\"code\":\"device1_code\",\"bump_seed\":2,\"location_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"contributor_code\":\"contributor1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"exchange_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPA\",\"exchange_code\":\"exchange1_code\",\"exchange_name\":\"exchange1_name\",\"device_type\":\"Hybrid\",\"public_ip\":\"1.2.3.4\",\"dz_prefixes\":\"1.2.3.4/32\",\"users\":0,\"max_users\":255,\"status\":\"Activated\",\"health\":\"ReadyForUsers\",\"mgmt_vrf\":\"default\",\"owner\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\"}]\n");
     }
 }

--- a/smartcontract/cli/src/device/resume.rs
+++ b/smartcontract/cli/src/device/resume.rs
@@ -117,6 +117,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/suspend.rs
+++ b/smartcontract/cli/src/device/suspend.rs
@@ -117,6 +117,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/device/update.rs
+++ b/smartcontract/cli/src/device/update.rs
@@ -236,6 +236,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -256,6 +257,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device3 = Device {
             account_type: AccountType::Device,
@@ -276,6 +278,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device_list = HashMap::from([
             (pda_pubkey, device1.clone()),
@@ -378,6 +381,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -398,6 +402,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device_list = HashMap::from([(pda_pubkey, device1.clone()), (other_pubkey, device2)]);
 
@@ -471,6 +476,7 @@ mod tests {
             interfaces: vec![],
             max_users: 1024,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -491,6 +497,7 @@ mod tests {
             interfaces: vec![],
             max_users: 1024,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device_list = HashMap::from([(pda_pubkey, device1.clone()), (other_pubkey, device2)]);
 

--- a/smartcontract/cli/src/exchange/get.rs
+++ b/smartcontract/cli/src/exchange/get.rs
@@ -96,6 +96,7 @@ mod tests {
             dz_prefixes: "10.0.0.1/24".parse().unwrap(),
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/exchange/list.rs
+++ b/smartcontract/cli/src/exchange/list.rs
@@ -132,6 +132,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2_pubkey = Pubkey::new_unique();
         let device2 = Device {
@@ -153,6 +154,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client.expect_list_device().returning(move |_| {

--- a/smartcontract/cli/src/exchange/setdevice.rs
+++ b/smartcontract/cli/src/exchange/setdevice.rs
@@ -107,6 +107,7 @@ mod tests {
             reference_count: 0,
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let exchange = Exchange {

--- a/smartcontract/cli/src/link/accept.rs
+++ b/smartcontract/cli/src/link/accept.rs
@@ -160,6 +160,7 @@ mod tests {
             mgmt_vrf: "default".to_string(),
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client
@@ -200,6 +201,7 @@ mod tests {
             mgmt_vrf: "default".to_string(),
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client
@@ -229,6 +231,7 @@ mod tests {
             owner: pda_pubkey,
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         client

--- a/smartcontract/cli/src/link/delete.rs
+++ b/smartcontract/cli/src/link/delete.rs
@@ -84,6 +84,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -107,6 +108,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let tunnel = Link {
@@ -129,6 +131,7 @@ mod tests {
             owner: pda_pubkey,
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         client

--- a/smartcontract/cli/src/link/dzx_create.rs
+++ b/smartcontract/cli/src/link/dzx_create.rs
@@ -211,6 +211,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -245,6 +246,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkcx");
         let exchange3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkce");
@@ -279,6 +281,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let link = Link {
             account_type: AccountType::Link,
@@ -300,6 +303,7 @@ mod tests {
             contributor_pk,
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         client

--- a/smartcontract/cli/src/link/get.rs
+++ b/smartcontract/cli/src/link/get.rs
@@ -33,6 +33,7 @@ jitter: {}ms\r\n\
 delay_override: {}ms\r\n\
 tunnel_net: {}\r\n\
 status: {}\r\n\
+health: {}\r\n\
 owner: {}",
             pubkey,
             link.code,
@@ -49,6 +50,7 @@ owner: {}",
             link.delay_override_ns as f32 / 1000000.0,
             link.tunnel_net,
             link.status,
+            link.link_health,
             link.owner
         )?;
 
@@ -98,6 +100,7 @@ mod tests {
             owner: pda_pubkey,
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         let tunnel2 = tunnel.clone();
@@ -133,7 +136,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
+        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
 
         // Expected success
         let mut output = Vec::new();
@@ -143,6 +146,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
+        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
     }
 }

--- a/smartcontract/cli/src/link/latency.rs
+++ b/smartcontract/cli/src/link/latency.rs
@@ -188,6 +188,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             delay_override_ns: 0,
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         }
     }
 

--- a/smartcontract/cli/src/link/update.rs
+++ b/smartcontract/cli/src/link/update.rs
@@ -190,6 +190,7 @@ mod tests {
             owner: pda_pubkey,
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         let link2 = Link {
@@ -212,6 +213,7 @@ mod tests {
             owner: pda_pubkey,
             side_a_iface_name: "eth2".to_string(),
             side_z_iface_name: "eth3".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         client

--- a/smartcontract/cli/src/link/wan_create.rs
+++ b/smartcontract/cli/src/link/wan_create.rs
@@ -242,6 +242,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -276,6 +277,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkcx");
         let exchange3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkce");
@@ -310,6 +312,7 @@ mod tests {
             .to_interface()],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let link = Link {
             account_type: AccountType::Link,
@@ -331,6 +334,7 @@ mod tests {
             contributor_pk,
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
+            link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
         };
 
         client

--- a/smartcontract/cli/src/multicastgroup/delete.rs
+++ b/smartcontract/cli/src/multicastgroup/delete.rs
@@ -86,6 +86,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -109,6 +110,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let multicastgroup = MulticastGroup {

--- a/smartcontract/cli/src/multicastgroup/get.rs
+++ b/smartcontract/cli/src/multicastgroup/get.rs
@@ -231,6 +231,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         let cloned_device = device.clone();

--- a/smartcontract/cli/src/multicastgroup/list.rs
+++ b/smartcontract/cli/src/multicastgroup/list.rs
@@ -113,6 +113,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9");
         let device2 = Device {
@@ -134,6 +135,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client.expect_list_device().returning(move |_| {

--- a/smartcontract/cli/src/user/create.rs
+++ b/smartcontract/cli/src/user/create.rs
@@ -115,6 +115,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -173,6 +173,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -396,6 +396,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let device2_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8");
         let device2 = Device {
@@ -417,6 +418,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
         };
         let mgroup1_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8");
         let mgroup1 = MulticastGroup {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -155,6 +155,7 @@ pub fn process_create_device(
         interfaces: vec![],
         users_count: 0,
         max_users: 0, // Initially, the Device is locked and must be activated by modifying the maximum number of users.
+        device_health: DeviceHealth::Pending,
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/mod.rs
@@ -5,5 +5,6 @@ pub mod delete;
 pub mod interface;
 pub mod reject;
 pub mod resume;
+pub mod sethealth;
 pub mod suspend;
 pub mod update;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/sethealth.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/sethealth.rs
@@ -1,0 +1,80 @@
+use core::fmt;
+
+use crate::{
+    error::DoubleZeroError,
+    serializer::try_acc_write,
+    state::{accounttype::AccountType, device::*, globalstate::GlobalState},
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+#[cfg(test)]
+use solana_program::msg;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct DeviceSetHealthArgs {
+    pub health: DeviceHealth,
+}
+
+impl fmt::Debug for DeviceSetHealthArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "health: {:?}", self.health)
+    }
+}
+
+pub fn process_set_health_device(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &DeviceSetHealthArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let device_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    #[cfg(test)]
+    msg!("process_set_health_device({:?})", value);
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    // Check the owner of the accounts
+    assert_eq!(
+        device_account.owner, program_id,
+        "Invalid PDA Account Owner"
+    );
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+    assert!(device_account.is_writable, "PDA Account is not writable");
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    assert_eq!(globalstate.account_type, AccountType::GlobalState);
+
+    if globalstate.health_oracle_pk != *payer_account.key
+        && !globalstate.foundation_allowlist.contains(payer_account.key)
+    {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
+    let mut device: Device = Device::try_from(device_account)?;
+    device.device_health = value.health;
+
+    try_acc_write(&device, device_account, payer_account, accounts)?;
+
+    #[cfg(test)]
+    msg!("Set health: {:?}", device);
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/resume.rs
@@ -89,24 +89,13 @@ pub fn process_resume_exchange(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{accounttype::AccountType, globalstate::GlobalState};
+    use crate::state::globalstate::GlobalState;
 
     #[test]
     fn payer_not_in_foundation_allowlist_cannot_resume() {
         let payer = Pubkey::new_unique();
 
-        let globalstate = GlobalState {
-            account_type: AccountType::GlobalState,
-            bump_seed: 0,
-            account_index: 0,
-            foundation_allowlist: vec![],
-            device_allowlist: vec![],
-            user_allowlist: vec![],
-            activator_authority_pk: Pubkey::default(),
-            sentinel_authority_pk: Pubkey::default(),
-            contributor_airdrop_lamports: 0,
-            user_airdrop_lamports: 0,
-        };
+        let globalstate = GlobalState::default();
 
         let is_foundation = globalstate.foundation_allowlist.contains(&payer);
         assert!(!is_foundation);
@@ -116,18 +105,7 @@ mod tests {
     fn payer_in_foundation_allowlist_can_resume() {
         let payer = Pubkey::new_unique();
 
-        let mut globalstate = GlobalState {
-            account_type: AccountType::GlobalState,
-            bump_seed: 0,
-            account_index: 0,
-            foundation_allowlist: vec![],
-            device_allowlist: vec![],
-            user_allowlist: vec![],
-            activator_authority_pk: Pubkey::default(),
-            sentinel_authority_pk: Pubkey::default(),
-            contributor_airdrop_lamports: 0,
-            user_airdrop_lamports: 0,
-        };
+        let mut globalstate = GlobalState::default();
 
         // Not in allowlist: should fail auth condition
         let is_foundation = globalstate.foundation_allowlist.contains(&payer);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/exchange/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/exchange/suspend.rs
@@ -86,24 +86,13 @@ pub fn process_suspend_exchange(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{accounttype::AccountType, globalstate::GlobalState};
+    use crate::state::globalstate::GlobalState;
 
     #[test]
     fn payer_not_in_foundation_allowlist_cannot_suspend() {
         let payer = Pubkey::new_unique();
 
-        let globalstate = GlobalState {
-            account_type: AccountType::GlobalState,
-            bump_seed: 0,
-            account_index: 0,
-            foundation_allowlist: vec![],
-            device_allowlist: vec![],
-            user_allowlist: vec![],
-            activator_authority_pk: Pubkey::default(),
-            sentinel_authority_pk: Pubkey::default(),
-            contributor_airdrop_lamports: 0,
-            user_airdrop_lamports: 0,
-        };
+        let globalstate = GlobalState::default();
 
         let is_foundation = globalstate.foundation_allowlist.contains(&payer);
         assert!(!is_foundation);
@@ -113,18 +102,7 @@ mod tests {
     fn payer_in_foundation_allowlist_can_suspend() {
         let payer = Pubkey::new_unique();
 
-        let mut globalstate = GlobalState {
-            account_type: AccountType::GlobalState,
-            bump_seed: 0,
-            account_index: 0,
-            foundation_allowlist: vec![],
-            device_allowlist: vec![],
-            user_allowlist: vec![],
-            activator_authority_pk: Pubkey::default(),
-            sentinel_authority_pk: Pubkey::default(),
-            contributor_airdrop_lamports: 0,
-            user_airdrop_lamports: 0,
-        };
+        let mut globalstate = GlobalState::default();
 
         // Not in allowlist: should fail auth condition
         let is_foundation = globalstate.foundation_allowlist.contains(&payer);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -103,6 +103,7 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         sentinel_authority_pk: *payer_account.key,
         contributor_airdrop_lamports: 1_000_000_000,
         user_airdrop_lamports: 40_000,
+        health_oracle_pk: *payer_account.key,
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setauthority.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setauthority.rs
@@ -16,6 +16,7 @@ use solana_program::{
 pub struct SetAuthorityArgs {
     pub activator_authority_pk: Option<Pubkey>,
     pub sentinel_authority_pk: Option<Pubkey>,
+    pub health_oracle_pk: Option<Pubkey>,
 }
 
 impl fmt::Debug for SetAuthorityArgs {
@@ -79,6 +80,9 @@ pub fn process_set_authority(
 
     if let Some(sentinel_authority_pk) = value.sentinel_authority_pk {
         globalstate.sentinel_authority_pk = sentinel_authority_pk;
+    }
+    if let Some(health_oracle_pk) = value.health_oracle_pk {
+        globalstate.health_oracle_pk = health_oracle_pk;
     }
 
     try_acc_write(&globalstate, globalstate_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -180,6 +180,7 @@ pub fn process_create_link(
         side_a_iface_name: value.side_a_iface_name.clone(),
         side_z_iface_name,
         delay_override_ns: 0,
+        link_health: LinkHealth::Pending,
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/mod.rs
@@ -5,5 +5,6 @@ pub mod create;
 pub mod delete;
 pub mod reject;
 pub mod resume;
+pub mod sethealth;
 pub mod suspend;
 pub mod update;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/sethealth.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/sethealth.rs
@@ -1,0 +1,76 @@
+use crate::{
+    error::DoubleZeroError,
+    serializer::try_acc_write,
+    state::{globalstate::GlobalState, link::*},
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct LinkSetHealthArgs {
+    pub health: LinkHealth,
+}
+
+impl fmt::Debug for LinkSetHealthArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "health: {:?}", self.health)
+    }
+}
+
+pub fn process_set_health_link(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &LinkSetHealthArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let link_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    #[cfg(test)]
+    msg!("process_set_health_link({:?})", value);
+
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    // Check the owner of the accounts
+    assert_eq!(link_account.owner, program_id, "Invalid PDA Account Owner");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+    // Check if the account is writable
+    assert!(link_account.is_writable, "PDA Account is not writable");
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+
+    if globalstate.health_oracle_pk != *payer_account.key
+        && !globalstate.foundation_allowlist.contains(payer_account.key)
+    {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
+    let mut link: Link = Link::try_from(link_account)?;
+
+    link.link_health = value.health;
+
+    try_acc_write(&link, link_account, payer_account, accounts)?;
+
+    msg!("Set Health: {:?}", link);
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
@@ -20,6 +20,25 @@ pub struct GlobalState {
     pub sentinel_authority_pk: Pubkey,     // 32
     pub contributor_airdrop_lamports: u64, // 8
     pub user_airdrop_lamports: u64,        // 8
+    pub health_oracle_pk: Pubkey,          // 32
+}
+
+impl Default for GlobalState {
+    fn default() -> Self {
+        Self {
+            account_type: AccountType::GlobalState,
+            bump_seed: 0,
+            account_index: 0,
+            foundation_allowlist: Vec::new(),
+            device_allowlist: Vec::new(),
+            user_allowlist: Vec::new(),
+            activator_authority_pk: Pubkey::default(),
+            sentinel_authority_pk: Pubkey::default(),
+            contributor_airdrop_lamports: 0,
+            user_airdrop_lamports: 0,
+            health_oracle_pk: Pubkey::default(),
+        }
+    }
 }
 
 impl fmt::Display for GlobalState {
@@ -34,7 +53,8 @@ user_allowlist: {:?}, \
 activator_authority_pk: {:?}, \
 sentinel_authority_pk: {:?}, \
 contributor_airdrop_lamports: {}, \
-user_airdrop_lamports: {}",
+user_airdrop_lamports: {},
+health_oracle_pk: {:?}",
             self.account_type,
             self.account_index,
             self.foundation_allowlist,
@@ -44,6 +64,7 @@ user_airdrop_lamports: {}",
             self.sentinel_authority_pk,
             self.contributor_airdrop_lamports,
             self.user_airdrop_lamports,
+            self.health_oracle_pk,
         )
     }
 }
@@ -64,6 +85,7 @@ impl TryFrom<&[u8]> for GlobalState {
             contributor_airdrop_lamports: BorshDeserialize::deserialize(&mut data)
                 .unwrap_or_default(),
             user_airdrop_lamports: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            health_oracle_pk: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::GlobalState {
@@ -151,6 +173,7 @@ mod tests {
             sentinel_authority_pk: Pubkey::new_unique(),
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -194,6 +217,7 @@ mod tests {
             sentinel_authority_pk: Pubkey::new_unique(),
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
         };
         let err = val.validate();
         assert!(err.is_err());

--- a/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
@@ -7,8 +7,8 @@ use doublezero_serviceability::{
     },
     state::{
         accounttype::AccountType,
-        device::{Device, DeviceStatus, DeviceType},
-        link::{Link, LinkLinkType, LinkStatus},
+        device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+        link::{Link, LinkHealth, LinkLinkType, LinkStatus},
     },
 };
 use doublezero_telemetry::{
@@ -431,6 +431,7 @@ async fn test_initialize_device_latency_samples_fail_origin_device_wrong_owner()
         interfaces: vec![],
         users_count: 0,
         max_users: 0,
+        device_health: DeviceHealth::Pending,
     };
 
     let mut device_data = Vec::new();
@@ -502,6 +503,7 @@ async fn test_initialize_device_latency_samples_fail_target_device_wrong_owner()
         interfaces: vec![],
         users_count: 0,
         max_users: 0,
+        device_health: DeviceHealth::Pending,
     };
 
     let mut data = Vec::new();
@@ -574,6 +576,7 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_owner() {
         tunnel_net: NetworkV4::default(),
         side_a_iface_name: "Ethernet0".to_string(),
         side_z_iface_name: "Ethernet1".to_string(),
+        link_health: LinkHealth::ReadyForService,
     };
 
     let mut data = Vec::new();

--- a/smartcontract/sdk/rs/src/commands/device/interface/create.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/create.rs
@@ -68,7 +68,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceStatus, DeviceType},
+            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -100,6 +100,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/interface/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/delete.rs
@@ -46,7 +46,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceStatus, DeviceType},
+            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -78,6 +78,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/interface/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/remove.rs
@@ -37,7 +37,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceStatus, DeviceType},
+            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -69,6 +69,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/sdk/rs/src/commands/device/interface/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/update.rs
@@ -73,7 +73,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceStatus, DeviceType},
+            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -105,6 +105,7 @@ mod tests {
             interfaces: vec![],
             max_users: 255,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/update.rs
@@ -86,7 +86,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceStatus, DeviceType},
+            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -118,6 +118,7 @@ mod tests {
             interfaces: vec![],
             max_users: 250,
             users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
         };
 
         client

--- a/smartcontract/sdk/rs/src/commands/globalstate/setauthority.rs
+++ b/smartcontract/sdk/rs/src/commands/globalstate/setauthority.rs
@@ -8,6 +8,7 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 pub struct SetAuthorityCommand {
     pub activator_authority_pk: Option<Pubkey>,
     pub sentinel_authority_pk: Option<Pubkey>,
+    pub health_oracle_pk: Option<Pubkey>,
 }
 
 impl SetAuthorityCommand {
@@ -20,6 +21,7 @@ impl SetAuthorityCommand {
             DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
                 activator_authority_pk: self.activator_authority_pk,
                 sentinel_authority_pk: self.sentinel_authority_pk,
+                health_oracle_pk: self.health_oracle_pk,
             }),
             vec![AccountMeta::new(globalstate_pubkey, false)],
         )
@@ -47,6 +49,7 @@ mod tests {
 
         let activator_authority_pk = Pubkey::new_unique();
         let sentinel_authority_pk = Pubkey::new_unique();
+        let health_oracle_pk = Pubkey::new_unique();
 
         client
             .expect_execute_transaction()
@@ -54,6 +57,7 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
                     activator_authority_pk: Some(activator_authority_pk),
                     sentinel_authority_pk: Some(sentinel_authority_pk),
+                    health_oracle_pk: Some(health_oracle_pk),
                 })),
                 predicate::eq(vec![AccountMeta::new(globalstate_pubkey, false)]),
             )
@@ -62,6 +66,7 @@ mod tests {
         let res = SetAuthorityCommand {
             activator_authority_pk: Some(activator_authority_pk),
             sentinel_authority_pk: Some(sentinel_authority_pk),
+            health_oracle_pk: Some(health_oracle_pk),
         }
         .execute(&client);
         assert!(res.is_ok());

--- a/smartcontract/sdk/rs/src/tests.rs
+++ b/smartcontract/sdk/rs/src/tests.rs
@@ -36,6 +36,7 @@ pub mod utils {
             sentinel_authority_pk: Pubkey::new_unique(),
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
         };
         client
             .expect_get()


### PR DESCRIPTION
This update introduces a comprehensive health management framework for devices and links. It adds the DeviceHealth and LinkHealth enums to explicitly represent health states, along with new set_health functionality that allows authorized updates to those statuses. The global state has been extended to include a health_oracle_pk, enabling controlled and auditable health operations. Existing processors and state structures were updated to integrate these features seamlessly, and the test suite was enhanced to validate health transitions and ensure correct behavior across all supported scenarios.

- Introduced DeviceHealth and LinkHealth enums to represent the health status of devices and links.
- Implemented sethealth functionality for devices and links, allowing updates to their health status.
- Updated global state to include health_oracle_pk for managing health-related operations.
- Modified existing processors and state structures to accommodate health management features.
- Enhanced tests to validate health status changes and ensure proper functionality.

Solves: https://github.com/malbeclabs/doublezero/issues/2477 https://github.com/malbeclabs/doublezero/issues/2475