### PR TITLE
telemetry: refactor annotator interface

### DIFF
--- a/telemetry/flow-enricher/internal/flow-enricher/enricher_integration_test.go
+++ b/telemetry/flow-enricher/internal/flow-enricher/enricher_integration_test.go
@@ -246,6 +246,8 @@ func TestFlowEnrichment(t *testing.T) {
 		WithEnricherMetrics(NewEnricherMetrics(reg)),
 		WithServiceabilityFetcher(mockServiceability),
 	)
+	enricher.AddAnnotator(NewServiceabilityAnnotator(enricher.ServiceabilityData))
+
 	go func() {
 		if err := enricher.Run(ctx); err != nil {
 			logger.Error("error during enrichment", "error", err)

--- a/telemetry/flow-enricher/internal/flow-enricher/serviceability.go
+++ b/telemetry/flow-enricher/internal/flow-enricher/serviceability.go
@@ -21,14 +21,14 @@ type ServiceabilityAnnotator struct {
 	mu             sync.RWMutex
 }
 
-func NewServiceabilityAnnotator() *ServiceabilityAnnotator {
+func NewServiceabilityAnnotator(getProgramData func() serviceability.ProgramData) *ServiceabilityAnnotator {
 	return &ServiceabilityAnnotator{
-		name: "serviceability annotator",
+		name:           "serviceability annotator",
+		getProgramData: getProgramData,
 	}
 }
 
-func (s *ServiceabilityAnnotator) Init(ctx context.Context, getProgramData func() serviceability.ProgramData) error {
-	s.getProgramData = getProgramData
+func (s *ServiceabilityAnnotator) Init(ctx context.Context) error {
 	s.updateServiceabilityCache()
 
 	go func() {


### PR DESCRIPTION
## Summary of Changes
This refactors the Annotator interface of the flow enricher to make it less clumsy when adding annotators that require other external dependencies. Prior, external dependencies were passed as part of the Init method into all annotators whether they needed them or not, which then requires touching all Init method signatures when a single dependency is added. These dependencies are now moved into the annotator constructors themselves.

## Testing Verification
Existing unit/integration tests should pass. There's no functional change that should be introduced.
