### PR TITLE
Network Provisioning [2/3] Add desired status to health 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - Add missing system program account owner checks in multiple instructions
   - Refactor codebase for improved maintainability and future development
   - Introduced health management for Devices and Links, adding explicit health states, authorized health updates, and related state, processor, and test enhancements.
+  - Introduce desired status to Link and Devices
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle

--- a/activator/src/activator_metrics.rs
+++ b/activator/src/activator_metrics.rs
@@ -70,6 +70,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let mut device = DeviceState::new(&device);

--- a/activator/src/process/device.rs
+++ b/activator/src/process/device.rs
@@ -181,6 +181,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             let mut expected_interfaces = [
@@ -364,6 +366,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let mut ip_block_allocator = IPBlockAllocator::new("1.1.1.0/24".parse().unwrap());

--- a/activator/src/process/link.rs
+++ b/activator/src/process/link.rs
@@ -191,6 +191,8 @@ mod tests {
                 side_a_iface_name: "Ethernet0".to_string(),
                 side_z_iface_name: "Ethernet1".to_string(),
                 link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
+                desired_status:
+                    doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
             };
 
             let tunnel_cloned = tunnel.clone();
@@ -313,6 +315,7 @@ mod tests {
             side_a_iface_name: "Ethernet0".to_string(),
             side_z_iface_name: "Ethernet1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         let link_cloned = link.clone();
@@ -370,6 +373,8 @@ mod tests {
                 side_a_iface_name: "Ethernet0".to_string(),
                 side_z_iface_name: "Ethernet1".to_string(),
                 link_health: doublezero_serviceability::state::link::LinkHealth::Pending,
+                desired_status:
+                    doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
             };
 
             let _ = link_ips.next_available_block(0, 2);

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -454,6 +454,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -646,6 +648,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -893,6 +897,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -1001,6 +1007,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             let user_pubkey = Pubkey::new_unique();
@@ -1134,6 +1142,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
 
             devices.insert(device_pubkey, DeviceState::new(&device));

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -942,6 +942,8 @@ mod tests {
                 users_count: 0,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             };
             devices.insert(pk, device.clone());
             (pk, device)

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -182,6 +182,8 @@ mod tests {
                 max_users: 128,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             },
         );
 
@@ -209,6 +211,8 @@ mod tests {
                 max_users: 128,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             },
         );
 
@@ -373,6 +377,8 @@ mod tests {
                 max_users: 128,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             },
         );
 
@@ -400,6 +406,8 @@ mod tests {
                 max_users: 128,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             },
         );
 

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -143,6 +143,8 @@ mod tests {
                 max_users: 1,
                 device_health:
                     doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+                desired_status:
+                    doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             },
         )
     }

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -341,6 +341,8 @@ mod tests {
             max_users: 100,
             owner: Pubkey::default(),
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let mut devices = HashMap::new();

--- a/smartcontract/cli/src/device/delete.rs
+++ b/smartcontract/cli/src/device/delete.rs
@@ -118,6 +118,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/get.rs
+++ b/smartcontract/cli/src/device/get.rs
@@ -31,6 +31,7 @@ mgmt_vrf: {}\r\n\
 interfaces: {:?}\r\n\
 max_users: {}\r\n\
 users_count: {}\r\n\
+desired_status: {}\r\n\
 status: {}\r\n\
 health: {}\r\n\
 owner: {}",
@@ -47,6 +48,7 @@ owner: {}",
             device.interfaces,
             device.max_users,
             device.users_count,
+            device.desired_status,
             device.status,
             device.device_health,
             device.owner
@@ -97,6 +99,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client
@@ -125,6 +129,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\nstatus: activated\r\nhealth: ready-for-users\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\ndesired_status: activated\r\nstatus: activated\r\nhealth: ready-for-users\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }
 }

--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -155,6 +155,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/delete.rs
+++ b/smartcontract/cli/src/device/interface/delete.rs
@@ -132,6 +132,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/get.rs
+++ b/smartcontract/cli/src/device/interface/get.rs
@@ -121,6 +121,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/list.rs
+++ b/smartcontract/cli/src/device/interface/list.rs
@@ -186,6 +186,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -203,6 +203,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -257,6 +257,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client.expect_list_device().returning(move |_| {

--- a/smartcontract/cli/src/device/resume.rs
+++ b/smartcontract/cli/src/device/resume.rs
@@ -118,6 +118,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/suspend.rs
+++ b/smartcontract/cli/src/device/suspend.rs
@@ -118,6 +118,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/device/update.rs
+++ b/smartcontract/cli/src/device/update.rs
@@ -12,6 +12,7 @@ use doublezero_sdk::{
     },
     *,
 };
+use doublezero_serviceability::state::device::DeviceDesiredStatus;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr, str::FromStr};
 
@@ -49,10 +50,13 @@ pub struct UpdateDeviceCliCommand {
     pub users_count: Option<u16>,
     /// Updated status for the device (optional)
     #[arg(long)]
-    pub status: Option<String>,
+    pub status: Option<DeviceStatus>,
     /// Device type (optional)
     #[arg(long)]
     pub device_type: Option<DeviceType>,
+    /// Desired status for the device (optional)
+    #[arg(long)]
+    pub desired_status: Option<DeviceDesiredStatus>,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -148,12 +152,6 @@ impl UpdateDeviceCliCommand {
             None
         };
 
-        let status = self
-            .status
-            .map(|s| s.parse())
-            .transpose()
-            .map_err(|e| eyre::eyre!("Invalid status: {e}"))?;
-
         let signature = client.update_device(UpdateDeviceCommand {
             pubkey,
             code: self.code,
@@ -170,7 +168,8 @@ impl UpdateDeviceCliCommand {
             interfaces: None,
             max_users: self.max_users,
             users_count: self.users_count,
-            status,
+            status: self.status,
+            desired_status: self.desired_status,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -237,6 +236,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -258,6 +259,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device3 = Device {
             account_type: AccountType::Device,
@@ -279,6 +282,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device_list = HashMap::from([
             (pda_pubkey, device1.clone()),
@@ -323,6 +328,7 @@ mod tests {
                 max_users: Some(1025),
                 users_count: Some(0),
                 status: None,
+                desired_status: None,
             }))
             .times(1)
             .returning(move |_| Ok(signature));
@@ -342,6 +348,7 @@ mod tests {
             max_users: Some(1025),
             users_count: Some(0),
             status: None,
+            desired_status: None,
             wait: false,
         }
         .execute(&client, &mut output);
@@ -382,6 +389,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -403,6 +412,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device_list = HashMap::from([(pda_pubkey, device1.clone()), (other_pubkey, device2)]);
 
@@ -437,6 +448,7 @@ mod tests {
             max_users: Some(255),
             users_count: Some(0),
             status: None,
+            desired_status: None,
             wait: false,
         }
         .execute(&client, &mut output);
@@ -477,6 +489,8 @@ mod tests {
             max_users: 1024,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2 = Device {
             account_type: AccountType::Device,
@@ -498,6 +512,8 @@ mod tests {
             max_users: 1024,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device_list = HashMap::from([(pda_pubkey, device1.clone()), (other_pubkey, device2)]);
 
@@ -531,6 +547,7 @@ mod tests {
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
             wait: false,
         }
         .execute(&client, &mut output);

--- a/smartcontract/cli/src/exchange/get.rs
+++ b/smartcontract/cli/src/exchange/get.rs
@@ -97,6 +97,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/exchange/list.rs
+++ b/smartcontract/cli/src/exchange/list.rs
@@ -133,6 +133,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2_pubkey = Pubkey::new_unique();
         let device2 = Device {
@@ -155,6 +157,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client.expect_list_device().returning(move |_| {

--- a/smartcontract/cli/src/exchange/setdevice.rs
+++ b/smartcontract/cli/src/exchange/setdevice.rs
@@ -108,6 +108,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let exchange = Exchange {

--- a/smartcontract/cli/src/link/accept.rs
+++ b/smartcontract/cli/src/link/accept.rs
@@ -161,6 +161,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client
@@ -202,6 +204,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client
@@ -232,6 +236,7 @@ mod tests {
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/link/delete.rs
+++ b/smartcontract/cli/src/link/delete.rs
@@ -85,6 +85,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -109,6 +111,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let tunnel = Link {
@@ -132,6 +136,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/link/dzx_create.rs
+++ b/smartcontract/cli/src/link/dzx_create.rs
@@ -212,6 +212,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -247,6 +249,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkcx");
         let exchange3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkce");
@@ -282,6 +286,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let link = Link {
             account_type: AccountType::Link,
@@ -304,6 +310,7 @@ mod tests {
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/link/get.rs
+++ b/smartcontract/cli/src/link/get.rs
@@ -19,22 +19,23 @@ impl GetLinkCliCommand {
         writeln!(
             out,
             "account: {}\r\n\
-code: {}\r\n\
-contributor: {}\r\n\
-side_a: {}\r\n\
-side_a_iface_name: {}\r\n\
-side_z: {}\r\n\
-side_z_iface_name: {}\r\n\
-tunnel_type: {}\r\n\
-bandwidth: {}\r\n\
-mtu: {}\r\n\
-delay: {}ms\r\n\
-jitter: {}ms\r\n\
-delay_override: {}ms\r\n\
-tunnel_net: {}\r\n\
-status: {}\r\n\
-health: {}\r\n\
-owner: {}",
+        code: {}\r\n\
+        contributor: {}\r\n\
+        side_a: {}\r\n\
+        side_a_iface_name: {}\r\n\
+        side_z: {}\r\n\
+        side_z_iface_name: {}\r\n\
+        tunnel_type: {}\r\n\
+        bandwidth: {}\r\n\
+        mtu: {}\r\n\
+        delay: {}ms\r\n\
+        jitter: {}ms\r\n\
+        delay_override: {}ms\r\n\
+        tunnel_net: {}\r\n\
+        desired_status: {}\r\n\
+        status: {}\r\n\
+        health: {}\r\n\
+        owner: {}",
             pubkey,
             link.code,
             link.contributor_pk,
@@ -49,6 +50,7 @@ owner: {}",
             link.jitter_ns as f32 / 1000000.0,
             link.delay_override_ns as f32 / 1000000.0,
             link.tunnel_net,
+            link.desired_status,
             link.status,
             link.link_health,
             link.owner
@@ -101,6 +103,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         let tunnel2 = tunnel.clone();
@@ -136,7 +139,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
+        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\ndesired_status: activated\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
 
         // Expected success
         let mut output = Vec::new();
@@ -146,6 +149,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by code");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
+        assert_eq!(output_str, "account: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nside_a: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb\r\nside_a_iface_name: eth0\r\nside_z: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf\r\nside_z_iface_name: eth1\r\ntunnel_type: WAN\r\nbandwidth: 1000000000\r\nmtu: 1500\r\ndelay: 10000ms\r\njitter: 5000ms\r\ndelay_override: 0ms\r\ntunnel_net: 10.0.0.1/16\r\ndesired_status: activated\r\nstatus: activated\r\nhealth: ready-for-service\r\nowner: 313hjD3qvP9CCxdbTGKpuACJrBwh8DhXjdVoL6gc6rf9\n");
     }
 }

--- a/smartcontract/cli/src/link/latency.rs
+++ b/smartcontract/cli/src/link/latency.rs
@@ -189,6 +189,7 @@ mod tests {
             side_z_iface_name: "eth1".to_string(),
             delay_override_ns: 0,
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         }
     }
 

--- a/smartcontract/cli/src/link/list.rs
+++ b/smartcontract/cli/src/link/list.rs
@@ -12,7 +12,7 @@ use doublezero_sdk::{
     },
     Link, LinkLinkType, LinkStatus,
 };
-use doublezero_serviceability::state::link::LinkHealth;
+use doublezero_serviceability::state::link::{LinkDesiredStatus, LinkHealth};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -67,6 +67,8 @@ pub struct LinkDisplay {
     pub delay_override_ns: u64,
     pub tunnel_id: u16,
     pub tunnel_net: NetworkV4,
+    #[tabled(skip)]
+    pub desired_status: LinkDesiredStatus,
     pub status: LinkStatus,
     pub health: LinkHealth,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
@@ -137,6 +139,7 @@ impl ListLinkCliCommand {
                     delay_override_ns: link.delay_override_ns,
                     tunnel_id: link.tunnel_id,
                     tunnel_net: link.tunnel_net,
+                    desired_status: link.desired_status,
                     status: link.status,
                     health: link.link_health,
                     owner: link.owner,
@@ -228,6 +231,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9");
         let device2 = Device {
@@ -250,6 +255,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client.expect_list_device().returning(move |_| {
@@ -281,6 +288,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client.expect_list_link().returning(move |_| {
@@ -315,7 +323,7 @@ mod tests {
         assert!(res.is_ok());
 
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"code\":\"tunnel_code\",\"contributor_code\":\"contributor1_code\",\"side_a_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_a_name\":\"device2_code\",\"side_a_iface_name\":\"eth0\",\"side_z_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_z_name\":\"device2_code\",\"side_z_iface_name\":\"eth1\",\"link_type\":\"WAN\",\"bandwidth\":\"10Gbps\",\"mtu\":4500,\"delay_ns\":20000,\"jitter_ns\":1121,\"delay_override_ns\":0,\"tunnel_id\":1234,\"tunnel_net\":\"1.2.3.4/32\",\"status\":\"Activated\",\"health\":\"ReadyForService\",\"owner\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"code\":\"tunnel_code\",\"contributor_code\":\"contributor1_code\",\"side_a_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_a_name\":\"device2_code\",\"side_a_iface_name\":\"eth0\",\"side_z_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_z_name\":\"device2_code\",\"side_z_iface_name\":\"eth1\",\"link_type\":\"WAN\",\"bandwidth\":\"10Gbps\",\"mtu\":4500,\"delay_ns\":20000,\"jitter_ns\":1121,\"delay_override_ns\":0,\"tunnel_id\":1234,\"tunnel_net\":\"1.2.3.4/32\",\"desired_status\":\"Activated\",\"status\":\"Activated\",\"health\":\"ReadyForService\",\"owner\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\"}]\n");
     }
 
     #[test]
@@ -389,6 +397,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2_pubkey = Pubkey::new_unique();
         let device2 = Device {
@@ -411,6 +421,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client.expect_list_device().returning(move |_| {
@@ -442,6 +454,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
         let tunnel2_pubkey = Pubkey::new_unique();
         let tunnel2 = Link {
@@ -465,6 +478,7 @@ mod tests {
             side_a_iface_name: "eth2".to_string(),
             side_z_iface_name: "eth3".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client.expect_list_link().returning(move |_| {

--- a/smartcontract/cli/src/link/update.rs
+++ b/smartcontract/cli/src/link/update.rs
@@ -13,6 +13,7 @@ use doublezero_sdk::commands::{
     contributor::get::GetContributorCommand,
     link::{get::GetLinkCommand, update::UpdateLinkCommand},
 };
+use doublezero_serviceability::state::link::LinkDesiredStatus;
 use eyre::eyre;
 use std::io::Write;
 
@@ -48,6 +49,9 @@ pub struct UpdateLinkCliCommand {
     /// Update link status (e.g. activated, soft-drained, hard-drained)
     #[arg(long)]
     pub status: Option<String>,
+    /// Update link desired status (e.g. activated, soft-drained, hard-drained)
+    #[arg(long)]
+    pub desired_status: Option<LinkDesiredStatus>,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -113,6 +117,7 @@ impl UpdateLinkCliCommand {
                 .delay_override_ms
                 .map(|delay_override_ms| (delay_override_ms * 1000000.0) as u64),
             status,
+            desired_status: self.desired_status,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -191,6 +196,7 @@ mod tests {
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         let link2 = Link {
@@ -214,6 +220,7 @@ mod tests {
             side_a_iface_name: "eth2".to_string(),
             side_z_iface_name: "eth3".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client
@@ -257,6 +264,7 @@ mod tests {
                 jitter_ns: Some(5000000),
                 delay_override_ns: None,
                 status: None,
+                desired_status: None,
             }))
             .returning(move |_| Ok(signature));
 
@@ -272,8 +280,9 @@ mod tests {
             delay_ms: Some(10.0),
             jitter_ms: Some(5.0),
             delay_override_ms: None,
-            wait: false,
             status: None,
+            desired_status: None,
+            wait: false,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());
@@ -294,8 +303,9 @@ mod tests {
             delay_ms: Some(10.0),
             jitter_ms: Some(5.0),
             delay_override_ms: None,
-            wait: false,
             status: None,
+            desired_status: None,
+            wait: false,
         }
         .execute(&client, &mut output);
         assert_eq!(

--- a/smartcontract/cli/src/link/wan_create.rs
+++ b/smartcontract/cli/src/link/wan_create.rs
@@ -243,6 +243,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -278,6 +280,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkcx");
         let exchange3_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquCkce");
@@ -313,6 +317,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let link = Link {
             account_type: AccountType::Link,
@@ -335,6 +341,7 @@ mod tests {
             side_a_iface_name: "Ethernet1/1".to_string(),
             side_z_iface_name: "Ethernet1/2".to_string(),
             link_health: doublezero_serviceability::state::link::LinkHealth::ReadyForService,
+            desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/multicastgroup/delete.rs
+++ b/smartcontract/cli/src/multicastgroup/delete.rs
@@ -87,6 +87,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
@@ -111,6 +113,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let multicastgroup = MulticastGroup {

--- a/smartcontract/cli/src/multicastgroup/get.rs
+++ b/smartcontract/cli/src/multicastgroup/get.rs
@@ -232,6 +232,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         let cloned_device = device.clone();

--- a/smartcontract/cli/src/multicastgroup/list.rs
+++ b/smartcontract/cli/src/multicastgroup/list.rs
@@ -114,6 +114,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9");
         let device2 = Device {
@@ -136,6 +138,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client.expect_list_device().returning(move |_| {

--- a/smartcontract/cli/src/user/create.rs
+++ b/smartcontract/cli/src/user/create.rs
@@ -116,6 +116,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -174,6 +174,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -397,6 +397,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let device2_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8");
         let device2 = Device {
@@ -419,6 +421,8 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
         };
         let mgroup1_pubkey = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8");
         let mgroup1 = MulticastGroup {

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -641,6 +641,7 @@ mod tests {
                 max_users: None,
                 users_count: None,
                 status: None,
+                desired_status: None,
             }),
             "UpdateDevice",
         );
@@ -687,6 +688,7 @@ mod tests {
                 jitter_ns: Some(100),
                 delay_override_ns: Some(0),
                 status: None,
+                desired_status: None,
             }),
             "UpdateLink",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -156,6 +156,7 @@ pub fn process_create_device(
         users_count: 0,
         max_users: 0, // Initially, the Device is locked and must be activated by modifying the maximum number of users.
         device_health: DeviceHealth::Pending,
+        desired_status: DeviceDesiredStatus::Pending,
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/sethealth.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/sethealth.rs
@@ -70,6 +70,7 @@ pub fn process_set_health_device(
 
     let mut device: Device = Device::try_from(device_account)?;
     device.device_health = value.health;
+    device.check_status_transition();
 
     try_acc_write(&device, device_account, payer_account, accounts)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
@@ -29,6 +29,7 @@ pub struct DeviceUpdateArgs {
     pub max_users: Option<u16>,
     pub users_count: Option<u16>,
     pub status: Option<DeviceStatus>,
+    pub desired_status: Option<DeviceDesiredStatus>,
 }
 
 impl fmt::Debug for DeviceUpdateArgs {
@@ -62,6 +63,9 @@ impl fmt::Debug for DeviceUpdateArgs {
         }
         if self.status.is_some() {
             write!(f, "status: {:?}, ", self.status)?;
+        }
+        if self.desired_status.is_some() {
+            write!(f, "desired_status: {:?}, ", self.desired_status)?;
         }
         Ok(())
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -181,6 +181,7 @@ pub fn process_create_link(
         side_z_iface_name,
         delay_override_ns: 0,
         link_health: LinkHealth::Pending,
+        desired_status: LinkDesiredStatus::Pending,
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -25,6 +25,7 @@ pub struct LinkUpdateArgs {
     pub jitter_ns: Option<u64>,
     pub status: Option<LinkStatus>,
     pub delay_override_ns: Option<u64>,
+    pub desired_status: Option<LinkDesiredStatus>,
 }
 
 impl fmt::Debug for LinkUpdateArgs {
@@ -56,6 +57,9 @@ impl fmt::Debug for LinkUpdateArgs {
         }
         if let Some(delay_override_ns) = self.delay_override_ns {
             parts.push(format!("delay_override_ns: {:?}", delay_override_ns));
+        }
+        if let Some(ref desired_status) = self.desired_status {
+            parts.push(format!("desired_status: {:?}", desired_status));
         }
         write!(f, "{}", parts.join(", "))
     }
@@ -192,6 +196,11 @@ pub fn process_update_link(
             }
         }
     }
+    if let Some(desired_status) = value.desired_status {
+        link.desired_status = desired_status;
+    }
+
+    link.check_status_transition();
 
     try_acc_write(&link, link_account, payer_account, accounts)?;
 
@@ -242,6 +251,7 @@ mod tests {
             jitter_ns: Some(100_000),
             status: Some(LinkStatus::Activated),
             delay_override_ns: None,
+            desired_status: None,
         };
 
         let serialized = borsh::to_vec(&args_before).unwrap();

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -170,6 +170,55 @@ impl fmt::Display for DeviceHealth {
     }
 }
 
+#[repr(u8)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Copy, Clone, PartialEq, Default)]
+#[borsh(use_discriminant = true)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DeviceDesiredStatus {
+    #[default]
+    Pending = 0,
+    Activated = 1,
+    HardDrained = 6,
+    SoftDrained = 7,
+}
+
+impl From<u8> for DeviceDesiredStatus {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => DeviceDesiredStatus::Pending,
+            1 => DeviceDesiredStatus::Activated,
+            6 => DeviceDesiredStatus::HardDrained,
+            7 => DeviceDesiredStatus::SoftDrained,
+            _ => DeviceDesiredStatus::Pending,
+        }
+    }
+}
+
+impl FromStr for DeviceDesiredStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "pending" => Ok(DeviceDesiredStatus::Pending),
+            "activated" => Ok(DeviceDesiredStatus::Activated),
+            "hard-drained" => Ok(DeviceDesiredStatus::HardDrained),
+            "soft-drained" => Ok(DeviceDesiredStatus::SoftDrained),
+            _ => Err(format!("Invalid DeviceDesiredStatus: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for DeviceDesiredStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeviceDesiredStatus::Pending => write!(f, "pending"),
+            DeviceDesiredStatus::Activated => write!(f, "activated"),
+            DeviceDesiredStatus::HardDrained => write!(f, "hard-drained"),
+            DeviceDesiredStatus::SoftDrained => write!(f, "soft-drained"),
+        }
+    }
+}
+
 #[derive(BorshSerialize, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Device {
@@ -227,6 +276,7 @@ pub struct Device {
     pub users_count: u16,          // 2
     pub max_users: u16,            // 2
     pub device_health: DeviceHealth, // 1
+    pub desired_status: DeviceDesiredStatus, // 1
 }
 
 impl Default for Device {
@@ -251,6 +301,7 @@ impl Default for Device {
             users_count: 0,
             max_users: 0,
             device_health: DeviceHealth::Pending,
+            desired_status: DeviceDesiredStatus::Pending,
         }
     }
 }
@@ -276,6 +327,11 @@ impl Device {
             && (self.device_type == DeviceType::Edge || self.device_type == DeviceType::Hybrid)
             && (self.max_users > 0 && self.users_count < self.max_users)
     }
+
+    pub fn check_status_transition(&self) {
+        // Implement any necessary status transition checks here
+        // this will be added in future iterations
+    }
 }
 
 impl fmt::Display for Device {
@@ -284,10 +340,10 @@ impl fmt::Display for Device {
             f,
             "account_type: {}, owner: {}, index: {}, contributor_pk: {}, location_pk: {}, exchange_pk: {}, device_type: {}, \
             public_ip: {}, dz_prefixes: {}, status: {}, code: {}, metrics_publisher_pk: {}, mgmt_vrf: {}, interfaces: {:?}, \
-            reference_count: {}, users_count: {}, max_users: {}, device_health: {}",
+            reference_count: {}, users_count: {}, max_users: {}, device_health: {}, desired_status: {}",
             self.account_type, self.owner, self.index, self.contributor_pk, self.location_pk, self.exchange_pk, self.device_type,
             &self.public_ip, &self.dz_prefixes, self.status, self.code, self.metrics_publisher_pk, self.mgmt_vrf, self.interfaces,
-            self.reference_count, self.users_count, self.max_users, self.device_health
+            self.reference_count, self.users_count, self.max_users, self.device_health, self.desired_status
         )
     }
 }
@@ -316,6 +372,7 @@ impl TryFrom<&[u8]> for Device {
             users_count: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             max_users: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             device_health: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            desired_status: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::Device {
@@ -508,6 +565,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidAccountType);
@@ -535,6 +593,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::CodeTooLong);
@@ -562,6 +621,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidLocation);
@@ -589,6 +649,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -617,6 +678,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidClientIp);
@@ -644,6 +706,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidDzPrefix);
@@ -671,6 +734,7 @@ mod tests {
             users_count: 0,
             max_users: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         // max_users == 0 means "locked", so validation should still succeed
         val.validate().unwrap();
@@ -698,6 +762,7 @@ mod tests {
             users_count: 6,
             max_users: 5,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
 
         let err = val.validate();
@@ -726,6 +791,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -771,6 +837,7 @@ mod tests {
             users_count: 1,
             max_users: 2,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -834,6 +901,7 @@ mod tests {
             users_count: 111,
             max_users: 222,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -896,6 +964,7 @@ mod tests {
             users_count: 0,
             max_users: 0,
             device_health: DeviceHealth::Pending,
+            desired_status: DeviceDesiredStatus::Pending,
         };
 
         let oldsize = size_of_pre_dzd_metadata_device(val.code.len(), val.dz_prefixes.len());

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -339,6 +339,7 @@ async fn test_device() {
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),
@@ -637,6 +638,7 @@ async fn test_device_update_metrics_publisher_by_foundation_allowlist_account() 
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
@@ -336,6 +336,7 @@ async fn device_update_location_test() {
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),
@@ -376,6 +377,7 @@ async fn device_update_location_test() {
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
@@ -644,6 +644,7 @@ async fn test_dzx_link() {
             jitter_ns: Some(100000),
             delay_override_ns: Some(0),
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(link_dzx_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -620,6 +620,7 @@ async fn test_wan_link() {
             jitter_ns: Some(100000),
             delay_override_ns: Some(0),
             status: None,
+            desired_status: None,
         }),
         vec![
             AccountMeta::new(tunnel_pubkey, false),

--- a/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/initialize_device_latency_samples_tests.rs
@@ -7,7 +7,7 @@ use doublezero_serviceability::{
     },
     state::{
         accounttype::AccountType,
-        device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+        device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         link::{Link, LinkHealth, LinkLinkType, LinkStatus},
     },
 };
@@ -432,6 +432,7 @@ async fn test_initialize_device_latency_samples_fail_origin_device_wrong_owner()
         users_count: 0,
         max_users: 0,
         device_health: DeviceHealth::Pending,
+        desired_status: DeviceDesiredStatus::Pending,
     };
 
     let mut device_data = Vec::new();
@@ -504,6 +505,7 @@ async fn test_initialize_device_latency_samples_fail_target_device_wrong_owner()
         users_count: 0,
         max_users: 0,
         device_health: DeviceHealth::Pending,
+        desired_status: DeviceDesiredStatus::Pending,
     };
 
     let mut data = Vec::new();
@@ -577,6 +579,7 @@ async fn test_initialize_device_latency_samples_fail_link_wrong_owner() {
         side_a_iface_name: "Ethernet0".to_string(),
         side_z_iface_name: "Ethernet1".to_string(),
         link_health: LinkHealth::ReadyForService,
+        desired_status: doublezero_serviceability::state::link::LinkDesiredStatus::Activated,
     };
 
     let mut data = Vec::new();

--- a/smartcontract/sdk/rs/src/commands/device/interface/create.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/create.rs
@@ -68,7 +68,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+            device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -101,6 +101,7 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/interface/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/delete.rs
@@ -46,7 +46,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+            device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -79,6 +79,7 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/interface/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/remove.rs
@@ -37,7 +37,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+            device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -70,6 +70,7 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
         };
 
         client

--- a/smartcontract/sdk/rs/src/commands/device/interface/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/update.rs
@@ -73,7 +73,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+            device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -106,6 +106,7 @@ mod tests {
             max_users: 255,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
         };
 
         let contributor_pk = device.contributor_pk;

--- a/smartcontract/sdk/rs/src/commands/device/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/update.rs
@@ -7,7 +7,7 @@ use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
     processors::device::update::DeviceUpdateArgs,
     state::{
-        device::{DeviceStatus, DeviceType},
+        device::{DeviceDesiredStatus, DeviceStatus, DeviceType},
         interface::Interface,
     },
 };
@@ -29,6 +29,7 @@ pub struct UpdateDeviceCommand {
     pub max_users: Option<u16>,
     pub users_count: Option<u16>,
     pub status: Option<DeviceStatus>,
+    pub desired_status: Option<DeviceDesiredStatus>,
 }
 
 impl UpdateDeviceCommand {
@@ -61,6 +62,7 @@ impl UpdateDeviceCommand {
                 max_users: self.max_users,
                 users_count: self.users_count,
                 status: self.status,
+                desired_status: self.desired_status,
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -86,7 +88,7 @@ mod tests {
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
-            device::{Device, DeviceHealth, DeviceStatus, DeviceType},
+            device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
         },
     };
     use mockall::predicate;
@@ -119,6 +121,7 @@ mod tests {
             max_users: 250,
             users_count: 0,
             device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
         };
 
         client
@@ -139,6 +142,7 @@ mod tests {
                     max_users: None,
                     users_count: None,
                     status: None,
+                    desired_status: None,
                 })),
                 predicate::always(),
             )
@@ -158,6 +162,7 @@ mod tests {
             max_users: None,
             users_count: None,
             status: None,
+            desired_status: None,
         };
 
         let update_invalid = UpdateDeviceCommand {

--- a/smartcontract/sdk/rs/src/commands/link/update.rs
+++ b/smartcontract/sdk/rs/src/commands/link/update.rs
@@ -3,7 +3,7 @@ use doublezero_program_common::validate_account_code;
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
     processors::link::update::LinkUpdateArgs,
-    state::link::{LinkLinkType, LinkStatus},
+    state::link::{LinkDesiredStatus, LinkLinkType, LinkStatus},
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
@@ -19,6 +19,7 @@ pub struct UpdateLinkCommand {
     pub jitter_ns: Option<u64>,
     pub delay_override_ns: Option<u64>,
     pub status: Option<LinkStatus>,
+    pub desired_status: Option<LinkDesiredStatus>,
 }
 
 impl UpdateLinkCommand {
@@ -51,6 +52,7 @@ impl UpdateLinkCommand {
                 jitter_ns: self.jitter_ns,
                 delay_override_ns: self.delay_override_ns,
                 status: self.status,
+                desired_status: self.desired_status,
             }),
             vec![
                 AccountMeta::new(self.pubkey, false),


### PR DESCRIPTION
This pull request primarily updates tests and CLI code to support the new `desired_status` field for devices and links, ensuring that the activated status is consistently set and displayed throughout the codebase. Additionally, it improves CLI commands to allow specifying the desired status when updating a device and updates output formatting and test assertions accordingly.

**Support for `desired_status` field:**

* Added the `desired_status` field with the value `DeviceDesiredStatus::Activated` or `LinkDesiredStatus::Activated` to device and link test instances in multiple modules, including `activator_metrics.rs`, `process/device.rs`, `process/link.rs`, `process/user.rs`, and various CLI test files. [[1]](diffhunk://#diff-d2c97b8908f4c2dfc05d08b66e7eeb38241c4e0c628bf2e659dd17ed3364073aR73-R74) [[2]](diffhunk://#diff-0aed512054e126f7dc8b0bffbc2aad2bd5e2aade35d7e902e08138cc36f94341R184-R185) [[3]](diffhunk://#diff-0aed512054e126f7dc8b0bffbc2aad2bd5e2aade35d7e902e08138cc36f94341R369-R370) [[4]](diffhunk://#diff-d9c91ea17e4fe3e26302887a60fd0596f950bcc4949005b71ae4fbf2acfc5ebbR194-R195) [[5]](diffhunk://#diff-d9c91ea17e4fe3e26302887a60fd0596f950bcc4949005b71ae4fbf2acfc5ebbR318) [[6]](diffhunk://#diff-d9c91ea17e4fe3e26302887a60fd0596f950bcc4949005b71ae4fbf2acfc5ebbR376-R377) [[7]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR457-R458) [[8]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR651-R652) [[9]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR900-R901) [[10]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR1010-R1011) [[11]](diffhunk://#diff-2107e91f8266f8029aa94b2388d3a6f1d9c0761df5d67c8ea8abd161d1b1183dR1145-R1146) [[12]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184R945-R946) [[13]](diffhunk://#diff-4f704cf90f1dcb068f7142fc69c3b334575f5606872d549c25298747c6e130cdR185-R186) [[14]](diffhunk://#diff-4f704cf90f1dcb068f7142fc69c3b334575f5606872d549c25298747c6e130cdR214-R215) [[15]](diffhunk://#diff-4f704cf90f1dcb068f7142fc69c3b334575f5606872d549c25298747c6e130cdR380-R381) [[16]](diffhunk://#diff-4f704cf90f1dcb068f7142fc69c3b334575f5606872d549c25298747c6e130cdR409-R410) [[17]](diffhunk://#diff-a328db46d168fde4ba89c6db52b212ff4a6fce24102dfd343838cc737197269aR146-R147) [[18]](diffhunk://#diff-28204afbc0daa4568757cbf5a6f1073eabc5092155099845b859903fce876ac0R344-R345) [[19]](diffhunk://#diff-b2814652d96b9eb3fd21b1e9b32cfeae734fd3936d8e3561000f63c1c6067c4cR121-R122) [[20]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36R102-R103) [[21]](diffhunk://#diff-98b13948555a064cdbee66bdab1bc1c830f4b1731bb9176aeff9facfbc13e87bR158-R159) [[22]](diffhunk://#diff-bc33a0ed68e3fcf3d117d4ff41af6059eb3a9b3e30df8399d6eed5fe3c1da9e7R135-R136) [[23]](diffhunk://#diff-ba23250c9b31130c07a5c9342b1891b942c51695e79f474f560e2ce1eed50565R124-R125) [[24]](diffhunk://#diff-1202e1ef0267b835d18d21f72877848420aea034a2e97b7a2012ef22c82e9833R189-R190) [[25]](diffhunk://#diff-52bdbf566ffc6593f29e9a41c098bac9d461b171042134d06f8b9c3f79415828R206-R207) [[26]](diffhunk://#diff-69138b28bf84ce525ad21f83f3811592e6b42112dcd96251d4bbbff25e2dd4edR260-R261) [[27]](diffhunk://#diff-4ba2120eeee612bb002113e947fa1c74a16b6b5556c9792f3363871de1dd108cR121-R122) [[28]](diffhunk://#diff-a4e237e9852f54c0f669b6a4f3d45df3a7e16abb099f87c261af631b79c8960aR121-R122)

**CLI enhancements for device status:**

* Updated `UpdateDeviceCliCommand` in `device/update.rs` to accept a `desired_status` argument, allowing users to specify the desired status when updating a device. The `status` argument is now typed as `DeviceStatus` instead of `String`.
* Added import for `DeviceDesiredStatus` to support the new argument.
* Removed unnecessary parsing logic for the `status` argument in the update command implementation.

**Output formatting and test assertion updates:**

* Modified device information output in `device/get.rs` to include the `desired_status` field, both in the format string and in the printed values. [[1]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36R34) [[2]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36R51)
* Updated related test assertions to expect the new `desired_status` line in output.

## Testing Verification
* Show evidence of testing the change

Solves: https://github.com/malbeclabs/doublezero/issues/2476 https://github.com/malbeclabs/doublezero/issues/2478
