### PR TITLE
feat: contributor account verification in multiple places

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/closeaccount.rs
@@ -85,6 +85,9 @@ pub fn process_closeaccount_link(
     let mut side_a_dev = Device::try_from(side_a_account)?;
     let mut side_z_dev = Device::try_from(side_z_account)?;
     let link: Link = Link::try_from(link_account)?;
+    if link.contributor_pk != *contributor_account.key {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
 
     if link.owner != *owner_account.key {
         return Err(ProgramError::InvalidAccountData);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
@@ -66,14 +66,18 @@ pub fn process_delete_link(
 
     let contributor = Contributor::try_from(contributor_account)?;
 
-    if contributor.owner != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
+    let payer_in_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
+
+    if contributor.owner != *payer_account.key && !payer_in_foundation {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
     // Any link can be deleted by its contributor or foundation allowlist on any status
     let mut link: Link = Link::try_from(link_account)?;
+    if !payer_in_foundation && link.contributor_pk != *contributor_account.key {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
     link.status = LinkStatus::Deleting;
 
     try_acc_write(&link, link_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
@@ -62,13 +62,16 @@ pub fn process_suspend_link(
     let globalstate = GlobalState::try_from(globalstate_account)?;
     let contributor = Contributor::try_from(contributor_account)?;
 
-    if contributor.owner != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
+    let payer_in_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
+
+    if contributor.owner != *payer_account.key && !payer_in_foundation {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
     let mut link: Link = Link::try_from(link_account)?;
+    if !payer_in_foundation && link.contributor_pk != *contributor_account.key {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
 
     if link.status != LinkStatus::Activated {
         #[cfg(test)]


### PR DESCRIPTION
## Summary of Changes
* Enforced contributor identity across instructions to ensure contributor_account.key == link.contributor_pk where appropriate.
* Preserved foundation/activator authority flows by introducing a payer_in_foundation guard:
    * Foundation-allowlisted payers bypass the contributor/link equality check in suspend, resume, and delete flows.
* Prevents contributors from suspending, resuming, deleting, or closing links they do not own.
* Establishes a consistent authorization invariant across all serviceability paths.
* Still supports privileged foundation and activator workflows without breaking existing operational flows.

## Testing Verification
* Existing unit and integration tests passed after updates.

Closes #2213 
