### PR TITLE
feat: verification of side_z in AcceptLink

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
@@ -73,7 +73,6 @@ pub fn process_accept_link(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    // Validate that the stored side_z_pk matches the provided side_z_account
     if link.side_z_pk != *side_z_account.key {
         return Err(DoubleZeroError::InvalidAccountOwner.into());
     }


### PR DESCRIPTION
## Summary of Changes
* Added an explicit check in process_accept_link to enforce link.side_z_pk == *side_z_account.key.
* The instruction now fails early with DoubleZeroError::InvalidAccountOwner if the Side-Z account does not match the link.
* Prevents accepting a link with a Side-Z device that differs from the one recorded on-chain.

## Testing Verification
* Existing tests pass.

Closes #2214 