### PR TITLE
feat: add verification for user.device pk

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -68,6 +68,10 @@ pub fn process_closeaccount_user(
 
     let user = User::try_from(user_account)?;
 
+    if user.device_pk != *device_account.key {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
     if user.owner != *owner_account.key {
         return Err(ProgramError::InvalidAccountData);
     }


### PR DESCRIPTION
## Summary of Changes
* CloseAccountUser: Added a strict check enforcing user.device_pk == device_account.key, failing with ProgramError::InvalidAccountData on mismatch.
* Authorization: Existing user.owner == owner_account.key validation remains unchanged.
* Ensures the user being closed is actually attached to the provided device account.

## Testing Verification
* Existing tests pass

Fixes #2216 
