### PR TITLE
cli: use dz ip to find user during status lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
   - `doublezero resource` commands added for managing ResourceExtension accounts.
   - Added health_oracle to the smart contract global configuration to manage and authorize health-related operations.
   - Added --ip-net support to create to match the existing behavior in update.
+  - Use DZ IP for user lookup during status command instead of client IP
 - Onchain programs
   - Allow contributor owner to update ops manager key
   - Add new arguments on create interface cli command

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -63,7 +63,7 @@ impl StatusCliCommand {
             let mut metro = None;
             let user = users
                 .iter()
-                .find(|(_, u)| Some(u.client_ip.to_string()) == response.tunnel_src)
+                .find(|(_, u)| Some(u.dz_ip.to_string()) == response.doublezero_ip)
                 .map(|(_, u)| u);
             if let Some(user) = user {
                 current_device = Some(&user.device_pk);
@@ -114,6 +114,7 @@ mod tests {
         AccountType, Device, DeviceStatus, DeviceType, Exchange, ExchangeStatus, User, UserCYOA,
         UserStatus, UserType,
     };
+    use doublezero_serviceability::state::device::{DeviceDesiredStatus, DeviceHealth};
     use mockall::predicate::*;
     use solana_sdk::pubkey::Pubkey;
 
@@ -482,5 +483,148 @@ mod tests {
         assert_eq!(result[0].lowest_latency_device, "device2".to_string());
         assert_eq!(result[0].metro, "N/A".to_string());
         assert_eq!(result[0].network, "testnet".to_string());
+    }
+
+    #[tokio::test]
+    async fn test_status_command_matches_dz_ip_not_client_ip() {
+        let mut mock_command = MockCliCommand::new();
+        let mut mock_controller = MockServiceController::new();
+
+        let mut devices = std::collections::HashMap::<Pubkey, Device>::new();
+        let mut users = std::collections::HashMap::<Pubkey, User>::new();
+        let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
+        let status_responses = vec![StatusResponse {
+            doublezero_status: DoubleZeroStatus {
+                session_status: "up".to_string(),
+                last_session_update: Some(1625247600),
+            },
+            tunnel_name: Some("tunnel_name".to_string()),
+            tunnel_src: Some("20.20.20.20".to_string()),
+            tunnel_dst: Some("42.42.42.42".to_string()),
+            doublezero_ip: Some("1.2.3.4".to_string()),
+            user_type: Some("IBRL".to_string()),
+        }];
+
+        let exchange_pk = Pubkey::new_unique();
+        exchanges.insert(
+            exchange_pk,
+            Exchange {
+                account_type: AccountType::Exchange,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                lat: 0.0,
+                lng: 0.0,
+                bgp_community: 0,
+                unused: 0,
+                status: ExchangeStatus::Activated,
+                code: "met".to_string(),
+                name: "metro".to_string(),
+                reference_count: 0,
+                device1_pk: Pubkey::default(),
+                device2_pk: Pubkey::default(),
+            },
+        );
+
+        let device1_pk = Pubkey::new_unique();
+        devices.insert(
+            device1_pk,
+            Device {
+                account_type: AccountType::Device,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                location_pk: Pubkey::default(),
+                exchange_pk,
+                device_type: DeviceType::Hybrid,
+                public_ip: "5.6.7.8".parse().unwrap(),
+                status: DeviceStatus::Activated,
+                code: "device1".to_string(),
+                dz_prefixes: NetworkV4List::default(),
+                metrics_publisher_pk: Pubkey::default(),
+                contributor_pk: Pubkey::default(),
+                mgmt_vrf: "default".to_string(),
+                interfaces: vec![],
+                reference_count: 0,
+                users_count: 64,
+                max_users: 128,
+                desired_status: DeviceDesiredStatus::Activated,
+                device_health: DeviceHealth::ReadyForUsers,
+            },
+        );
+
+        let user_pk = Pubkey::new_unique();
+        users.insert(
+            user_pk,
+            User {
+                account_type: AccountType::User,
+                owner: Pubkey::default(),
+                index: 0,
+                bump_seed: 0,
+                user_type: UserType::IBRL,
+                tenant_pk: Pubkey::default(),
+                device_pk: device1_pk,
+                cyoa_type: UserCYOA::GREOverDIA,
+                client_ip: "10.10.10.10".parse().unwrap(),
+                dz_ip: "1.2.3.4".parse().unwrap(),
+                tunnel_id: 501,
+                tunnel_net: NetworkV4::default(),
+                status: UserStatus::Activated,
+                publishers: vec![],
+                subscribers: vec![],
+                validator_pubkey: Pubkey::default(),
+            },
+        );
+
+        let latencies = vec![LatencyRecord {
+            device_pk: device1_pk.to_string(),
+            device_code: "device1".to_string(),
+            device_ip: "5.6.7.8".to_string(),
+            min_latency_ns: 5000000,
+            max_latency_ns: 5000000,
+            avg_latency_ns: 5000000,
+            reachable: true,
+        }];
+
+        mock_controller
+            .expect_status()
+            .returning(move || Ok(status_responses.clone()));
+        mock_controller
+            .expect_latency()
+            .returning(move || Ok(latencies.clone()));
+        mock_command
+            .expect_get_environment()
+            .return_const(doublezero_config::Environment::Testnet);
+        mock_command
+            .expect_list_device()
+            .with(eq(ListDeviceCommand))
+            .returning({
+                let devices = devices.clone();
+                move |_| Ok(devices.clone())
+            });
+        mock_command
+            .expect_list_user()
+            .with(eq(ListUserCommand))
+            .returning({
+                let users = users.clone();
+                move |_| Ok(users.clone())
+            });
+        mock_command
+            .expect_list_exchange()
+            .with(eq(ListExchangeCommand))
+            .returning({
+                let exchanges = exchanges.clone();
+                move |_| Ok(exchanges.clone())
+            });
+
+        let result = StatusCliCommand { json: true }
+            .command_impl(&mock_command, &mock_controller)
+            .await;
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].current_device, "device1".to_string());
+        assert_eq!(result[0].metro, "metro".to_string());
     }
 }

--- a/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local
+ up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | N/A            | ✅ ny5-dz01           | N/A      | local


### PR DESCRIPTION
## Summary of Changes
- Update CLI `status` user lookup to use DZ IP instead of client IP vs tunnel source, since tunnel source will not be the client IP when behind NAT
- This fixes an issue where the status command is not able to show the currently connected device, and just shows it as N/A

## Testing Verification
- Added test coverage for the update
