### PR TITLE
Verify device.reference_count is 0 when calling CloseAccountDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
   - Added health_oracle to the smart contract global configuration to manage and authorize health-related operations.
   - Added --ip-net support to create to match the existing behavior in update.
 - Onchain programs
+  - Add on-chain validation to reject CloseAccountDevice when device has active references (reference_count > 0)
   - Allow contributor owner to update ops manager key
   - Add new arguments on create interface cli command
   - Add ResourceExtension to track IP/ID allocations. Foundation instructions added to create/allocate/deallocate.

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/closeaccount.rs
@@ -80,6 +80,11 @@ pub fn process_closeaccount_device(
         msg!("{:?}", device);
         return Err(solana_program::program_error::ProgramError::Custom(1));
     }
+    // This catches edge cases where reference_count could be incremented
+    // after DeleteDevice but before CloseAccountDevice
+    if device.reference_count > 0 {
+        return Err(DoubleZeroError::ReferenceCountNotZero.into());
+    }
     if device.location_pk != *location_account.key {
         return Err(DoubleZeroError::InvalidLocationPubkey.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -4,16 +4,29 @@ use doublezero_serviceability::{
     instructions::*,
     pda::*,
     processors::{
+        accesspass::set::SetAccessPassArgs,
         contributor::create::ContributorCreateArgs,
         device::{closeaccount::*, create::*, delete::*, resume::*, suspend::*, update::*},
+        user::create::UserCreateArgs,
         *,
     },
-    state::{accounttype::AccountType, contributor::ContributorStatus, device::*},
+    state::{
+        accesspass::AccessPassType,
+        accounttype::AccountType,
+        contributor::ContributorStatus,
+        device::*,
+        user::{UserCYOA, UserType},
+    },
 };
 use globalconfig::set::SetGlobalConfigArgs;
 use solana_program_test::*;
 use solana_sdk::{
-    hash::Hash, instruction::AccountMeta, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    hash::Hash,
+    instruction::{AccountMeta, InstructionError},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::TransactionError,
 };
 
 mod test_helpers;
@@ -817,4 +830,160 @@ async fn wait_for_new_blockhash(banks_client: &mut BanksClient) -> Hash {
     }
 
     new_blockhash
+}
+
+#[tokio::test]
+async fn test_delete_device_fails_with_reference_count_not_zero() {
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        location_pubkey,
+        exchange_pubkey,
+        contributor_pubkey,
+    ) = setup_program_with_location_and_exchange().await;
+
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+
+    // Create device
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "dev1".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "100.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(DeviceActivateArgs {}),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let device = get_account_data(&mut banks_client, device_pubkey)
+        .await
+        .unwrap()
+        .get_device()
+        .unwrap();
+    assert_eq!(device.status, DeviceStatus::Activated);
+    assert_eq!(device.reference_count, 0);
+
+    // Create access pass and user to increment device.reference_count
+    let user_ip = [100, 0, 0, 1].into();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &user_ip, &payer.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::IBRL);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateUser(UserCreateArgs {
+            client_ip: user_ip,
+            user_type: UserType::IBRL,
+            cyoa_type: UserCYOA::GREOverDIA,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let device = get_account_data(&mut banks_client, device_pubkey)
+        .await
+        .unwrap()
+        .get_device()
+        .unwrap();
+    assert_eq!(device.reference_count, 1);
+
+    // DeleteDevice should fail with ReferenceCountNotZero (error code 13)
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::DeleteDevice(DeviceDeleteArgs {}),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    match result {
+        Err(BanksClientError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(13),
+        ))) => {}
+        _ => panic!(
+            "Expected ReferenceCountNotZero error (Custom(13)), got {:?}",
+            result
+        ),
+    }
 }


### PR DESCRIPTION
Resolves: #2217

## Summary of Changes
* Added on-chain validation in `process_closeaccount_device` to reject closing a device account when reference_count > 0
* Previously this check only existed in the SDK client-side code, allowing it to be bypassed with raw transactions
* CHANGELOG.md updated

## Testing Verification
* Added an assert in existing test
