### PR TITLE
e2e: add unit tests for QA alldevices

### DIFF
--- a/e2e/internal/qa/device_assignment_test.go
+++ b/e2e/internal/qa/device_assignment_test.go
@@ -363,7 +363,7 @@ func TestFilterStatusUpClients(t *testing.T) {
 	clients := []*Client{client1, client2, client3}
 
 	t.Run("filters to clients in batch with status up", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			"client2": {Device: dev2},
 			// client3 not in batch
@@ -381,7 +381,7 @@ func TestFilterStatusUpClients(t *testing.T) {
 	})
 
 	t.Run("excludes clients not in batch", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			// client2, client3 not in batch
 		}
@@ -402,7 +402,7 @@ func TestFilterStatusUpClients(t *testing.T) {
 	})
 
 	t.Run("excludes clients with status not up", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			"client2": {Device: dev2},
 		}
@@ -422,7 +422,7 @@ func TestFilterStatusUpClients(t *testing.T) {
 	})
 
 	t.Run("excludes clients with missing status", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			"client2": {Device: dev2},
 		}
@@ -463,7 +463,7 @@ func TestComputeRouteTargets(t *testing.T) {
 	}
 
 	t.Run("returns IPs of clients in different exchanges", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1}, // ex1
 			"client2": {Device: dev2}, // ex2
 		}
@@ -480,7 +480,7 @@ func TestComputeRouteTargets(t *testing.T) {
 	})
 
 	t.Run("excludes self", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			"client2": {Device: dev2},
 		}
@@ -496,7 +496,7 @@ func TestComputeRouteTargets(t *testing.T) {
 	})
 
 	t.Run("excludes clients in same exchange", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1}, // ex1
 			"client2": {Device: dev2}, // ex2
 			"client3": {Device: dev3}, // ex1 (same as client1)
@@ -514,7 +514,7 @@ func TestComputeRouteTargets(t *testing.T) {
 	})
 
 	t.Run("handles nil IP from getter", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 			"client2": {Device: dev2},
 		}
@@ -529,7 +529,7 @@ func TestComputeRouteTargets(t *testing.T) {
 	})
 
 	t.Run("returns empty for single client", func(t *testing.T) {
-		batch := map[string]*BatchAssignment{
+		batch := map[string]*BatchResult{
 			"client1": {Device: dev1},
 		}
 		connectedClients := []*Client{client1}

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -268,7 +268,7 @@ func connectClientsAndWaitForRoutes(
 	log *slog.Logger,
 	clientsToConnect []*qa.Client,
 	allClients []*qa.Client,
-	batch map[string]*qa.BatchAssignment,
+	batch map[string]*qa.BatchResult,
 ) []*qa.Client {
 	// Connect only clients whose device changed from previous batch
 	// Note: errors here must increment FailedTests so Success() returns false
@@ -329,7 +329,7 @@ func runConnectivitySubtests(
 	t *testing.T,
 	outerLog *slog.Logger,
 	clients []*qa.Client,
-	batch map[string]*qa.BatchAssignment,
+	batch map[string]*qa.BatchResult,
 	resultsMu *sync.Mutex,
 ) {
 	for _, client := range clients {


### PR DESCRIPTION
## Summary of Changes
* Extract logic from e2e/qa_alldevices_unicast_test.go into e2e/internal/qa
* Add unit test coverage
* Also fixed a bug where some failures weren't reflected on the report
