### PR TITLE
feat: add verification in ActiveDeviceInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
   - Introduce desired status to Link and Devices
   - Updated validation to allow public IP prefixes for CYOA/DIA, removing the restriction imposed by type-based checks.
   - Transit devices can now be provisioned without a public IP, aligning the requirements with their actual networking model and avoiding unnecessary configuration constraints.
+  - Enforce that ActivateDeviceInterface only activates interfaces in Pending or Unlinked status, returning InvalidStatus for all other interface states
 - Internet Latency Telemetry
   - Fixed a bug that prevented unresponsive ripeatlas probes from being replaced
   - Fixed a bug that caused ripeatlas samples to be dropped when they were delayed to the next collection cycle

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/activate.rs
@@ -69,7 +69,7 @@ pub fn process_activate_device_interface(
         .find_interface(&value.name)
         .map_err(|_| DoubleZeroError::InterfaceNotFound)?;
 
-    if iface.status == InterfaceStatus::Deleting {
+    if iface.status != InterfaceStatus::Pending && iface.status != InterfaceStatus::Unlinked {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
@@ -560,6 +560,56 @@ async fn test_device_interfaces() {
 
     println!("✅ Device interfaces activated");
     /*****************************************************************************************************************************************************/
+    println!(
+        "🟢 9a. Regression: ActivateDeviceInterface should fail for invalid interface statuses..."
+    );
+
+    // Attempt to activate an interface that is already Activated (Loopback0)
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(DeviceInterfaceActivateArgs {
+            name: "loopback0".to_string(),
+            ip_net: "10.1.1.2/31".parse().unwrap(),
+            node_segment_idx: 11,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("custom program error: 0x7")); // DoubleZeroError::InvalidStatus == 0x7
+
+    // Attempt to activate an interface that is Rejected (Loopback1)
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(DeviceInterfaceActivateArgs {
+            name: "loopback1".to_string(),
+            ip_net: "10.1.1.4/31".parse().unwrap(),
+            node_segment_idx: 12,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("custom program error: 0x7")); // DoubleZeroError::InvalidStatus == 0x7
+
+    println!("✅ Regression checks for ActivateDeviceInterface status validation passed");
+    /*****************************************************************************************************************************************************/
     println!("🟢 10. Deleting device interfaces...");
     execute_transaction(
         &mut banks_client,


### PR DESCRIPTION
## Summary of Changes
* Now only allows activation when iface.status is Pending or Unlinked; all other states return InvalidStatus.
* Updated interface_test.rs to assert activation fails for Activated and Rejected interfaces with InvalidStatus.
* Changelog.md updated.

## Testing Verification
* All rust & fmt checks green.


Closes #2228 
