### PR TITLE
Update DeviceStatus and LinkStatus to include SuspendedDeprecated

### DIFF
--- a/controlplane/monitor/internal/serviceability/events_test.go
+++ b/controlplane/monitor/internal/serviceability/events_test.go
@@ -67,8 +67,8 @@ func TestCompare(t *testing.T) {
 		},
 		{
 			name:             "multiple event types",
-			before:           []serviceability.Device{newTestDevice("1", serviceability.DeviceStatusActivated), newTestDevice("2", serviceability.DeviceStatusPending)}, // 2 is removed
-			after:            []serviceability.Device{newTestDevice("1", serviceability.DeviceStatusSuspended), newTestDevice("3", serviceability.DeviceStatusPending)}, // 1 is modified, 3 is added
+			before:           []serviceability.Device{newTestDevice("1", serviceability.DeviceStatusActivated), newTestDevice("2", serviceability.DeviceStatusPending)},           // 2 is removed
+			after:            []serviceability.Device{newTestDevice("1", serviceability.DeviceStatusSuspendedDeprecated), newTestDevice("3", serviceability.DeviceStatusPending)}, // 1 is modified, 3 is added
 			expectedAdded:    1,
 			expectedRemoved:  1,
 			expectedModified: 1,

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -119,7 +119,7 @@ type DeviceStatus uint8
 const (
 	DeviceStatusPending DeviceStatus = iota
 	DeviceStatusActivated
-	DeviceStatusSuspended
+	DeviceStatusSuspendedDeprecated
 	DeviceStatusDeleted
 	DeviceStatusRejected
 )
@@ -400,7 +400,7 @@ type LinkStatus uint8
 const (
 	LinkStatusPending LinkStatus = iota
 	LinkStatusActivated
-	LinkStatusSuspended
+	LinkStatusSuspendedDeprecated
 	LinkStatusDeleted
 	LinkStatusRejected
 	LinkStatusRequested


### PR DESCRIPTION
This pull request updates device and link status enumerations to deprecate the use of the "Suspended" status in favor of "SuspendedDeprecated". The changes ensure consistency in status naming across the codebase and update related test cases accordingly.

**Deprecation and renaming of status enums:**

* Renamed the `DeviceStatusSuspended` enum value to `DeviceStatusSuspendedDeprecated` in `smartcontract/sdk/go/serviceability/state.go` to indicate that the "Suspended" status is deprecated.
* Renamed the `LinkStatusSuspended` enum value to `LinkStatusSuspendedDeprecated` in `smartcontract/sdk/go/serviceability/state.go` for consistency with device status changes.

**Test updates:**

* Updated the device status in the "multiple event types" test case in `events_test.go` to use `DeviceStatusSuspendedDeprecated` instead of the deprecated `DeviceStatusSuspended`.

## Testing Verification
* Show evidence of testing the change
