### PR TITLE
telemetry: fix flaky test in state-ingest handler

### DIFF
--- a/telemetry/state-ingest/pkg/server/handler_test.go
+++ b/telemetry/state-ingest/pkg/server/handler_test.go
@@ -863,9 +863,14 @@ func TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAnd
 	require.Len(t, resp.ShowCommands, 2)
 	require.Len(t, resp.Custom, 1)
 
-	require.Equal(t, []types.ShowCommand{
-		{Kind: "snmp-mib-ifmib-ifindex", Command: "show snmp mib ifmib ifindex"},
-		{Kind: "isis-database-detail", Command: "show isis database detail"},
-	}, resp.ShowCommands)
+	// Convert to map for order-independent comparison (map iteration is non-deterministic)
+	respMap := make(map[string]string)
+	for _, sc := range resp.ShowCommands {
+		respMap[sc.Kind] = sc.Command
+	}
+	require.Equal(t, map[string]string{
+		"snmp-mib-ifmib-ifindex": "show snmp mib ifmib ifindex",
+		"isis-database-detail":   "show isis database detail",
+	}, respMap)
 	require.Equal(t, []string{"bgp-sockets"}, resp.Custom)
 }


### PR DESCRIPTION
## Summary
This fixes a flake in the state ingest unit tests and uses order-independent map comparison instead of slice equality since ShowCommands is populated by iterating over a map, which has non-deterministic ordering in Go.

## Testing Verification
```
$ go test ./telemetry/state-ingest/pkg/server/... -run TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAndCustom -count=10
ok      github.com/malbeclabs/doublezero/telemetry/state-ingest/pkg/server      0.003s
```
