### PR TITLE
client/daemon: always delegate RouteAdd regardless of noUninstall flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Client
+  - Always delegate RouteAdd regardless of noUninstall flag
+
 ## [v0.8.1](https://github.com/malbeclabs/doublezero/compare/client/v0.8.0...client/v0.8.1) – 2025-01-12
 
 ### Breaking

--- a/client/doublezerod/internal/bgp/routerw.go
+++ b/client/doublezerod/internal/bgp/routerw.go
@@ -15,9 +15,6 @@ func newRouteReaderWriterWithNoUninstall(routeReaderWriter RouteReaderWriter, no
 }
 
 func (r *routeReaderWriterWithNoUninstall) RouteAdd(route *routing.Route) error {
-	if r.noUninstall {
-		return nil
-	}
 	return r.routeReaderWriter.RouteAdd(route)
 }
 


### PR DESCRIPTION
## Summary of Changes
- Always delegate RouteAdd regardless of noUninstall flag in client daemon `routeReaderWriterWithNoUninstall`
- This is a bug that affects IBRL-with-allocated-ip users who do not have route liveness passive or active mode enabled, and causes BGP-learned routes not to be installed

## Testing Verification
- Updated test coverage to check for the expectation
