### PR TITLE
sdk/serviceability: reject empty GetProgramAccounts responses 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
   - Add influxdb, prometheus, and device-health-oracle containers
 - SDK
   - Commands for setting global config, activating devices, updating devices, and closing device accounts now manage resource accounts.
+  - Serviceability: return error when GetProgramAccounts returns empty result instead of silently returning empty data
 - Smartcontract
   - feat(smartcontract): RFC 11 activation for User entity
 - Device Health Oracle

--- a/e2e/internal/devnet/smartcontract_init.go
+++ b/e2e/internal/devnet/smartcontract_init.go
@@ -85,7 +85,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 		doublezero --version
 		doublezero init
 		echo
-		
+
 		doublezero global-config authority set --activator-authority me --sentinel-authority me
 		echo
 
@@ -97,7 +97,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 		doublezero global-config get
 		echo
 
-		doublezero global-config authority set --activator-authority me --sentinel-authority me		
+		doublezero global-config authority set --activator-authority me --sentinel-authority me
 
 		# Populate location information onchain.
 		echo "==> Populating location information onchain"
@@ -144,6 +144,12 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 	err = poll.Until(ctx, func() (bool, error) {
 		data, err := client.GetProgramData(ctx)
 		if err != nil {
+			// GetProgramData returns an error when the program has no accounts yet,
+			// which is expected before initialization completes. Continue polling.
+			if strings.Contains(err.Error(), "GetProgramAccounts returned empty result") {
+				dn.log.Debug("--> Waiting for program accounts to be created")
+				return false, nil
+			}
 			return false, fmt.Errorf("failed to load serviceability program client: %w", err)
 		}
 		config := data.Config

--- a/smartcontract/sdk/go/serviceability/client.go
+++ b/smartcontract/sdk/go/serviceability/client.go
@@ -2,6 +2,7 @@ package serviceability
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 )
@@ -35,6 +36,10 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 	out, err := c.rpc.GetProgramAccounts(ctx, c.programID)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("GetProgramAccounts returned empty result for program %s", c.programID)
 	}
 
 	// We need to re-init these fields to prevent appending if this client is reused


### PR DESCRIPTION
## Summary of Changes
- Reject empty GetProgramAccounts responses instead of silently returning empty data

## Testing Verification
- Add test coverage for the change
