### PR TITLE
gnmi-writer: commit offsets for non-retryable ClickHouse errors

### DIFF
--- a/telemetry/gnmi-writer/internal/gnmi/clickhouse_test.go
+++ b/telemetry/gnmi-writer/internal/gnmi/clickhouse_test.go
@@ -1,0 +1,50 @@
+package gnmi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func TestIsRetryableClickhouseError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "table not found (code 60)",
+			err:      &clickhouse.Exception{Code: 60, Message: "Table does not exist"},
+			expected: false,
+		},
+		{
+			name:     "wrapped table not found",
+			err:      fmt.Errorf("write failed: %w", &clickhouse.Exception{Code: 60}),
+			expected: false,
+		},
+		{
+			name:     "other clickhouse error is retryable",
+			err:      &clickhouse.Exception{Code: 999, Message: "Some other error"},
+			expected: true,
+		},
+		{
+			name:     "non-clickhouse error is retryable",
+			err:      fmt.Errorf("network timeout"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetryableClickhouseError(tt.err); got != tt.expected {
+				t.Errorf("IsRetryableClickhouseError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary of Changes

When ClickHouse returns a permanent error like "table does not exist" (code 60), the processor now commits offsets to skip those messages instead of retrying indefinitely. This prevents an infinite loop where the same messages are reprocessed forever.

Transient errors (network issues, etc.) still trigger retries as before.

## Testing Verification
Unit test added:
```
=== RUN   TestIsRetryableClickhouseError
=== RUN   TestIsRetryableClickhouseError/nil_error
=== RUN   TestIsRetryableClickhouseError/table_not_found_(code_60)
=== RUN   TestIsRetryableClickhouseError/wrapped_table_not_found
=== RUN   TestIsRetryableClickhouseError/other_clickhouse_error_is_retryable
=== RUN   TestIsRetryableClickhouseError/non-clickhouse_error_is_retryable
--- PASS: TestIsRetryableClickhouseError (0.00s)
    --- PASS: TestIsRetryableClickhouseError/nil_error (0.00s)
    --- PASS: TestIsRetryableClickhouseError/table_not_found_(code_60) (0.00s)
    --- PASS: TestIsRetryableClickhouseError/wrapped_table_not_found (0.00s)
    --- PASS: TestIsRetryableClickhouseError/other_clickhouse_error_is_retryable (0.00s)
    --- PASS: TestIsRetryableClickhouseError/non-clickhouse_error_is_retryable (0.00s)
```

Also, rolled snapshot image to devnet and write errors stopped:
```
➜  infra git:(ss/gnmi) ✗ kdn logs telemetry-gnmi-writer-59645dcdd6-7hz55
2026-01-12T20:37:55.080Z INF prometheus metrics server listening address=[::]:2112
2026-01-12T20:37:55.808Z INF starting gnmi-writer output=clickhouse kafka_topic=telemetry-snapshots-devnet kafka_group=gnmi-writer-devnet
2026-01-12T20:37:55.808Z INF starting gNMI processor extractors=4
2026-01-12T20:38:38.297Z ERR error writing records error="error writing to table system_state: error preparing batch: code: 60, message: Table default.system_state does not exist"
2026-01-12T20:38:41.482Z ERR error writing records error="error writing to table system_state: error preparing batch: code: 60, message: Table default.system_state does not exist"
2026-01-12T20:38:46.474Z ERR error writing records error="error writing to table system_state: error preparing batch: code: 60, message: Table default.system_state does not exist"

<rolled image>

➜  infra git:(ss/gnmi) ✗ kdn logs telemetry-gnmi-writer-7f6b88bbf-8cj5j
2026-01-13T03:17:27.586Z INF prometheus metrics server listening address=[::]:2112
2026-01-13T03:17:28.300Z INF starting gnmi-writer output=clickhouse kafka_topic=telemetry-snapshots-devnet kafka_group=gnmi-writer-devnet
2026-01-13T03:17:28.300Z INF starting gNMI processor extractors=4
➜  infra git:(ss/gnmi) ✗ 
