### PR TITLE
release: v0.8.2 cargo.toml and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
+- None for this release
+
+### Changes
+
+## [v0.8.2](https://github.com/malbeclabs/doublezero/compare/client/v0.8.1...client/v0.8.2) – 2025-01-13
+
+### Breaking
+
+- None for this release
+
 ### Changes
 
 - Client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "backon",
  "base64 0.22.1",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "backon",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "eyre",
  "serde",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- `Cargo.toml` and `CHANGELOG.md` update for https://github.com/malbeclabs/doublezero/issues/2615
