### PR TITLE
cli: remove log noise on resolve route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- CLI
+  - Remove log noise on resolve route
+
 ### Breaking
 
 - None for this release

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -407,8 +407,6 @@ impl ServiceController for ServiceControllerImpl {
             .body(Full::new(Bytes::from(body_bytes)))?;
         let res = client.request(req).await?;
 
-        println!("resolve-route: res: {:?}", res);
-
         // If route not found (404) or API error, return src=None instead of error
         if res.status() == StatusCode::NOT_FOUND || !res.status().is_success() {
             return Ok(ResolveRouteResponse { src: None });
@@ -416,7 +414,6 @@ impl ServiceController for ServiceControllerImpl {
 
         let data = res.into_body().collect().await?.to_bytes();
         let response = serde_json::from_slice::<ResolveRouteResponse>(&data)?;
-        println!("resolve-route: response: {:?}", response);
         Ok(response)
     }
 }


### PR DESCRIPTION
## Summary of Changes
- Remove log noise from `resolve_route` that happens during IBRL with allocated IP
- Closes https://github.com/malbeclabs/doublezero/issues/2607
