### PR TITLE
Remove "unknown" status and add "failed" and "unreachable" statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 - CLI
   - Remove log noise on resolve route
+  - Remove "unknown" status from doublezero status command and implement "failed" and "unreachable" statuses
 - Onchain programs
    - Removed device and user allowlist functionality, updating the global state, initialization flow, tests, and processors accordingly, and cleaning up unused account checks.
 - Device Health Oracle

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -77,7 +77,9 @@ impl StatusCliCommand {
                         let is_current = user
                             .map(|u| best.device_pk == u.device_pk.to_string())
                             .unwrap_or(false);
-                        if self.json || response.doublezero_status.session_status != "up" {
+                        if self.json
+                            || response.doublezero_status.session_status != "BGP Session Up"
+                        {
                             best.device_code
                         } else if is_current || current_device.is_none() {
                             format!("✅ {}", best.device_code)
@@ -128,7 +130,7 @@ mod tests {
         let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
         let status_responses = vec![StatusResponse {
             doublezero_status: DoubleZeroStatus {
-                session_status: "up".to_string(),
+                session_status: "BGP Session Up".to_string(),
                 last_session_update: Some(1625247600),
             },
             tunnel_name: Some("tunnel_name".to_string()),
@@ -301,7 +303,10 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.len(), 1);
         let status_response = &result[0].response;
-        assert_eq!(status_response.doublezero_status.session_status, "up");
+        assert_eq!(
+            status_response.doublezero_status.session_status,
+            "BGP Session Up"
+        );
         assert_eq!(status_response.tunnel_name.as_deref(), Some("tunnel_name"));
         assert_eq!(status_response.tunnel_src.as_deref(), Some("1.2.3.4"));
         assert_eq!(status_response.tunnel_dst.as_deref(), Some("42.42.42.42"));
@@ -323,7 +328,7 @@ mod tests {
         let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
         let status_responses = vec![StatusResponse {
             doublezero_status: DoubleZeroStatus {
-                session_status: "down".to_string(),
+                session_status: "BGP Session Down".to_string(),
                 last_session_update: None,
             },
             tunnel_name: None,
@@ -473,7 +478,10 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.len(), 1);
         let status_response = &result[0].response;
-        assert_eq!(status_response.doublezero_status.session_status, "down");
+        assert_eq!(
+            status_response.doublezero_status.session_status,
+            "BGP Session Down"
+        );
         assert_eq!(status_response.tunnel_name.as_deref(), None);
         assert_eq!(status_response.tunnel_src.as_deref(), None);
         assert_eq!(status_response.tunnel_dst.as_deref(), None);
@@ -495,7 +503,7 @@ mod tests {
         let mut exchanges = std::collections::HashMap::<Pubkey, Exchange>::new();
         let status_responses = vec![StatusResponse {
             doublezero_status: DoubleZeroStatus {
-                session_status: "up".to_string(),
+                session_status: "BGP Session Up".to_string(),
                 last_session_update: Some(1625247600),
             },
             tunnel_name: Some("tunnel_name".to_string()),

--- a/client/doublezerod/internal/manager/http_test.go
+++ b/client/doublezerod/internal/manager/http_test.go
@@ -207,7 +207,7 @@ func TestHttpStatus(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("wanted 200 response; got %d", resp.StatusCode)
 		}
-		want := `[{"tunnel_name":"doublezero0","tunnel_src":"1.1.1.1","tunnel_dst":"2.2.2.2","doublezero_ip":"3.3.3.3","doublezero_status":{"session_status":"unknown","last_session_update":0},"user_type":"IBRL"}]` + "\n"
+		want := `[{"tunnel_name":"doublezero0","tunnel_src":"1.1.1.1","tunnel_dst":"2.2.2.2","doublezero_ip":"3.3.3.3","doublezero_status":{"session_status":"Pending BGP Session","last_session_update":0},"user_type":"IBRL"}]` + "\n"
 		got, _ := io.ReadAll(resp.Body)
 		if diff := cmp.Diff(want, string(got), cmpopts.IgnoreFields(bgp.Session{}, "LastSessionUpdate")); diff != "" {
 			t.Fatalf("Response body mismatch (-want +got): %s\n", diff)

--- a/e2e/fixtures/ibrl/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src    | Tunnel Dst  | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- up            | 2025-10-14 17:59:41 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ClientIP}} | IBRL      | ny5-dz01       | ✅ ny5-dz01           | New York | local
+ BGP Session Up | 2025-10-14 17:59:41 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ClientIP}} | IBRL      | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro | Network
- up            | 2025-06-03 19:58:21 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}}  | IBRLWithAllocatedIP | ny5-dz01 | ✅ ny5-dz01 | New York | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero0 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}}  | IBRLWithAllocatedIP | ny5-dz01 | ✅ ny5-dz01 | New York | local

--- a/e2e/fixtures/multicast_publisher/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}} | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}} | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_status_connected.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- up            | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | N/A            | ✅ ny5-dz01           | N/A      | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | N/A            | ✅ ny5-dz01           | N/A      | local

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -336,8 +336,8 @@ type ClientSession struct {
 }
 
 const (
-	ClientSessionStatusUp           ClientSessionStatus = "up"
-	ClientSessionStatusDown         ClientSessionStatus = "down"
+	ClientSessionStatusUp           ClientSessionStatus = "BGP Session Up"
+	ClientSessionStatusDown         ClientSessionStatus = "BGP Session Down"
 	ClientSessionStatusDisconnected ClientSessionStatus = "disconnected"
 )
 

--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -42,7 +42,7 @@ const (
 	grpcDialTimeout    = 10 * time.Second
 	grpcDialMaxRetries = 5
 
-	UserStatusUp           = "up"
+	UserStatusUp           = "BGP Session Up"
 	UserStatusDisconnected = "disconnected"
 )
 

--- a/e2e/internal/rpc/agent_test.go
+++ b/e2e/internal/rpc/agent_test.go
@@ -37,7 +37,7 @@ func TestQAAgentConnectivity(t *testing.T) {
 	// Create a mock HTTP server to simulate the doublezerod unix socket API
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/status" {
-			_, _ = w.Write([]byte(`[{"tunnel_name":"dz-1","doublezero_ip":"100.64.0.1","user_type":"ibrl","doublezero_status":{"session_status":"up"}}]`))
+			_, _ = w.Write([]byte(`[{"tunnel_name":"dz-1","doublezero_ip":"100.64.0.1","user_type":"ibrl","doublezero_status":{"session_status":"BGP Session Up"}}]`))
 		}
 		if r.URL.Path == "/latency" {
 			_, _ = w.Write([]byte(`[{"device_pk":"8PQkip3CxWhQTdP7doCyhT2kwjSL2csRTdnRg2zbDPs1","device_code":"chi-dn-dzd1","device_ip":"100.0.0.1","min_latency_ns":24989983,"max_latency_ns":25115111,"avg_latency_ns":25063568,"reachable":true}]`))
@@ -127,7 +127,7 @@ func TestQAAgentConnectivity(t *testing.T) {
 		statusResult, err := client.GetStatus(ctx, &emptypb.Empty{})
 		require.NoError(t, err)
 		require.NotNil(t, statusResult)
-		require.Equal(t, "up", statusResult.GetStatus()[0].GetSessionStatus())
+		require.Equal(t, "BGP Session Up", statusResult.GetStatus()[0].GetSessionStatus())
 	})
 
 	t.Run("GetLatency", func(t *testing.T) {


### PR DESCRIPTION
Resolves: #2622

## Summary of Changes
* Removed unknown status
* Renamed status labels to be more descriptive:
  * pending → Pending BGP Session
  * initializing → Initializing BGP Session
  * down → BGP Session Down
  * up → BGP Session Up
* Added BGP Session Failed (TCP connected but BGP handshake timed out after 5 seconds)
* Added Network Unreachable (TCP connection failed, likely firewall issue)


## Testing Verification
* Fixed existing tests
* Added new tests
