### PR TITLE
gnmi-writer: rename metric prefix from gnmi_ingest to gnmi_writer

### DIFF
--- a/telemetry/gnmi-writer/README.md
+++ b/telemetry/gnmi-writer/README.md
@@ -323,11 +323,24 @@ Only one extractor processes each update. When multiple extractors match a path,
 
 ### Metrics
 
-The processor exposes Prometheus metrics:
-- `gnmi_processor_records_processed_total` - Records successfully written
-- `gnmi_processor_processing_duration_seconds` - Time spent processing batches
-- `gnmi_processor_processing_errors_total` - Unmarshal/extraction failures
-- `gnmi_processor_write_errors_total` - ClickHouse write failures
+The service exposes Prometheus metrics for monitoring pipeline health:
+
+**Consumer Metrics:**
+- `gnmi_writer_notifications_consumed_total` - gNMI notifications consumed from Kafka
+- `gnmi_writer_fetch_errors_total` - Kafka fetch errors
+- `gnmi_writer_unmarshal_errors_total` - Protobuf unmarshal errors
+
+**Processor Metrics:**
+- `gnmi_writer_records_processed_total` - Records successfully extracted and processed
+- `gnmi_writer_processing_duration_seconds` - Time spent processing notification batches
+- `gnmi_writer_processing_errors_total` - Notification processing failures (unmarshal/extraction errors)
+- `gnmi_writer_write_errors_total` - Record write failures
+- `gnmi_writer_commit_errors_total` - Kafka offset commit errors
+
+**ClickHouse Metrics:**
+- `gnmi_writer_clickhouse_insert_duration_seconds` - Time spent inserting batches into ClickHouse
+- `gnmi_writer_clickhouse_insert_errors_total` - ClickHouse insert errors
+- `gnmi_writer_clickhouse_records_written_total` - Records successfully written to ClickHouse
 
 ## File Reference
 

--- a/telemetry/gnmi-writer/cmd/gnmi-writer/main.go
+++ b/telemetry/gnmi-writer/cmd/gnmi-writer/main.go
@@ -35,8 +35,9 @@ const (
 // BuildInfo is a Prometheus gauge for build metadata.
 var BuildInfo = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Name: "gnmi_writer_build_info",
-		Help: "Build information for gnmi-writer",
+		Namespace: gnmi.MetricsNamespace,
+		Name:      "build_info",
+		Help:      "Build information for gnmi-writer",
 	},
 	[]string{"version", "commit", "date"},
 )

--- a/telemetry/gnmi-writer/internal/gnmi/metrics.go
+++ b/telemetry/gnmi-writer/internal/gnmi/metrics.go
@@ -5,6 +5,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// MetricsNamespace is the Prometheus namespace for all gnmi-writer metrics.
+const MetricsNamespace = "gnmi_writer"
+
 // ConsumerMetrics holds Prometheus metrics for the Kafka consumer.
 type ConsumerMetrics struct {
 	NotificationsConsumed prometheus.Counter
@@ -17,16 +20,19 @@ func NewConsumerMetrics(reg prometheus.Registerer) *ConsumerMetrics {
 	factory := promauto.With(reg)
 	return &ConsumerMetrics{
 		NotificationsConsumed: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_notifications_consumed_total",
-			Help: "Total number of gNMI notifications consumed from Kafka",
+			Namespace: MetricsNamespace,
+			Name:      "notifications_consumed_total",
+			Help:      "Total number of gNMI notifications consumed from Kafka",
 		}),
 		FetchErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_fetch_errors_total",
-			Help: "Total number of Kafka fetch errors",
+			Namespace: MetricsNamespace,
+			Name:      "fetch_errors_total",
+			Help:      "Total number of Kafka fetch errors",
 		}),
 		UnmarshalErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_unmarshal_errors_total",
-			Help: "Total number of protobuf unmarshal errors",
+			Namespace: MetricsNamespace,
+			Name:      "unmarshal_errors_total",
+			Help:      "Total number of protobuf unmarshal errors",
 		}),
 	}
 }
@@ -45,25 +51,30 @@ func NewProcessorMetrics(reg prometheus.Registerer) *ProcessorMetrics {
 	factory := promauto.With(reg)
 	return &ProcessorMetrics{
 		RecordsProcessed: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_records_processed_total",
-			Help: "Total number of state records processed",
+			Namespace: MetricsNamespace,
+			Name:      "records_processed_total",
+			Help:      "Total number of state records processed",
 		}),
 		ProcessingErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_processing_errors_total",
-			Help: "Total number of notification processing errors",
+			Namespace: MetricsNamespace,
+			Name:      "processing_errors_total",
+			Help:      "Total number of notification processing errors",
 		}),
 		ProcessingDuration: factory.NewHistogram(prometheus.HistogramOpts{
-			Name:    "gnmi_ingest_processing_duration_seconds",
-			Help:    "Time spent processing notifications",
-			Buckets: prometheus.DefBuckets,
+			Namespace: MetricsNamespace,
+			Name:      "processing_duration_seconds",
+			Help:      "Time spent processing notifications",
+			Buckets:   prometheus.DefBuckets,
 		}),
 		WriteErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_write_errors_total",
-			Help: "Total number of write errors",
+			Namespace: MetricsNamespace,
+			Name:      "write_errors_total",
+			Help:      "Total number of write errors",
 		}),
 		CommitErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_commit_errors_total",
-			Help: "Total number of Kafka commit errors",
+			Namespace: MetricsNamespace,
+			Name:      "commit_errors_total",
+			Help:      "Total number of Kafka commit errors",
 		}),
 	}
 }
@@ -80,17 +91,23 @@ func NewClickhouseMetrics(reg prometheus.Registerer) *ClickhouseMetrics {
 	factory := promauto.With(reg)
 	return &ClickhouseMetrics{
 		InsertDuration: factory.NewHistogram(prometheus.HistogramOpts{
-			Name:    "gnmi_ingest_clickhouse_insert_duration_seconds",
-			Help:    "Time spent inserting batches into ClickHouse",
-			Buckets: prometheus.DefBuckets,
+			Namespace: MetricsNamespace,
+			Subsystem: "clickhouse",
+			Name:      "insert_duration_seconds",
+			Help:      "Time spent inserting batches into ClickHouse",
+			Buckets:   prometheus.DefBuckets,
 		}),
 		InsertErrors: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_clickhouse_insert_errors_total",
-			Help: "Total number of ClickHouse insert errors",
+			Namespace: MetricsNamespace,
+			Subsystem: "clickhouse",
+			Name:      "insert_errors_total",
+			Help:      "Total number of ClickHouse insert errors",
 		}),
 		RecordsWritten: factory.NewCounter(prometheus.CounterOpts{
-			Name: "gnmi_ingest_clickhouse_records_written_total",
-			Help: "Total number of records written to ClickHouse",
+			Namespace: MetricsNamespace,
+			Subsystem: "clickhouse",
+			Name:      "records_written_total",
+			Help:      "Total number of records written to ClickHouse",
 		}),
 	}
 }


### PR DESCRIPTION
## Summary of Changes
gnmi-writer was previously named gnmi-ingest but the metric names weren't changed. This fixes that.

## Testing Verification
  All metrics now use the gnmi_writer_ prefix:
```
  gnmi_writer_build_info{commit="none",date="unknown",version="dev"} 1
  gnmi_writer_commit_errors_total 0
  gnmi_writer_fetch_errors_total 0
  gnmi_writer_notifications_consumed_total 0
  gnmi_writer_processing_duration_seconds_bucket{le="0.005"} 0
  ...
  gnmi_writer_processing_duration_seconds_sum 0
  gnmi_writer_processing_duration_seconds_count 0
  gnmi_writer_processing_errors_total 0
  gnmi_writer_records_processed_total 0
  gnmi_writer_unmarshal_errors_total 0
  gnmi_writer_write_errors_total 0
```