### PR TITLE
gnmi-writer: use interface-level ifindex path

### DIFF
--- a/telemetry/gnmi-writer/README.md
+++ b/telemetry/gnmi-writer/README.md
@@ -104,7 +104,7 @@ func extractLldpNeighbors(device *oc.Device, meta Metadata) []Record {
 **State Container Access:**
 OpenConfig uses uncompressed paths, meaning all operational state fields are accessed through explicit `.State` containers. For example:
 - BGP neighbor peer AS: `neighbor.State.PeerAs` (not `neighbor.PeerAs`)
-- Interface ifindex: `subif.State.Ifindex` (not `subif.Ifindex`)
+- Interface ifindex: `iface.State.Ifindex` (not `iface.Ifindex`)
 - System hostname: `device.System.State.Hostname` (not `device.System.Hostname`)
 
 Always check if the `.State` container exists before accessing its fields to avoid nil pointer panics.

--- a/telemetry/gnmi-writer/clickhouse/interface_ifindex.sql
+++ b/telemetry/gnmi-writer/clickhouse/interface_ifindex.sql
@@ -5,12 +5,11 @@ CREATE TABLE IF NOT EXISTS interface_ifindex (
     timestamp DateTime64(9) CODEC(DoubleDelta, ZSTD(1)),
     device_pubkey LowCardinality(String),
     interface_name String,
-    subif_index UInt32,
     ifindex UInt32
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(timestamp)
-ORDER BY (device_pubkey, interface_name, subif_index, timestamp)
+ORDER BY (device_pubkey, interface_name, timestamp)
 TTL toDateTime(timestamp) + INTERVAL 30 DAY
 SETTINGS index_granularity = 8192;
 

--- a/telemetry/gnmi-writer/internal/gnmi/extractors.go
+++ b/telemetry/gnmi-writer/internal/gnmi/extractors.go
@@ -221,6 +221,7 @@ func extractBgpNeighbors(device *oc.Device, meta Metadata) []Record {
 }
 
 // extractInterfaceIfindex extracts interface ifindex mappings from an oc.Device.
+// Extracts from /interfaces/interface/state/ifindex.
 func extractInterfaceIfindex(device *oc.Device, meta Metadata) []Record {
 	var records []Record
 
@@ -229,23 +230,16 @@ func extractInterfaceIfindex(device *oc.Device, meta Metadata) []Record {
 	}
 
 	for ifName, iface := range device.Interfaces.Interface {
-		if iface.Subinterfaces == nil {
+		if iface.State == nil || iface.State.Ifindex == nil {
 			continue
 		}
-		for subifIdx, subif := range iface.Subinterfaces.Subinterface {
-			// Ifindex is now in State
-			if subif.State == nil || subif.State.Ifindex == nil {
-				continue
-			}
-			record := InterfaceIfindexRecord{
-				Timestamp:     meta.Timestamp,
-				DevicePubkey:  meta.DevicePubkey,
-				InterfaceName: ifName,
-				SubifIndex:    subifIdx,
-				Ifindex:       *subif.State.Ifindex,
-			}
-			records = append(records, record)
+		record := InterfaceIfindexRecord{
+			Timestamp:     meta.Timestamp,
+			DevicePubkey:  meta.DevicePubkey,
+			InterfaceName: ifName,
+			Ifindex:       *iface.State.Ifindex,
 		}
+		records = append(records, record)
 	}
 
 	return records

--- a/telemetry/gnmi-writer/internal/gnmi/records.go
+++ b/telemetry/gnmi-writer/internal/gnmi/records.go
@@ -69,7 +69,6 @@ type InterfaceIfindexRecord struct {
 	Timestamp     time.Time `json:"timestamp" ch:"timestamp"`
 	DevicePubkey  string    `json:"device_pubkey" ch:"device_pubkey"`
 	InterfaceName string    `json:"interface_name" ch:"interface_name"`
-	SubifIndex    uint32    `json:"subif_index" ch:"subif_index"`
 	Ifindex       uint32    `json:"ifindex" ch:"ifindex"`
 }
 

--- a/telemetry/gnmi-writer/internal/gnmi/testdata/interfaces_ifindex.prototext
+++ b/telemetry/gnmi-writer/internal/gnmi/testdata/interfaces_ifindex.prototext
@@ -1,5 +1,5 @@
 update: {
-  timestamp: 1768423321496926903
+  timestamp: 1768513139679215657
   prefix: {
     target: "DZd011111111111111111111111111111111111111111"
   }
@@ -13,16 +13,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -49,16 +39,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -79,16 +59,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -115,16 +85,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -145,16 +105,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet5"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -181,16 +131,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -211,16 +151,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet7"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -247,16 +177,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -277,16 +197,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet9"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -313,16 +223,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -343,16 +243,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet11"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -379,16 +269,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -409,16 +289,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet13"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -445,16 +315,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -475,16 +335,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet15"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -511,16 +361,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -541,16 +381,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet17"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -577,16 +407,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -607,16 +427,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet19"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -643,16 +453,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -673,16 +473,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet21"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -709,16 +499,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -739,16 +519,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet23"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -775,16 +545,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -805,16 +565,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet25"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -841,16 +591,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -871,16 +611,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet27"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -907,16 +637,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -937,16 +657,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet29"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -973,16 +683,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1003,16 +703,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet31"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1039,16 +729,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1069,16 +749,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet33"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1105,16 +775,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1135,16 +795,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet35"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1171,16 +821,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1201,16 +841,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet37"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1237,16 +867,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1267,16 +887,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet39"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1303,16 +913,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1333,16 +933,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet41"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1369,16 +959,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1399,16 +979,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet43"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1435,16 +1005,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1465,16 +1025,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet45"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1501,16 +1051,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1531,16 +1071,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet47"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1567,16 +1097,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1597,16 +1117,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet49/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1633,16 +1143,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1663,16 +1163,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet49/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1699,16 +1189,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1729,16 +1209,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet50/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1765,16 +1235,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1795,16 +1255,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet50/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1831,16 +1281,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1861,16 +1301,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet51/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1897,16 +1327,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1927,16 +1347,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet51/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -1963,16 +1373,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -1993,16 +1393,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet52/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2029,16 +1419,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2059,16 +1439,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet52/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2095,16 +1465,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2125,16 +1485,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet53/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2161,16 +1511,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2191,16 +1531,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet54/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2227,16 +1557,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2257,16 +1577,6 @@ update: {
         key: {
           key: "name"
           value: "Ethernet54/6"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2293,16 +1603,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2326,16 +1626,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -2355,149 +1645,7 @@ update: {
         name: "interface"
         key: {
           key: "name"
-          value: "Loopback100"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 5000100
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Loopback255"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 5000255
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Loopback256"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 5000256
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Loopback1000"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 5001000
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
           value: "Management1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
         }
       }
       elem: {
@@ -2520,4079 +1668,10 @@ update: {
         name: "interface"
         key: {
           key: "name"
-          value: "Port-Channel1000"
+          value: "Port-Channel10"
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 1001000
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Port-Channel1000"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "2013"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 1601692648
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Port-Channel1000"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "2035"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 1607459816
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Port-Channel2000"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 1002000
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Port-Channel2000"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "1000"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 1336141776
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/1/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001013
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/1/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001014
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/1/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001015
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/1/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001016
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/2/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001025
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/2/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001026
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/2/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001027
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/2/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001028
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/3/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001037
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/3/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001038
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/3/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001039
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/3/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001040
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/4/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001049
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/4/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001050
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/4/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001051
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/4/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001052
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/5/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001061
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/5/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001062
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/5/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001063
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/5/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001064
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/6/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001073
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/6/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001074
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/6/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001075
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/6/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001076
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/7/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001085
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/7/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001086
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/7/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001087
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/7/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001088
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/8/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001097
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/8/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001098
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/8/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001099
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/8/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001100
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/9/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001109
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/9/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001110
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/9/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001111
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/9/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001112
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/10/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001121
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/10/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001122
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/10/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001123
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/10/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001124
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/11/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001133
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/11/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001134
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/11/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001135
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/11/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001136
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/12/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001145
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/12/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001146
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/12/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001147
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/12/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001148
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/13/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001157
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/13/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001158
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/13/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001159
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/13/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001160
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/14/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001169
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/14/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001170
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/14/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001171
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/14/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001172
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/15/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001181
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/15/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001182
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/15/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001183
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/15/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001184
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/16/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001193
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/16/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001194
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/16/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001195
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/16/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001196
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/17/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001205
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/17/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001206
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/17/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001207
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/17/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001208
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/18/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001217
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/18/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001218
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/18/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001219
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/18/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001220
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/19/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001229
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/19/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001230
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/19/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001231
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/19/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001232
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/20/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001241
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/20/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001242
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/20/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001243
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/20/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001244
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/21/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001253
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/21/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001254
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/21/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001255
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/21/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "1020"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 16000000
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/21/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001256
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/22/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001265
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/22/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001266
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/22/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001267
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/22/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001268
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/23/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001277
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/23/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001278
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/23/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001279
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/23/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001280
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/24/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001289
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/24/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001290
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/24/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001291
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/24/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001292
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001301
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001302
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001303
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001304
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/5"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001305
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/6"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001306
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/7"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001307
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/25/8"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001308
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/26"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001313
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/1"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001325
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/2"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001326
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/3"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001327
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/4"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001328
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/5"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001329
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/6"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001330
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/7"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001331
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/27/8"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001332
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/28"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001337
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/29"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001349
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/30"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001361
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/31"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
-        name: "state"
-      }
-      elem: {
-        name: "ifindex"
-      }
-    }
-    val: {
-      uint_val: 8001373
-    }
-  }
-  update: {
-    path: {
-      elem: {
-        name: "interfaces"
-      }
-      elem: {
-        name: "interface"
-        key: {
-          key: "name"
-          value: "Switch1/32"
-        }
-      }
-      elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -6600,7 +1679,7 @@ update: {
       }
     }
     val: {
-      uint_val: 8001385
+      uint_val: 1000010
     }
   }
   update: {
@@ -6616,16 +1695,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -6633,7 +1702,7 @@ update: {
       }
     }
     val: {
-      uint_val: 15000500
+      uint_val: 0
     }
   }
   update: {
@@ -6649,16 +1718,6 @@ update: {
         }
       }
       elem: {
-        name: "subinterfaces"
-      }
-      elem: {
-        name: "subinterface"
-        key: {
-          key: "index"
-          value: "0"
-        }
-      }
-      elem: {
         name: "state"
       }
       elem: {
@@ -6666,7 +1725,7 @@ update: {
       }
     }
     val: {
-      uint_val: 15000501
+      uint_val: 0
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
Switch from /interfaces/interface/subinterfaces/subinterface/state/ifindex to /interfaces/interface/state/ifindex since some devices don't support the subinterface path.

- Update extractor to read ifindex from interface state
- Remove subif_index field from record and schema

## Testing Verification
```
Unit test:
  === RUN   TestUnmarshal_InterfacesIfindex
      processor_test.go:801: successfully unmarshalled 75 interfaces
  --- PASS: TestUnmarshal_InterfacesIfindex (0.13s)

  Integration test (end-to-end with ClickHouse + Redpanda):
  === RUN   TestIntegration/InterfaceIfindex
      processor_integration_test.go:299: published 5777 bytes to topic gnmi-notifications
      ...
      msg="wrote records to clickhouse" count=75
      msg="processed notifications" count=75
      processor_integration_test.go:222: table interface_ifindex has 75 rows
      processor_integration_test.go:446: found 75 interface ifindex records
  --- PASS: TestIntegration/InterfaceIfindex (14.65s)
  ```
