### PR TITLE
gnmi-writer: fix transceiver state/threshold record aggregation

### DIFF
--- a/telemetry/gnmi-writer/internal/gnmi/extractors.go
+++ b/telemetry/gnmi-writer/internal/gnmi/extractors.go
@@ -278,14 +278,24 @@ func extractTransceiverState(device *oc.Device, meta Metadata) []Record {
 				ChannelIndex:  chanIdx,
 			}
 
+			// Check if any power metrics are present in the update.
+			// Skip updates that only contain other fields (e.g., description).
+			hasInputPower := channel.State.InputPower != nil && channel.State.InputPower.Instant != nil
+			hasOutputPower := channel.State.OutputPower != nil && channel.State.OutputPower.Instant != nil
+			hasLaserBias := channel.State.LaserBiasCurrent != nil && channel.State.LaserBiasCurrent.Instant != nil
+
+			if !hasInputPower && !hasOutputPower && !hasLaserBias {
+				continue
+			}
+
 			// Extract optical power metrics
-			if channel.State.InputPower != nil && channel.State.InputPower.Instant != nil {
+			if hasInputPower {
 				record.InputPower = *channel.State.InputPower.Instant
 			}
-			if channel.State.OutputPower != nil && channel.State.OutputPower.Instant != nil {
+			if hasOutputPower {
 				record.OutputPower = *channel.State.OutputPower.Instant
 			}
-			if channel.State.LaserBiasCurrent != nil && channel.State.LaserBiasCurrent.Instant != nil {
+			if hasLaserBias {
 				record.LaserBiasCurrent = *channel.State.LaserBiasCurrent.Instant
 			}
 

--- a/telemetry/gnmi-writer/internal/gnmi/processor.go
+++ b/telemetry/gnmi-writer/internal/gnmi/processor.go
@@ -221,6 +221,12 @@ func (p *Processor) processNotifications(ctx context.Context, notifications []*g
 		}
 	}
 
+	// Aggregate records that need deduplication.
+	// gNMI sends individual updates for each leaf value, so records with the same
+	// key need to be merged into a single row.
+	records = AggregateTransceiverState(records)
+	records = AggregateTransceiverThresholds(records)
+
 	return records
 }
 


### PR DESCRIPTION
## Summary of Changes
This fixes two issues:
- Devices send transceiver descriptions as separate gnmi update messages, which were being parsed as individual records and written as a duplicate row with zero values.
- Transceiver thresholds are sent as individual updates for each severity. These were being written as it's own row per severity and are now aggregated into a single row per interface/severity.

## Testing Verification
Transceiver state before containing a duplicate row w/ zero values:
```
 53. │ 2026-01-16 04:08:51.197958931 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet1      │             0 │       -1.95 │        -2.35 │               6.25 │
 54. │ 2026-01-16 04:08:51.197958931 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet1      │             0 │           0 │            0 │                  0 │
```
Transceiver state now:
```
SELECT *
FROM transceiver_state_latest
WHERE (device_pubkey = '9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r') AND (interface_name = 'Ethernet1')

   ┌─────────────────────timestamp─┬─device_pubkey────────────────────────────────┬─interface_name─┬─channel_index─┬─input_power─┬─output_power─┬─laser_bias_current─┐
1. │ 2026-01-16 04:20:56.145597378 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet1      │             0 │       -1.94 │        -2.33 │               6.25 │
   └───────────────────────────────┴──────────────────────────────────────────────┴────────────────┴───────────────┴─────────────┴──────────────┴────────────────────┘
```

Transceiver thresholds before:
```
41551. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        0 │                        0 │                        0 │                        0 │                 2.97 │                    0 │
41552. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        0 │                        0 │                        0 │                        0 │                    0 │   3.6300000000000003 │
41553. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        2 │                        0 │                        0 │                        0 │                    0 │                    0 │
41554. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        0 │                       14 │                        0 │                        0 │                    0 │                    0 │
41555. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │ -13.904055907747797 │                   0 │                   0 │                   0 │                        0 │                        0 │                        0 │                        0 │                    0 │                    0 │
41556. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │   3.000082025538127 │                   0 │                   0 │                        0 │                        0 │                        0 │                        0 │                    0 │                    0 │
41557. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │ -11.301817920206716 │                   0 │                        0 │                        0 │                        0 │                        0 │                    0 │                    0 │
41558. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │   3.000082025538127 │                        0 │                        0 │                        0 │                        0 │                    0 │                    0 │
41559. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        0 │                        0 │                       -5 │                        0 │                    0 │                    0 │
41560. │ 2026-01-16 03:19:02.908902719 │ 9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r │ Ethernet54     │ CRITICAL │                   0 │                   0 │                   0 │                   0 │                        0 │                        0 │                        0 │                       75 │                    0 │                    0 │
```

 Transceiver thresholds now (single record per interface/severity):
```
SELECT *
FROM transceiver_thresholds_latest
WHERE (device_pubkey = '9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r') AND (interface_name = 'Ethernet54') AND (severity = 'CRITICAL')

Row 1:
──────
timestamp:                2026-01-16 04:24:56.624986659
device_pubkey:            9rSYq2eyR5sPiu5Ug5bBP8AVNtXf1rD59pbAgrT6Yx5r
interface_name:           Ethernet54
severity:                 CRITICAL
input_power_lower:        -13.904055907747797
input_power_upper:        3.000082025538127
output_power_lower:       -11.301817920206716
output_power_upper:       3.000082025538127
laser_bias_current_lower: 2
laser_bias_current_upper: 14
module_temperature_lower: -5
module_temperature_upper: 75
supply_voltage_lower:     2.97
supply_voltage_upper:     3.6300000000000003
```