### PR TITLE
Enhance access pass functionality with new types and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Breaking
-
-### Changes
-
-## [v0.8.5](https://github.com/malbeclabs/doublezero/compare/client/v0.8.4...client/v0.8.5) – 2026-02-02
-
-- Smartcontract
-  - fix(smartcontract): reserve first IP of DzPrefixBlock for device ([#2753](https://github.com/malbeclabs/doublezero/pull/2753))
-- Client
-  - Fix race in bgp status handling on peer deletion
-
-### Breaking
-
-### Changes
+- CLI
+  - Remove log noise on resolve route
+- Onchain programs
+   - Removed device and user allowlist functionality, updating the global state, initialization flow, tests, and processors accordingly, and cleaning up unused account checks.
+   - Serviceability: require DeactivateMulticastGroup to only close multicast group accounts when both `publisher_count` and `subscriber_count` are zero, preventing deletion of groups that still have active publishers or subscribers.
+   - Deprecated the user suspend status, as it is no longer used.
+   - Serviceability: enforce that CloseAccountUser instructions verify the target user has no multicast publishers or subscribers (both `publishers` and `subscribers` are empty) before closing, and add regression coverage for this behavior.
+   - Enhance access pass functionality with new Solana-specific types
 
 - Telemetry
   - Fix goroutine leak in TWAMP sender — `cleanUpReceived` goroutines now exit on `Close()` instead of living until process shutdown

--- a/smartcontract/Makefile
+++ b/smartcontract/Makefile
@@ -30,7 +30,11 @@ test-programs: test-sbf
 
 .PHONY: test-sbf
 test-sbf:
-	cargo test-sbf
+	cargo test --lib \
+		-p doublezero-program-common \
+		-p doublezero-record \
+		-p doublezero-telemetry \
+		-p doublezero-serviceability
 
 .PHONY: lint
 lint: lint-programs

--- a/smartcontract/cli/src/accesspass/set.rs
+++ b/smartcontract/cli/src/accesspass/set.rs
@@ -12,11 +12,15 @@ use std::{io::Write, net::Ipv4Addr, str::FromStr};
 pub enum CliAccessPassType {
     Prepaid,
     SolanaValidator,
+    SolanaRPC,
+    SolanaMulticastPublisher,
+    SolanaMulticastSubscriber,
+    Others,
 }
 
 #[derive(Args, Debug)]
 pub struct SetAccessPassCliCommand {
-    /// Specifies the type of access pass being set.
+    /// Specifies the access pass type (prepaid, solana_validator, solana_rpc, solana_multicast_publisher, solana_multicast_subscriber)
     #[arg(long, default_value = "prepaid")]
     pub accesspass_type: CliAccessPassType,
     /// Client IP address in IPv4 format
@@ -28,12 +32,24 @@ pub struct SetAccessPassCliCommand {
     /// Specifies the number of epochs for the access pass.
     #[arg(long, default_value = "max")]
     pub epochs: String,
-    /// Specifies the solana validator node id for the access pass. Required if accesspass_type is solana_validator
-    #[arg(long)]
-    pub solana_validator: Option<Pubkey>,
-    /// Allow multiple IP addresses for this access pass (only for Prepaid type)
+    /// Specifies the solana validator node id for the access pass. Required if accesspass_type is solana_validator, solana_rpc, solana_multicast_publisher, or solana_multicast_subscriber
+    #[arg(
+        long,
+        required_if_eq("accesspass_type", "solana_validator"),
+        required_if_eq("accesspass_type", "solana_rpc"),
+        required_if_eq("accesspass_type", "solana_multicast_publisher"),
+        required_if_eq("accesspass_type", "solana_multicast_subscriber")
+    )]
+    pub solana_validator: Option<Pubkey>, // This will be integrated with identity for all access pass types in future
+    /// Allow multiple IP addresses for this access pass (only for Prepaid type)    
     #[arg(long, default_value_t = false)]
     pub allow_multiple_ip: bool,
+    /// Specifies the name for other access pass types. Required if accesspass_type is others.
+    #[arg(long, required_if_eq("accesspass_type", "others"))]
+    pub others_name: Option<String>,
+    /// Specifies the key for other access pass types. Required if accesspass_type is others.
+    #[arg(long, required_if_eq("accesspass_type", "others"))]
+    pub others_key: Option<String>,
 }
 
 impl SetAccessPassCliCommand {
@@ -62,6 +78,34 @@ impl SetAccessPassCliCommand {
                 Some(solana_validator) => AccessPassType::SolanaValidator(solana_validator),
                 None => eyre::bail!(
                     "Solana validator access pass type requires --solana-validator <PUBKEY>"
+                ),
+            },
+            CliAccessPassType::SolanaRPC => match self.solana_validator {
+                Some(solana_validator) => AccessPassType::SolanaRPC(solana_validator),
+                None => {
+                    eyre::bail!("Solana RPC access pass type requires --solana-validator <STRING>")
+                }
+            },
+            CliAccessPassType::SolanaMulticastPublisher => match self.solana_validator {
+                Some(solana_validator) => {
+                    AccessPassType::SolanaMulticastPublisher(solana_validator)
+                }
+                None => eyre::bail!(
+                    "Solana Multicast Publisher access pass type requires --solana-validator <STRING>"
+                ),
+            },
+            CliAccessPassType::SolanaMulticastSubscriber => match self.solana_validator {
+                Some(solana_validator) => {
+                    AccessPassType::SolanaMulticastSubscriber(solana_validator)
+                }
+                None => eyre::bail!(
+                    "Solana Multicast Subscriber access pass type requires --solana-validator <STRING>"
+                ),
+            },
+            CliAccessPassType::Others => match (self.others_name, self.others_key) {
+                (Some(name), Some(key)) => AccessPassType::Others( name, key ),
+                _ => eyre::bail!(
+                    "Others access pass type requires --others-name <STRING> and --others-key <STRING>"
                 ),
             },
         };
@@ -101,7 +145,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cli_accesspass_set() {
+    fn test_cli_accesspass_set_prepaid() {
         let mut client = create_test_client();
 
         let client_ip = [100, 0, 0, 1].into();
@@ -117,9 +161,92 @@ mod tests {
         ]);
 
         client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::Prepaid,
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: u64::MAX,
+                allow_multiple_ip: false,
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::Prepaid,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "max".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_validator_missing_validator() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaValidator,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Solana validator access pass type requires --solana-validator <PUBKEY>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_validator_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
 
         let solana_validator = Pubkey::new_unique();
 
+        client.expect_get_epoch().returning(|| Ok(10));
         client
             .expect_check_requirements()
             .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
@@ -141,30 +268,394 @@ mod tests {
             client_ip: Some(client_ip),
             user_payer: payer.to_string(),
             epochs: "1".into(),
-            solana_validator: None,
-            allow_multiple_ip: false,
-        }
-        .execute(&client, &mut output);
-        assert!(res.is_err());
-        assert_eq!(
-            res.err().unwrap().to_string(),
-            "Solana validator access pass type requires --solana-validator <PUBKEY>"
-        );
-
-        let mut output = Vec::new();
-        let res = SetAccessPassCliCommand {
-            accesspass_type: CliAccessPassType::SolanaValidator,
-            client_ip: Some(client_ip),
-            user_payer: payer.to_string(),
-            epochs: "1".into(),
             solana_validator: Some(solana_validator),
             allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(
-            output_str,"AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_rpc_missing_validator() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaRPC,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Solana RPC access pass type requires --solana-validator <STRING>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_rpc_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let solana_validator = Pubkey::new_unique();
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::SolanaRPC(solana_validator),
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: 11,
+                allow_multiple_ip: false,
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaRPC,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: Some(solana_validator),
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_multicast_publisher_missing_validator() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaMulticastPublisher,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Solana Multicast Publisher access pass type requires --solana-validator <STRING>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_multicast_publisher_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let solana_validator = Pubkey::new_unique();
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::SolanaMulticastPublisher(solana_validator),
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: 11,
+                allow_multiple_ip: false,
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaMulticastPublisher,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: Some(solana_validator),
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_multicast_subscriber_missing_validator() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaMulticastSubscriber,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Solana Multicast Subscriber access pass type requires --solana-validator <STRING>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_solana_multicast_subscriber_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let solana_validator = Pubkey::new_unique();
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::SolanaMulticastSubscriber(solana_validator),
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: 11,
+                allow_multiple_ip: false,
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::SolanaMulticastSubscriber,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: Some(solana_validator),
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_others_missing_name_and_key() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::Others,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Others access pass type requires --others-name <STRING> and --others-key <STRING>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_others_missing_key() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::Others,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: Some("custom-name".to_string()),
+            others_key: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "Others access pass type requires --others-name <STRING> and --others-key <STRING>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_others_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::Others(
+                    "custom-name".to_string(),
+                    "custom-key".to_string(),
+                ),
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: 11,
+                allow_multiple_ip: false,
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::Others,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: Some("custom-name".to_string()),
+            others_key: Some("custom-key".to_string()),
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
         );
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -50,7 +50,7 @@ pub enum DoubleZeroError {
     #[error("Unauthorized")]
     Unauthorized, // variant 22
     #[error("Invalid Solana Validator Pubkey")]
-    InvalidSolanaValidatorPubkey, // variant 23
+    InvalidSolanaPubkey, // variant 23
     #[error("InterfaceNotFound")]
     InterfaceNotFound, // variant 24
     #[error("Invalid Access Pass")]
@@ -173,7 +173,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::MaxUsersExceeded => ProgramError::Custom(20),
             DoubleZeroError::InvalidLastAccessEpoch => ProgramError::Custom(21),
             DoubleZeroError::Unauthorized => ProgramError::Custom(22),
-            DoubleZeroError::InvalidSolanaValidatorPubkey => ProgramError::Custom(23),
+            DoubleZeroError::InvalidSolanaPubkey => ProgramError::Custom(23),
             DoubleZeroError::InterfaceNotFound => ProgramError::Custom(24),
             DoubleZeroError::AccessPassUnauthorized => ProgramError::Custom(25),
             DoubleZeroError::InvalidClientIp => ProgramError::Custom(26),
@@ -250,7 +250,7 @@ impl From<u32> for DoubleZeroError {
             20 => DoubleZeroError::MaxUsersExceeded,
             21 => DoubleZeroError::InvalidLastAccessEpoch,
             22 => DoubleZeroError::Unauthorized,
-            23 => DoubleZeroError::InvalidSolanaValidatorPubkey,
+            23 => DoubleZeroError::InvalidSolanaPubkey,
             24 => DoubleZeroError::InterfaceNotFound,
             25 => DoubleZeroError::AccessPassUnauthorized,
             26 => DoubleZeroError::InvalidClientIp,
@@ -347,7 +347,7 @@ mod tests {
             MaxUsersExceeded,
             InvalidLastAccessEpoch,
             Unauthorized,
-            InvalidSolanaValidatorPubkey,
+            InvalidSolanaPubkey,
             InterfaceNotFound,
             AccessPassUnauthorized,
             InvalidClientIp,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -113,7 +113,7 @@ pub fn process_set_access_pass(
     if let AccessPassType::SolanaValidator(node_id) = value.accesspass_type {
         if node_id == Pubkey::default() {
             msg!("Solana validator access pass type requires a validator pubkey");
-            return Err(DoubleZeroError::InvalidSolanaValidatorPubkey.into());
+            return Err(DoubleZeroError::InvalidSolanaPubkey.into());
         }
     }
 
@@ -138,7 +138,7 @@ pub fn process_set_access_pass(
         let accesspass = AccessPass {
             account_type: AccountType::AccessPass,
             bump_seed,
-            accesspass_type: value.accesspass_type,
+            accesspass_type: value.accesspass_type.clone(),
             client_ip: value.client_ip,
             user_payer: *user_payer.key,
             last_access_epoch: value.last_access_epoch,
@@ -181,7 +181,7 @@ pub fn process_set_access_pass(
             AccessPass {
                 account_type: AccountType::AccessPass,
                 bump_seed,
-                accesspass_type: value.accesspass_type,
+                accesspass_type: value.accesspass_type.clone(),
                 client_ip: value.client_ip,
                 flags,
                 user_payer: *user_payer.key,
@@ -195,7 +195,7 @@ pub fn process_set_access_pass(
         };
 
         // Update fields
-        accesspass.accesspass_type = value.accesspass_type;
+        accesspass.accesspass_type = value.accesspass_type.clone();
         accesspass.last_access_epoch = value.last_access_epoch;
         accesspass.flags = flags;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -160,9 +160,9 @@ pub fn process_create_user(
     accesspass.status = AccessPassStatus::Connected;
 
     // Read validator_pubkey from AccessPass
-    let validator_pubkey = match accesspass.accesspass_type {
-        AccessPassType::SolanaValidator(pk) => pk,
-        AccessPassType::Prepaid => Pubkey::default(),
+    let validator_pubkey = match &accesspass.accesspass_type {
+        AccessPassType::SolanaValidator(pk) => *pk,
+        _ => Pubkey::default(),
     };
 
     let mut device = Device::try_from(device_account)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -173,9 +173,9 @@ pub fn process_create_subscribe_user(
     }
 
     // Read validator_pubkey from AccesPass
-    let validator_pubkey = match accesspass.accesspass_type {
-        AccessPassType::SolanaValidator(pk) => pk,
-        AccessPassType::Prepaid => Pubkey::default(),
+    let validator_pubkey = match &accesspass.accesspass_type {
+        AccessPassType::SolanaValidator(pk) => *pk,
+        _ => Pubkey::default(),
     };
 
     let mut mgroup: MulticastGroup = MulticastGroup::try_from(mgroup_account)?;

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -324,9 +324,9 @@ impl User {
     pub fn try_activate(&mut self, accesspass: &mut AccessPass) -> ProgramResult {
         accesspass.update_status()?;
 
-        self.validator_pubkey = match accesspass.accesspass_type {
-            AccessPassType::SolanaValidator(pk) => pk,
-            AccessPassType::Prepaid => Pubkey::default(),
+        self.validator_pubkey = match &accesspass.accesspass_type {
+            AccessPassType::SolanaValidator(pk) => *pk,
+            _ => Pubkey::default(),
         };
 
         self.status = if accesspass.status == AccessPassStatus::Expired {

--- a/smartcontract/sdk/rs/src/commands/accesspass/set.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set.rs
@@ -39,7 +39,7 @@ impl SetAccessPassCommand {
 
         client.execute_transaction(
             DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
-                accesspass_type: self.accesspass_type,
+                accesspass_type: self.accesspass_type.clone(),
                 client_ip: self.client_ip,
                 last_access_epoch: self.last_access_epoch,
                 allow_multiple_ip: self.allow_multiple_ip,


### PR DESCRIPTION
This pull request introduces new access pass types for Solana RPC and Solana Multicast (Publisher and Subscriber), expands validation and serialization logic, and refactors related code for clarity and extensibility. It also standardizes error handling for invalid Solana pubkeys and updates test coverage accordingly.

### Access Pass Type Expansion

* Added new variants to `AccessPassType` and `CliAccessPassType` for SolanaRPC, SolanaMulticastPublisher, and SolanaMulticastSubscriber, including support for serialization, deserialization, display formatting, and discriminant string conversion. [[1]](diffhunk://#diff-dd0b8fce2acca223e0b8169ce27bb2986acabb1d568a7ccc5fb4c94464c0d595R15-R22) [[2]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802R31-R72) [[3]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802R82-R88) [[4]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802L148-R217) [[5]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802R228-R236)

* Updated CLI command logic to support the new access pass types, requiring a validator pubkey for each and updating help text. [[1]](diffhunk://#diff-dd0b8fce2acca223e0b8169ce27bb2986acabb1d568a7ccc5fb4c94464c0d595L33-R36) [[2]](diffhunk://#diff-dd0b8fce2acca223e0b8169ce27bb2986acabb1d568a7ccc5fb4c94464c0d595R70-R91)

### Validation and Error Handling

* Extended validation logic for all new access pass types to check for default pubkeys and standardized error reporting using a renamed `InvalidSolanaPubkey` error. [[1]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802L100-R176) [[2]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122L53-R53) [[3]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122L170-R170) [[4]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122L244-R244) [[5]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802L445-R523)

* Updated all code references, conversions, and tests to use the new `InvalidSolanaPubkey` error variant. [[1]](diffhunk://#diff-559217d399440457caa17c5ab1c2601d3f928d52298b70ba22d24ce1d4a4e122L338-R338) [[2]](diffhunk://#diff-535d30342766bf91b24868a6585cfb47852f365617445470bc5ed6edf8259da2L116-R116) [[3]](diffhunk://#diff-80e0bb5297b02b4e5f38a82aa45cb97bdeb0a7c4b07248e6acdf53dceda15802L445-R523)

### Refactoring and Code Consistency

* Refactored code to use `.clone()` for `AccessPassType` where necessary to avoid ownership issues and ensure proper value passing. [[1]](diffhunk://#diff-535d30342766bf91b24868a6585cfb47852f365617445470bc5ed6edf8259da2L141-R141) [[2]](diffhunk://#diff-535d30342766bf91b24868a6585cfb47852f365617445470bc5ed6edf8259da2L184-R184) [[3]](diffhunk://#diff-535d30342766bf91b24868a6585cfb47852f365617445470bc5ed6edf8259da2L198-R198) [[4]](diffhunk://#diff-ba79fbd618394a445d84d37b9d5b9dec5e967299434bb677763831419c43b393L42-R42)

* Updated logic for extracting validator pubkeys from `AccessPassType` to support all new variants and use references for consistency. [[1]](diffhunk://#diff-50a1438f8af41564d2206a2bc66f4efbd8d410b02b1273d63634342dc8ba321eL163-R165) [[2]](diffhunk://#diff-cddaff613b96778de97f99ba3220571784cbb1d1d3533c475f24ad47af738624L176-R178) [[3]](diffhunk://#diff-0e24a7e1473ca2f2de965d23e72a3b5212b2d7d3255e6042659604eb08ee19f6L327-R329)

### Test and Build Improvements

* Updated the `test-sbf` target in `smartcontract/Makefile` to run tests for individual packages, improving granularity and coverage.

## Testing Verification
* Show evidence of testing the change
