### PR TITLE
Rename ReadyForService LinkStatus field to Provisioning

### DIFF
--- a/smartcontract/cli/src/poll_for_activation.rs
+++ b/smartcontract/cli/src/poll_for_activation.rs
@@ -141,7 +141,7 @@ pub fn poll_for_link_activated(
             pubkey_or_code: link_pubkey.to_string(),
         }) {
             Ok((_, link)) => {
-                if link.status == LinkStatus::ReadyForService
+                if link.status == LinkStatus::Provisioning
                     || link.status == LinkStatus::Activated
                     || link.status == LinkStatus::Rejected
                 {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
@@ -123,7 +123,7 @@ pub fn process_activate_link(
 
     link.tunnel_id = value.tunnel_id;
     link.tunnel_net = value.tunnel_net;
-    link.status = LinkStatus::ReadyForService;
+    link.status = LinkStatus::Provisioning;
 
     link.check_status_transition();
 

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -461,6 +461,7 @@ const (
 	LinkStatusRequested
 	LinkStatusHardDrained
 	LinkStatusSoftDrained
+	LinkStatusProvisioning
 )
 
 func (l LinkStatus) String() string {
@@ -473,6 +474,7 @@ func (l LinkStatus) String() string {
 		"requested",
 		"hard-drained",
 		"soft-drained",
+		"provisioning",
 	}[l]
 }
 


### PR DESCRIPTION
Resolves: #2660

## Summary of Changes
* Rename ReadyForService LinkStatus field to Provisioning
