### PR TITLE
e2e: add prometheus container and validate controller_grpc_getconfig_requests_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - Activator
   - fix(activator): ip_to_index fn honors ip range #2658
 - E2E tests
-  - Add influxdb and device-health-oracle containers
+  - Add influxdb, prometheus, and device-health-oracle containers
 - SDK
   - Commands for setting global config, activating devices, updating devices, and closing device accounts now manage resource accounts.
 

--- a/e2e/docker/controller/Dockerfile
+++ b/e2e/docker/controller/Dockerfile
@@ -4,11 +4,16 @@ FROM ${BASE_IMAGE} AS base
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y curl iproute2 iputils-ping vim
+    apt-get install -y curl iproute2 iputils-ping vim gpg && \
+    curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" > /etc/apt/sources.list.d/grafana.list && \
+    apt-get update && \
+    apt-get install -y alloy
 
 COPY --from=base /doublezero/bin/doublezero-controller /usr/local/bin/
 
 ARG DOCKERFILE_DIR
 COPY ${DOCKERFILE_DIR}/entrypoint.sh /entrypoint.sh
+COPY ${DOCKERFILE_DIR}/alloy.config /etc/alloy/config.alloy
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/e2e/docker/controller/alloy.config
+++ b/e2e/docker/controller/alloy.config
@@ -1,0 +1,17 @@
+prometheus.scrape "controller" {
+  targets = [
+    {
+      __address__ = "127.0.0.1:2112",
+      component   = "controller",
+      env         = "devnet",
+    },
+  ]
+  forward_to = [prometheus.remote_write.default.receiver]
+  scrape_interval = "10s"
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = env("ALLOY_PROMETHEUS_URL")
+  }
+}

--- a/e2e/docker/controller/entrypoint.sh
+++ b/e2e/docker/controller/entrypoint.sh
@@ -19,5 +19,11 @@ while ! curl -sf -X POST -H 'Content-Type: application/json' \
     sleep 1
 done
 
+# Start Alloy in background if ALLOY_PROMETHEUS_URL is set
+if [ -n "${ALLOY_PROMETHEUS_URL:-}" ]; then
+  echo "Starting Alloy..."
+  alloy run /etc/alloy/config.alloy &
+fi
+
 # Start the controller.
 doublezero-controller start -listen-addr 0.0.0.0 -listen-port 7000 -program-id ${DZ_SERVICEABILITY_PROGRAM_ID} -solana-rpc-endpoint ${DZ_LEDGER_URL} -device-local-asn 65342 -no-hardware

--- a/e2e/docker/device-health-oracle/Dockerfile
+++ b/e2e/docker/device-health-oracle/Dockerfile
@@ -4,11 +4,16 @@ FROM ${BASE_IMAGE} AS base
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y curl iproute2 iputils-ping vim
+    apt-get install -y curl iproute2 iputils-ping vim gpg && \
+    curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" > /etc/apt/sources.list.d/grafana.list && \
+    apt-get update && \
+    apt-get install -y alloy
 
 COPY --from=base /doublezero/bin/device-health-oracle /usr/local/bin/
 
 ARG DOCKERFILE_DIR
 COPY ${DOCKERFILE_DIR}/entrypoint.sh /entrypoint.sh
+COPY ${DOCKERFILE_DIR}/alloy.config /etc/alloy/config.alloy
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/e2e/docker/device-health-oracle/alloy.config
+++ b/e2e/docker/device-health-oracle/alloy.config
@@ -1,0 +1,17 @@
+prometheus.scrape "device_health_oracle" {
+  targets = [
+    {
+      __address__ = "127.0.0.1:2112",
+      component   = "device-health-oracle",
+      env         = "devnet",
+    },
+  ]
+  forward_to = [prometheus.remote_write.default.receiver]
+  scrape_interval = "10s"
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = env("ALLOY_PROMETHEUS_URL")
+  }
+}

--- a/e2e/docker/device-health-oracle/entrypoint.sh
+++ b/e2e/docker/device-health-oracle/entrypoint.sh
@@ -15,5 +15,11 @@ if [ -z "${DZ_TELEMETRY_PROGRAM_ID}" ]; then
   exit 1
 fi
 
+# Start Alloy in background if ALLOY_PROMETHEUS_URL is set
+if [ -n "${ALLOY_PROMETHEUS_URL:-}" ]; then
+  echo "Starting Alloy..."
+  alloy run /etc/alloy/config.alloy &
+fi
+
 # start device-health-oracle
-device-health-oracle -ledger-rpc-url ${DZ_LEDGER_URL} -serviceability-program-id ${DZ_SERVICEABILITY_PROGRAM_ID} -telemetry-program-id ${DZ_TELEMETRY_PROGRAM_ID} -metrics-addr 0.0.0.0:8080 -interval 1m
+device-health-oracle -ledger-rpc-url ${DZ_LEDGER_URL} -serviceability-program-id ${DZ_SERVICEABILITY_PROGRAM_ID} -telemetry-program-id ${DZ_TELEMETRY_PROGRAM_ID} -metrics-addr ":2112" -interval ${DZ_INTERVAL:-1m}

--- a/e2e/internal/devnet/device_health_oracle.go
+++ b/e2e/internal/devnet/device_health_oracle.go
@@ -108,6 +108,9 @@ func (d *DeviceHealthOracle) Start(ctx context.Context) error {
 		"DZ_TELEMETRY_PROGRAM_ID":      d.dn.Manager.TelemetryProgramID,
 		"DZ_INTERVAL":                  d.dn.Spec.DeviceHealthOracle.Interval.String(),
 	}
+	if d.dn.Prometheus != nil && d.dn.Prometheus.InternalURL != "" {
+		env["ALLOY_PROMETHEUS_URL"] = d.dn.Prometheus.RemoteWriteURL()
+	}
 
 	req := testcontainers.ContainerRequest{
 		Image: d.dn.Spec.DeviceHealthOracle.ContainerImage,

--- a/e2e/internal/devnet/prometheus.go
+++ b/e2e/internal/devnet/prometheus.go
@@ -1,0 +1,217 @@
+package devnet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	dockerfilters "github.com/docker/docker/api/types/filters"
+	"github.com/docker/go-connections/nat"
+	"github.com/malbeclabs/doublezero/e2e/internal/logging"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	prometheusImage        = "prom/prometheus:v2.54.1"
+	prometheusInternalPort = 9090
+)
+
+type PrometheusSpec struct {
+	ContainerImage string
+}
+
+func (s *PrometheusSpec) Validate() error {
+	if s.ContainerImage == "" {
+		s.ContainerImage = prometheusImage
+	}
+	return nil
+}
+
+type Prometheus struct {
+	dn  *Devnet
+	log *slog.Logger
+
+	ContainerID      string
+	DefaultNetworkIP string
+	InternalURL      string
+}
+
+func (p *Prometheus) dockerContainerName() string {
+	return p.dn.Spec.DeployID + "-" + p.dockerContainerHostname()
+}
+
+func (p *Prometheus) dockerContainerHostname() string {
+	return "prometheus"
+}
+
+func (p *Prometheus) Exists(ctx context.Context) (bool, error) {
+	containers, err := p.dn.dockerClient.ContainerList(ctx, dockercontainer.ListOptions{
+		All:     true,
+		Filters: dockerfilters.NewArgs(dockerfilters.Arg("name", p.dockerContainerName())),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to list containers: %w", err)
+	}
+	for _, container := range containers {
+		if container.Names[0] == "/"+p.dockerContainerName() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *Prometheus) StartIfNotRunning(ctx context.Context) (bool, error) {
+	exists, err := p.Exists(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if prometheus exists: %w", err)
+	}
+	if exists {
+		container, err := p.dn.dockerClient.ContainerInspect(ctx, p.dockerContainerName())
+		if err != nil {
+			return false, fmt.Errorf("failed to inspect container: %w", err)
+		}
+
+		if container.State.Running {
+			p.log.Info("--> Prometheus already running", "container", shortContainerID(container.ID))
+
+			err = p.setState(ctx, container.ID)
+			if err != nil {
+				return false, fmt.Errorf("failed to set prometheus state: %w", err)
+			}
+
+			return false, nil
+		}
+
+		err = p.dn.dockerClient.ContainerStart(ctx, container.ID, dockercontainer.StartOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to start prometheus: %w", err)
+		}
+
+		err = p.setState(ctx, container.ID)
+		if err != nil {
+			return false, fmt.Errorf("failed to set prometheus state: %w", err)
+		}
+
+		return true, nil
+	}
+
+	return false, p.Start(ctx)
+}
+
+func (p *Prometheus) Start(ctx context.Context) error {
+	p.log.Info("==> Starting prometheus", "image", p.dn.Spec.Prometheus.ContainerImage)
+
+	req := testcontainers.ContainerRequest{
+		Image: p.dn.Spec.Prometheus.ContainerImage,
+		Name:  p.dockerContainerName(),
+		ConfigModifier: func(cfg *dockercontainer.Config) {
+			cfg.Hostname = p.dockerContainerHostname()
+		},
+		Cmd:          []string{"--config.file=/etc/prometheus/prometheus.yml", "--web.enable-remote-write-receiver"},
+		ExposedPorts: []string{fmt.Sprintf("%d/tcp", prometheusInternalPort)},
+		Networks:     []string{p.dn.DefaultNetwork.Name},
+		NetworkAliases: map[string][]string{
+			p.dn.DefaultNetwork.Name: {"prometheus"},
+		},
+		Resources: dockercontainer.Resources{
+			NanoCPUs: defaultContainerNanoCPUs,
+			Memory:   defaultContainerMemory,
+		},
+		Labels: p.dn.labels,
+		WaitingFor: wait.ForHTTP("/-/ready").
+			WithPort(nat.Port(fmt.Sprintf("%d/tcp", prometheusInternalPort))).
+			WithStatusCodeMatcher(func(status int) bool {
+				return status == 200
+			}).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+		Logger:           logging.NewTestcontainersAdapter(p.log),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start prometheus: %w", err)
+	}
+
+	err = p.setState(ctx, container.GetContainerID())
+	if err != nil {
+		return fmt.Errorf("failed to set prometheus state: %w", err)
+	}
+
+	p.log.Info("--> Prometheus started", "container", p.ContainerID, "url", p.InternalURL)
+	return nil
+}
+
+func (p *Prometheus) setState(ctx context.Context, containerID string) error {
+	container, err := p.dn.dockerClient.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect container: %w", err)
+	}
+
+	networkSettings := container.NetworkSettings.Networks[p.dn.DefaultNetwork.Name]
+	if networkSettings == nil {
+		return fmt.Errorf("prometheus not connected to default network")
+	}
+
+	p.ContainerID = shortContainerID(containerID)
+	p.DefaultNetworkIP = networkSettings.IPAddress
+	p.InternalURL = fmt.Sprintf("http://%s:%d", p.DefaultNetworkIP, prometheusInternalPort)
+
+	return nil
+}
+
+func (p *Prometheus) RemoteWriteURL() string {
+	return fmt.Sprintf("http://%s:%d/api/v1/write", p.DefaultNetworkIP, prometheusInternalPort)
+}
+
+// HasDeviceMetrics checks if the device has metrics in Prometheus.
+// It queries Prometheus for controller_grpc_getconfig_requests_total{pubkey="<devicePubkey>"}.
+// TODO: this can be removed once rfc12 has been fully implemented
+func (p *Prometheus) HasDeviceMetrics(ctx context.Context, devicePubkey string) (bool, error) {
+	query := fmt.Sprintf(`controller_grpc_getconfig_requests_total{pubkey="%s"}`, devicePubkey)
+	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s", p.InternalURL, url.QueryEscape(query))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to query prometheus: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("prometheus query failed with status: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false, fmt.Errorf("failed to decode prometheus response: %w", err)
+	}
+
+	if result.Status != "success" {
+		return false, fmt.Errorf("prometheus query returned non-success status: %s", result.Status)
+	}
+
+	return len(result.Data.Result) > 0, nil
+}


### PR DESCRIPTION
## Summary of Changes
* e2e: add prometheus container and validate controller_grpc_getconfig_requests_total metric
* controller and device-health-oracle containers now include alloy, which forwards metrics to prometheus container
* e2e/main_test.go validates that each device published controller_grpc_getconfig_requests_total metrics
* Required for rfcs/rfc-network-provisioning.md

