### PR TITLE
e2e: check for old status up string for backward compatibility

### DIFF
--- a/e2e/internal/qa/device_assignment.go
+++ b/e2e/internal/qa/device_assignment.go
@@ -60,7 +60,7 @@ func DetermineClientsToConnect(
 
 		// Same device as previous batch - check if client is still connected
 		status, err := getStatus(client.Host)
-		if err != nil || status != UserStatusUp {
+		if err != nil || !IsStatusUp(status) {
 			clientsToConnect = append(clientsToConnect, client)
 		}
 	}
@@ -76,7 +76,7 @@ func FilterStatusUpClients(clients []*Client, batch map[string]*BatchResult, sta
 		if _, inBatch := batch[c.Host]; !inBatch {
 			continue
 		}
-		if statuses[c.Host] != UserStatusUp {
+		if !IsStatusUp(statuses[c.Host]) {
 			continue
 		}
 		connected = append(connected, c)

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -304,7 +304,7 @@ func connectClientsAndWaitForRoutes(
 			continue
 		}
 		statuses[c.Host] = status.SessionStatus
-		if status.SessionStatus != qa.UserStatusUp {
+		if !qa.IsStatusUp(status.SessionStatus) {
 			log.Warn("Client not up", "client", c.Host, "status", status.SessionStatus)
 		}
 	}


### PR DESCRIPTION
## Summary of Changes
* e2e: check for old status up string for backward compatibility
- This avoids failures due to the QA tests expecting the new status string even though the clients on QA hosts have not yet been upgraded to a version that outputs the new string

## Testing Verification
* Ran a successful test from the command line
