### PR TITLE
Create identity that can connect without any checks for status or max-users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - CLI
   - Remove log noise on resolve route
+  - Add `global-config qa-allowlist` commands to manage QA identity allowlist to bypass status and max_users checks in QA
 - Onchain programs
   - Removed device and user allowlist functionality, updating the global state, initialization flow, tests, and processors accordingly, and cleaning up unused account checks.
   - Serviceability: require DeactivateMulticastGroup to only close multicast group accounts when both `publisher_count` and `subscriber_count` are zero, preventing deletion of groups that still have active publishers or subscribers.

--- a/activator/src/tests.rs
+++ b/activator/src/tests.rs
@@ -34,6 +34,7 @@ pub mod utils {
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
             health_oracle_pk: payer,
+            qa_allowlist: vec![],
         };
 
         let (globalconfig_pubkey, _) = get_globalconfig_pda(&program_id);

--- a/client/doublezero/src/cli/globalconfig.rs
+++ b/client/doublezero/src/cli/globalconfig.rs
@@ -1,8 +1,11 @@
 use clap::{Args, Subcommand};
 use doublezero_cli::{
-    allowlist::foundation::{
-        add::AddFoundationAllowlistCliCommand, list::ListFoundationAllowlistCliCommand,
-        remove::RemoveFoundationAllowlistCliCommand,
+    allowlist::{
+        foundation::{
+            add::AddFoundationAllowlistCliCommand, list::ListFoundationAllowlistCliCommand,
+            remove::RemoveFoundationAllowlistCliCommand,
+        },
+        qa::{add::AddQaCliCommand, list::ListQaCliCommand, remove::RemoveQaCliCommand},
     },
     globalconfig::{
         airdrop::{get::GetAirdropCliCommand, set::SetAirdropCliCommand},
@@ -36,6 +39,9 @@ pub enum GlobalConfigCommands {
     /// Manage the foundation allowlist
     #[clap()]
     Allowlist(FoundationAllowlistCliCommand),
+    /// Manage the QA allowlist
+    #[clap()]
+    QaAllowlist(QaAllowlistCliCommand),
     /// Set the minimum compatible client version
     #[clap(hide = true)]
     SetVersion(SetVersionCliCommand),
@@ -90,4 +96,23 @@ pub enum FoundationAllowlistCommands {
     /// Remove a foundation from the allowlist
     #[clap()]
     Remove(RemoveFoundationAllowlistCliCommand),
+}
+
+#[derive(Args, Debug)]
+pub struct QaAllowlistCliCommand {
+    #[command(subcommand)]
+    pub command: QaAllowlistCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum QaAllowlistCommands {
+    /// List QA allowlist
+    #[clap()]
+    List(ListQaCliCommand),
+    /// Add a pubkey to the QA allowlist
+    #[clap()]
+    Add(AddQaCliCommand),
+    /// Remove a pubkey from the QA allowlist
+    #[clap()]
+    Remove(RemoveQaCliCommand),
 }

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -15,6 +15,7 @@ use crate::cli::{
     exchange::ExchangeCommands,
     globalconfig::{
         AirdropCommands, AuthorityCommands, FoundationAllowlistCommands, GlobalConfigCommands,
+        QaAllowlistCommands,
     },
     link::LinkCommands,
     location::LocationCommands,
@@ -131,6 +132,11 @@ async fn main() -> eyre::Result<()> {
                 FoundationAllowlistCommands::List(args) => args.execute(&client, &mut handle),
                 FoundationAllowlistCommands::Add(args) => args.execute(&client, &mut handle),
                 FoundationAllowlistCommands::Remove(args) => args.execute(&client, &mut handle),
+            },
+            GlobalConfigCommands::QaAllowlist(command) => match command.command {
+                QaAllowlistCommands::List(args) => args.execute(&client, &mut handle),
+                QaAllowlistCommands::Add(args) => args.execute(&client, &mut handle),
+                QaAllowlistCommands::Remove(args) => args.execute(&client, &mut handle),
             },
             GlobalConfigCommands::SetVersion(args) => args.execute(&client, &mut handle),
         },

--- a/e2e/internal/qa/test.go
+++ b/e2e/internal/qa/test.go
@@ -78,7 +78,10 @@ func (t *Test) Devices() map[string]*Device {
 	return t.devices
 }
 
-func (t *Test) ValidDevices(minCapacity int) []*Device {
+// ValidDevices returns devices that pass filtering criteria.
+// If skipCapacityCheck is true (e.g., when using a QA identity that bypasses on-chain capacity checks),
+// devices are not filtered by available capacity.
+func (t *Test) ValidDevices(minCapacity int, skipCapacityCheck bool) []*Device {
 	devices := make([]*Device, 0, len(t.devices))
 
 	for _, device := range t.Devices() {
@@ -88,11 +91,14 @@ func (t *Test) ValidDevices(minCapacity int) []*Device {
 			continue
 		}
 
-		// Check if device has capacity for at least 2 users
-		availableSlots := device.MaxUsers - device.UsersCount
-		if availableSlots < minCapacity {
-			t.log.Info("Skipping device with insufficient capacity", "device", device.Code, "users", device.UsersCount, "maxUsers", device.MaxUsers)
-			continue
+		// Skip capacity check if using QA identity (bypasses on-chain max_users check)
+		if !skipCapacityCheck {
+			// Check if device has capacity for at least minCapacity users
+			availableSlots := device.MaxUsers - device.UsersCount
+			if availableSlots < minCapacity {
+				t.log.Info("Skipping device with insufficient capacity", "device", device.Code, "users", device.UsersCount, "maxUsers", device.MaxUsers)
+				continue
+			}
 		}
 		devices = append(devices, device)
 	}

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	devicesFlag       = flag.String("devices", "", "comma separated list of devices to run tests against")
-	allocateAddrHosts = flag.String("allocate-addr-hosts", "", "comma separated list of hosts that will have `--allocate-addr` passed to `doublezero connect ibrl`")
+	devicesFlag           = flag.String("devices", "", "comma separated list of devices to run tests against")
+	allocateAddrHosts     = flag.String("allocate-addr-hosts", "", "comma separated list of hosts that will have `--allocate-addr` passed to `doublezero connect ibrl`")
+	skipCapacityCheckFlag = flag.Bool("skip-capacity-check", false, "skip device capacity checks (use when running with QA identity that bypasses on-chain max_users)")
 )
 
 func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
@@ -49,7 +50,8 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 	require.GreaterOrEqual(t, len(clients), 2, "At least 2 clients are required for connectivity testing")
 
 	// Filter devices to only include those with sufficient capacity and skip test devices
-	devices := test.ValidDevices(2)
+	// When using a QA identity (--skip-capacity-check), all devices are included regardless of capacity
+	devices := test.ValidDevices(2, *skipCapacityCheckFlag)
 	if len(devices) == 0 {
 		t.Skip("No valid devices found with sufficient capacity")
 	}

--- a/smartcontract/cli/src/allowlist/mod.rs
+++ b/smartcontract/cli/src/allowlist/mod.rs
@@ -1,1 +1,2 @@
 pub mod foundation;
+pub mod qa;

--- a/smartcontract/cli/src/allowlist/qa/add.rs
+++ b/smartcontract/cli/src/allowlist/qa/add.rs
@@ -1,0 +1,80 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::allowlist::qa::add::AddQaAllowlistCommand;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct AddQaCliCommand {
+    /// QA Pubkey to add to the allowlist
+    #[arg(long)]
+    pub pubkey: String,
+}
+
+impl AddQaCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        // Check requirements
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let pubkey = {
+            if self.pubkey.eq_ignore_ascii_case("me") {
+                client.get_payer()
+            } else {
+                Pubkey::from_str(&self.pubkey)?
+            }
+        };
+
+        let signature = client.add_qa_allowlist(AddQaAllowlistCommand { pubkey })?;
+        writeln!(out, "Signature: {signature}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        allowlist::qa::add::{AddQaAllowlistCommand, AddQaCliCommand},
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_cli_qa_allowlist_add() {
+        let mut client = create_test_client();
+
+        let pubkey = Pubkey::new_unique();
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_add_qa_allowlist()
+            .with(predicate::eq(AddQaAllowlistCommand { pubkey }))
+            .returning(move |_| Ok(signature));
+
+        /*****************************************************************************************************/
+        let mut output = Vec::new();
+        let res = AddQaCliCommand {
+            pubkey: pubkey.to_string(),
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,"Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+}

--- a/smartcontract/cli/src/allowlist/qa/list.rs
+++ b/smartcontract/cli/src/allowlist/qa/list.rs
@@ -1,0 +1,90 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_sdk::commands::allowlist::qa::list::ListQaAllowlistCommand;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct ListQaCliCommand {
+    /// Output as pretty JSON
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+    /// Output as compact JSON
+    #[arg(long, default_value_t = false)]
+    pub json_compact: bool,
+}
+
+impl ListQaCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let list = client.list_qa_allowlist(ListQaAllowlistCommand)?;
+
+        if self.json || self.json_compact {
+            let list = list
+                .into_iter()
+                .map(|pubkey| pubkey.to_string())
+                .collect::<Vec<_>>();
+
+            let json = {
+                if self.json_compact {
+                    serde_json::to_string(&list)?
+                } else {
+                    serde_json::to_string_pretty(&list)?
+                }
+            };
+            writeln!(out, "{json}")?;
+        } else {
+            writeln!(out, "Pubkeys:")?;
+            for user in list {
+                writeln!(out, "\t{user}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{allowlist::qa::list::ListQaCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::commands::allowlist::qa::list::ListQaAllowlistCommand;
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_cli_qa_allowlist_list() {
+        let mut client = create_test_client();
+
+        let pubkey1 = Pubkey::from_str_const("1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM");
+        let pubkey2 = Pubkey::from_str_const("1111111ogCyDbaRMvkdsHB3qfdyFYaG1WtRUAfdh");
+        let pubkey3 = Pubkey::from_str_const("11111112D1oxKts8YPdTJRG5FzxTNpMtWmq8hkVx3");
+
+        client
+            .expect_list_qa_allowlist()
+            .with(predicate::eq(ListQaAllowlistCommand))
+            .returning(move |_| Ok(vec![pubkey1, pubkey2, pubkey3]));
+
+        /*****************************************************************************************************/
+        let mut output = Vec::new();
+        let res = ListQaCliCommand {
+            json: false,
+            json_compact: false,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,"Pubkeys:\n\t1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM\n\t1111111ogCyDbaRMvkdsHB3qfdyFYaG1WtRUAfdh\n\t11111112D1oxKts8YPdTJRG5FzxTNpMtWmq8hkVx3\n"
+        );
+
+        let mut output = Vec::new();
+        let res = ListQaCliCommand {
+            json: false,
+            json_compact: true,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,"[\"1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM\",\"1111111ogCyDbaRMvkdsHB3qfdyFYaG1WtRUAfdh\",\"11111112D1oxKts8YPdTJRG5FzxTNpMtWmq8hkVx3\"]\n"
+        );
+    }
+}

--- a/smartcontract/cli/src/allowlist/qa/mod.rs
+++ b/smartcontract/cli/src/allowlist/qa/mod.rs
@@ -1,0 +1,3 @@
+pub mod add;
+pub mod list;
+pub mod remove;

--- a/smartcontract/cli/src/allowlist/qa/remove.rs
+++ b/smartcontract/cli/src/allowlist/qa/remove.rs
@@ -1,0 +1,81 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::allowlist::qa::remove::RemoveQaAllowlistCommand;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct RemoveQaCliCommand {
+    /// QA Pubkey to remove from the allowlist
+    #[arg(long)]
+    pub pubkey: String,
+}
+
+impl RemoveQaCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        // Check requirements
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let pubkey = {
+            if self.pubkey.eq_ignore_ascii_case("me") {
+                client.get_payer()
+            } else {
+                Pubkey::from_str(&self.pubkey)?
+            }
+        };
+
+        let signature = client.remove_qa_allowlist(RemoveQaAllowlistCommand { pubkey })?;
+        writeln!(out, "Signature: {signature}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        allowlist::qa::remove::RemoveQaCliCommand,
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_sdk::commands::allowlist::qa::remove::RemoveQaAllowlistCommand;
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_cli_qa_allowlist_remove() {
+        let mut client = create_test_client();
+
+        let pubkey = Pubkey::new_unique();
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_remove_qa_allowlist()
+            .with(predicate::eq(RemoveQaAllowlistCommand { pubkey }))
+            .returning(move |_| Ok(signature));
+
+        /*****************************************************************************************************/
+        let mut output = Vec::new();
+        let res = RemoveQaCliCommand {
+            pubkey: pubkey.to_string(),
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,"Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
+    }
+}

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -5,9 +5,15 @@ use doublezero_sdk::{
             close::CloseAccessPassCommand, get::GetAccessPassCommand, list::ListAccessPassCommand,
             set::SetAccessPassCommand,
         },
-        allowlist::foundation::{
-            add::AddFoundationAllowlistCommand, list::ListFoundationAllowlistCommand,
-            remove::RemoveFoundationAllowlistCommand,
+        allowlist::{
+            foundation::{
+                add::AddFoundationAllowlistCommand, list::ListFoundationAllowlistCommand,
+                remove::RemoveFoundationAllowlistCommand,
+            },
+            qa::{
+                add::AddQaAllowlistCommand, list::ListQaAllowlistCommand,
+                remove::RemoveQaAllowlistCommand,
+            },
         },
         contributor::{
             create::CreateContributorCommand, delete::DeleteContributorCommand,
@@ -218,6 +224,9 @@ pub trait CliCommand {
         &self,
         cmd: RemoveFoundationAllowlistCommand,
     ) -> eyre::Result<Signature>;
+    fn list_qa_allowlist(&self, cmd: ListQaAllowlistCommand) -> eyre::Result<Vec<Pubkey>>;
+    fn add_qa_allowlist(&self, cmd: AddQaAllowlistCommand) -> eyre::Result<Signature>;
+    fn remove_qa_allowlist(&self, cmd: RemoveQaAllowlistCommand) -> eyre::Result<Signature>;
     fn create_multicastgroup(
         &self,
         cmd: CreateMulticastGroupCommand,
@@ -549,6 +558,15 @@ impl CliCommand for CliCommandImpl<'_> {
         &self,
         cmd: RemoveFoundationAllowlistCommand,
     ) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn list_qa_allowlist(&self, cmd: ListQaAllowlistCommand) -> eyre::Result<Vec<Pubkey>> {
+        cmd.execute(self.client)
+    }
+    fn add_qa_allowlist(&self, cmd: AddQaAllowlistCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn remove_qa_allowlist(&self, cmd: RemoveQaAllowlistCommand) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }
     fn create_multicastgroup(

--- a/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
@@ -6,9 +6,15 @@ use crate::{
             check_status::process_check_status_access_pass, close::process_close_access_pass,
             set::process_set_access_pass,
         },
-        allowlist::foundation::{
-            add::process_add_foundation_allowlist_globalconfig,
-            remove::process_remove_foundation_allowlist_globalconfig,
+        allowlist::{
+            foundation::{
+                add::process_add_foundation_allowlist_globalconfig,
+                remove::process_remove_foundation_allowlist_globalconfig,
+            },
+            qa::{
+                add::process_add_qa_allowlist_globalconfig,
+                remove::process_remove_qa_allowlist_globalconfig,
+            },
         },
         contributor::{
             create::process_create_contributor, delete::process_delete_contributor,
@@ -351,6 +357,12 @@ pub fn process_instruction(
         }
         DoubleZeroInstruction::SetLinkHealth(value) => {
             process_set_health_link(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::AddQaAllowlist(value) => {
+            process_add_qa_allowlist_globalconfig(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::RemoveQaAllowlist(value) => {
+            process_remove_qa_allowlist_globalconfig(program_id, accounts, &value)?
         }
     };
     Ok(())

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -2,8 +2,9 @@ use crate::processors::{
     accesspass::{
         check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs, set::SetAccessPassArgs,
     },
-    allowlist::foundation::{
-        add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs,
+    allowlist::{
+        foundation::{add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs},
+        qa::{add::AddQaAllowlistArgs, remove::RemoveQaAllowlistArgs},
     },
     contributor::{
         create::ContributorCreateArgs, delete::ContributorDeleteArgs,
@@ -184,6 +185,9 @@ pub enum DoubleZeroInstruction {
     SetLinkHealth(LinkSetHealthArgs),     // variant 84
 
     CloseResource(ResourceExtensionCloseAccountArgs), // variant 85
+
+    AddQaAllowlist(AddQaAllowlistArgs),       // variant 86
+    RemoveQaAllowlist(RemoveQaAllowlistArgs), // variant 87
 }
 
 impl DoubleZeroInstruction {
@@ -298,6 +302,9 @@ impl DoubleZeroInstruction {
             84 => Ok(Self::SetLinkHealth(LinkSetHealthArgs::try_from(rest).unwrap())),
             85 => Ok(Self::CloseResource(ResourceExtensionCloseAccountArgs::try_from(rest).unwrap())),
 
+            86 => Ok(Self::AddQaAllowlist(AddQaAllowlistArgs::try_from(rest).unwrap())),
+            87 => Ok(Self::RemoveQaAllowlist(RemoveQaAllowlistArgs::try_from(rest).unwrap())),
+
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }
@@ -408,6 +415,9 @@ impl DoubleZeroInstruction {
             Self::SetDeviceHealth(_) => "SetDeviceHealth".to_string(), // variant 83
             Self::SetLinkHealth(_) => "SetLinkHealth".to_string(), // variant 84
             Self::CloseResource(_) => "CloseResource".to_string(), // variant 85
+
+            Self::AddQaAllowlist(_) => "AddQaAllowlist".to_string(), // variant 86
+            Self::RemoveQaAllowlist(_) => "RemoveQaAllowlist".to_string(), // variant 87
         }
     }
 
@@ -511,6 +521,9 @@ impl DoubleZeroInstruction {
             Self::SetDeviceHealth(args) => format!("{args:?}"), // variant 83
             Self::SetLinkHealth(args) => format!("{args:?}"), // variant 84
             Self::CloseResource(args) => format!("{args:?}"), // variant 85
+
+            Self::AddQaAllowlist(args) => format!("{args:?}"), // variant 86
+            Self::RemoveQaAllowlist(args) => format!("{args:?}"), // variant 87
         }
     }
 }
@@ -778,6 +791,18 @@ mod tests {
                 pubkey: Pubkey::new_unique(),
             }),
             "RemoveFoundationAllowlist",
+        );
+        test_instruction(
+            DoubleZeroInstruction::AddQaAllowlist(AddQaAllowlistArgs {
+                pubkey: Pubkey::new_unique(),
+            }),
+            "AddQaAllowlist",
+        );
+        test_instruction(
+            DoubleZeroInstruction::RemoveQaAllowlist(RemoveQaAllowlistArgs {
+                pubkey: Pubkey::new_unique(),
+            }),
+            "RemoveQaAllowlist",
         );
         test_instruction(
             DoubleZeroInstruction::AddDeviceAllowlist(),

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/mod.rs
@@ -1,1 +1,2 @@
 pub mod foundation;
+pub mod qa;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/add.rs
@@ -1,0 +1,88 @@
+use crate::{
+    error::DoubleZeroError, pda::*, serializer::try_acc_write, state::globalstate::GlobalState,
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+#[cfg(test)]
+use solana_program::msg;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+use std::fmt;
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct AddQaAllowlistArgs {
+    pub pubkey: Pubkey,
+}
+
+impl fmt::Debug for AddQaAllowlistArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "pubkey: {}", self.pubkey)
+    }
+}
+
+pub fn process_add_qa_allowlist_globalconfig(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &AddQaAllowlistArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    #[cfg(test)]
+    msg!("process_add_qa_allowlist_globalconfig({:?})", value);
+
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    // Check the owner of the accounts
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid PDA Account Owner"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+    // Check if the account is writable
+    assert!(
+        globalstate_account.is_writable,
+        "PDA Account is not writable"
+    );
+
+    let (expected_pda_account, _) = get_globalstate_pda(program_id);
+    assert_eq!(
+        globalstate_account.key, &expected_pda_account,
+        "Invalid GlobalState PubKey"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+
+    // Parse the global state account & check if the payer is in the allowlist
+    let mut globalstate = GlobalState::try_from(globalstate_account)?;
+    if !globalstate.foundation_allowlist.contains(payer_account.key) {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
+    if globalstate.qa_allowlist.contains(&value.pubkey) {
+        return Err(ProgramError::InvalidArgument);
+    }
+    globalstate.qa_allowlist.push(value.pubkey);
+
+    try_acc_write(&globalstate, globalstate_account, payer_account, accounts)?;
+
+    #[cfg(test)]
+    msg!("Updated: {:?}", globalstate);
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/mod.rs
@@ -1,0 +1,2 @@
+pub mod add;
+pub mod remove;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/allowlist/qa/remove.rs
@@ -1,0 +1,84 @@
+use crate::{
+    error::DoubleZeroError, pda::*, serializer::try_acc_write, state::globalstate::GlobalState,
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+#[cfg(test)]
+use solana_program::msg;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct RemoveQaAllowlistArgs {
+    pub pubkey: Pubkey,
+}
+
+impl fmt::Debug for RemoveQaAllowlistArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "pubkey: {}", self.pubkey)
+    }
+}
+
+pub fn process_remove_qa_allowlist_globalconfig(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &RemoveQaAllowlistArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    #[cfg(test)]
+    msg!("process_remove_qa_allowlist_globalconfig({:?})", value);
+
+    // Check if the payer is a signer
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    // Check the owner of the accounts
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid PDA Account Owner"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+    // Check if the account is writable
+    assert!(
+        globalstate_account.is_writable,
+        "PDA Account is not writable"
+    );
+
+    let (expected_pda_account, _) = get_globalstate_pda(program_id);
+    assert_eq!(
+        globalstate_account.key, &expected_pda_account,
+        "Invalid GlobalState PubKey"
+    );
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_program::system_program::id(),
+        "Invalid System Program Account Owner"
+    );
+
+    // Parse the global state account & check if the payer is in the allowlist
+    let mut globalstate = GlobalState::try_from(globalstate_account)?;
+    if !globalstate.foundation_allowlist.contains(payer_account.key) {
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
+    globalstate.qa_allowlist.retain(|x| x != &value.pubkey);
+
+    try_acc_write(&globalstate, globalstate_account, payer_account, accounts)?;
+
+    #[cfg(test)]
+    msg!("Updated: {:?}", globalstate);
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -104,6 +104,7 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         contributor_airdrop_lamports: 1_000_000_000,
         user_airdrop_lamports: 40_000,
         health_oracle_pk: *payer_account.key,
+        qa_allowlist: vec![*payer_account.key],
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -167,15 +167,18 @@ pub fn process_create_user(
 
     let mut device = Device::try_from(device_account)?;
 
+    let is_qa = globalstate.qa_allowlist.contains(payer_account.key);
+
     // Only activated devices can have users, or if in foundation allowlist
     if device.status != DeviceStatus::Activated
         && !globalstate.foundation_allowlist.contains(payer_account.key)
+        && !is_qa
     {
         msg!("{:?}", device);
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    if device.users_count >= device.max_users {
+    if device.users_count >= device.max_users && !is_qa {
         msg!("{:?}", device);
         return Err(DoubleZeroError::MaxUsersExceeded.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -193,15 +193,18 @@ pub fn process_create_subscribe_user(
 
     let mut device = Device::try_from(device_account)?;
 
+    let is_qa = globalstate.qa_allowlist.contains(payer_account.key);
+
     // Only activated devices can have users, or if in foundation allowlist
     if device.status != DeviceStatus::Activated
         && !globalstate.foundation_allowlist.contains(payer_account.key)
+        && !is_qa
     {
         msg!("{:?}", device);
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    if device.users_count >= device.max_users {
+    if device.users_count >= device.max_users && !is_qa {
         msg!("{:?}", device);
         return Err(DoubleZeroError::MaxUsersExceeded.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
@@ -27,6 +27,7 @@ pub struct GlobalState {
     pub contributor_airdrop_lamports: u64, // 8
     pub user_airdrop_lamports: u64,        // 8
     pub health_oracle_pk: Pubkey,          // 32
+    pub qa_allowlist: Vec<Pubkey>,         // 4 + 32 * len
 }
 
 impl Default for GlobalState {
@@ -43,6 +44,7 @@ impl Default for GlobalState {
             contributor_airdrop_lamports: 0,
             user_airdrop_lamports: 0,
             health_oracle_pk: Pubkey::default(),
+            qa_allowlist: Vec::new(),
         }
     }
 }
@@ -92,6 +94,7 @@ impl TryFrom<&[u8]> for GlobalState {
                 .unwrap_or_default(),
             user_airdrop_lamports: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             health_oracle_pk: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            qa_allowlist: deserialize_vec_with_capacity(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::GlobalState {
@@ -180,6 +183,7 @@ mod tests {
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
             health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![Pubkey::new_unique(), Pubkey::new_unique()],
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -224,6 +228,7 @@ mod tests {
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
             health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![Pubkey::new_unique(), Pubkey::new_unique()],
         };
         let err = val.validate();
         assert!(err.is_err());

--- a/smartcontract/sdk/rs/src/commands/allowlist/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/allowlist/mod.rs
@@ -1,1 +1,2 @@
 pub mod foundation;
+pub mod qa;

--- a/smartcontract/sdk/rs/src/commands/allowlist/qa/add.rs
+++ b/smartcontract/sdk/rs/src/commands/allowlist/qa/add.rs
@@ -1,0 +1,25 @@
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::allowlist::qa::add::AddQaAllowlistArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::DoubleZeroClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct AddQaAllowlistCommand {
+    pub pubkey: Pubkey,
+}
+
+impl AddQaAllowlistCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (pda_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_transaction(
+            DoubleZeroInstruction::AddQaAllowlist(AddQaAllowlistArgs {
+                pubkey: self.pubkey,
+            }),
+            vec![AccountMeta::new(pda_pubkey, false)],
+        )
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/allowlist/qa/list.rs
+++ b/smartcontract/sdk/rs/src/commands/allowlist/qa/list.rs
@@ -1,0 +1,19 @@
+use doublezero_serviceability::{pda::get_globalstate_pda, state::accountdata::AccountData};
+use eyre::eyre;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::DoubleZeroClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ListQaAllowlistCommand;
+
+impl ListQaAllowlistCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Vec<Pubkey>> {
+        let (pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        match client.get(pubkey)? {
+            AccountData::GlobalState(globalstate) => Ok(globalstate.qa_allowlist),
+            _ => Err(eyre!("Invalid global state")),
+        }
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/allowlist/qa/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/allowlist/qa/mod.rs
@@ -1,0 +1,3 @@
+pub mod add;
+pub mod list;
+pub mod remove;

--- a/smartcontract/sdk/rs/src/commands/allowlist/qa/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/allowlist/qa/remove.rs
@@ -1,0 +1,25 @@
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::allowlist::qa::remove::RemoveQaAllowlistArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::DoubleZeroClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct RemoveQaAllowlistCommand {
+    pub pubkey: Pubkey,
+}
+
+impl RemoveQaAllowlistCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (pda_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_transaction(
+            DoubleZeroInstruction::RemoveQaAllowlist(RemoveQaAllowlistArgs {
+                pubkey: self.pubkey,
+            }),
+            vec![AccountMeta::new(pda_pubkey, false)],
+        )
+    }
+}

--- a/smartcontract/sdk/rs/src/tests.rs
+++ b/smartcontract/sdk/rs/src/tests.rs
@@ -37,6 +37,7 @@ pub mod utils {
             contributor_airdrop_lamports: 1_000_000_000,
             user_airdrop_lamports: 40_000,
             health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![],
         };
         client
             .expect_get()


### PR DESCRIPTION
Resolves: #2486

## Summary of Changes

Added QA identity allowlist to bypass device capacity and status checks for QA testing:

**Smart Contract (Solana)**:
- Added `qa_allowlist: Vec<Pubkey>` to `GlobalState`
- Created `AddQaAllowlist` and `RemoveQaAllowlist` instructions
- Modified `user/create.rs` and `user/create_subscribe.rs` to bypass `device.status` and `max_users` checks when payer is in `qa_allowlist`
- Only `foundation_allowlist` members can manage the `qa_allowlist`

**CLI (`doublezero`)**:
- Added `doublezero global-config qa-allowlist {list|add|remove}` commands to manage QA allowlist

**E2E Tests**:
- Added `--skip-capacity-check` flag to `ValidDevices()` function
- When enabled, skips client-side device capacity filtering
- Flag defaults to `false` for backward compatibility

**Two-Phase Rollout**:
1. **Phase 1 (this PR)**: Merge with flag disabled - tests run as before
2. **Phase 2 (post-deployment)**: Add QA host pubkeys to allowlist, then enable `--skip-capacity-check` in CI workflows

## Testing Verification
```
cd /home/martin/Documents/malbec/doublezero && cargo run -p doublezero -- global-config qa-allowlist --help 2>&1

Manage the QA allowlist

Usage: doublezero global-config qa-allowlist [OPTIONS] <COMMAND>

Commands:
  list    List QA allowlist
  add     Add a pubkey to the QA allowlist
  remove  Remove a pubkey from the QA allowlist
  help    Print this message or the help of the given subcommand(s)

Options:
  -e, --env <ENV>                DZ env (testnet, devnet, or mainnet-beta)
      --url <RPC_URL>            DZ ledger RPC URL
      --ws <WEBSOCKET_URL>       DZ ledger WebSocket URL
      --program-id <PROGRAM_ID>  DZ program ID (testnet or devnet)
      --keypair <KEYPAIR>        Path to the keypair file
      --no-version-warning       Suppress version warning output
  -h, --help                     Print help
```
