### PR TITLE
client/daemon: route liveness default-on passive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - CLI
   - Remove log noise on resolve route
   - Add `global-config qa-allowlist` commands to manage QA identity allowlist to bypass status and max_users checks in QA
+- Client
+  - Enable route liveness passive-mode by default
 - Onchain programs
   - Enforce Activated status check before suspending contributor, exchange, location, and multicastgroup accounts
   - Removed device and user allowlist functionality, updating the global state, initialization flow, tests, and processors accordingly, and cleaning up unused account checks.

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -49,7 +49,7 @@ var (
 	// TODO(snormore): These flags are temporary for initial rollout testing.
 	// They will be superceded by a single `route-liveness-enable` flag, where false means
 	// passive-mode and true means active-mode.
-	routeLivenessEnablePassive = flag.Bool("route-liveness-enable-passive", false, "enables route liveness in passive mode (experimental)")
+	routeLivenessEnablePassive = flag.Bool("route-liveness-enable-passive", true, "enables route liveness in passive mode")
 	routeLivenessEnableActive  = flag.Bool("route-liveness-enable-active", false, "enables route liveness in active mode (experimental)")
 
 	// set by LDFLAGS

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -173,9 +173,13 @@ func (c *Client) Start(ctx context.Context) error {
 	extraArgs := []string{}
 	if c.Spec.RouteLivenessEnablePassive {
 		extraArgs = append(extraArgs, "-route-liveness-enable-passive")
+	} else {
+		extraArgs = append(extraArgs, "-route-liveness-enable-passive=false")
 	}
 	if c.Spec.RouteLivenessEnableActive {
 		extraArgs = append(extraArgs, "-route-liveness-enable-active")
+	} else {
+		extraArgs = append(extraArgs, "-route-liveness-enable-active=false")
 	}
 	if c.Spec.RouteLivenessPeerMetrics {
 		extraArgs = append(extraArgs, "-route-liveness-peer-metrics")


### PR DESCRIPTION
## Summary of Changes
- Enable route liveness passive-mode as the default
- Related to https://github.com/malbeclabs/doublezero/issues/2054 and https://github.com/malbeclabs/doublezero/issues/2055

## Testing Verification
- This has been running on QA for over a month
