### PR TITLE
e2e: fix prometheus query external addr

### DIFF
--- a/e2e/internal/devnet/controller.go
+++ b/e2e/internal/devnet/controller.go
@@ -114,7 +114,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		"DZ_SERVICEABILITY_PROGRAM_ID": c.dn.Manager.ServiceabilityProgramID,
 	}
 	if c.dn.Prometheus != nil && c.dn.Prometheus.InternalURL != "" {
-		env["ALLOY_PROMETHEUS_URL"] = c.dn.Prometheus.RemoteWriteURL()
+		env["ALLOY_PROMETHEUS_URL"] = c.dn.Prometheus.InternalRemoteWriteURL()
 	}
 
 	req := testcontainers.ContainerRequest{

--- a/e2e/internal/devnet/device_health_oracle.go
+++ b/e2e/internal/devnet/device_health_oracle.go
@@ -109,7 +109,7 @@ func (d *DeviceHealthOracle) Start(ctx context.Context) error {
 		"DZ_INTERVAL":                  d.dn.Spec.DeviceHealthOracle.Interval.String(),
 	}
 	if d.dn.Prometheus != nil && d.dn.Prometheus.InternalURL != "" {
-		env["ALLOY_PROMETHEUS_URL"] = d.dn.Prometheus.RemoteWriteURL()
+		env["ALLOY_PROMETHEUS_URL"] = d.dn.Prometheus.InternalRemoteWriteURL()
 	}
 
 	req := testcontainers.ContainerRequest{

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -241,7 +241,7 @@ func (dn *TestDevnet) Start(t *testing.T) (*devnet.Device, *devnet.Client) {
 
 		# For testing link.status=soft-drained:
 		doublezero link create wan --code "ny5-dz01_e5:la2-dz01_e5" --contributor co01 --side-a ny5-dz01 --side-a-interface Ethernet5 --side-z la2-dz01 --side-z-interface Ethernet5 --bandwidth "10 Gbps" --mtu 9000 --delay-ms 30 --jitter-ms 3 --desired-status activated -w
-		
+
 		# For testing link.status=hard-drained:
 		doublezero link create wan --code "ny5-dz01_e6:la2-dz01_e6" --contributor co01 --side-a ny5-dz01 --side-a-interface Ethernet6 --side-z la2-dz01 --side-z-interface Ethernet6 --bandwidth "10 Gbps" --mtu 9000 --delay-ms 8 --jitter-ms 3 --desired-status activated -w
 


### PR DESCRIPTION
## Summary of Changes
- Fix e2e prometheus container queries to use external addr instead of docker network addr, which does not work on mac

## Testing Verification
- Ran the tests on mac
