### PR TITLE
ci: separate testnet and mainnet-beta cloudsmith repos

### DIFF
--- a/.github/workflows/promote.mainnet-beta.yml
+++ b/.github/workflows/promote.mainnet-beta.yml
@@ -1,0 +1,123 @@
+name: promote.mainnet-beta
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to promote (e.g., 0.8.2-1)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (show what would be copied without copying)'
+        required: false
+        type: boolean
+        default: true
+
+env:
+  SOURCE_REPO: malbeclabs/doublezero-testnet
+  DEST_REPO: doublezero
+  EXPECTED_PACKAGES: >-
+    doublezero-funder
+    #    TODO: uncomment the remaining components after testing with funder
+    #    doublezero-activator
+    #    doublezero-admin
+    #    doublezero-agent
+    #    doublezero-client
+    #    doublezero-controller
+    #    doublezero-device-telemetry-agent
+    #    doublezero-funder
+    #    doublezero-global-monitor
+    #    doublezero-internet-latency-collector
+    #    doublezero-monitor
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.find-packages.outputs.packages }}
+      package_count: ${{ steps.find-packages.outputs.count }}
+    steps:
+      - name: Install Cloudsmith CLI
+        run: pip install cloudsmith-cli
+
+      - name: Find packages for version
+        id: find-packages
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_TOKEN }}
+        run: |
+          echo "Searching for packages with version ${{ inputs.version }} in $SOURCE_REPO..."
+
+          # Get all packages matching the version
+          PACKAGES=$(cloudsmith ls pkg $SOURCE_REPO -q "version:^${{ inputs.version }}$" -F json -l 100)
+
+          # Extract package names and slugs
+          echo "$PACKAGES" | jq -r '.data[] | "\(.name) (\(.slug))"' | sort
+
+          # Get count
+          COUNT=$(echo "$PACKAGES" | jq '.data | length')
+          echo "Found $COUNT packages"
+
+          # Save slugs for later
+          SLUGS=$(echo "$PACKAGES" | jq -r '.data[].slug' | tr '\n' ' ')
+          echo "packages=$SLUGS" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+      - name: Validate all expected packages exist
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_TOKEN }}
+        run: |
+          echo "Validating expected packages..."
+          MISSING=""
+
+          for pkg in $EXPECTED_PACKAGES; do
+            # Check if package exists with this version
+            RESULT=$(cloudsmith ls pkg $SOURCE_REPO -q "name:^${pkg}$ AND version:^${{ inputs.version }}$" -F json)
+            COUNT=$(echo "$RESULT" | jq '.data | length')
+
+            if [ "$COUNT" -eq 0 ]; then
+              echo "❌ Missing: $pkg"
+              MISSING="$MISSING $pkg"
+            else
+              echo "✅ Found: $pkg"
+            fi
+          done
+
+          if [ -n "$MISSING" ]; then
+            echo ""
+            echo "::error::Missing packages:$MISSING"
+            exit 1
+          fi
+
+          echo ""
+          echo "All expected packages found!"
+
+  promote:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Cloudsmith CLI
+        run: pip install cloudsmith-cli
+
+      - name: Copy packages to mainnet-beta
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_TOKEN }}
+        run: |
+          echo "Promoting ${{ needs.validate.outputs.package_count }} packages to $DEST_REPO"
+          echo "Dry run: ${{ inputs.dry_run }}"
+          echo ""
+
+          for slug in ${{ needs.validate.outputs.packages }}; do
+            if [ "${{ inputs.dry_run }}" == "true" ]; then
+              echo "[DRY RUN] Would copy: $SOURCE_REPO/$slug -> $DEST_REPO"
+            else
+              echo "Copying: $SOURCE_REPO/$slug -> $DEST_REPO"
+              cloudsmith cp $SOURCE_REPO/$slug $DEST_REPO
+            fi
+          done
+
+          echo ""
+          if [ "${{ inputs.dry_run }}" == "true" ]; then
+            echo "Dry run complete. Re-run with dry_run=false to copy packages."
+          else
+            echo "Promotion complete!"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file.
   - feat(smartcontract): RFC 11 activation for User entity
 - Device Health Oracle
   - Calculate burn-in timestamp based from slot numbers (current minus 200_000 slots for provisioning, current minus 5_000 slots for maintenance)
+- CI
+  - Add separate apt repo for doublezero-testnet
 
 ### Breaking
 

--- a/release/.goreleaser.testnet.activator.yaml
+++ b/release/.goreleaser.testnet.activator.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.admin.yaml
+++ b/release/.goreleaser.testnet.admin.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.agent.yaml
+++ b/release/.goreleaser.testnet.agent.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.client.yaml
+++ b/release/.goreleaser.testnet.client.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.controller.yaml
+++ b/release/.goreleaser.testnet.controller.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.device-telemetry-agent.yaml
+++ b/release/.goreleaser.testnet.device-telemetry-agent.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.doublezero.monitor.tool.yaml
+++ b/release/.goreleaser.testnet.doublezero.monitor.tool.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.funder.yaml
+++ b/release/.goreleaser.testnet.funder.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.global-monitor.yaml
+++ b/release/.goreleaser.testnet.global-monitor.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.internet-latency-collector.yaml
+++ b/release/.goreleaser.testnet.internet-latency-collector.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.monitor.yaml
+++ b/release/.goreleaser.testnet.monitor.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.qa-agent.yaml
+++ b/release/.goreleaser.testnet.qa-agent.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.s3-uploader.yaml
+++ b/release/.goreleaser.testnet.s3-uploader.yaml
@@ -7,7 +7,7 @@ includes:
 
 cloudsmiths:
   - organization: malbeclabs
-    repository: doublezero
+    repository: doublezero-testnet
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"


### PR DESCRIPTION
## Summary of Changes
* ci: separate testnet and mainnet-beta cloudsmith repos
* Prevents mainnet-beta users from getting client package updates before the new version is released to mainnet-beta
