### PR TITLE
Fix typo in Reject files

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
@@ -81,7 +81,7 @@ pub fn process_reject_device(
     try_acc_write(&device, device_account, payer_account, accounts)?;
 
     #[cfg(test)]
-    msg!("Rejectd: {:?}", device);
+    msg!("Rejected: {:?}", device);
 
     Ok(())
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
@@ -75,7 +75,7 @@ pub fn process_reject_link(
     try_acc_write(&link, link_account, payer_account, accounts)?;
 
     #[cfg(test)]
-    msg!("Rejectd: {:?}", link);
+    msg!("Rejected: {:?}", link);
 
     Ok(())
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
@@ -84,7 +84,7 @@ pub fn process_reject_multicastgroup(
     )?;
 
     #[cfg(test)]
-    msg!("Rejectd: {:?}", multicastgroup);
+    msg!("Rejected: {:?}", multicastgroup);
 
     Ok(())
 }


### PR DESCRIPTION
Resolves: #2238

## Summary of Changes
* Fix typo: `Rejectd` -> `Rejected`
