### PR TITLE
Avoid QA all devices failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - E2E tests
   - Add influxdb, prometheus, and device-health-oracle containers
   - Add interface lifecycle tests ([#2700](https://github.com/malbeclabs/doublezero/pull/2700))
+  - Only fail QA alldevices test run if device status is "Activated" and max users > 0
 - SDK
   - Commands for setting global config, activating devices, updating devices, and closing device accounts now manage resource accounts.
 - Smartcontract

--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -58,6 +58,7 @@ type Device struct {
 	ExchangeCode string
 	MaxUsers     int
 	UsersCount   int
+	Status       serviceability.DeviceStatus
 }
 
 type Client struct {

--- a/e2e/internal/qa/test.go
+++ b/e2e/internal/qa/test.go
@@ -149,6 +149,7 @@ func getDevices(ctx context.Context, serviceabilityClient *serviceability.Client
 			ExchangeCode: exchangeCode,
 			MaxUsers:     int(device.MaxUsers),
 			UsersCount:   int(device.UsersCount),
+			Status:       device.Status,
 		}
 	}
 	return devices, nil

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -123,6 +123,8 @@ const (
 	DeviceStatusDeleted
 	DeviceStatusRejected
 	DeviceStatusDrained
+	DeviceStatusDeviceProvisioning
+	DeviceStatusLinkProvisioning
 )
 
 func (d DeviceStatus) String() string {
@@ -133,10 +135,11 @@ func (d DeviceStatus) String() string {
 		"deleted",
 		"rejected",
 		"drained",
+		"device-provisioning",
+		"link-provisioning",
 	}[d]
 }
 
-// IsDrained returns true if the device status is drained
 func (d DeviceStatus) IsDrained() bool {
 	return d == DeviceStatusDrained
 }


### PR DESCRIPTION
Resolves: #2679

## Summary of Changes
* If a device in provisioning status fails, do not mark the whole test run as failed
