### PR TITLE
telemetry/gnmic: force IPv4-only connections and fix TLS credential handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Telemetry
+  - Force IPv4-only connections for gNMI tunnel client and fix TLS credential handling
+
 ## [v0.8.3](https://github.com/malbeclabs/doublezero/compare/client/v0.8.2...client/v0.8.3) – 2026-01-22
 
 

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -443,13 +443,8 @@ func startGNMITunnelClient(ctx context.Context, cancel context.CancelFunc, log *
 			})
 		}
 		cfg.GRPCClientConnFactory = func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-			// Add insecure credentials by default for the tunnel server connection.
-			// TODO: Support TLS configuration for production deployments.
-			allOpts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, opts...)
-			return netns.NewNamespacedGRPCConn(ctx, *managementNamespace, target, allOpts...)
+			return netns.NewNamespacedGRPCConn(ctx, *managementNamespace, target, opts...)
 		}
-	} else {
-		cfg.GRPCDialOpts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	}
 
 	gnmiTunnelClient, err := gnmitunnel.NewClient(cfg)


### PR DESCRIPTION
## **Summary of Changes**

- Force IPv4-only DNS resolution for gNMI tunnel server connections to avoid IPv6 connectivity issues
- Fix TLS credential handling by removing redundant insecure credential overrides; TLS is now consistently configured via makeTransportCredentials()
- Remove unused GRPCDialOpts config field

## **Testing Verification**

- Added unit tests for default GRPCClientConnFactory covering IPv4 resolution, invalid target format, and unresolvable hostname error paths
- All existing gnmitunnel tests pass
- Running on a couple DZDs