### PR TITLE
e2e: Update QA alldevices test to skip devices with type = transit

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -59,6 +59,7 @@ type Device struct {
 	MaxUsers     int
 	UsersCount   int
 	Status       serviceability.DeviceStatus
+	DeviceType   serviceability.DeviceDeviceType
 }
 
 type Client struct {

--- a/e2e/internal/qa/test.go
+++ b/e2e/internal/qa/test.go
@@ -150,6 +150,7 @@ func getDevices(ctx context.Context, serviceabilityClient *serviceability.Client
 			MaxUsers:     int(device.MaxUsers),
 			UsersCount:   int(device.UsersCount),
 			Status:       device.Status,
+			DeviceType:   device.DeviceType,
 		}
 	}
 	return devices, nil

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -57,6 +57,15 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 		t.Skip("No valid devices found with sufficient capacity")
 	}
 
+	// Filter out transit devices - they don't participate in unicast connectivity tests
+	devices = slices.DeleteFunc(devices, func(d *qa.Device) bool {
+		if d.DeviceType == serviceability.DeviceDeviceTypeTransit {
+			log.Info("Skipping transit device", "device", d.Code)
+			return true
+		}
+		return false
+	})
+
 	// If devices flag is provided, filter devices to only include those in the list.
 	if *devicesFlag != "" {
 		deviceCodes := make(map[string]struct{})


### PR DESCRIPTION
Resolves: #2687

Context: https://github.com/malbeclabs/doublezero/issues/2486

## Summary of Changes
* Add check to skip devices in transit
