### PR TITLE
serviceability: Go SDK updates allowing device-health-oracle to write to device.health and link.health as per rfc12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   - Force IPv4-only connections for gNMI tunnel client and fix TLS credential handling
 - Client
   - Support simultaneous unicast and multicast tunnels in doublezerod
+- SDK
+  - Go SDK can now perform batch writes to device.health and link.health as per rfc12
 
 ## [v0.8.3](https://github.com/malbeclabs/doublezero/compare/client/v0.8.2...client/v0.8.3) – 2026-01-22
 

--- a/smartcontract/sdk/go/serviceability/executor.go
+++ b/smartcontract/sdk/go/serviceability/executor.go
@@ -1,0 +1,365 @@
+package serviceability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+)
+
+const (
+	instructionSetDeviceHealth = 83
+	instructionSetLinkHealth   = 84
+)
+
+var (
+	ErrNoPrivateKey      = errors.New("no private key configured")
+	ErrNoProgramID       = errors.New("no program ID configured")
+	ErrAllUpdatesFailed  = errors.New("all updates in batch failed")
+	ErrInstructionFailed = errors.New("instruction failed")
+)
+
+type Executor struct {
+	log                   *slog.Logger
+	rpc                   ExecutorRPCClient
+	signer                *solana.PrivateKey
+	programID             solana.PublicKey
+	waitForVisibleTimeout time.Duration
+}
+
+type ExecutorRPCClient interface {
+	GetLatestBlockhash(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetLatestBlockhashResult, error)
+	SendTransactionWithOpts(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error)
+	GetSignatureStatuses(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error)
+	GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
+}
+
+type ExecutorOption func(*Executor)
+
+func WithWaitForVisibleTimeout(timeout time.Duration) ExecutorOption {
+	return func(e *Executor) {
+		e.waitForVisibleTimeout = timeout
+	}
+}
+
+func NewExecutor(log *slog.Logger, rpc ExecutorRPCClient, signer *solana.PrivateKey, programID solana.PublicKey, opts ...ExecutorOption) *Executor {
+	e := &Executor{
+		log:                   log,
+		rpc:                   rpc,
+		signer:                signer,
+		programID:             programID,
+		waitForVisibleTimeout: 3 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+type DeviceHealthUpdate struct {
+	DevicePubkey solana.PublicKey
+	Health       DeviceHealth
+}
+
+type LinkHealthUpdate struct {
+	LinkPubkey solana.PublicKey
+	Health     LinkHealth
+}
+
+func (e *Executor) SetDeviceHealthBatch(ctx context.Context, updates []DeviceHealthUpdate, globalStatePubkey solana.PublicKey) (solana.Signature, error) {
+	if len(updates) == 0 {
+		return solana.Signature{}, nil
+	}
+
+	remaining := updates
+	var lastSig solana.Signature
+
+	for len(remaining) > 0 {
+		instructions := make([]solana.Instruction, len(remaining))
+		for i, update := range remaining {
+			instructions[i] = e.buildSetDeviceHealthInstruction(update.DevicePubkey, globalStatePubkey, update.Health)
+		}
+
+		sig, _, err := e.executeTransaction(ctx, instructions)
+		if err == nil {
+			return sig, nil
+		}
+		lastSig = sig
+
+		failingIdx, parseErr := parseFailingInstructionIndex(err)
+		if parseErr != nil {
+			return sig, err
+		}
+
+		if failingIdx < 0 || failingIdx >= len(remaining) {
+			return sig, fmt.Errorf("invalid failing instruction index %d for batch size %d: %w", failingIdx, len(remaining), err)
+		}
+
+		failedUpdate := remaining[failingIdx]
+		e.log.Warn("Device health update failed, removing from batch and retrying",
+			"failingIndex", failingIdx,
+			"devicePubkey", failedUpdate.DevicePubkey.String(),
+			"remainingBefore", len(remaining),
+			"error", err)
+
+		remaining = append(remaining[:failingIdx], remaining[failingIdx+1:]...)
+	}
+
+	return lastSig, ErrAllUpdatesFailed
+}
+
+func (e *Executor) SetLinkHealthBatch(ctx context.Context, updates []LinkHealthUpdate, globalStatePubkey solana.PublicKey) (solana.Signature, error) {
+	if len(updates) == 0 {
+		return solana.Signature{}, nil
+	}
+
+	remaining := updates
+	var lastSig solana.Signature
+
+	for len(remaining) > 0 {
+		instructions := make([]solana.Instruction, len(remaining))
+		for i, update := range remaining {
+			instructions[i] = e.buildSetLinkHealthInstruction(update.LinkPubkey, globalStatePubkey, update.Health)
+		}
+
+		sig, _, err := e.executeTransaction(ctx, instructions)
+		if err == nil {
+			return sig, nil
+		}
+		lastSig = sig
+
+		failingIdx, parseErr := parseFailingInstructionIndex(err)
+		if parseErr != nil {
+			return sig, err
+		}
+
+		if failingIdx < 0 || failingIdx >= len(remaining) {
+			return sig, fmt.Errorf("invalid failing instruction index %d for batch size %d: %w", failingIdx, len(remaining), err)
+		}
+
+		failedUpdate := remaining[failingIdx]
+		e.log.Warn("Link health update failed, removing from batch and retrying",
+			"failingIndex", failingIdx,
+			"linkPubkey", failedUpdate.LinkPubkey.String(),
+			"remainingBefore", len(remaining),
+			"error", err)
+
+		remaining = append(remaining[:failingIdx], remaining[failingIdx+1:]...)
+	}
+
+	return lastSig, ErrAllUpdatesFailed
+}
+
+func (e *Executor) buildSetDeviceHealthInstruction(devicePubkey, globalStatePubkey solana.PublicKey, health DeviceHealth) solana.Instruction {
+	return &genericInstruction{
+		programID: e.programID,
+		accounts: solana.AccountMetaSlice{
+			solana.Meta(devicePubkey).WRITE(),
+			solana.Meta(globalStatePubkey),
+			solana.Meta(e.signer.PublicKey()).SIGNER().WRITE(),
+			solana.Meta(solana.SystemProgramID),
+		},
+		data: []byte{instructionSetDeviceHealth, byte(health)},
+	}
+}
+
+func (e *Executor) buildSetLinkHealthInstruction(linkPubkey, globalStatePubkey solana.PublicKey, health LinkHealth) solana.Instruction {
+	return &genericInstruction{
+		programID: e.programID,
+		accounts: solana.AccountMetaSlice{
+			solana.Meta(linkPubkey).WRITE(),
+			solana.Meta(globalStatePubkey),
+			solana.Meta(e.signer.PublicKey()).SIGNER().WRITE(),
+			solana.Meta(solana.SystemProgramID),
+		},
+		data: []byte{instructionSetLinkHealth, byte(health)},
+	}
+}
+
+type genericInstruction struct {
+	programID solana.PublicKey
+	accounts  solana.AccountMetaSlice
+	data      []byte
+}
+
+func (i *genericInstruction) ProgramID() solana.PublicKey {
+	return i.programID
+}
+
+func (i *genericInstruction) Accounts() []*solana.AccountMeta {
+	return i.accounts
+}
+
+func (i *genericInstruction) Data() ([]byte, error) {
+	return i.data, nil
+}
+
+func (e *Executor) executeTransaction(ctx context.Context, instructions []solana.Instruction) (solana.Signature, *solanarpc.GetTransactionResult, error) {
+	if e.signer == nil {
+		return solana.Signature{}, nil, ErrNoPrivateKey
+	}
+	if e.programID.IsZero() {
+		return solana.Signature{}, nil, ErrNoProgramID
+	}
+
+	blockhashResult, err := e.rpc.GetLatestBlockhash(ctx, solanarpc.CommitmentFinalized)
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("failed to get latest blockhash: %w", err)
+	}
+
+	tx, err := solana.NewTransaction(
+		instructions,
+		blockhashResult.Value.Blockhash,
+		solana.TransactionPayer(e.signer.PublicKey()),
+	)
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("failed to build transaction: %w", err)
+	}
+	if tx == nil {
+		return solana.Signature{}, nil, errors.New("transaction build failed: nil result")
+	}
+
+	_, err = tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if key.Equals(e.signer.PublicKey()) {
+			return e.signer
+		}
+		return nil
+	})
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("failed to sign transaction (likely missing signer): %w", err)
+	}
+	if len(tx.Signatures) == 0 {
+		return solana.Signature{}, nil, errors.New("signed transaction appears malformed")
+	}
+
+	sig, err := e.rpc.SendTransactionWithOpts(ctx, tx, solanarpc.TransactionOpts{})
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("failed to send transaction: %w", err)
+	}
+
+	err = e.waitForSignatureVisible(ctx, sig, e.waitForVisibleTimeout)
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("transaction dropped or rejected before cluster saw it: %w", err)
+	}
+
+	res, err := e.waitForTransactionFinalized(ctx, sig)
+	if err != nil {
+		return solana.Signature{}, nil, fmt.Errorf("failed to get transaction: %w", err)
+	}
+
+	return sig, res, nil
+}
+
+func (e *Executor) waitForSignatureVisible(ctx context.Context, sig solana.Signature, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := e.rpc.GetSignatureStatuses(ctx, true, sig)
+		if err != nil {
+			return err
+		}
+		if len(resp.Value) > 0 && resp.Value[0] != nil {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return errors.New("signature not found after wait")
+}
+
+func (e *Executor) waitForTransactionFinalized(ctx context.Context, sig solana.Signature) (*solanarpc.GetTransactionResult, error) {
+	e.log.Debug("--> Waiting for transaction to be finalized", "sig", sig)
+	start := time.Now()
+	for {
+		statusResp, err := e.rpc.GetSignatureStatuses(ctx, true, sig)
+		if err != nil {
+			return nil, err
+		}
+		if len(statusResp.Value) == 0 {
+			return nil, errors.New("transaction not found")
+		}
+		status := statusResp.Value[0]
+		if status != nil && status.ConfirmationStatus == solanarpc.ConfirmationStatusFinalized {
+			e.log.Debug("--> Transaction finalized", "sig", sig, "duration", time.Since(start))
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(1 * time.Second):
+			if time.Since(start)/time.Second%5 == 0 {
+				e.log.Debug("--> Still waiting for transaction to be finalized", "sig", sig, "elapsed", time.Since(start))
+			}
+		}
+	}
+
+	tx, err := e.rpc.GetTransaction(ctx, sig, &solanarpc.GetTransactionOpts{
+		Encoding:   solana.EncodingBase64,
+		Commitment: solanarpc.CommitmentFinalized,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if tx == nil || tx.Meta == nil {
+		return nil, errors.New("transaction not found or missing metadata after finalization")
+	}
+	return tx, nil
+}
+
+func GetGlobalStatePDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress(
+		[][]byte{
+			[]byte("doublezero"),
+			[]byte("globalstate"),
+		},
+		programID,
+	)
+}
+
+// parseFailingInstructionIndex extracts the failing instruction index from a Solana RPC error.
+// Solana returns errors in the format: {"err": {"InstructionError": [index, errorDetails]}}
+func parseFailingInstructionIndex(err error) (int, error) {
+	var rpcErr *jsonrpc.RPCError
+	if !errors.As(err, &rpcErr) {
+		return -1, fmt.Errorf("not an RPC error: %w", ErrInstructionFailed)
+	}
+
+	data, ok := rpcErr.Data.(map[string]any)
+	if !ok {
+		return -1, fmt.Errorf("unexpected RPC error data type: %w", ErrInstructionFailed)
+	}
+
+	errField, ok := data["err"]
+	if !ok {
+		return -1, fmt.Errorf("no err field in RPC error: %w", ErrInstructionFailed)
+	}
+
+	errMap, ok := errField.(map[string]any)
+	if !ok {
+		return -1, fmt.Errorf("err field is not a map: %w", ErrInstructionFailed)
+	}
+
+	instructionError, ok := errMap["InstructionError"].([]any)
+	if !ok || len(instructionError) < 2 {
+		return -1, fmt.Errorf("no InstructionError in err: %w", ErrInstructionFailed)
+	}
+
+	// The first element is the instruction index
+	switch idx := instructionError[0].(type) {
+	case json.Number:
+		i, err := idx.Int64()
+		if err != nil {
+			return -1, fmt.Errorf("failed to parse instruction index: %w", ErrInstructionFailed)
+		}
+		return int(i), nil
+	case float64:
+		return int(idx), nil
+	default:
+		return -1, fmt.Errorf("unexpected instruction index type %T: %w", idx, ErrInstructionFailed)
+	}
+}

--- a/smartcontract/sdk/go/serviceability/executor_test.go
+++ b/smartcontract/sdk/go/serviceability/executor_test.go
@@ -1,0 +1,624 @@
+package serviceability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRPCClient struct {
+	getLatestBlockhashFunc   func(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetLatestBlockhashResult, error)
+	sendTransactionFunc      func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error)
+	getSignatureStatusesFunc func(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error)
+	getTransactionFunc       func(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
+	sentTransactions         []*solana.Transaction
+}
+
+func (m *mockRPCClient) GetLatestBlockhash(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetLatestBlockhashResult, error) {
+	if m.getLatestBlockhashFunc != nil {
+		return m.getLatestBlockhashFunc(ctx, commitment)
+	}
+	return &solanarpc.GetLatestBlockhashResult{
+		Value: &solanarpc.LatestBlockhashResult{
+			Blockhash: solana.MustHashFromBase58("4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"),
+		},
+	}, nil
+}
+
+func (m *mockRPCClient) SendTransactionWithOpts(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+	m.sentTransactions = append(m.sentTransactions, transaction)
+	if m.sendTransactionFunc != nil {
+		return m.sendTransactionFunc(ctx, transaction, opts)
+	}
+	return solana.MustSignatureFromBase58("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"), nil
+}
+
+func (m *mockRPCClient) GetSignatureStatuses(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error) {
+	if m.getSignatureStatusesFunc != nil {
+		return m.getSignatureStatusesFunc(ctx, searchTransactionHistory, transactionSignatures...)
+	}
+	return &solanarpc.GetSignatureStatusesResult{
+		Value: []*solanarpc.SignatureStatusesResult{
+			{ConfirmationStatus: solanarpc.ConfirmationStatusFinalized},
+		},
+	}, nil
+}
+
+func (m *mockRPCClient) GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error) {
+	if m.getTransactionFunc != nil {
+		return m.getTransactionFunc(ctx, txSig, opts)
+	}
+	return &solanarpc.GetTransactionResult{
+		Meta: &solanarpc.TransactionMeta{},
+	}, nil
+}
+
+func newTestExecutor(t *testing.T, rpc *mockRPCClient) (*Executor, solana.PrivateKey) {
+	t.Helper()
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+	log := slog.Default()
+	return NewExecutor(log, rpc, &signer, programID), signer
+}
+
+func TestNewExecutor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates executor with defaults", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		assert.NotNil(t, executor)
+		assert.Equal(t, 3*time.Second, executor.waitForVisibleTimeout)
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		signer := solana.NewWallet().PrivateKey
+		programID := solana.NewWallet().PublicKey()
+		log := slog.Default()
+
+		executor := NewExecutor(log, rpc, &signer, programID, WithWaitForVisibleTimeout(10*time.Second))
+
+		assert.Equal(t, 10*time.Second, executor.waitForVisibleTimeout)
+	})
+}
+
+func TestSetDeviceHealthBatch(t *testing.T) {
+	t.Parallel()
+
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	t.Run("returns zero signature for empty updates", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		sig, err := executor.SetDeviceHealthBatch(context.Background(), []DeviceHealthUpdate{}, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.Equal(t, solana.Signature{}, sig)
+		assert.Empty(t, rpc.sentTransactions)
+	})
+
+	t.Run("sends transaction with single device update", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		devicePubkey := solana.NewWallet().PublicKey()
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: devicePubkey, Health: DeviceHealthReadyForUsers},
+		}
+
+		sig, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		require.Len(t, rpc.sentTransactions, 1)
+
+		tx := rpc.sentTransactions[0]
+		assert.Len(t, tx.Message.Instructions, 1)
+	})
+
+	t.Run("sends transaction with multiple device updates", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForLinks},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthPending},
+		}
+
+		sig, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		require.Len(t, rpc.sentTransactions, 1)
+
+		tx := rpc.sentTransactions[0]
+		assert.Len(t, tx.Message.Instructions, 3)
+	})
+
+	t.Run("returns error when RPC fails", func(t *testing.T) {
+		rpc := &mockRPCClient{
+			getLatestBlockhashFunc: func(ctx context.Context, commitment solanarpc.CommitmentType) (*solanarpc.GetLatestBlockhashResult, error) {
+				return nil, errors.New("RPC error")
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get latest blockhash")
+	})
+}
+
+func TestSetLinkHealthBatch(t *testing.T) {
+	t.Parallel()
+
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	t.Run("returns zero signature for empty updates", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		sig, err := executor.SetLinkHealthBatch(context.Background(), []LinkHealthUpdate{}, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.Equal(t, solana.Signature{}, sig)
+		assert.Empty(t, rpc.sentTransactions)
+	})
+
+	t.Run("sends transaction with single link update", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		linkPubkey := solana.NewWallet().PublicKey()
+		updates := []LinkHealthUpdate{
+			{LinkPubkey: linkPubkey, Health: LinkHealthReadyForService},
+		}
+
+		sig, err := executor.SetLinkHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		require.Len(t, rpc.sentTransactions, 1)
+
+		tx := rpc.sentTransactions[0]
+		assert.Len(t, tx.Message.Instructions, 1)
+	})
+
+	t.Run("sends transaction with multiple link updates", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []LinkHealthUpdate{
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthReadyForService},
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthPending},
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthImpaired},
+		}
+
+		sig, err := executor.SetLinkHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		require.Len(t, rpc.sentTransactions, 1)
+
+		tx := rpc.sentTransactions[0]
+		assert.Len(t, tx.Message.Instructions, 3)
+	})
+}
+
+func TestBuildSetDeviceHealthInstruction(t *testing.T) {
+	t.Parallel()
+
+	rpc := &mockRPCClient{}
+	executor, signer := newTestExecutor(t, rpc)
+
+	devicePubkey := solana.NewWallet().PublicKey()
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	instruction := executor.buildSetDeviceHealthInstruction(devicePubkey, globalStatePubkey, DeviceHealthReadyForUsers)
+
+	assert.Equal(t, executor.programID, instruction.ProgramID())
+
+	accounts := instruction.Accounts()
+	require.Len(t, accounts, 4)
+	assert.Equal(t, devicePubkey, accounts[0].PublicKey)
+	assert.True(t, accounts[0].IsWritable)
+	assert.Equal(t, globalStatePubkey, accounts[1].PublicKey)
+	assert.Equal(t, signer.PublicKey(), accounts[2].PublicKey)
+	assert.True(t, accounts[2].IsSigner)
+	assert.Equal(t, solana.SystemProgramID, accounts[3].PublicKey)
+
+	data, err := instruction.Data()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{instructionSetDeviceHealth, byte(DeviceHealthReadyForUsers)}, data)
+}
+
+func TestBuildSetLinkHealthInstruction(t *testing.T) {
+	t.Parallel()
+
+	rpc := &mockRPCClient{}
+	executor, signer := newTestExecutor(t, rpc)
+
+	linkPubkey := solana.NewWallet().PublicKey()
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	instruction := executor.buildSetLinkHealthInstruction(linkPubkey, globalStatePubkey, LinkHealthReadyForService)
+
+	assert.Equal(t, executor.programID, instruction.ProgramID())
+
+	accounts := instruction.Accounts()
+	require.Len(t, accounts, 4)
+	assert.Equal(t, linkPubkey, accounts[0].PublicKey)
+	assert.True(t, accounts[0].IsWritable)
+	assert.Equal(t, globalStatePubkey, accounts[1].PublicKey)
+	assert.Equal(t, signer.PublicKey(), accounts[2].PublicKey)
+	assert.True(t, accounts[2].IsSigner)
+	assert.Equal(t, solana.SystemProgramID, accounts[3].PublicKey)
+
+	data, err := instruction.Data()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{instructionSetLinkHealth, byte(LinkHealthReadyForService)}, data)
+}
+
+func TestExecuteTransaction_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when program ID is zero", func(t *testing.T) {
+		rpc := &mockRPCClient{}
+		signer := solana.NewWallet().PrivateKey
+		executor := NewExecutor(slog.Default(), rpc, &signer, solana.PublicKey{})
+
+		globalStatePubkey := solana.NewWallet().PublicKey()
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoProgramID)
+	})
+
+	t.Run("returns error when send transaction fails", func(t *testing.T) {
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				return solana.Signature{}, errors.New("send failed")
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		globalStatePubkey := solana.NewWallet().PublicKey()
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to send transaction")
+	})
+
+	t.Run("returns error when signature not visible", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			getSignatureStatusesFunc: func(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error) {
+				callCount++
+				return &solanarpc.GetSignatureStatusesResult{
+					Value: []*solanarpc.SignatureStatusesResult{nil},
+				}, nil
+			},
+		}
+		signer := solana.NewWallet().PrivateKey
+		programID := solana.NewWallet().PublicKey()
+		executor := NewExecutor(slog.Default(), rpc, &signer, programID, WithWaitForVisibleTimeout(100*time.Millisecond))
+
+		globalStatePubkey := solana.NewWallet().PublicKey()
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transaction dropped or rejected")
+	})
+}
+
+func TestGetGlobalStatePDA(t *testing.T) {
+	t.Parallel()
+
+	programID := solana.NewWallet().PublicKey()
+
+	pda, bump, err := GetGlobalStatePDA(programID)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, solana.PublicKey{}, pda)
+	assert.Greater(t, bump, uint8(0))
+
+	// Verify deterministic - same inputs should produce same outputs
+	pda2, bump2, err := GetGlobalStatePDA(programID)
+	require.NoError(t, err)
+	assert.Equal(t, pda, pda2)
+	assert.Equal(t, bump, bump2)
+}
+
+func makeInstructionError(instructionIndex int) *jsonrpc.RPCError {
+	return &jsonrpc.RPCError{
+		Code:    -32000,
+		Message: "Transaction simulation failed",
+		Data: map[string]any{
+			"err": map[string]any{
+				"InstructionError": []any{
+					json.Number(string(rune('0' + instructionIndex))),
+					map[string]any{
+						"Custom": json.Number("1001"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSetDeviceHealthBatch_RetryOnFailure(t *testing.T) {
+	t.Parallel()
+
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	t.Run("retries batch after removing failing instruction", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				callCount++
+				if callCount == 1 {
+					// First call fails on instruction index 1
+					return solana.Signature{}, makeInstructionError(1)
+				}
+				// Second call succeeds
+				return solana.MustSignatureFromBase58("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"), nil
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		device1 := solana.NewWallet().PublicKey()
+		device2 := solana.NewWallet().PublicKey() // This one will fail
+		device3 := solana.NewWallet().PublicKey()
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: device1, Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: device2, Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: device3, Health: DeviceHealthReadyForUsers},
+		}
+
+		sig, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		assert.Equal(t, 2, callCount, "should have retried once")
+		require.Len(t, rpc.sentTransactions, 2)
+
+		// First transaction should have 3 instructions
+		assert.Len(t, rpc.sentTransactions[0].Message.Instructions, 3)
+		// Second transaction should have 2 instructions (device2 removed)
+		assert.Len(t, rpc.sentTransactions[1].Message.Instructions, 2)
+	})
+
+	t.Run("retries multiple times until success", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				callCount++
+				switch callCount {
+				case 1:
+					return solana.Signature{}, makeInstructionError(2) // Fail on index 2
+				case 2:
+					return solana.Signature{}, makeInstructionError(0) // Fail on index 0
+				default:
+					return solana.MustSignatureFromBase58("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"), nil
+				}
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		sig, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		assert.Equal(t, 3, callCount, "should have retried twice")
+		require.Len(t, rpc.sentTransactions, 3)
+
+		assert.Len(t, rpc.sentTransactions[0].Message.Instructions, 3)
+		assert.Len(t, rpc.sentTransactions[1].Message.Instructions, 2)
+		assert.Len(t, rpc.sentTransactions[2].Message.Instructions, 1)
+	})
+
+	t.Run("returns ErrAllUpdatesFailed when all updates fail", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				callCount++
+				return solana.Signature{}, makeInstructionError(0) // Always fail on first instruction
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrAllUpdatesFailed)
+		assert.Equal(t, 2, callCount, "should have tried for each update")
+	})
+
+	t.Run("does not retry on non-instruction errors", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				callCount++
+				return solana.Signature{}, errors.New("network error")
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+
+		_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.Equal(t, 1, callCount, "should not have retried")
+		assert.Contains(t, err.Error(), "failed to send transaction")
+	})
+}
+
+func TestSetLinkHealthBatch_RetryOnFailure(t *testing.T) {
+	t.Parallel()
+
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	t.Run("retries batch after removing failing instruction", func(t *testing.T) {
+		callCount := 0
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				callCount++
+				if callCount == 1 {
+					return solana.Signature{}, makeInstructionError(0)
+				}
+				return solana.MustSignatureFromBase58("5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"), nil
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []LinkHealthUpdate{
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthReadyForService},
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthReadyForService},
+		}
+
+		sig, err := executor.SetLinkHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.NoError(t, err)
+		assert.NotEqual(t, solana.Signature{}, sig)
+		assert.Equal(t, 2, callCount)
+		require.Len(t, rpc.sentTransactions, 2)
+
+		assert.Len(t, rpc.sentTransactions[0].Message.Instructions, 2)
+		assert.Len(t, rpc.sentTransactions[1].Message.Instructions, 1)
+	})
+
+	t.Run("returns ErrAllUpdatesFailed when all updates fail", func(t *testing.T) {
+		rpc := &mockRPCClient{
+			sendTransactionFunc: func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error) {
+				return solana.Signature{}, makeInstructionError(0)
+			},
+		}
+		executor, _ := newTestExecutor(t, rpc)
+
+		updates := []LinkHealthUpdate{
+			{LinkPubkey: solana.NewWallet().PublicKey(), Health: LinkHealthReadyForService},
+		}
+
+		_, err := executor.SetLinkHealthBatch(context.Background(), updates, globalStatePubkey)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrAllUpdatesFailed)
+	})
+}
+
+func TestParseFailingInstructionIndex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses instruction index from json.Number", func(t *testing.T) {
+		err := makeInstructionError(5)
+
+		idx, parseErr := parseFailingInstructionIndex(err)
+
+		require.NoError(t, parseErr)
+		assert.Equal(t, 5, idx)
+	})
+
+	t.Run("parses instruction index from float64", func(t *testing.T) {
+		err := &jsonrpc.RPCError{
+			Code:    -32000,
+			Message: "Transaction simulation failed",
+			Data: map[string]any{
+				"err": map[string]any{
+					"InstructionError": []any{
+						float64(3),
+						map[string]any{"Custom": float64(1001)},
+					},
+				},
+			},
+		}
+
+		idx, parseErr := parseFailingInstructionIndex(err)
+
+		require.NoError(t, parseErr)
+		assert.Equal(t, 3, idx)
+	})
+
+	t.Run("returns error for non-RPC error", func(t *testing.T) {
+		err := errors.New("not an RPC error")
+
+		_, parseErr := parseFailingInstructionIndex(err)
+
+		require.Error(t, parseErr)
+		assert.ErrorIs(t, parseErr, ErrInstructionFailed)
+	})
+
+	t.Run("returns error for missing err field", func(t *testing.T) {
+		err := &jsonrpc.RPCError{
+			Code:    -32000,
+			Message: "error",
+			Data:    map[string]any{},
+		}
+
+		_, parseErr := parseFailingInstructionIndex(err)
+
+		require.Error(t, parseErr)
+		assert.ErrorIs(t, parseErr, ErrInstructionFailed)
+	})
+
+	t.Run("returns error for missing InstructionError", func(t *testing.T) {
+		err := &jsonrpc.RPCError{
+			Code:    -32000,
+			Message: "error",
+			Data: map[string]any{
+				"err": map[string]any{
+					"SomeOtherError": "value",
+				},
+			},
+		}
+
+		_, parseErr := parseFailingInstructionIndex(err)
+
+		require.Error(t, parseErr)
+		assert.ErrorIs(t, parseErr, ErrInstructionFailed)
+	})
+}


### PR DESCRIPTION
## Summary of Changes
* serviceability: add support for batch updates of link.health and device.health to Go SDK update
* Follows the pattern established by smartcontract/sdk/go/telemetry/executor.go
* Batch updates are required because e2e tests create many devices and links that must be updated at once, and sequential updates introduce several minutes of delay to the tests
* To be used by device-health-oracle as per rfc12

## Testing Verification
* Includes unit tests
* e2e tested with device-health-oracle in a separate branch
