### PR TITLE
Fix disconnect not cleaning up daemon state

### DIFF
--- a/client/doublezero/src/command/disconnect.rs
+++ b/client/doublezero/src/command/disconnect.rs
@@ -92,11 +92,16 @@ impl DecommissioningCliCommand {
             }
 
             spinner.inc(1);
-            let _ = controller
+            if let Err(e) = controller
                 .remove(RemoveTunnelCliCommand {
                     user_type: user.user_type.to_string(),
                 })
-                .await;
+                .await
+            {
+                spinner.println(format!(
+                    "⚠️  Warning: Failed to remove tunnel from daemon: {e}"
+                ));
+            }
 
             self.poll_for_user_closed(client, pubkey, &spinner)?;
         }

--- a/client/doublezerod/internal/bgp/bgp.go
+++ b/client/doublezerod/internal/bgp/bgp.go
@@ -188,6 +188,11 @@ func (b *BgpServer) DeletePeer(ip net.IP) error {
 	if errors.Is(err, corebgp.ErrPeerNotExist) {
 		return ErrBgpPeerNotExists
 	}
+	if err == nil {
+		b.peerStatusLock.Lock()
+		delete(b.peerStatus, ip.String())
+		b.peerStatusLock.Unlock()
+	}
 	return err
 }
 


### PR DESCRIPTION
## Summary of Changes
  1. CLI disconnect (disconnect.rs):
  - Changed let _ = controller.remove(...) to properly handle errors
  - Now prints a warning if daemon remove fails: ⚠️ Warning: Failed to remove tunnel from daemon: {e}

  2. BGP peer status (bgp.go):
  - Added code to clear the peer from peerStatus map on successful deletion
  - This prevents stale status data after disconnect

Reason for change:
1. Daemon remove might fail silently
2. Even if it succeeded, the BGP status map isn't cleared, showing stale "Network Unreachable"

Bug:
```
❯ (base) ubuntu@chi-dn-bm1:~$ doublezero status
  Tunnel Status       | Last Session Update     | Tunnel Name | Tunnel Src      | Tunnel Dst |
  Doublezero IP   | User Type | Current Device | Lowest Latency Device | Metro | Network
  Network Unreachable | 2026-01-26 14:17:11 UTC | doublezero0 | 137.174.145.138 | 100.0.0.1  |
  137.174.145.138 | IBRL      | N/A            | chi-dn-dzd1           | N/A   | devnet
  (base) ubuntu@chi-dn-bm1:~$ doublezero disconnect
  DoubleZero Service Provisioning
  🔍  Decommissioning User
  Public IP detected: 137.174.145.138 - If you want to use a different IP, you can specify it with
  `--client-ip x.x.x.x`
  ✅  Deprovisioning Complete
  (base) ubuntu@chi-dn-bm1:~$ doublezero status
  Tunnel Status       | Last Session Update     | Tunnel Name | Tunnel Src      | Tunnel Dst |            Doublezero IP   | User Type | Current Device | Lowest Latency Device | Metro | Network
  Network Unreachable | 2026-01-26 14:17:11 UTC | doublezero0 | 137.174.145.138 | 100.0.0.1  |            137.174.145.138 | IBRL      | N/A            | chi-dn-dzd1           | N/A   | devnet
  (base) ubuntu@chi-dn-bm1:~$ doublezero connect ibrl                                                     DoubleZero Service Provisioning
  🔗  Start Provisioning User to devnet...                                                                Public IP detected: 137.174.145.138 - If you want to use a different IP, you can specify it with
  `--client-ip x.x.x.x`                                                                                   DoubleZero ID: DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan
  🔍  Provisioning User for IP: 137.174.145.138                                                           Creating user account...
  Device selected: chi-dn-dzd1                                                                            ❌ Error provisioning service: malformed stuff: cannot provision multiple tunnels at the same
  time
  Location:                                                                                               client/doublezero/src/servicecontroller.rs:309:17
  ✅  User Provisioned                                                                                    (base) ubuntu@chi-dn-bm1:~$ doublezero status
  Tunnel Status       | Last Session Update     | Tunnel Name | Tunnel Src      | Tunnel Dst |            Doublezero IP   | User Type | Current Device | Lowest Latency Device | Metro   | Network
  Network Unreachable | 2026-01-26 14:17:11 UTC | doublezero0 | 137.174.145.138 | 100.0.0.1  |            137.174.145.138 | IBRL      | chi-dn-dzd1    | chi-dn-dzd1           | Chicago | devnet
```

## Testing Verification
*
