### PR TITLE
e2e: enable onchain allocation in activator for all tests

### DIFF
--- a/e2e/docker/activator/entrypoint.sh
+++ b/e2e/docker/activator/entrypoint.sh
@@ -29,11 +29,7 @@ doublezero config set --ws $DZ_LEDGER_WS
 doublezero config set --program-id $DZ_SERVICEABILITY_PROGRAM_ID
 
 # Build activator command with optional flags.
-ACTIVATOR_CMD="doublezero-activator --program-id ${DZ_SERVICEABILITY_PROGRAM_ID} --rpc ${DZ_LEDGER_URL} --ws ${DZ_LEDGER_WS} --keypair /root/.config/doublezero/id.json"
-
-if [ "${DZ_ONCHAIN_ALLOCATION:-}" = "true" ]; then
-  ACTIVATOR_CMD="${ACTIVATOR_CMD} --onchain-allocation"
-fi
+ACTIVATOR_CMD="doublezero-activator --program-id ${DZ_SERVICEABILITY_PROGRAM_ID} --rpc ${DZ_LEDGER_URL} --ws ${DZ_LEDGER_WS} --keypair /root/.config/doublezero/id.json --onchain-allocation"
 
 # Start the activator.
 exec ${ACTIVATOR_CMD}

--- a/e2e/fixtures/ibrl/doublezero_agent_config_drained.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_drained.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,114 +143,114 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.15
+   neighbor 172.16.0.15 remote-as 65342
+   neighbor 172.16.0.15 next-hop-self
+   neighbor 172.16.0.15 update-source Loopback256
+   neighbor 172.16.0.15 description ams-dz001-ipv4
+   neighbor 172.16.0.15 timers 3 9
+   neighbor 172.16.0.15 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
+   no neighbor 172.16.0.7
+   neighbor 172.16.0.7 remote-as 65342
+   neighbor 172.16.0.7 next-hop-self
+   neighbor 172.16.0.7 update-source Loopback255
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
+   neighbor 172.16.0.7 timers 3 9
+   neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.15 activate
+      neighbor 172.16.0.11 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
+      no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
+      neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
    !
    vrf vrf1
       rd 65342:1
@@ -259,8 +259,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -310,27 +310,27 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
+      description ty2-dz01
+   peer 172.16.0.10
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
+   peer 172.16.0.12
+      mesh-group DZ-1
+      local-interface Loopback256
       description sg1-dz01
-   peer 172.16.0.16
+   peer 172.16.0.15
       mesh-group DZ-1
       local-interface Loopback256
       description ams-dz001
-   peer 172.16.0.12
+   peer 172.16.0.11
       mesh-group DZ-1
       local-interface Loopback256
       description frk-dz01

--- a/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,114 +143,114 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.15
+   neighbor 172.16.0.15 remote-as 65342
+   neighbor 172.16.0.15 next-hop-self
+   neighbor 172.16.0.15 update-source Loopback256
+   neighbor 172.16.0.15 description ams-dz001-ipv4
+   neighbor 172.16.0.15 timers 3 9
+   neighbor 172.16.0.15 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
+   no neighbor 172.16.0.7
+   neighbor 172.16.0.7 remote-as 65342
+   neighbor 172.16.0.7 next-hop-self
+   neighbor 172.16.0.7 update-source Loopback255
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
+   neighbor 172.16.0.7 timers 3 9
+   neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.15 activate
+      neighbor 172.16.0.11 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
+      no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
+      neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
    !
    vrf vrf1
       rd 65342:1
@@ -259,8 +259,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -310,27 +310,27 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
+      description ty2-dz01
+   peer 172.16.0.10
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
+   peer 172.16.0.12
+      mesh-group DZ-1
+      local-interface Loopback256
       description sg1-dz01
-   peer 172.16.0.16
+   peer 172.16.0.15
       mesh-group DZ-1
       local-interface Loopback256
       description ams-dz001
-   peer 172.16.0.12
+   peer 172.16.0.11
       mesh-group DZ-1
       local-interface Loopback256
       description frk-dz01

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -155,131 +155,131 @@ interface Tunnel500
    no shutdown
 !
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -297,8 +297,8 @@ router bgp 65342
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -378,31 +378,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,131 +143,131 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -276,8 +276,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -327,31 +327,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -155,131 +155,131 @@ interface Tunnel500
    no shutdown
 !
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -297,8 +297,8 @@ router bgp 65342
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -378,31 +378,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,131 +143,131 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -276,8 +276,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -327,31 +327,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_added.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -158,107 +158,107 @@ interface Tunnel500
    no shutdown
 !
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    no neighbor 169.254.0.1
    neighbor 169.254.0.1 remote-as 65000
    neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
@@ -270,29 +270,29 @@ router bgp 65342
    neighbor 169.254.0.1 maximum-accepted-routes 1
    address-family ipv4
       neighbor 169.254.0.1 activate
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -301,8 +301,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -373,31 +373,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_publisher/doublezero_agent_config_user_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,131 +143,131 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -276,8 +276,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -327,31 +327,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_added.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -157,107 +157,107 @@ interface Tunnel500
    no shutdown
 !
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    no neighbor 169.254.0.1
    neighbor 169.254.0.1 remote-as 65000
    neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
@@ -269,29 +269,29 @@ router bgp 65342
    neighbor 169.254.0.1 maximum-accepted-routes 1
    address-family ipv4
       neighbor 169.254.0.1 activate
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -300,8 +300,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -372,31 +372,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01

--- a/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/multicast_subscriber/doublezero_agent_config_user_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.19/31
+   ip address 172.16.0.17/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address 172.16.0.28/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address 172.16.0.30/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.34/31
+   ip address 172.16.0.32/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -110,17 +110,17 @@ interface Ethernet6
    isis network point-to-point
 !
 interface Loopback255
-   ip address 172.16.0.1/32
+   ip address 172.16.0.0/32
    node-segment ipv4 index 1
    isis enable 1
 !
 interface Loopback256
-   ip address 172.16.0.9/32
+   ip address 172.16.0.8/32
    isis enable 1
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.20/31
+   ip address 172.16.0.18/31
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -143,131 +143,131 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
-   router-id 172.16.0.1
+   router-id 172.16.0.0
    timers bgp 1 3
    distance bgp 20 200 200
-   no neighbor 172.16.0.14
-   neighbor 172.16.0.14 remote-as 65342
-   neighbor 172.16.0.14 next-hop-self
-   neighbor 172.16.0.14 update-source Loopback256
-   neighbor 172.16.0.14 description ty2-dz01-ipv4
-   neighbor 172.16.0.14 timers 3 9
-   neighbor 172.16.0.14 send-community
-   no neighbor 172.16.0.11
-   neighbor 172.16.0.11 remote-as 65342
-   neighbor 172.16.0.11 next-hop-self
-   neighbor 172.16.0.11 update-source Loopback256
-   neighbor 172.16.0.11 description ld4-dz01-ipv4
-   neighbor 172.16.0.11 timers 3 9
-   neighbor 172.16.0.11 send-community
-   no neighbor 172.16.0.10
-   neighbor 172.16.0.10 remote-as 65342
-   neighbor 172.16.0.10 next-hop-self
-   neighbor 172.16.0.10 update-source Loopback256
-   neighbor 172.16.0.10 description la2-dz01-ipv4
-   neighbor 172.16.0.10 timers 3 9
-   neighbor 172.16.0.10 send-community
    no neighbor 172.16.0.13
    neighbor 172.16.0.13 remote-as 65342
    neighbor 172.16.0.13 next-hop-self
    neighbor 172.16.0.13 update-source Loopback256
-   neighbor 172.16.0.13 description sg1-dz01-ipv4
+   neighbor 172.16.0.13 description ty2-dz01-ipv4
    neighbor 172.16.0.13 timers 3 9
    neighbor 172.16.0.13 send-community
-   no neighbor 172.16.0.16
-   neighbor 172.16.0.16 remote-as 65342
-   neighbor 172.16.0.16 next-hop-self
-   neighbor 172.16.0.16 update-source Loopback256
-   neighbor 172.16.0.16 description ams-dz001-ipv4
-   neighbor 172.16.0.16 timers 3 9
-   neighbor 172.16.0.16 send-community
+   no neighbor 172.16.0.10
+   neighbor 172.16.0.10 remote-as 65342
+   neighbor 172.16.0.10 next-hop-self
+   neighbor 172.16.0.10 update-source Loopback256
+   neighbor 172.16.0.10 description ld4-dz01-ipv4
+   neighbor 172.16.0.10 timers 3 9
+   neighbor 172.16.0.10 send-community
+   no neighbor 172.16.0.9
+   neighbor 172.16.0.9 remote-as 65342
+   neighbor 172.16.0.9 next-hop-self
+   neighbor 172.16.0.9 update-source Loopback256
+   neighbor 172.16.0.9 description la2-dz01-ipv4
+   neighbor 172.16.0.9 timers 3 9
+   neighbor 172.16.0.9 send-community
    no neighbor 172.16.0.12
    neighbor 172.16.0.12 remote-as 65342
    neighbor 172.16.0.12 next-hop-self
    neighbor 172.16.0.12 update-source Loopback256
-   neighbor 172.16.0.12 description frk-dz01-ipv4
+   neighbor 172.16.0.12 description sg1-dz01-ipv4
    neighbor 172.16.0.12 timers 3 9
    neighbor 172.16.0.12 send-community
    no neighbor 172.16.0.15
    neighbor 172.16.0.15 remote-as 65342
    neighbor 172.16.0.15 next-hop-self
    neighbor 172.16.0.15 update-source Loopback256
-   neighbor 172.16.0.15 description pit-dzd01-ipv4
+   neighbor 172.16.0.15 description ams-dz001-ipv4
    neighbor 172.16.0.15 timers 3 9
    neighbor 172.16.0.15 send-community
-   no neighbor 172.16.0.6
-   neighbor 172.16.0.6 remote-as 65342
-   neighbor 172.16.0.6 next-hop-self
-   neighbor 172.16.0.6 update-source Loopback255
-   neighbor 172.16.0.6 description ty2-dz01-vpnv4
-   neighbor 172.16.0.6 timers 3 9
-   neighbor 172.16.0.6 send-community
-   no neighbor 172.16.0.3
-   neighbor 172.16.0.3 remote-as 65342
-   neighbor 172.16.0.3 next-hop-self
-   neighbor 172.16.0.3 update-source Loopback255
-   neighbor 172.16.0.3 description ld4-dz01-vpnv4
-   neighbor 172.16.0.3 timers 3 9
-   neighbor 172.16.0.3 send-community
-   no neighbor 172.16.0.2
-   neighbor 172.16.0.2 remote-as 65342
-   neighbor 172.16.0.2 next-hop-self
-   neighbor 172.16.0.2 update-source Loopback255
-   neighbor 172.16.0.2 description la2-dz01-vpnv4
-   neighbor 172.16.0.2 timers 3 9
-   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.11
+   neighbor 172.16.0.11 remote-as 65342
+   neighbor 172.16.0.11 next-hop-self
+   neighbor 172.16.0.11 update-source Loopback256
+   neighbor 172.16.0.11 description frk-dz01-ipv4
+   neighbor 172.16.0.11 timers 3 9
+   neighbor 172.16.0.11 send-community
+   no neighbor 172.16.0.14
+   neighbor 172.16.0.14 remote-as 65342
+   neighbor 172.16.0.14 next-hop-self
+   neighbor 172.16.0.14 update-source Loopback256
+   neighbor 172.16.0.14 description pit-dzd01-ipv4
+   neighbor 172.16.0.14 timers 3 9
+   neighbor 172.16.0.14 send-community
    no neighbor 172.16.0.5
    neighbor 172.16.0.5 remote-as 65342
    neighbor 172.16.0.5 next-hop-self
    neighbor 172.16.0.5 update-source Loopback255
-   neighbor 172.16.0.5 description sg1-dz01-vpnv4
+   neighbor 172.16.0.5 description ty2-dz01-vpnv4
    neighbor 172.16.0.5 timers 3 9
    neighbor 172.16.0.5 send-community
-   no neighbor 172.16.0.8
-   neighbor 172.16.0.8 remote-as 65342
-   neighbor 172.16.0.8 next-hop-self
-   neighbor 172.16.0.8 update-source Loopback255
-   neighbor 172.16.0.8 description ams-dz001-vpnv4
-   neighbor 172.16.0.8 timers 3 9
-   neighbor 172.16.0.8 send-community
+   no neighbor 172.16.0.2
+   neighbor 172.16.0.2 remote-as 65342
+   neighbor 172.16.0.2 next-hop-self
+   neighbor 172.16.0.2 update-source Loopback255
+   neighbor 172.16.0.2 description ld4-dz01-vpnv4
+   neighbor 172.16.0.2 timers 3 9
+   neighbor 172.16.0.2 send-community
+   no neighbor 172.16.0.1
+   neighbor 172.16.0.1 remote-as 65342
+   neighbor 172.16.0.1 next-hop-self
+   neighbor 172.16.0.1 update-source Loopback255
+   neighbor 172.16.0.1 description la2-dz01-vpnv4
+   neighbor 172.16.0.1 timers 3 9
+   neighbor 172.16.0.1 send-community
    no neighbor 172.16.0.4
    neighbor 172.16.0.4 remote-as 65342
    neighbor 172.16.0.4 next-hop-self
    neighbor 172.16.0.4 update-source Loopback255
-   neighbor 172.16.0.4 description frk-dz01-vpnv4
+   neighbor 172.16.0.4 description sg1-dz01-vpnv4
    neighbor 172.16.0.4 timers 3 9
    neighbor 172.16.0.4 send-community
    no neighbor 172.16.0.7
    neighbor 172.16.0.7 remote-as 65342
    neighbor 172.16.0.7 next-hop-self
    neighbor 172.16.0.7 update-source Loopback255
-   neighbor 172.16.0.7 description pit-dzd01-vpnv4
+   neighbor 172.16.0.7 description ams-dz001-vpnv4
    neighbor 172.16.0.7 timers 3 9
    neighbor 172.16.0.7 send-community
+   no neighbor 172.16.0.3
+   neighbor 172.16.0.3 remote-as 65342
+   neighbor 172.16.0.3 next-hop-self
+   neighbor 172.16.0.3 update-source Loopback255
+   neighbor 172.16.0.3 description frk-dz01-vpnv4
+   neighbor 172.16.0.3 timers 3 9
+   neighbor 172.16.0.3 send-community
+   no neighbor 172.16.0.6
+   neighbor 172.16.0.6 remote-as 65342
+   neighbor 172.16.0.6 next-hop-self
+   neighbor 172.16.0.6 update-source Loopback255
+   neighbor 172.16.0.6 description pit-dzd01-vpnv4
+   neighbor 172.16.0.6 timers 3 9
+   neighbor 172.16.0.6 send-community
    address-family ipv4
-      neighbor 172.16.0.14 activate
-      neighbor 172.16.0.11 activate
-      neighbor 172.16.0.10 activate
       neighbor 172.16.0.13 activate
-      neighbor 172.16.0.16 activate
+      neighbor 172.16.0.10 activate
+      neighbor 172.16.0.9 activate
       neighbor 172.16.0.12 activate
       neighbor 172.16.0.15 activate
-      no neighbor 172.16.0.6 activate
-      no neighbor 172.16.0.3 activate
-      no neighbor 172.16.0.2 activate
+      neighbor 172.16.0.11 activate
+      neighbor 172.16.0.14 activate
       no neighbor 172.16.0.5 activate
-      no neighbor 172.16.0.8 activate
+      no neighbor 172.16.0.2 activate
+      no neighbor 172.16.0.1 activate
       no neighbor 172.16.0.4 activate
       no neighbor 172.16.0.7 activate
+      no neighbor 172.16.0.3 activate
+      no neighbor 172.16.0.6 activate
    !
    address-family vpn-ipv4
-      neighbor 172.16.0.6 activate
-      neighbor 172.16.0.3 activate
-      neighbor 172.16.0.2 activate
       neighbor 172.16.0.5 activate
-      neighbor 172.16.0.8 activate
+      neighbor 172.16.0.2 activate
+      neighbor 172.16.0.1 activate
       neighbor 172.16.0.4 activate
       neighbor 172.16.0.7 activate
+      neighbor 172.16.0.3 activate
+      neighbor 172.16.0.6 activate
    !
    vrf vrf1
       rd 65342:1
@@ -276,8 +276,8 @@ router bgp 65342
       router-id {{.DeviceIP}}
 !
 router isis 1
-   net 49.0000.ac10.0001.0000.00
-   router-id ipv4 172.16.0.1
+   net 49.0000.ac10.0000.0000.00
+   router-id ipv4 172.16.0.0
    log-adjacency-changes
    !
    address-family ipv4 unicast
@@ -327,31 +327,31 @@ ip access-list SEC-USER-SUB-MCAST-IN
 !
 no router msdp
 router msdp
-   peer 172.16.0.14
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ty2-dz01
-   peer 172.16.0.11
-      mesh-group DZ-1
-      local-interface Loopback256
-      description ld4-dz01
-   peer 172.16.0.10
-      mesh-group DZ-1
-      local-interface Loopback256
-      description la2-dz01
    peer 172.16.0.13
       mesh-group DZ-1
       local-interface Loopback256
-      description sg1-dz01
-   peer 172.16.0.16
+      description ty2-dz01
+   peer 172.16.0.10
       mesh-group DZ-1
       local-interface Loopback256
-      description ams-dz001
+      description ld4-dz01
+   peer 172.16.0.9
+      mesh-group DZ-1
+      local-interface Loopback256
+      description la2-dz01
    peer 172.16.0.12
       mesh-group DZ-1
       local-interface Loopback256
-      description frk-dz01
+      description sg1-dz01
    peer 172.16.0.15
+      mesh-group DZ-1
+      local-interface Loopback256
+      description ams-dz001
+   peer 172.16.0.11
+      mesh-group DZ-1
+      local-interface Loopback256
+      description frk-dz01
+   peer 172.16.0.14
       mesh-group DZ-1
       local-interface Loopback256
       description pit-dzd01


### PR DESCRIPTION
## Summary of Changes
* Change e2e tests so that the activator always uses onchain allocation
* Change includes:
  * Updated activator/entrypoint.sh to always pass --onchain-allocation
  * Changed expected IP address in agent config to match new allocation rules

## Testing Verification
* e2e passes
