### PR TITLE
Enhance delete multicast group command to cascade into deleting AP entry too

### DIFF
--- a/smartcontract/cli/src/multicastgroup/delete.rs
+++ b/smartcontract/cli/src/multicastgroup/delete.rs
@@ -4,10 +4,19 @@ use crate::{
     validators::validate_pubkey_or_code,
 };
 use clap::Args;
-use doublezero_sdk::commands::multicastgroup::{
-    delete::DeleteMulticastGroupCommand, get::GetMulticastGroupCommand,
+use doublezero_sdk::commands::{
+    accesspass::list::ListAccessPassCommand,
+    multicastgroup::{
+        allowlist::{
+            publisher::remove::RemoveMulticastGroupPubAllowlistCommand,
+            subscriber::remove::RemoveMulticastGroupSubAllowlistCommand,
+        },
+        delete::DeleteMulticastGroupCommand,
+        get::GetMulticastGroupCommand,
+    },
 };
-use std::io::Write;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::{io::Write, net::Ipv4Addr, time::Duration};
 
 #[derive(Args, Debug)]
 pub struct DeleteMulticastGroupCliCommand {
@@ -16,17 +25,162 @@ pub struct DeleteMulticastGroupCliCommand {
     pub pubkey: String,
 }
 
+struct RemovalFailure {
+    client_ip: Ipv4Addr,
+    allowlist_type: &'static str,
+    error: String,
+}
+
 impl DeleteMulticastGroupCliCommand {
     pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
         // Check requirements
         client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
 
-        let (pubkey, _) = client.get_multicastgroup(GetMulticastGroupCommand {
-            pubkey_or_code: self.pubkey,
+        let pubkey_or_code = self.pubkey;
+        let (pubkey, mgroup) = client.get_multicastgroup(GetMulticastGroupCommand {
+            pubkey_or_code: pubkey_or_code.clone(),
         })?;
 
+        // Remove the group from all AccessPass allowlists before deleting
+        let accesspasses = client.list_accesspass(ListAccessPassCommand {})?;
+
+        // Filter to only AccessPasses that reference this group
+        let affected: Vec<_> = accesspasses
+            .into_iter()
+            .filter(|(_, ap)| {
+                ap.mgroup_pub_allowlist.contains(&pubkey)
+                    || ap.mgroup_sub_allowlist.contains(&pubkey)
+            })
+            .collect();
+
+        let mut failures: Vec<RemovalFailure> = Vec::new();
+        let mut removed_count = 0;
+
+        if !affected.is_empty() {
+            // Initialize spinner
+            let spinner = ProgressBar::new(affected.len() as u64);
+            spinner.set_style(
+                ProgressStyle::default_spinner()
+                    .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} {msg}")
+                    .expect("Failed to set template")
+                    .progress_chars("#>-")
+                    .tick_strings(&["-", "\\", "|", "/"]),
+            );
+            spinner.enable_steady_tick(Duration::from_millis(100));
+            spinner.println(format!(
+                "Removing multicast group '{}' from {} AccessPass allowlist(s)...",
+                mgroup.code,
+                affected.len()
+            ));
+
+            for (_, accesspass) in affected {
+                spinner.set_message(format!("Processing {}", accesspass.client_ip));
+
+                // Try to remove from publisher allowlist
+                if accesspass.mgroup_pub_allowlist.contains(&pubkey) {
+                    match client.remove_multicastgroup_pub_allowlist(
+                        RemoveMulticastGroupPubAllowlistCommand {
+                            pubkey_or_code: pubkey_or_code.clone(),
+                            client_ip: accesspass.client_ip,
+                            user_payer: accesspass.user_payer,
+                        },
+                    ) {
+                        Ok(_) => {
+                            spinner.println(format!(
+                                "  ✓ Removed {} from publisher allowlist",
+                                accesspass.client_ip
+                            ));
+                            removed_count += 1;
+                        }
+                        Err(e) => {
+                            spinner.println(format!(
+                                "  ✗ Failed to remove {} from publisher allowlist: {}",
+                                accesspass.client_ip, e
+                            ));
+                            failures.push(RemovalFailure {
+                                client_ip: accesspass.client_ip,
+                                allowlist_type: "publisher",
+                                error: e.to_string(),
+                            });
+                        }
+                    }
+                }
+
+                // Try to remove from subscriber allowlist
+                if accesspass.mgroup_sub_allowlist.contains(&pubkey) {
+                    match client.remove_multicastgroup_sub_allowlist(
+                        RemoveMulticastGroupSubAllowlistCommand {
+                            pubkey_or_code: pubkey_or_code.clone(),
+                            client_ip: accesspass.client_ip,
+                            user_payer: accesspass.user_payer,
+                        },
+                    ) {
+                        Ok(_) => {
+                            spinner.println(format!(
+                                "  ✓ Removed {} from subscriber allowlist",
+                                accesspass.client_ip
+                            ));
+                            removed_count += 1;
+                        }
+                        Err(e) => {
+                            spinner.println(format!(
+                                "  ✗ Failed to remove {} from subscriber allowlist: {}",
+                                accesspass.client_ip, e
+                            ));
+                            failures.push(RemovalFailure {
+                                client_ip: accesspass.client_ip,
+                                allowlist_type: "subscriber",
+                                error: e.to_string(),
+                            });
+                        }
+                    }
+                }
+
+                spinner.inc(1);
+            }
+
+            spinner.finish_with_message("Done processing AccessPasses");
+        }
+
+        // Delete the multicast group
         let signature = client.delete_multicastgroup(DeleteMulticastGroupCommand { pubkey })?;
-        writeln!(out, "Signature: {signature}",)?;
+
+        // Print summary
+        writeln!(out)?;
+        writeln!(
+            out,
+            "✓ Multicast group '{}' deleted successfully",
+            mgroup.code
+        )?;
+        writeln!(out, "  Signature: {signature}")?;
+
+        if removed_count > 0 {
+            writeln!(
+                out,
+                "  Removed from {removed_count} AccessPass allowlist(s)"
+            )?;
+        }
+
+        if !failures.is_empty() {
+            writeln!(out)?;
+            writeln!(
+                out,
+                "⚠ Warning: Failed to remove group from {} AccessPass allowlist(s):",
+                failures.len()
+            )?;
+            for failure in &failures {
+                writeln!(
+                    out,
+                    "  - {} ({}): {}",
+                    failure.client_ip, failure.allowlist_type, failure.error
+                )?;
+            }
+            writeln!(out)?;
+            writeln!(
+                out,
+                "These AccessPasses may contain stale references to the deleted group."
+            )?;
+        }
 
         Ok(())
     }
@@ -41,21 +195,28 @@ mod tests {
         tests::utils::create_test_client,
     };
     use doublezero_sdk::{
-        commands::{
-            device::get::GetDeviceCommand,
-            multicastgroup::{delete::DeleteMulticastGroupCommand, get::GetMulticastGroupCommand},
+        commands::multicastgroup::{
+            allowlist::{
+                publisher::remove::RemoveMulticastGroupPubAllowlistCommand,
+                subscriber::remove::RemoveMulticastGroupSubAllowlistCommand,
+            },
+            delete::DeleteMulticastGroupCommand,
+            get::GetMulticastGroupCommand,
         },
-        get_multicastgroup_pda, AccountType, Device, DeviceStatus, DeviceType, MulticastGroup,
-        MulticastGroupStatus,
+        get_multicastgroup_pda, AccountType, MulticastGroup, MulticastGroupStatus,
+    };
+    use doublezero_serviceability::state::accesspass::{
+        AccessPass, AccessPassStatus, AccessPassType,
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::collections::HashMap;
 
     #[test]
     fn test_cli_multicastgroup_delete() {
         let mut client = create_test_client();
 
-        let (pda_pubkey, _bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
+        let (mgroup_pubkey, _bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
         let signature = Signature::from([
             120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
             82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
@@ -63,113 +224,149 @@ mod tests {
             100, 221, 20, 137, 4, 5,
         ]);
 
-        let contributor_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
-        let location1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
-        let exchange1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkca");
-        let device1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb");
-        let device1 = Device {
-            account_type: AccountType::Device,
-            index: 1,
-            bump_seed: 255,
-            reference_count: 0,
-            code: "test".to_string(),
-            contributor_pk,
-            location_pk: location1_pk,
-            exchange_pk: exchange1_pk,
-            device_type: DeviceType::Hybrid,
-            public_ip: [10, 0, 0, 1].into(),
-            dz_prefixes: "10.1.0.0/16".parse().unwrap(),
-            status: DeviceStatus::Activated,
-            metrics_publisher_pk: Pubkey::new_unique(),
-            owner: pda_pubkey,
-            mgmt_vrf: "default".to_string(),
-            interfaces: vec![],
-            max_users: 255,
-            users_count: 0,
-            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
-            desired_status:
-                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
-        };
-        let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
-        let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
-        let device2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");
-        let device2 = Device {
-            account_type: AccountType::Device,
-            index: 1,
-            bump_seed: 255,
-            reference_count: 0,
-            code: "test".to_string(),
-            contributor_pk,
-            location_pk: location2_pk,
-            exchange_pk: exchange2_pk,
-            device_type: DeviceType::Hybrid,
-            public_ip: [10, 0, 0, 1].into(),
-            dz_prefixes: "10.1.0.0/16".parse().unwrap(),
-            status: DeviceStatus::Activated,
-            metrics_publisher_pk: Pubkey::new_unique(),
-            owner: pda_pubkey,
-            mgmt_vrf: "default".to_string(),
-            interfaces: vec![],
-            max_users: 255,
-            users_count: 0,
-            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
-            desired_status:
-                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
-        };
-
         let multicastgroup = MulticastGroup {
             account_type: AccountType::MulticastGroup,
             index: 1,
             bump_seed: 255,
-            code: "test".to_string(),
+            code: "testgroup".to_string(),
             tenant_pk: Pubkey::new_unique(),
-            multicast_ip: [10, 0, 0, 1].into(),
+            multicast_ip: [239, 0, 0, 1].into(),
             max_bandwidth: 1000000000,
             status: MulticastGroupStatus::Activated,
-            owner: pda_pubkey,
+            owner: mgroup_pubkey,
             publisher_count: 1,
-            subscriber_count: 0,
+            subscriber_count: 2,
+        };
+
+        // AccessPass with group in publisher allowlist
+        let publisher_ip: std::net::Ipv4Addr = [100, 0, 0, 1].into();
+        let publisher_payer = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo1");
+        let accesspass_publisher = AccessPass {
+            account_type: AccountType::AccessPass,
+            bump_seed: 1,
+            client_ip: publisher_ip,
+            accesspass_type: AccessPassType::Prepaid,
+            last_access_epoch: u64::MAX,
+            user_payer: publisher_payer,
+            mgroup_pub_allowlist: vec![mgroup_pubkey], // Has the group as publisher
+            mgroup_sub_allowlist: vec![],
+            owner: Pubkey::new_unique(),
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            flags: 0,
+        };
+
+        // AccessPass with group in subscriber allowlist
+        let subscriber_ip: std::net::Ipv4Addr = [100, 0, 0, 2].into();
+        let subscriber_payer = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo2");
+        let accesspass_subscriber = AccessPass {
+            account_type: AccountType::AccessPass,
+            bump_seed: 1,
+            client_ip: subscriber_ip,
+            accesspass_type: AccessPassType::Prepaid,
+            last_access_epoch: u64::MAX,
+            user_payer: subscriber_payer,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![mgroup_pubkey], // Has the group as subscriber
+            owner: Pubkey::new_unique(),
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            flags: 0,
+        };
+
+        // AccessPass with no reference to the group (should not trigger remove)
+        let accesspass_unrelated = AccessPass {
+            account_type: AccountType::AccessPass,
+            bump_seed: 1,
+            client_ip: [100, 0, 0, 3].into(),
+            accesspass_type: AccessPassType::Prepaid,
+            last_access_epoch: u64::MAX,
+            user_payer: Pubkey::new_unique(),
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            owner: Pubkey::new_unique(),
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            flags: 0,
         };
 
         client
             .expect_check_requirements()
             .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
             .returning(|_| Ok(()));
-        client
-            .expect_get_device()
-            .with(predicate::eq(GetDeviceCommand {
-                pubkey_or_code: device1_pk.to_string(),
-            }))
-            .returning(move |_| Ok((device1_pk, device1.clone())));
-        client
-            .expect_get_device()
-            .with(predicate::eq(GetDeviceCommand {
-                pubkey_or_code: device2_pk.to_string(),
-            }))
-            .returning(move |_| Ok((device2_pk, device2.clone())));
+
         client
             .expect_get_multicastgroup()
             .with(predicate::eq(GetMulticastGroupCommand {
-                pubkey_or_code: pda_pubkey.to_string(),
+                pubkey_or_code: mgroup_pubkey.to_string(),
             }))
-            .returning(move |_| Ok((pda_pubkey, multicastgroup.clone())));
+            .returning(move |_| Ok((mgroup_pubkey, multicastgroup.clone())));
+
+        // Return AccessPasses - some with group references, one without
+        client.expect_list_accesspass().returning(move |_| {
+            let mut list: HashMap<Pubkey, AccessPass> = HashMap::new();
+            list.insert(Pubkey::new_unique(), accesspass_publisher.clone());
+            list.insert(Pubkey::new_unique(), accesspass_subscriber.clone());
+            list.insert(Pubkey::new_unique(), accesspass_unrelated.clone());
+            Ok(list)
+        });
+
+        // Expect remove from publisher allowlist to be called (for accesspass_publisher)
+        client
+            .expect_remove_multicastgroup_pub_allowlist()
+            .with(predicate::eq(RemoveMulticastGroupPubAllowlistCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+                client_ip: publisher_ip,
+                user_payer: publisher_payer,
+            }))
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        // Expect remove from subscriber allowlist to be called (for accesspass_subscriber)
+        client
+            .expect_remove_multicastgroup_sub_allowlist()
+            .with(predicate::eq(RemoveMulticastGroupSubAllowlistCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+                client_ip: subscriber_ip,
+                user_payer: subscriber_payer,
+            }))
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        // Finally expect the group to be deleted
         client
             .expect_delete_multicastgroup()
             .with(predicate::eq(DeleteMulticastGroupCommand {
-                pubkey: pda_pubkey,
+                pubkey: mgroup_pubkey,
             }))
             .returning(move |_| Ok(signature));
 
         /*****************************************************************************************************/
         let mut output = Vec::new();
         let res = DeleteMulticastGroupCliCommand {
-            pubkey: pda_pubkey.to_string(),
+            pubkey: mgroup_pubkey.to_string(),
         }
         .execute(&client, &mut output);
-        assert!(res.is_ok());
+        assert!(res.is_ok(), "Expected delete to succeed: {:?}", res);
+
+        // Verify output contains the expected messages
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(
-            output_str,"Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        assert!(
+            output_str.contains("Multicast group 'testgroup' deleted successfully"),
+            "Expected success message in output: {output_str}"
+        );
+        assert!(
+            output_str.contains("Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv"),
+            "Expected signature in output: {output_str}"
+        );
+        assert!(
+            output_str.contains("Removed from 2 AccessPass allowlist(s)"),
+            "Expected removal count in output: {output_str}"
+        );
+        // Should NOT contain warning since all removals succeeded
+        assert!(
+            !output_str.contains("Warning"),
+            "Should not have warnings when all removals succeed: {output_str}"
         );
     }
 }


### PR DESCRIPTION
## Summary of Changes
* Before deleting, call client.list_accesspass() to get all AccessPasses
* Filter to those whose mgroup_pub_allowlist or mgroup_sub_allowlist contains the group's pubkey
* For each matching AccessPass, call the existing:
* client.remove_multicastgroup_pub_allowlist(...)
* client.remove_multicastgroup_sub_allowlist(...)
* Then proceed with the existing client.delete_multicastgroup(...)

## Testing Verification
```
…/smartcontract/cli ms/fix-multicast-ap ❯ cd /home/martin/Documents/malbec/doublezero/smartcontract/cli && cargo test test_cli_multicastgroup_delete -- --nocapture
warning: doublezero-telemetry@0.8.4: Environment: localnet
warning: doublezero-telemetry@0.8.4: Serviceability Program ID: 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests src/lib.rs (/home/martin/Documents/malbec/doublezero/target/debug/deps/doublezero_cli-fe643953505e64a8)

running 1 test
test multicastgroup::delete::tests::test_cli_multicastgroup_delete ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 128 filtered out; finished in 0.00s

```

Running test-validator:
```
…/smartcontract/test ms/fix-multicast-ap  ? ❯ ./target/doublezero multicast group delete --pubkey mg01
Removing multicast group 'mg01' from 2 AccessPass allowlist(s)...
  ✓ Removed 100.0.0.5 from subscriber allowlist
  ✓ Removed 100.0.0.6 from publisher allowlist
  ✓ Removed 100.0.0.6 from subscriber allowlist
/ [00:00:01] [########################################] 2/2 Done processing AccessPasses                                               
✓ Multicast group 'mg01' deleted successfully
  Signature: 3BjoKE7wnYEFEtkkGvT2ddGDGDeXysqRhMCHTmdWSVc2ZJL3cSGKKnL9PtrZtYyMnTnibaMNWpcFa6DDBMxacsAE
  Removed from 3 AccessPass allowlist(s)

…/smartcontract/test ms/fix-multicast-ap  ? ❯ ./target/doublezero access-pass list
 account                                      | accesspass_type | client_ip       | user_payer                                  | multicast      | last_access_epoch | remaining_epoch | flags | connections | status    | owner                                       
 5cN6vbkekNez2JttrCuZ4vbfDCQd8ADarg9VdcY4v3iY | prepaid         | 100.0.0.5       | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q | S:mg02, S:mg03 | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
 783TrtfTBB6ZcYNvuCQvcuPy1tytbJQVC6TiYRtk4dqB | prepaid         | 100.0.0.6       | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q | P:mg02, P:mg03 | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
 DZDGGevmhabUmSPbdLASCMox3ZXBsNqa28jyB3ZpMwN9 | prepaid         | 100.100.100.100 | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q |                | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
 5yKfBVfkiC1Rhv42fPUpJE5x5BEgxW6jhcz7yTzaht6P | prepaid         | 147.28.171.51   | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q |                | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
 GadpJXYNkbGPQpGpXfH4HjiwAw5yVWDfX719HTLb3vNw | prepaid         | 177.54.159.95   | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q |                | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
 8txUAH4ezaNfoooaCC7AQWRd9Kzz7gswVGrrpxSmgXRn | prepaid         | 200.200.200.200 | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q |                | MAX               | MAX             |       | 1           | connected | UYAjYh8tgVjLwBwE4W4xX5vYCrg8H6erHNd8FmTcB3q 
```