### PR TITLE
doublezerod: fix session timeout race conditions on peer deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - Smartcontract
   - fix(smartcontract): reserve first IP of DzPrefixBlock for device ([#2753](https://github.com/malbeclabs/doublezero/pull/2753))
+- Client
+  - Fix race in bgp status handling on peer deletion
 
 ### Breaking
 

--- a/client/doublezerod/internal/bgp/plugin_test.go
+++ b/client/doublezerod/internal/bgp/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/jwhited/corebgp"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
@@ -385,5 +386,314 @@ func TestEmitTimeoutStatus_NoEmitWhenEstablished(t *testing.T) {
 		t.Fatal("unexpected event in status channel")
 	default:
 		// Expected: channel should be empty
+	}
+}
+
+// TestPlugin_MarkDeleted_PreventsTimeoutEmission tests that marking a plugin as deleted
+// prevents timeout status emissions. This is critical for avoiding "BGP Session Failed"
+// status when a peer is intentionally deleted during device rollover.
+func TestPlugin_MarkDeleted_PreventsTimeoutEmission(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		tcpConnected      bool
+		expectedEmitted   bool
+		markDeletedBefore bool
+	}{
+		{
+			name:              "deleted before timeout prevents emission",
+			tcpConnected:      false,
+			expectedEmitted:   false,
+			markDeletedBefore: true,
+		},
+		{
+			name:              "not deleted allows timeout emission for unreachable",
+			tcpConnected:      false,
+			expectedEmitted:   true,
+			markDeletedBefore: false,
+		},
+		{
+			name:              "not deleted allows timeout emission for failed",
+			tcpConnected:      true,
+			expectedEmitted:   true,
+			markDeletedBefore: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusChan := make(chan SessionEvent, 10)
+			mockRW := &MockRouteReaderWriter{
+				RouteByProtocolFunc: func(p int) ([]*routing.Route, error) {
+					return nil, nil
+				},
+			}
+			plugin := NewBgpPlugin(
+				[]NLRI{},
+				net.ParseIP("10.0.0.1"),
+				100,
+				statusChan,
+				true,
+				mockRW,
+			)
+			plugin.peerAddr = net.ParseIP("192.0.2.1")
+
+			if tt.tcpConnected {
+				plugin.tcpConnected.Store(true)
+			}
+
+			if tt.markDeletedBefore {
+				plugin.MarkDeleted()
+			}
+
+			// Directly call emitTimeoutStatus to test the logic
+			emitted := plugin.emitTimeoutStatus()
+
+			require.Equal(t, tt.expectedEmitted, emitted, "unexpected emission result")
+
+			if tt.expectedEmitted {
+				select {
+				case event := <-statusChan:
+					if tt.tcpConnected {
+						require.Equal(t, SessionStatusFailed, event.Session.SessionStatus)
+					} else {
+						require.Equal(t, SessionStatusUnreachable, event.Session.SessionStatus)
+					}
+				default:
+					t.Fatal("expected status event but got none")
+				}
+			} else {
+				select {
+				case <-statusChan:
+					t.Fatal("unexpected status event received")
+				default:
+					// Expected: no event
+				}
+			}
+		})
+	}
+}
+
+// TestPlugin_OnClose_NoTimeoutAfterMarkDeleted tests that OnClose does not start a new
+// timeout when the peer has been marked as deleted. This prevents spurious timeout events
+// for peers that won't reconnect during device rollover.
+func TestPlugin_OnClose_NoTimeoutAfterMarkDeleted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		markDeletedBeforeClose bool
+		expectTimeoutStarted   bool
+	}{
+		{
+			name:                   "normal close starts timeout for reconnection",
+			markDeletedBeforeClose: false,
+			expectTimeoutStarted:   true,
+		},
+		{
+			name:                   "close after deletion does not start timeout",
+			markDeletedBeforeClose: true,
+			expectTimeoutStarted:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusChan := make(chan SessionEvent, 10)
+			mockRW := &MockRouteReaderWriter{
+				RouteByProtocolFunc: func(p int) ([]*routing.Route, error) {
+					return nil, nil
+				},
+			}
+			plugin := NewBgpPlugin(
+				[]NLRI{},
+				net.ParseIP("10.0.0.1"),
+				100,
+				statusChan,
+				true,
+				mockRW,
+			)
+			plugin.peerAddr = net.ParseIP("192.0.2.1")
+			plugin.currentlyEstablished.Store(true)
+
+			if tt.markDeletedBeforeClose {
+				plugin.MarkDeleted()
+			}
+
+			peerConfig := corebgp.PeerConfig{
+				RemoteAddress: netip.MustParseAddr("192.0.2.1"),
+			}
+			plugin.OnClose(peerConfig)
+
+			// Check if cancelTimeout was set (indicating timeout was started)
+			timeoutWasStarted := plugin.cancelTimeout != nil
+
+			require.Equal(t, tt.expectTimeoutStarted, timeoutWasStarted,
+				"timeout start state mismatch")
+		})
+	}
+}
+
+// TestPlugin_MarkDeleted_CancelsInFlightTimeout tests that MarkDeleted cancels any
+// in-flight timeout that may have been started from a prior network disconnect.
+func TestPlugin_MarkDeleted_CancelsInFlightTimeout(t *testing.T) {
+	t.Parallel()
+
+	statusChan := make(chan SessionEvent, 10)
+	mockRW := &MockRouteReaderWriter{
+		RouteByProtocolFunc: func(p int) ([]*routing.Route, error) {
+			return nil, nil
+		},
+	}
+	plugin := NewBgpPlugin(
+		[]NLRI{},
+		net.ParseIP("10.0.0.1"),
+		100,
+		statusChan,
+		true,
+		mockRW,
+	)
+	plugin.peerAddr = net.ParseIP("192.0.2.1")
+	plugin.tcpConnected.Store(true)
+
+	// Start a timeout
+	plugin.startSessionTimeout()
+	require.NotNil(t, plugin.cancelTimeout, "timeout should be started")
+
+	// Mark as deleted which should cancel the timeout
+	plugin.MarkDeleted()
+
+	// Wait for the original timeout period
+	// Note: Using a shorter wait for test speed
+	select {
+	case event := <-statusChan:
+		t.Fatalf("unexpected status event received after MarkDeleted: %v", event.Session.SessionStatus)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no event within reasonable time
+	}
+
+	// Verify deleted flag is set
+	require.True(t, plugin.deleted.Load(), "deleted flag should be set")
+}
+
+// TestPlugin_OnEstablished_TOCTOURace_MutexPreventsStatusOverwrite tests the fix for the
+// TOCTOU race where the timeout goroutine could emit a "Failed" status just as the session
+// establishes, overwriting the correct "Up" status. The mutex ensures the established flag
+// check in emitTimeoutStatus is atomic with the flag set in OnEstablished.
+func TestPlugin_OnEstablished_TOCTOURace_MutexPreventsStatusOverwrite(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that the mutex prevents the race condition.
+	// We simulate concurrent calls to OnEstablished and emitTimeoutStatus
+	// and verify that once established is set, timeout emission is blocked.
+
+	statusChan := make(chan SessionEvent, 10)
+	mockRW := &MockRouteReaderWriter{
+		RouteByProtocolFunc: func(p int) ([]*routing.Route, error) {
+			return nil, nil
+		},
+	}
+	plugin := NewBgpPlugin(
+		[]NLRI{},
+		net.ParseIP("10.0.0.1"),
+		100,
+		statusChan,
+		true,
+		mockRW,
+	)
+	plugin.peerAddr = net.ParseIP("192.0.2.1")
+	plugin.tcpConnected.Store(true)
+
+	// Spawn multiple goroutines that try to emit timeout concurrently with OnEstablished
+	done := make(chan bool)
+	var emitCount int
+
+	// Start goroutines trying to emit timeout
+	for i := 0; i < 5; i++ {
+		go func() {
+			time.Sleep(1 * time.Millisecond)
+			if plugin.emitTimeoutStatus() {
+				emitCount++
+			}
+			done <- true
+		}()
+	}
+
+	// Call OnEstablished which should set the flag under lock
+	peerConfig := corebgp.PeerConfig{
+		RemoteAddress: netip.MustParseAddr("192.0.2.1"),
+	}
+	plugin.OnEstablished(peerConfig, &mockUpdateWriter{})
+
+	// Wait for all goroutines
+	for i := 0; i < 5; i++ {
+		<-done
+	}
+
+	// Collect all events
+	var events []SessionEvent
+	for {
+		select {
+		case event := <-statusChan:
+			events = append(events, event)
+		default:
+			goto eventsDone
+		}
+	}
+eventsDone:
+
+	// Analyze the events: we should see only "Up" status from OnEstablished
+	// The mutex should prevent any emitTimeoutStatus calls from succeeding after established=true
+	var hasUp, hasFailed bool
+	for _, event := range events {
+		if event.Session.SessionStatus == SessionStatusUp {
+			hasUp = true
+		}
+		if event.Session.SessionStatus == SessionStatusFailed {
+			hasFailed = true
+		}
+	}
+
+	require.True(t, hasUp, "should have received SessionStatusUp from OnEstablished")
+	require.False(t, hasFailed, "should NOT have received SessionStatusFailed from timeout after establish due to mutex protection")
+}
+
+// TestPlugin_emitTimeoutStatus_RespectsEstablishedFlag tests that emitTimeoutStatus
+// returns false without emitting when the session is already established.
+func TestPlugin_emitTimeoutStatus_RespectsEstablishedFlag(t *testing.T) {
+	t.Parallel()
+
+	statusChan := make(chan SessionEvent, 10)
+	mockRW := &MockRouteReaderWriter{
+		RouteByProtocolFunc: func(p int) ([]*routing.Route, error) {
+			return nil, nil
+		},
+	}
+	plugin := NewBgpPlugin(
+		[]NLRI{},
+		net.ParseIP("10.0.0.1"),
+		100,
+		statusChan,
+		true,
+		mockRW,
+	)
+	plugin.peerAddr = net.ParseIP("192.0.2.1")
+	plugin.tcpConnected.Store(true)
+
+	// Mark as established
+	plugin.currentlyEstablished.Store(true)
+
+	// Try to emit timeout status
+	emitted := plugin.emitTimeoutStatus()
+
+	require.False(t, emitted, "should not emit when session is established")
+
+	// Verify no event was sent
+	select {
+	case <-statusChan:
+		t.Fatal("unexpected status event when session is established")
+	default:
+		// Expected: no event
 	}
 }


### PR DESCRIPTION
## Summary of Changes
Mark BGP plugins as deleted before calling DeletePeer to prevent OnClose from starting a new session timeout for peers that won't reconnect. This fixes flaky test failures in device rollover scenarios where stale timeout events caused "BGP Session Failed" status instead of allowing clean reconnection to a new device.

Also fix a TOCTOU race between OnEstablished and emitTimeoutStatus where the timeout goroutine could emit a "Failed" status just as the session establishes, overwriting the correct "Up" status. The fix uses a mutex to ensure the established flag check in emitTimeoutStatus is atomic with respect to the flag set in OnEstablished.

## Testing Verification
```
  Tests Added to client/doublezerod/internal/bgp/plugin_test.go                                                              
  Test: TestPlugin_MarkDeleted_PreventsTimeoutEmission                                                                       
  Purpose: Verifies marking a plugin deleted prevents spurious timeout status emissions                                      
  ────────────────────────────────────────                                                                                   
  Test: TestPlugin_OnClose_NoTimeoutAfterMarkDeleted                                                                         
  Purpose: Verifies OnClose doesn't start timeout for deleted peers                                                          
  ────────────────────────────────────────                                                                                   
  Test: TestPlugin_MarkDeleted_CancelsInFlightTimeout                                                                        
  Purpose: Verifies MarkDeleted cancels any in-flight timeout from prior disconnects                                         
  ────────────────────────────────────────                                                                                   
  Test: TestPlugin_OnEstablished_TOCTOURace_MutexPreventsStatusOverwrite                                                     
  Purpose: Tests TOCTOU race - ensures mutex prevents "Failed" from overwriting "Up" status                                  
  ────────────────────────────────────────                                                                                   
  Test: TestPlugin_emitTimeoutStatus_RespectsEstablishedFlag                                                                 
  Purpose: Verifies emitTimeoutStatus returns false when session already established                                         
  Code Paths Covered                                                                                                         
                                                                                                                             
  - plugin.go:100-106 - mutex-protected check in emitTimeoutStatus() for deleted peers                                       
  - plugin.go:138-144 - mutex protection in OnEstablished() setting established flag                                         
  - plugin.go:207-211 - OnClose() skipping timeout for deleted peers                                                         
  - plugin.go:218-223 - MarkDeleted() setting flag and canceling timeouts                                                    
  - bgp.go:198-206 - DeletePeer() marking plugin deleted before removal                                                      
                                                                                                                             
  Test Results                                                                                                               
                                                                                                                             
  === RUN   TestPlugin_MarkDeleted_PreventsTimeoutEmission                                                                   
  --- PASS: TestPlugin_MarkDeleted_PreventsTimeoutEmission                                                                   
  === RUN   TestPlugin_OnClose_NoTimeoutAfterMarkDeleted                                                                     
  --- PASS: TestPlugin_OnClose_NoTimeoutAfterMarkDeleted                                                                     
  === RUN   TestPlugin_MarkDeleted_CancelsInFlightTimeout                                                                    
  --- PASS: TestPlugin_MarkDeleted_CancelsInFlightTimeout                                                                    
  === RUN   TestPlugin_OnEstablished_TOCTOURace_MutexPreventsStatusOverwrite                                                 
  --- PASS: TestPlugin_OnEstablished_TOCTOURace_MutexPreventsStatusOverwrite                                                 
  === RUN   TestPlugin_emitTimeoutStatus_RespectsEstablishedFlag                                                             
  --- PASS: TestPlugin_emitTimeoutStatus_RespectsEstablishedFlag                                                             
  PASS                                                                                                                       
```                                          
  All tests pass with -race flag enabled (ran 10 iterations).                    
