### PR TITLE
e2e: fix device maxusers rollover test flake

### DIFF
--- a/e2e/device_maxusers_rollover_test.go
+++ b/e2e/device_maxusers_rollover_test.go
@@ -68,7 +68,7 @@ func TestE2E_DeviceMaxusersRollover(t *testing.T) {
 		Location: "lax",
 		Exchange: "xlax",
 		// .8/29 has network address .8, allocatable up to .14, and broadcast .15
-		CYOANetworkIPHostID:          9,
+		CYOANetworkIPHostID:          16,
 		CYOANetworkAllocatablePrefix: 29,
 		LoopbackInterfaces: map[string]string{
 			"Loopback255": "vpnv4",


### PR DESCRIPTION
## Summary of Changes
- Change device2 host ID from 9 to 16 in `TestE2E_DeviceMaxusersRollover`
- Related to https://github.com/malbeclabs/doublezero/issues/2750

The test creates two devices with host IDs 8 and 9. The overlay prefix (`dz_prefix`) for each device is computed as `((hostID + 128) / 8) * 8`, rounded to a `/29` boundary. Both host IDs 8 and 9 produce the same result (136), so both devices are assigned the same `/29` overlay prefix. This causes tunnel IP conflicts when the client disconnects from device1 and reconnects to device2 — the second device tries to allocate IPs from the same range, and the BGP session never comes up.

Changing device2's host ID to 16 produces a distinct `/29` block (144 vs 136), matching the pattern already used by other multi-device tests like `TestE2E_UserBan` and `TestE2E_MultiClient`.

## Testing Verification
- CI e2e tests pass