### PR TITLE
e2e: fix flaky tunnel ID assertions in IBRL with allocated IP test

### DIFF
--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_added.tmpl
@@ -1,7 +1,5 @@
  account | user_type           | groups | device   | location    | cyoa_type  | client_ip     | dz_ip         | accesspass     | tunnel_id | tunnel_net      | status    | owner
- IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4       | 1.2.3.4       | Prepaid: (MAX) | 500       | 169.254.0.2/31  | activated | {{.ClientPubkeyAddress}}
- IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5       | 2.3.4.5       | Prepaid: (MAX) | 501       | 169.254.0.4/31  | activated | {{.ClientPubkeyAddress}}
- IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6       | 3.4.5.6       | Prepaid: (MAX) | 502       | 169.254.0.6/31  | activated | {{.ClientPubkeyAddress}}
- IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7       | 4.5.6.7       | Prepaid: (MAX) | 503       | 169.254.0.8/31  | activated | {{.ClientPubkeyAddress}}
- IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8       | 5.6.7.8       | Prepaid: (MAX) | 504       | 169.254.0.10/31 | activated | {{.ClientPubkeyAddress}}
- IGNORED | IBRLWithAllocatedIP |        | ny5-dz01 | New York    | GREOverDIA | {{.ClientIP}} | {{.ExpectedAllocatedClientIP}} | Prepaid: (MAX) | 500       | 169.254.0.0/31  | activated | {{.ClientPubkeyAddress}}
+{{- range .IBRLUsers}}
+ IGNORED | IBRL                |        | la2-dz01 | Los Angeles | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | Prepaid: (MAX) | {{.TunnelID}} | {{.TunnelNet}} | activated | {{$.ClientPubkeyAddress}}
+{{- end}}
+ IGNORED | IBRLWithAllocatedIP |        | ny5-dz01 | New York    | GREOverDIA | {{.ClientIP}} | {{.ExpectedAllocatedClientIP}} | Prepaid: (MAX) | {{.AllocatedUserTunnelID}} | {{.AllocatedUserTunnelNet}} | activated | {{.ClientPubkeyAddress}}

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.tmpl
@@ -1,6 +1,4 @@
  account | user_type | groups | device   | location    | cyoa_type  | client_ip | dz_ip   | accesspass     | tunnel_id | tunnel_net      | status      | owner
- IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 1.2.3.4   | 1.2.3.4 | Prepaid: (MAX) | 500       | 169.254.0.2/31  | activated   | {{.ClientPubkeyAddress}}
- IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 2.3.4.5   | 2.3.4.5 | Prepaid: (MAX) | 501       | 169.254.0.4/31  | activated   | {{.ClientPubkeyAddress}}
- IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 3.4.5.6   | 3.4.5.6 | Prepaid: (MAX) | 502       | 169.254.0.6/31  | banned      | {{.ClientPubkeyAddress}}
- IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 4.5.6.7   | 4.5.6.7 | Prepaid: (MAX) | 503       | 169.254.0.8/31  | activated   | {{.ClientPubkeyAddress}}
- IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | 5.6.7.8   | 5.6.7.8 | Prepaid: (MAX) | 504       | 169.254.0.10/31 | activated   | {{.ClientPubkeyAddress}}
+{{- range .IBRLUsers}}
+ IGNORED | IBRL      |        | la2-dz01 | Los Angeles | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | Prepaid: (MAX) | {{.TunnelID}} | {{.TunnelNet}} | {{if eq .ClientIP "3.4.5.6"}}banned{{else}}activated{{end}} | {{$.ClientPubkeyAddress}}
+{{- end}}

--- a/e2e/ibrl_with_allocated_ip_test.go
+++ b/e2e/ibrl_with_allocated_ip_test.go
@@ -18,6 +18,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ibrlUserTunnelInfo holds tunnel assignment info for an IBRL user, parsed from user list output.
+type ibrlUserTunnelInfo struct {
+	ClientIP  string
+	TunnelID  string
+	TunnelNet string
+}
+
+// parseIBRLTunnelInfo parses user list output and returns tunnel info for IBRL and IBRLWithAllocatedIP users.
+func parseIBRLTunnelInfo(output []byte) (ibrlUsers []ibrlUserTunnelInfo, allocUserTunnelID, allocUserTunnelNet string) {
+	rows := fixtures.ParseCLITable(output)
+	for _, row := range rows {
+		switch row["user_type"] {
+		case "IBRL":
+			ibrlUsers = append(ibrlUsers, ibrlUserTunnelInfo{
+				ClientIP:  row["client_ip"],
+				TunnelID:  row["tunnel_id"],
+				TunnelNet: row["tunnel_net"],
+			})
+		case "IBRLWithAllocatedIP":
+			allocUserTunnelID = row["tunnel_id"]
+			allocUserTunnelNet = row["tunnel_net"]
+		}
+	}
+	return
+}
+
 func TestE2E_IBRL_WithAllocatedIP(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +146,11 @@ func checkIBRLWithAllocatedIPPostConnect(t *testing.T, dn *TestDevnet, device *d
 			t.Fail()
 		}
 
+		// Query actual tunnel assignments since tunnel IDs may not be allocated sequentially.
+		userListOutput, err := client.Exec(t.Context(), []string{"doublezero", "user", "list"})
+		require.NoError(t, err, "error querying user list for tunnel info")
+		ibrlUsers, allocatedUserTunnelID, allocatedUserTunnelNet := parseIBRLTunnelInfo(userListOutput)
+
 		tests := []struct {
 			name        string
 			fixturePath string
@@ -134,6 +165,9 @@ func checkIBRLWithAllocatedIPPostConnect(t *testing.T, dn *TestDevnet, device *d
 					"ClientPubkeyAddress":       client.Pubkey,
 					"DeviceIP":                  device.CYOANetworkIP,
 					"ExpectedAllocatedClientIP": expectedAllocatedClientIP,
+					"IBRLUsers":                 ibrlUsers,
+					"AllocatedUserTunnelID":     allocatedUserTunnelID,
+					"AllocatedUserTunnelNet":    allocatedUserTunnelNet,
 				},
 				cmd: []string{"doublezero", "user", "list"},
 			},
@@ -246,14 +280,14 @@ func checkIBRLWithAllocatedIPPostConnect(t *testing.T, dn *TestDevnet, device *d
 			t.Fail()
 		}
 
-		// User ban verified in the `doublezer_user_list_removed.txt` fixture.
+		// User ban verified in the `doublezero_user_list_user_removed.tmpl` fixture.
 		if !t.Run("ban_user", func(t *testing.T) {
 			t.Parallel()
 
-			// Find user with tunnel_net 169.254.0.6/31
-			output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero user list | grep 169.254.0.6/31"})
+			// Find IBRL user with client_ip 3.4.5.6
+			output, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero user list | grep 3.4.5.6"})
 			require.NoError(t, err)
-			require.NotEmpty(t, strings.TrimSpace(string(output)), "no user found with tunnel_net 169.254.0.6/31")
+			require.NotEmpty(t, strings.TrimSpace(string(output)), "no user found with client_ip 3.4.5.6")
 			userID := strings.TrimSpace(strings.Split(string(output), "|")[0])
 
 			// TODO: This is brittle, come up with a better solution.
@@ -338,8 +372,12 @@ func checkIBRLWithAllocatedIPPostDisconnect(t *testing.T, dn *TestDevnet, device
 			got, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero user list"})
 			require.NoError(t, err)
 
+			// Parse actual tunnel assignments since tunnel IDs may not be allocated sequentially.
+			ibrlUsers, _, _ := parseIBRLTunnelInfo(got)
+
 			want, err := fixtures.Render("fixtures/ibrl_with_allocated_addr/doublezero_user_list_user_removed.tmpl", map[string]any{
 				"ClientPubkeyAddress": client.Pubkey,
+				"IBRLUsers":           ibrlUsers,
 			})
 			require.NoError(t, err, "error reading user list fixture")
 

--- a/e2e/internal/fixtures/diff.go
+++ b/e2e/internal/fixtures/diff.go
@@ -53,6 +53,11 @@ func mapFromTable(output []byte, ignoreKeys []string) []map[string]string {
 	return sliceOfMaps
 }
 
+// ParseCLITable parses a pipe-delimited CLI table into a slice of maps keyed by column header.
+func ParseCLITable(output []byte) []map[string]string {
+	return mapFromTable(output, nil)
+}
+
 // canonicalKey builds a deterministic string representation of the map.
 func canonicalKey(m map[string]string, excludeKeys []string) string {
 	keys := make([]string, 0, len(m))


### PR DESCRIPTION
## Summary of Changes
- Replace hardcoded tunnel IDs (500-504) and tunnel_net values in IBRL user list fixtures with dynamic template variables populated from actual runtime allocations
- Parse tunnel assignments from `doublezero user list` output at runtime via new `ParseCLITable` helper and `parseIBRLTunnelInfo` function
- Fix `ban_user` subtest to find the target user by client_ip instead of hardcoded tunnel_net, which varies with non-sequential allocation
- Closes https://github.com/malbeclabs/doublezero/issues/2750

## Testing Verification
- Ran `TestE2E_IBRL_WithAllocatedIP` e2e test to verify fixture matching with dynamic tunnel IDs