### PR TITLE
qa: enable third qa host in devnet for multi-group multicast test

### DIFF
--- a/.github/workflows/qa.devnet.yml
+++ b/.github/workflows/qa.devnet.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test -tags=qa -short -v ./e2e --args -hosts=chi-dn-bm2,chi-dn-bm3 -env devnet
+      - run: go test -tags=qa -short -v ./e2e --args -hosts=chi-dn-bm2,chi-dn-bm3,chi-dn-bm4 -env devnet


### PR DESCRIPTION
## Summary of Changes
- Add third host to devnet QA run args for multi-group multicast test
- Fixes https://github.com/malbeclabs/doublezero/actions/runs/21518694482/job/62005006772

## Testing Verification
- 
