### PR TITLE
e2e: dump diagnostics on tunnel status wait timeout

### DIFF
--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -462,6 +462,7 @@ func (c *Client) dumpDiagnostics() {
 			command []string
 		}{
 			{"show running-config section Tunnel", []string{"Cli", "-p", "15", "-c", "show running-config section Tunnel"}},
+			{"show ip bgp summary", []string{"Cli", "-c", "show ip bgp summary"}},
 			{"show ip bgp summary vrf vrf1", []string{"Cli", "-c", "show ip bgp summary vrf vrf1"}},
 			{"doublezero-agent log (last 100 lines)", []string{"tail", "-100", "/var/log/agents-latest/doublezero-agent"}},
 			{"disk space /var/tmp", []string{"df", "-h", "/var/tmp"}},


### PR DESCRIPTION
## Summary
- When `WaitForTunnelStatus` times out, dump client and device diagnostics to stderr for debugging
- Covers all call sites via `WaitForTunnelUp`/`WaitForTunnelDisconnected` with no test code changes
- Output is buffered per-dump to avoid interleaving in parallel tests
- Includes controller config for each device to compare expected vs actual state

## Example output

Forced a 1s timeout on `TestE2E_Multicast` to trigger the dump:

```
=== DIAGNOSTIC DUMP (deploy=dz-e2e-TestE2E_Multicast-8817 client=CXXmMQviVF3zQYVyXcUGGTDx38WHXgcvd4ULRnhM1QAG) ===

--- Client: doublezero status
[{"tunnel_name":"doublezero1","tunnel_src":"9.180.179.100","tunnel_dst":"9.180.179.8","doublezero_ip":"9.180.179.138","doublezero_status":{"session_status":"Pending BGP Session","last_session_update":1769808953},"user_type":"Multicast"}]

--- Client: ip addr show
13: doublezero1@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1476 qdisc noqueue state UNKNOWN group default
    link/gre 9.180.179.100 peer 9.180.179.8
    inet 169.254.0.3/31 scope global doublezero1
    inet 9.180.179.138/32 scope global doublezero1
...

--- Client: ip route show
default via 192.168.0.1 dev eth1
9.180.179.0/24 dev eth0 proto kernel scope link src 9.180.179.100
169.254.0.2/31 dev doublezero1 proto kernel scope link src 169.254.0.3
233.84.178.0 via 169.254.0.2 dev doublezero1 proto static src 9.180.179.138
...

--- Client: doublezerod container logs (stdout)
{"time":"...","level":"INFO","msg":"network: starting network manager"}
{"time":"...","level":"INFO","msg":"bgp: starting bgp fsm"}
{"time":"...","level":"INFO","msg":"tunnel: adding address to tunnel interface","address":"169.254.0.3"}
{"time":"...","level":"INFO","msg":"tunnel: bringing up tunnel interface"}
{"time":"...","level":"INFO","msg":"[169.254.0.2] FSM-out transition disabled => idle"}
{"time":"...","level":"INFO","msg":"[169.254.0.2] FSM-out transition idle => connect"}

--- Device ny5-dz01: show running-config section Tunnel
mpls icmp ttl-exceeded tunneling

--- Device ny5-dz01: show ip bgp summary vrf vrf1
BGP summary information for VRF vrf1
Router identifier 9.180.179.8, local AS number 65342
Neighbor Status Codes: m - Under maintenance
  Neighbor V AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State   PfxRcd PfxAcc

--- Device ny5-dz01: doublezero-agent log (last 100 lines)
2026/01/30 21:35:24.514341 eapi.go:217: Received 1453 lines of configuration from controller
2026/01/30 21:35:25.206814 eapi.go:270: No changes detected, exiting config session without committing
2026/01/30 21:35:29.530755 eapi.go:217: Received 1471 lines of configuration from controller
2026/01/30 21:35:30.218970 eapi.go:273: Committing config session due to diffs detected: ...

--- Device ny5-dz01: disk space /var/tmp
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           410M  192K  410M   1% /var/tmp

--- Controller config for device ny5-dz01
!
logging buffered 128000
no logging console
...
interface Ethernet2
   mtu 2048
   no switchport
   ip address 172.16.0.17/31
   pim ipv4 sparse-mode
   isis enable 1
...

=== DIAGNOSTIC DUMP END ===
```

## Testing Verification
- Forced 1s timeout on `WaitForTunnelUp` in `TestE2E_Multicast`, confirmed diagnostic output appears
- Verified diagnostics do not appear on successful test runs
- BGP summary uses vrf1 to show client connections
- Controller config shows expected device configuration from controller