### PR TITLE
feat(cli): remove one tunnel restriction (#2725)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,27 +19,62 @@ fi
 
 # Check if any meaningful files are staged (excluding the changelog itself)
 has_changes=false
-changelog_updated=false
+changelog_staged=false
 
 for file in $STAGED_FILES; do
     if [[ "$file" == "CHANGELOG.md" ]]; then
-        changelog_updated=true
+        changelog_staged=true
     else
         has_changes=true
     fi
 done
 
-# If there are changes but changelog wasn't updated, fail
-if [ "$has_changes" = true ] && [ "$changelog_updated" = false ]; then
-    echo ""
-    echo "❌ CHANGELOG.md not updated"
-    echo ""
-    echo "Please update CHANGELOG.md with your changes."
-    echo ""
-    echo "To skip this check (use sparingly):"
-    echo "   git commit --no-verify"
-    echo ""
-    exit 1
+# If changelog is staged in this commit, we're good
+if [ "$changelog_staged" = true ]; then
+    exit 0
 fi
 
-exit 0
+# If no meaningful changes, we're good
+if [ "$has_changes" = false ]; then
+    exit 0
+fi
+
+# Check if changelog was updated anywhere in this branch compared to main/master
+# Try to find the base branch (main or master)
+base_branch=""
+if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    base_branch="origin/main"
+elif git rev-parse --verify main >/dev/null 2>&1; then
+    base_branch="main"
+elif git rev-parse --verify origin/master >/dev/null 2>&1; then
+    base_branch="origin/master"
+elif git rev-parse --verify master >/dev/null 2>&1; then
+    base_branch="master"
+fi
+
+if [ -n "$base_branch" ]; then
+    # Find the merge base between current branch and base branch
+    merge_base=$(git merge-base HEAD "$base_branch" 2>/dev/null || echo "")
+
+    if [ -n "$merge_base" ]; then
+        # Check if CHANGELOG.md was modified in any commit since the merge base
+        # Also include currently staged changes
+        changelog_in_branch=$(git diff --name-only "$merge_base" HEAD -- CHANGELOG.md 2>/dev/null || echo "")
+
+        if [ -n "$changelog_in_branch" ]; then
+            # Changelog was already updated in this branch
+            exit 0
+        fi
+    fi
+fi
+
+# If we get here, changelog hasn't been updated in this branch
+echo ""
+echo "❌ CHANGELOG.md not updated"
+echo ""
+echo "Please update CHANGELOG.md with your changes."
+echo ""
+echo "To skip this check (use sparingly):"
+echo "   git commit --no-verify"
+echo ""
+exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
   - Support publishing and subscribing to multiple multicast groups simultaneously
 - CLI
   - Support publishing and subscribing a user to multiple multicast groups via `--group` flag
+  - Remove single tunnel constraint 
 - SDK
   - Go SDK can now perform batch writes to device.health and link.health as per rfc12
 - Activator

--- a/e2e/fixtures/multicast/doublezero_status_connected_subscriber.tmpl
+++ b/e2e/fixtures/multicast/doublezero_status_connected_subscriber.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | N/A            | ✅ ny5-dz01           | N/A      | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/ibrl_multicast_coexistence_test.go
+++ b/e2e/ibrl_multicast_coexistence_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/malbeclabs/doublezero/e2e/internal/arista"
 	"github.com/malbeclabs/doublezero/e2e/internal/devnet"
 	"github.com/malbeclabs/doublezero/e2e/internal/docker"
-	"github.com/malbeclabs/doublezero/e2e/internal/netutil"
 	"github.com/malbeclabs/doublezero/e2e/internal/random"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +21,6 @@ import (
 // can coexist on the same device. Since a single client cannot have both modes
 // simultaneously, we test with multiple clients on the same device.
 func TestE2E_IBRL_Multicast_Coexistence(t *testing.T) {
-	// Skip test for now pending CLI changes
-	t.Skip()
 	t.Parallel()
 
 	dn, device, ibrlClient, mcastClient := setupCoexistenceTestDevnet(t)
@@ -39,8 +36,6 @@ func TestE2E_IBRL_Multicast_Coexistence(t *testing.T) {
 // TestE2E_IBRL_Multicast_Publisher_Coexistence tests IBRL and multicast publisher coexistence.
 // This is a separate test from the subscriber test to avoid devnet lifecycle issues.
 func TestE2E_IBRL_Multicast_Publisher_Coexistence(t *testing.T) {
-	// Skip test for now pending CLI changes
-	t.Skip()
 	t.Parallel()
 
 	dn, device, ibrlClient, mcastClient := setupCoexistenceTestDevnet(t)
@@ -56,8 +51,6 @@ func TestE2E_IBRL_Multicast_Publisher_Coexistence(t *testing.T) {
 // TestE2E_IBRL_AllocatedAddr_Multicast_Coexistence verifies that IBRL mode with allocated address
 // and multicast subscriber can coexist on the same device.
 func TestE2E_IBRL_AllocatedAddr_Multicast_Coexistence(t *testing.T) {
-	// Skip test for now pending CLI changes
-	t.Skip()
 	t.Parallel()
 
 	dn, device, ibrlClient, mcastClient := setupCoexistenceTestDevnet(t)
@@ -73,8 +66,6 @@ func TestE2E_IBRL_AllocatedAddr_Multicast_Coexistence(t *testing.T) {
 // TestE2E_IBRL_AllocatedAddr_Multicast_Publisher_Coexistence tests IBRL with allocated address
 // and multicast publisher coexistence.
 func TestE2E_IBRL_AllocatedAddr_Multicast_Publisher_Coexistence(t *testing.T) {
-	// Skip test for now pending CLI changes
-	t.Skip()
 	t.Parallel()
 
 	dn, device, ibrlClient, mcastClient := setupCoexistenceTestDevnet(t)
@@ -85,6 +76,452 @@ func TestE2E_IBRL_AllocatedAddr_Multicast_Publisher_Coexistence(t *testing.T) {
 	}) {
 		t.Fail()
 	}
+}
+
+// TestE2E_SingleClient_IBRL_Then_Multicast verifies that a single client can have
+// both IBRL (unicast) and multicast tunnels simultaneously by first connecting
+// with IBRL mode and then adding a multicast subscription.
+func TestE2E_SingleClient_IBRL_Then_Multicast(t *testing.T) {
+	t.Parallel()
+
+	dn, device, mcastDevice, client := setupSingleClientTestDevnet(t)
+	log := logger.With("test", t.Name())
+
+	if !t.Run("single_client_ibrl_then_multicast_subscriber", func(t *testing.T) {
+		runSingleClientIBRLThenMulticastTest(t, log, dn, device, mcastDevice, client, false, false)
+	}) {
+		t.Fail()
+	}
+}
+
+// TestE2E_SingleClient_IBRL_AllocatedAddr_Then_Multicast tests a single client with
+// allocated address connecting to IBRL first, then adding multicast.
+func TestE2E_SingleClient_IBRL_AllocatedAddr_Then_Multicast(t *testing.T) {
+	t.Parallel()
+
+	dn, device, mcastDevice, client := setupSingleClientTestDevnet(t)
+	log := logger.With("test", t.Name())
+
+	if !t.Run("single_client_ibrl_allocated_then_multicast_subscriber", func(t *testing.T) {
+		runSingleClientIBRLThenMulticastTest(t, log, dn, device, mcastDevice, client, true, false)
+	}) {
+		t.Fail()
+	}
+}
+
+// TestE2E_SingleClient_IBRL_Then_Multicast_Publisher tests a single client connecting
+// to IBRL first, then adding multicast publisher capability.
+func TestE2E_SingleClient_IBRL_Then_Multicast_Publisher(t *testing.T) {
+	t.Parallel()
+
+	dn, device, mcastDevice, client := setupSingleClientTestDevnet(t)
+	log := logger.With("test", t.Name())
+
+	if !t.Run("single_client_ibrl_then_multicast_publisher", func(t *testing.T) {
+		runSingleClientIBRLThenMulticastTest(t, log, dn, device, mcastDevice, client, false, true)
+	}) {
+		t.Fail()
+	}
+}
+
+// TestE2E_Multicast_PublisherXorSubscriber verifies that a client cannot be both
+// a multicast publisher and subscriber simultaneously. A user must be exclusively
+// a publisher (of one or more groups) XOR a subscriber (of one or more groups).
+// This test uses two separate clients from the same devnet to test both directions:
+// - Client 1 (ibrlClient): subscriber first, then try publisher (should fail)
+// - Client 2 (mcastClient): publisher first, then try subscriber (should fail)
+func TestE2E_Multicast_PublisherXorSubscriber(t *testing.T) {
+	t.Parallel()
+
+	_, _, ibrlClient, mcastClient := setupCoexistenceTestDevnet(t)
+	log := logger.With("test", t.Name())
+
+	// Use ibrlClient for "subscriber then publisher" test
+	// Use mcastClient for "publisher then subscriber" test
+
+	t.Run("subscriber_cannot_add_publisher", func(t *testing.T) {
+		client := ibrlClient
+		log := log.With("subtest", "subscriber_cannot_add_publisher")
+
+		// First, connect as a multicast subscriber
+		log.Info("==> Connecting as multicast subscriber first")
+		subCmd := "doublezero connect multicast subscriber mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+		subOutput, err := client.Exec(t.Context(), []string{"bash", "-c", subCmd})
+		log.Info("==> Subscriber connect output", "output", string(subOutput))
+		require.NoError(t, err, "should be able to connect as subscriber")
+
+		// Wait for tunnel to come up
+		err = client.WaitForTunnelUp(t.Context(), 90*time.Second)
+		require.NoError(t, err, "subscriber tunnel should come up")
+		log.Info("--> Subscriber tunnel is up")
+
+		// Now try to also connect as a publisher - this should fail
+		log.Info("==> Attempting to also connect as multicast publisher (should fail)")
+		pubCmd := "doublezero connect multicast publisher mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+		pubOutput, err := client.Exec(t.Context(), []string{"bash", "-c", pubCmd})
+		log.Info("==> Publisher connect output", "output", string(pubOutput))
+
+		// The command should fail with an error indicating cannot be both
+		require.Error(t, err, "should not be able to connect as both publisher and subscriber")
+		require.Contains(t, string(pubOutput), "cannot be both a publisher and subscriber",
+			"error message should indicate the constraint violation")
+
+		log.Info("--> Correctly rejected attempt to be both publisher and subscriber")
+
+		// Verify we still have exactly one tunnel (the subscriber)
+		tunnelStatus, err := client.GetTunnelStatus(t.Context())
+		require.NoError(t, err)
+		require.Len(t, tunnelStatus, 1, "should still have exactly one tunnel")
+		require.Equal(t, devnet.ClientUserTypeMulticast, tunnelStatus[0].UserType,
+			"tunnel should still be multicast type")
+
+		log.Info("--> Verified: subscriber cannot add publisher subscription")
+	})
+
+	t.Run("publisher_cannot_add_subscriber", func(t *testing.T) {
+		client := mcastClient
+		log := log.With("subtest", "publisher_cannot_add_subscriber")
+
+		// First, connect as a multicast publisher
+		log.Info("==> Connecting as multicast publisher first")
+		pubCmd := "doublezero connect multicast publisher mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+		pubOutput, err := client.Exec(t.Context(), []string{"bash", "-c", pubCmd})
+		log.Info("==> Publisher connect output", "output", string(pubOutput))
+		require.NoError(t, err, "should be able to connect as publisher")
+
+		// Wait for tunnel to come up
+		err = client.WaitForTunnelUp(t.Context(), 90*time.Second)
+		require.NoError(t, err, "publisher tunnel should come up")
+		log.Info("--> Publisher tunnel is up")
+
+		// Now try to also connect as a subscriber - this should fail
+		log.Info("==> Attempting to also connect as multicast subscriber (should fail)")
+		subCmd := "doublezero connect multicast subscriber mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+		subOutput, err := client.Exec(t.Context(), []string{"bash", "-c", subCmd})
+		log.Info("==> Subscriber connect output", "output", string(subOutput))
+
+		// The command should fail with an error indicating cannot be both
+		require.Error(t, err, "should not be able to connect as both publisher and subscriber")
+		require.Contains(t, string(subOutput), "cannot be both a publisher and subscriber",
+			"error message should indicate the constraint violation")
+
+		log.Info("--> Correctly rejected attempt to be both publisher and subscriber")
+
+		// Verify we still have exactly one tunnel (the publisher)
+		tunnelStatus, err := client.GetTunnelStatus(t.Context())
+		require.NoError(t, err)
+		require.Len(t, tunnelStatus, 1, "should still have exactly one tunnel")
+		require.Equal(t, devnet.ClientUserTypeMulticast, tunnelStatus[0].UserType,
+			"tunnel should still be multicast type")
+
+		log.Info("--> Verified: publisher cannot add subscriber subscription")
+	})
+
+	log.Info("--> Test completed: user can only be publisher XOR subscriber, not both")
+}
+
+// setupSingleClientTestDevnet sets up a devnet with a single client for testing
+// concurrent IBRL+multicast on the same user account.
+func setupSingleClientTestDevnet(t *testing.T) (*devnet.Devnet, *devnet.Device, *devnet.Device, *devnet.Client) {
+	deployID := "dz-e2e-" + t.Name() + "-" + random.ShortID()
+	log := logger.With("test", t.Name(), "deployID", deployID)
+
+	log.Info("==> Setting up single client test devnet")
+
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	serviceabilityProgramKeypairPath := filepath.Join(currentDir, "data", "serviceability-program-keypair.json")
+
+	dn, err := devnet.New(devnet.DevnetSpec{
+		DeployID:  deployID,
+		DeployDir: t.TempDir(),
+
+		CYOANetwork: devnet.CYOANetworkSpec{
+			CIDRPrefix: subnetCIDRPrefix,
+		},
+		Manager: devnet.ManagerSpec{
+			ServiceabilityProgramKeypairPath: serviceabilityProgramKeypairPath,
+		},
+	}, log, dockerClient, subnetAllocator)
+	require.NoError(t, err)
+
+	log.Info("==> Starting devnet")
+	err = dn.Start(t.Context(), nil)
+	require.NoError(t, err)
+	log.Info("--> Devnet started")
+
+	// Add the main device for IBRL testing
+	log.Info("==> Adding device ny5-dz01")
+	device, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
+		Code:                         "ny5-dz01",
+		Location:                     "ewr",
+		Exchange:                     "xewr",
+		CYOANetworkIPHostID:          8,
+		CYOANetworkAllocatablePrefix: 29,
+	})
+	require.NoError(t, err)
+	log.Info("--> Device added", "deviceID", device.ID)
+
+	// Add second device for multicast (separate device required for concurrent tunnels)
+	log.Info("==> Adding device pit-dz01")
+	mcastDevice, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
+		Code:                         "pit-dz01",
+		Location:                     "pit",
+		Exchange:                     "xpit",
+		CYOANetworkIPHostID:          16,
+		CYOANetworkAllocatablePrefix: 29,
+	})
+	require.NoError(t, err)
+	log.Info("--> Multicast device added", "deviceID", mcastDevice.ID)
+
+	// Add additional devices for iBGP/MSDP peering
+	log.Info("==> Creating additional devices onchain")
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+		set -euo pipefail
+
+		echo "==> Populate device interface information onchain"
+		doublezero device interface create ny5-dz01 "Ethernet2" -w
+		doublezero device interface create ny5-dz01 "Loopback255" --loopback-type vpnv4 -w
+		doublezero device interface create ny5-dz01 "Loopback256" --loopback-type ipv4 -w
+		doublezero device interface create pit-dz01 "Ethernet2" -w
+		doublezero device interface create pit-dz01 "Loopback255" --loopback-type vpnv4 -w
+		doublezero device interface create pit-dz01 "Loopback256" --loopback-type ipv4 -w
+
+		echo "--> Device information onchain:"
+		doublezero device list
+	`})
+	require.NoError(t, err)
+
+	// Add single client that will be used for both IBRL and multicast
+	log.Info("==> Adding client for dual-mode testing")
+	client, err := dn.AddClient(t.Context(), devnet.ClientSpec{
+		CYOANetworkIPHostID: 100,
+	})
+	require.NoError(t, err)
+	log.Info("--> Client added", "clientIP", client.CYOANetworkIP, "pubkey", client.Pubkey)
+
+	// Create multicast group and add client to allowlists
+	log.Info("==> Creating multicast group onchain")
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+		set -euo pipefail
+
+		echo "==> Create multicast group"
+		doublezero multicast group create --code mg01 --max-bandwidth 10Gbps --owner me -w
+
+		echo "--> Multicast group created:"
+		doublezero multicast group list
+	`})
+	require.NoError(t, err)
+
+	// Add client to multicast allowlists (both publisher and subscriber)
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+		doublezero multicast group allowlist publisher add --code mg01 --user-payer me --client-ip ` + client.CYOANetworkIP + `
+		doublezero multicast group allowlist subscriber add --code mg01 --user-payer me --client-ip ` + client.CYOANetworkIP + `
+		doublezero multicast group allowlist publisher add --code mg01 --user-payer ` + client.Pubkey + ` --client-ip ` + client.CYOANetworkIP + `
+		doublezero multicast group allowlist subscriber add --code mg01 --user-payer ` + client.Pubkey + ` --client-ip ` + client.CYOANetworkIP + `
+	`})
+	require.NoError(t, err)
+
+	// Wait for latency results from both devices
+	log.Info("==> Waiting for latency results")
+	err = client.WaitForLatencyResults(t.Context(), device.ID, 75*time.Second)
+	require.NoError(t, err)
+	err = client.WaitForLatencyResults(t.Context(), mcastDevice.ID, 75*time.Second)
+	require.NoError(t, err)
+	log.Info("--> Latency results received from both devices")
+
+	log.Info("--> Single client test devnet setup complete")
+
+	return dn, device, mcastDevice, client
+}
+
+// runSingleClientIBRLThenMulticastTest tests a single client connecting with IBRL first,
+// then adding multicast capability. The IBRL tunnel goes to device and multicast goes to mcastDevice.
+func runSingleClientIBRLThenMulticastTest(t *testing.T, log *slog.Logger, dn *devnet.Devnet, device *devnet.Device,
+	mcastDevice *devnet.Device, client *devnet.Client, useAllocatedAddr bool, asPublisher bool,
+) {
+	mode := "standard"
+	if useAllocatedAddr {
+		mode = "allocated_addr"
+	}
+	mcastType := "subscriber"
+	if asPublisher {
+		mcastType = "publisher"
+	}
+	log = log.With("mode", mode, "multicast_type", mcastType)
+
+	// === CONNECT PHASE 1: IBRL ===
+	log.Info("==> CONNECT PHASE 1: IBRL")
+
+	// Set access pass for the client
+	log.Info("==> Setting access pass")
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
+	require.NoError(t, err)
+
+	// Connect IBRL client (latency-based device selection)
+	log.Info("==> Connecting client with IBRL", "useAllocatedAddr", useAllocatedAddr)
+	ibrlCmd := "doublezero connect ibrl --client-ip " + client.CYOANetworkIP
+	if useAllocatedAddr {
+		ibrlCmd += " --allocate-addr"
+	}
+	_, err = client.Exec(t.Context(), []string{"bash", "-c", ibrlCmd})
+	require.NoError(t, err)
+
+	// Wait for IBRL tunnel to come up
+	log.Info("==> Waiting for IBRL tunnel to come up")
+	err = client.WaitForTunnelUp(t.Context(), 90*time.Second)
+	require.NoError(t, err, "IBRL tunnel failed to come up")
+	log.Info("--> IBRL tunnel is up")
+
+	// Determine which device the IBRL tunnel connected to (may differ from expected due to latency selection)
+	tunnelStatus, err := client.GetTunnelStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tunnelStatus, 1, "expected exactly one tunnel")
+	ibrlTunnelDst := tunnelStatus[0].TunnelDst.String()
+	log.Info("==> IBRL tunnel destination", "tunnelDst", ibrlTunnelDst)
+
+	// Determine actual IBRL and multicast devices based on tunnel destination
+	var ibrlDevice, actualMcastDevice *devnet.Device
+	if ibrlTunnelDst == device.CYOANetworkIP {
+		ibrlDevice = device
+		actualMcastDevice = mcastDevice
+	} else if ibrlTunnelDst == mcastDevice.CYOANetworkIP {
+		ibrlDevice = mcastDevice
+		actualMcastDevice = device
+	} else {
+		t.Fatalf("IBRL tunnel destination %s doesn't match any device (device=%s, mcastDevice=%s)",
+			ibrlTunnelDst, device.CYOANetworkIP, mcastDevice.CYOANetworkIP)
+	}
+	log.Info("==> Device assignment", "ibrlDevice", ibrlDevice.Spec.Code, "mcastDevice", actualMcastDevice.Spec.Code)
+
+	// Verify IBRL is working on the actual device
+	log.Info("==> Verifying IBRL client")
+	verifyIBRLClient(t, log, ibrlDevice, client, useAllocatedAddr)
+	log.Info("--> IBRL client verified")
+
+	// === CONNECT PHASE 2: Add Multicast (creates separate Multicast user) ===
+	log.Info("==> CONNECT PHASE 2: Adding multicast (will create separate Multicast user)")
+
+	// Connect multicast (creates a NEW Multicast user, separate from IBRL user)
+	var mcastCmd string
+	if asPublisher {
+		log.Info("==> Adding multicast publisher subscription")
+		mcastCmd = "doublezero connect multicast publisher mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+	} else {
+		log.Info("==> Adding multicast subscriber subscription")
+		mcastCmd = "doublezero connect multicast subscriber mg01 --client-ip " + client.CYOANetworkIP + " 2>&1"
+	}
+	mcastOutput, err := client.Exec(t.Context(), []string{"bash", "-c", mcastCmd})
+	log.Info("==> Multicast connect command output", "output", string(mcastOutput))
+	require.NoError(t, err)
+
+	// List users to see if the Multicast user was created
+	listUsersCmd := "doublezero user list --client-ip " + client.CYOANetworkIP + " 2>&1"
+	listOutput, _ := client.Exec(t.Context(), []string{"bash", "-c", listUsersCmd})
+	log.Info("==> Users after multicast connect", "output", string(listOutput))
+
+	// Wait for agent config to be pushed to the multicast device BEFORE waiting for tunnel
+	// This is critical because the device needs to have the tunnel configured before the
+	// client's BGP session can be established
+	log.Info("==> Waiting for agent config to be pushed to multicast device",
+		"device", actualMcastDevice.Spec.Code,
+		"deviceID", actualMcastDevice.ID,
+		"deviceIP", actualMcastDevice.CYOANetworkIP,
+		"ibrlDeviceCode", ibrlDevice.Spec.Code,
+		"ibrlDeviceID", ibrlDevice.ID,
+		"ibrlDeviceIP", ibrlDevice.CYOANetworkIP)
+	waitForAgentConfigWithClient(t, log, dn, actualMcastDevice, client)
+	log.Info("--> Agent config pushed to multicast device")
+
+	// Give time for agent to apply the configuration
+	log.Info("==> Waiting for agent to apply configuration")
+	time.Sleep(10 * time.Second)
+
+	// Wait for BOTH tunnels (IBRL and Multicast) to be up on the client
+	log.Info("==> Waiting for both tunnels (IBRL and Multicast) to be up")
+	err = client.WaitForNTunnelsUp(t.Context(), 2, 90*time.Second)
+	require.NoError(t, err, "Both tunnels (IBRL and Multicast) should be up")
+	log.Info("--> Both tunnels are up")
+
+	// Log tunnel status for debugging
+	tunnelStatus, err = client.GetTunnelStatus(t.Context())
+	require.NoError(t, err)
+	log.Info("==> Tunnel status after multicast connect", "tunnels", tunnelStatus)
+
+	// Verify CLI status shows correct device/metro for all tunnels
+	log.Info("==> Verifying CLI status shows correct device/metro for all tunnels")
+	cliStatus, err := client.GetCLIStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, cliStatus, 2, "expected two tunnels in CLI status")
+
+	for _, status := range cliStatus {
+		switch status.Response.UserType {
+		case devnet.ClientUserTypeIBRL, devnet.ClientUserTypeIBRLWithAllocated:
+			require.NotEqual(t, "N/A", status.CurrentDevice,
+				"IBRL tunnel should have a current_device, got N/A")
+			require.NotEqual(t, "N/A", status.Metro,
+				"IBRL tunnel should have a metro, got N/A")
+		case devnet.ClientUserTypeMulticast:
+			// Both publishers and subscribers can be matched to a device via tunnel_dst (device public IP)
+			require.NotEqual(t, "N/A", status.CurrentDevice,
+				"Multicast tunnel should have a current_device, got N/A")
+			require.NotEqual(t, "N/A", status.Metro,
+				"Multicast tunnel should have a metro, got N/A")
+		default:
+			t.Fatalf("unexpected user type in CLI status: %s", status.Response.UserType)
+		}
+	}
+	log.Info("--> CLI status verified: all tunnels have device/metro info")
+
+	// === VERIFICATION PHASE ===
+	log.Info("==> VERIFICATION PHASE: Both tunnels should work")
+
+	// Verify IBRL still works on its device
+	log.Info("==> Verifying IBRL still works after adding multicast", "ibrlDevice", ibrlDevice.Spec.Code)
+	verifyIBRLClientBGPEstablished(t, log, ibrlDevice)
+	log.Info("--> IBRL BGP still established")
+
+	// Verify multicast is working on the other device
+	// Note: Agent config was already pushed and applied before waiting for tunnels above
+
+	if asPublisher {
+		// Publishers don't use PIM - they just send traffic and the device creates (S,G) state
+		verifyConcurrentMulticastPublisherMrouteState(t, log, actualMcastDevice, client)
+	} else {
+		// Subscribers need PIM adjacency to receive multicast traffic
+		verifyConcurrentMulticastPIMAdjacency(t, log, actualMcastDevice)
+		log.Info("--> PIM adjacency established on multicast device")
+	}
+
+	log.Info("--> Both IBRL and multicast verified as working on same client (separate tunnels)")
+
+	// === DISCONNECT PHASE ===
+	log.Info("==> DISCONNECT PHASE")
+
+	// Disconnect multicast first
+	log.Info("==> Disconnecting multicast")
+	_, disconnectMcastErr := client.Exec(t.Context(), []string{"bash", "-c", "doublezero disconnect multicast --client-ip " + client.CYOANetworkIP})
+	if disconnectMcastErr != nil {
+		log.Info("--> Warning: Multicast disconnect failed (ledger may be unavailable)", "error", disconnectMcastErr)
+	}
+
+	// Verify IBRL still works after multicast disconnect
+	log.Info("==> Verifying IBRL still works after multicast disconnect")
+	verifyIBRLClientBGPEstablished(t, log, ibrlDevice)
+	log.Info("--> IBRL still working after multicast disconnect")
+
+	// Disconnect IBRL
+	log.Info("==> Disconnecting IBRL")
+	_, disconnectErr := client.Exec(t.Context(), []string{"bash", "-c", "doublezero disconnect --client-ip " + client.CYOANetworkIP})
+	if disconnectErr != nil {
+		log.Info("--> Warning: IBRL disconnect failed (ledger may be unavailable)", "error", disconnectErr)
+	} else {
+		// Only verify tunnel removal if disconnect succeeded
+		log.Info("==> Verifying tunnel removed")
+		verifyTunnelRemoved(t, client, "doublezero0")
+	}
+
+	log.Info("--> Single client IBRL+multicast test completed successfully")
 }
 
 func setupCoexistenceTestDevnet(t *testing.T) (*devnet.Devnet, *devnet.Device, *devnet.Client, *devnet.Client) {
@@ -180,13 +617,25 @@ func setupCoexistenceTestDevnet(t *testing.T) (*devnet.Devnet, *devnet.Device, *
 	`})
 	require.NoError(t, err)
 
-	// Add multicast client to allowlists (both publisher and subscriber)
+	// Add both clients to allowlists (both publisher and subscriber)
+	// ibrlClient is used for the XOR constraint test as well as IBRL tests
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+		doublezero multicast group allowlist publisher add --code mg01 --user-payer me --client-ip ` + ibrlClient.CYOANetworkIP + `
+		doublezero multicast group allowlist subscriber add --code mg01 --user-payer me --client-ip ` + ibrlClient.CYOANetworkIP + `
+		doublezero multicast group allowlist publisher add --code mg01 --user-payer ` + ibrlClient.Pubkey + ` --client-ip ` + ibrlClient.CYOANetworkIP + `
+		doublezero multicast group allowlist subscriber add --code mg01 --user-payer ` + ibrlClient.Pubkey + ` --client-ip ` + ibrlClient.CYOANetworkIP + `
 		doublezero multicast group allowlist publisher add --code mg01 --user-payer me --client-ip ` + mcastClient.CYOANetworkIP + `
 		doublezero multicast group allowlist subscriber add --code mg01 --user-payer me --client-ip ` + mcastClient.CYOANetworkIP + `
 		doublezero multicast group allowlist publisher add --code mg01 --user-payer ` + mcastClient.Pubkey + ` --client-ip ` + mcastClient.CYOANetworkIP + `
 		doublezero multicast group allowlist subscriber add --code mg01 --user-payer ` + mcastClient.Pubkey + ` --client-ip ` + mcastClient.CYOANetworkIP + `
 	`})
+	require.NoError(t, err)
+
+	// Set access passes for both clients
+	log.Info("==> Setting access passes for both clients")
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + ibrlClient.CYOANetworkIP + " --user-payer " + ibrlClient.Pubkey})
+	require.NoError(t, err)
+	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + mcastClient.CYOANetworkIP + " --user-payer " + mcastClient.Pubkey})
 	require.NoError(t, err)
 
 	// Wait for latency results for all clients
@@ -204,8 +653,8 @@ func setupCoexistenceTestDevnet(t *testing.T) (*devnet.Devnet, *devnet.Device, *
 
 // runIBRLWithMulticastSubscriberTest tests IBRL and multicast subscriber coexistence.
 func runIBRLWithMulticastSubscriberTest(t *testing.T, log *slog.Logger, dn *devnet.Devnet, device *devnet.Device,
-	ibrlClient, mcastClient *devnet.Client, useAllocatedAddr bool) {
-
+	ibrlClient, mcastClient *devnet.Client, useAllocatedAddr bool,
+) {
 	mode := "standard"
 	if useAllocatedAddr {
 		mode = "allocated_addr"
@@ -244,12 +693,40 @@ func runIBRLWithMulticastSubscriberTest(t *testing.T, log *slog.Logger, dn *devn
 	require.NoError(t, err, "Multicast subscriber tunnel failed to come up")
 	log.Info("--> All tunnels are up")
 
+	// Verify CLI status shows correct device/metro for both clients
+	log.Info("==> Verifying CLI status shows correct device/metro for both clients")
+	ibrlCLIStatus, err := ibrlClient.GetCLIStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, ibrlCLIStatus, 1, "expected one tunnel for IBRL client")
+	require.NotEqual(t, "N/A", ibrlCLIStatus[0].CurrentDevice,
+		"IBRL tunnel should have a current_device, got N/A")
+	require.NotEqual(t, "N/A", ibrlCLIStatus[0].Metro,
+		"IBRL tunnel should have a metro, got N/A")
+
+	mcastCLIStatus, err := mcastClient.GetCLIStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, mcastCLIStatus, 1, "expected one tunnel for multicast client")
+	// Multicast subscribers can be matched to a device via tunnel_dst (device public IP)
+	require.NotEqual(t, "N/A", mcastCLIStatus[0].CurrentDevice,
+		"Multicast subscriber tunnel should have a current_device, got N/A")
+	require.NotEqual(t, "N/A", mcastCLIStatus[0].Metro,
+		"Multicast subscriber tunnel should have a metro, got N/A")
+	log.Info("--> CLI status verified: all tunnels have device/metro info")
+
 	// === COEXISTENCE VERIFICATION ===
 	log.Info("==> COEXISTENCE VERIFICATION PHASE")
 
 	log.Info("==> Waiting for agent config to include multicast subscriber")
 	waitForAgentConfigWithClient(t, log, dn, device, mcastClient)
 
+	// Wait for agent config to be applied and verifications to pass
+	log.Info("==> Waiting for agent config to be applied to device")
+	require.Eventually(t, func() bool {
+		return checkIBRLClientReady(t, log, device, ibrlClient, useAllocatedAddr) &&
+			checkMulticastSubscriberPIMAdjacency(t, log, device)
+	}, 60*time.Second, 2*time.Second, "agent config not applied within timeout")
+
+	log.Info("--> Agent config applied, running final verification")
 	verifyIBRLClient(t, log, device, ibrlClient, useAllocatedAddr)
 	verifyMulticastSubscriberPIMAdjacency(t, log, device)
 
@@ -287,8 +764,8 @@ func runIBRLWithMulticastSubscriberTest(t *testing.T, log *slog.Logger, dn *devn
 
 // runIBRLWithMulticastPublisherTest tests IBRL and multicast publisher coexistence.
 func runIBRLWithMulticastPublisherTest(t *testing.T, log *slog.Logger, dn *devnet.Devnet, device *devnet.Device,
-	ibrlClient, mcastClient *devnet.Client, useAllocatedAddr bool) {
-
+	ibrlClient, mcastClient *devnet.Client, useAllocatedAddr bool,
+) {
 	mode := "standard"
 	if useAllocatedAddr {
 		mode = "allocated_addr"
@@ -326,6 +803,26 @@ func runIBRLWithMulticastPublisherTest(t *testing.T, log *slog.Logger, dn *devne
 	err = mcastClient.WaitForTunnelUp(t.Context(), 90*time.Second)
 	require.NoError(t, err, "Multicast publisher tunnel failed to come up")
 	log.Info("--> All tunnels are up")
+
+	// Verify CLI status shows correct device/metro for both clients
+	log.Info("==> Verifying CLI status shows correct device/metro for both clients")
+	ibrlCLIStatus, err := ibrlClient.GetCLIStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, ibrlCLIStatus, 1, "expected one tunnel for IBRL client")
+	require.NotEqual(t, "N/A", ibrlCLIStatus[0].CurrentDevice,
+		"IBRL tunnel should have a current_device, got N/A")
+	require.NotEqual(t, "N/A", ibrlCLIStatus[0].Metro,
+		"IBRL tunnel should have a metro, got N/A")
+
+	mcastCLIStatus, err := mcastClient.GetCLIStatus(t.Context())
+	require.NoError(t, err)
+	require.Len(t, mcastCLIStatus, 1, "expected one tunnel for multicast client")
+	// Multicast publishers can be matched to a device via tunnel_dst (device public IP)
+	require.NotEqual(t, "N/A", mcastCLIStatus[0].CurrentDevice,
+		"Multicast publisher tunnel should have a current_device, got N/A")
+	require.NotEqual(t, "N/A", mcastCLIStatus[0].Metro,
+		"Multicast publisher tunnel should have a metro, got N/A")
+	log.Info("--> CLI status verified: all tunnels have device/metro info")
 
 	// === COEXISTENCE VERIFICATION ===
 	log.Info("==> COEXISTENCE VERIFICATION PHASE")
@@ -429,49 +926,209 @@ func verifyIBRLClientBGPEstablished(t *testing.T, log *slog.Logger, device *devn
 	t.Fatalf("BGP session not established within timeout")
 }
 
+// checkIBRLClientReady checks if the IBRL client is ready (non-fatal version for polling).
+func checkIBRLClientReady(t *testing.T, log *slog.Logger, device *devnet.Device, client *devnet.Client, allocatedAddr bool) bool {
+	// Check doublezero0 interface exists
+	links, err := client.ExecReturnJSONList(t.Context(), []string{"bash", "-c", "ip -j link show dev doublezero0"})
+	if err != nil || len(links) != 1 {
+		return false
+	}
+
+	// Check BGP session is Established
+	neighbors, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPBGPSummary](t.Context(), device, arista.ShowIPBGPSummaryCmd("vrf1"))
+	if err != nil {
+		return false
+	}
+
+	peer, ok := neighbors.VRFs["vrf1"].Peers[expectedLinkLocalAddr]
+	if !ok || peer.PeerState != "Established" {
+		return false
+	}
+
+	return true
+}
+
+// checkMulticastSubscriberPIMAdjacency checks if PIM adjacency is formed (non-fatal version for polling).
+func checkMulticastSubscriberPIMAdjacency(t *testing.T, log *slog.Logger, device *devnet.Device) bool {
+	pim, err := devnet.DeviceExecAristaCliJSON[*arista.ShowPIMNeighbors](t.Context(), device, arista.ShowPIMNeighborsCmd())
+	if err != nil {
+		return false
+	}
+
+	for _, vrf := range pim.VRFs {
+		for intfName, intf := range vrf.Interfaces {
+			for addr := range intf.Neighbors {
+				if strings.HasPrefix(addr, "169.254.0.") {
+					if len(intfName) >= 6 && intfName[:6] == "Tunnel" {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 // verifyMulticastSubscriberPIMAdjacency verifies PIM adjacency is formed on the device for subscriber.
+// This function looks for any PIM neighbor on a Tunnel interface in the 169.254.0.x range.
+// In coexistence tests with multiple clients, the multicast client may not get 169.254.0.1
+// (e.g., if IBRL client connected first and got 169.254.0.1, multicast client gets 169.254.0.3).
 func verifyMulticastSubscriberPIMAdjacency(t *testing.T, log *slog.Logger, device *devnet.Device) {
 	log.Info("==> Verifying multicast subscriber PIM adjacency")
 
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
 		pim, err := devnet.DeviceExecAristaCliJSON[*arista.ShowPIMNeighbors](t.Context(), device, arista.ShowPIMNeighborsCmd())
 		require.NoError(t, err, "error fetching pim neighbors from doublezero device")
 
-		defaultVRF, ok := pim.VRFs["default"]
-		if !ok {
-			log.Debug("No default VRF in PIM neighbors")
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		for ifName, iface := range defaultVRF.Interfaces {
-			if strings.HasPrefix(ifName, "Tunnel") {
-				if _, ok := iface.Neighbors[expectedLinkLocalAddr]; ok {
-					log.Info("--> PIM adjacency verified", "interface", ifName, "address", expectedLinkLocalAddr)
-					return
+		// Look for any PIM neighbor in the 169.254.0.x range on a Tunnel interface
+		// The JSON structure is: vrfs -> vrf_name -> interfaces -> interface_name -> neighbors -> address -> details
+		for _, vrf := range pim.VRFs {
+			for intfName, intf := range vrf.Interfaces {
+				for addr, neighbor := range intf.Neighbors {
+					if strings.HasPrefix(addr, "169.254.0.") {
+						if len(intfName) >= 6 && intfName[:6] == "Tunnel" {
+							log.Info("--> PIM adjacency verified", "interface", intfName, "address", addr, "neighbor", neighbor)
+							return
+						}
+					}
 				}
 			}
 		}
 
-		log.Debug("PIM neighbor not found yet", "expectedAddr", expectedLinkLocalAddr)
+		log.Debug("PIM neighbor not found yet in 169.254.0.x range", "vrfs", pim.VRFs)
 		time.Sleep(1 * time.Second)
 	}
+
 	t.Fatalf("PIM neighbor not established on Tunnel interface within timeout")
+}
+
+// verifyConcurrentMulticastPIMAdjacency verifies PIM adjacency for concurrent IBRL+multicast tunnels.
+// For single-client scenarios where the same user has both IBRL and multicast, both tunnels
+// use sequential addresses in the 169.254.0.x range (e.g., IBRL on .0/.1, multicast on .2/.3).
+func verifyConcurrentMulticastPIMAdjacency(t *testing.T, log *slog.Logger, device *devnet.Device) {
+	tunnelOut, _ := devnet.DeviceExecAristaCliJSON[any](t.Context(), device, "show interfaces Tunnel1-100")
+	log.Info("Device tunnel interfaces", "output", tunnelOut)
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		pim, err := devnet.DeviceExecAristaCliJSON[*arista.ShowPIMNeighbors](t.Context(), device, arista.ShowPIMNeighborsCmd())
+		require.NoError(t, err, "error fetching pim neighbors from doublezero device")
+
+		// Look for any PIM neighbor in the 169.254.x.x range on a Tunnel interface
+		// The JSON structure is: vrfs -> vrf_name -> interfaces -> interface_name -> neighbors -> address -> details
+		for _, vrf := range pim.VRFs {
+			for intfName, intf := range vrf.Interfaces {
+				for addr := range intf.Neighbors {
+					if strings.HasPrefix(addr, "169.254.") {
+						if len(intfName) >= 6 && intfName[:6] == "Tunnel" {
+							log.Info("--> Concurrent mcast PIM adjacency verified", "interface", intfName, "address", addr)
+							return
+						}
+					}
+				}
+			}
+		}
+
+		log.Debug("Concurrent mcast PIM neighbor not found yet, checking all VRFs", "vrfs", pim.VRFs)
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("Concurrent multicast PIM neighbor not established on Tunnel interface within timeout")
+}
+
+// verifyConcurrentMulticastPublisherMrouteState verifies mroute state for concurrent IBRL+multicast publisher.
+func verifyConcurrentMulticastPublisherMrouteState(t *testing.T, log *slog.Logger, device *devnet.Device, client *devnet.Client) {
+	log.Info("==> Verifying concurrent multicast publisher mroute state")
+
+	// Get the actual allocated IP from the client's tunnel status
+	// This is more reliable than calculating it, especially when the client
+	// has both IBRL and multicast tunnels with allocated IPs
+	tunnelStatus, err := client.GetTunnelStatus(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, tunnelStatus, "client should have at least one tunnel")
+
+	// Find the multicast tunnel's DoubleZeroIP
+	var expectedAllocatedIP string
+	for _, ts := range tunnelStatus {
+		if ts.UserType == devnet.ClientUserTypeMulticast {
+			expectedAllocatedIP = ts.DoubleZeroIP.String()
+			break
+		}
+	}
+	require.NotEmpty(t, expectedAllocatedIP, "could not find multicast tunnel's DoubleZeroIP")
+	log.Info("==> Using client's actual allocated IP", "expectedAllocatedIP", expectedAllocatedIP)
+
+	// Diagnostic: Check tunnel and route state
+	log.Info("==> Diagnostic: Checking tunnel interfaces")
+	tunnelOut, _ := client.Exec(t.Context(), []string{"bash", "-c", "ip -j link show type gre 2>/dev/null || ip link show type gre"}, docker.NoPrintOnError())
+	log.Info("Tunnel interfaces", "output", string(tunnelOut))
+
+	log.Info("==> Diagnostic: Checking routes to multicast group")
+	routeOut, _ := client.Exec(t.Context(), []string{"bash", "-c", "ip route get 233.84.178.0 2>&1"}, docker.NoPrintOnError())
+	log.Info("Route to multicast group", "output", string(routeOut))
+
+	log.Info("==> Diagnostic: Checking addresses on doublezero1")
+	addrOut, _ := client.Exec(t.Context(), []string{"bash", "-c", "ip addr show dev doublezero1 2>&1"}, docker.NoPrintOnError())
+	log.Info("Addresses on doublezero1", "output", string(addrOut))
+
+	// Trigger S,G creation with ping to multicast group using the allocated DZ IP as source
+	// The -I flag with an IP address forces that IP as the source address
+	log.Info("==> Triggering S,G creation with ping to multicast group", "sourceIP", expectedAllocatedIP, "interface", "doublezero1")
+	pingOut, pingErr := client.Exec(t.Context(), []string{"bash", "-c", "ping -c 3 -w 5 -I " + expectedAllocatedIP + " 233.84.178.0"}, docker.NoPrintOnError())
+	log.Info("Ping result", "output", string(pingOut), "error", pingErr)
+
+	// Verify mroute state on device - poll for 60 seconds (longer for concurrent case)
+	mGroup := "233.84.178.0"
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		mroutes, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPMroute](t.Context(), device, arista.ShowIPMrouteCmd())
+		if err != nil {
+			log.Debug("Error fetching mroutes", "error", err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		groups, ok := mroutes.Groups[mGroup]
+		if !ok {
+			log.Debug("Multicast group not found yet", "mGroup", mGroup)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		_, ok = groups.GroupSources[expectedAllocatedIP]
+		if ok {
+			log.Info("--> Concurrent mcast mroute state verified", "group", mGroup, "source", expectedAllocatedIP)
+			return
+		}
+
+		log.Debug("Source not found in multicast group", "expectedIP", expectedAllocatedIP, "sources", groups.GroupSources)
+		time.Sleep(2 * time.Second)
+	}
+
+	t.Fatalf("Concurrent mcast mroute state not created within timeout for group %s with source %s", mGroup, expectedAllocatedIP)
 }
 
 // verifyMulticastPublisherMrouteState verifies mroute state is created on the device for publisher.
 func verifyMulticastPublisherMrouteState(t *testing.T, log *slog.Logger, device *devnet.Device, client *devnet.Client) {
 	log.Info("==> Verifying multicast publisher mroute state")
 
-	// Calculate expected allocated IP from device's dz_prefix
-	dzPrefixIP, dzPrefixNet, err := netutil.ParseCIDR(device.DZPrefix)
+	// Get the actual allocated IP from the client's tunnel status
+	// This is more reliable than calculating it, especially when multiple clients
+	// have allocated IPs from the same prefix
+	tunnelStatus, err := client.GetTunnelStatus(t.Context())
 	require.NoError(t, err)
-	ones, _ := dzPrefixNet.Mask.Size()
-	allocatableBits := 32 - ones
-	// First IP is reserved for device tunnel endpoint (Loopback100 interface)
-	expectedAllocatedIP, err := nextAllocatableIP(dzPrefixIP, allocatableBits, map[string]bool{dzPrefixIP: true})
-	require.NoError(t, err)
+	require.NotEmpty(t, tunnelStatus, "client should have at least one tunnel")
+
+	// Find the multicast tunnel's DoubleZeroIP
+	var expectedAllocatedIP string
+	for _, ts := range tunnelStatus {
+		if ts.UserType == devnet.ClientUserTypeMulticast {
+			expectedAllocatedIP = ts.DoubleZeroIP.String()
+			break
+		}
+	}
+	require.NotEmpty(t, expectedAllocatedIP, "could not find multicast tunnel's DoubleZeroIP")
+	log.Info("==> Using client's actual allocated IP", "expectedAllocatedIP", expectedAllocatedIP)
 
 	// Trigger S,G creation with ping to multicast group
 	log.Info("==> Triggering S,G creation with ping to multicast group")
@@ -519,20 +1176,37 @@ func verifyTunnelRemoved(t *testing.T, client *devnet.Client, interfaceName stri
 // waitForAgentConfigWithClient waits for the agent configuration to include the specified client.
 // This ensures the controller has pushed the configuration to the device before we verify PIM/mroutes.
 func waitForAgentConfigWithClient(t *testing.T, log *slog.Logger, dn *devnet.Devnet, device *devnet.Device, client *devnet.Client) {
+	var lastConfigSnippet string
 	require.Eventually(t, func() bool {
 		config, err := dn.Controller.GetAgentConfig(t.Context(), device.ID)
 		if err != nil {
-			log.Debug("Error getting agent config", "error", err)
+			log.Debug("Error getting agent config", "error", err, "deviceID", device.ID, "deviceCode", device.Spec.Code)
 			return false
 		}
 
 		// Check if the config contains the client IP (indicating the tunnel is configured)
 		if strings.Contains(config.Config, client.CYOANetworkIP) {
-			log.Info("--> Agent config includes client", "clientIP", client.CYOANetworkIP)
+			log.Info("--> Agent config includes client", "clientIP", client.CYOANetworkIP, "deviceCode", device.Spec.Code)
 			return true
 		}
 
-		log.Debug("Agent config does not yet include client", "clientIP", client.CYOANetworkIP)
+		// Log a snippet of the config to help debug what's being returned
+		configLen := len(config.Config)
+		snippet := config.Config
+		if configLen > 500 {
+			snippet = config.Config[:500] + "..."
+		}
+		if snippet != lastConfigSnippet {
+			log.Info("Agent config does not yet include client",
+				"clientIP", client.CYOANetworkIP,
+				"deviceCode", device.Spec.Code,
+				"deviceID", device.ID,
+				"configLen", configLen,
+				"configSnippet", snippet)
+			lastConfigSnippet = snippet
+		} else {
+			log.Debug("Agent config does not yet include client", "clientIP", client.CYOANetworkIP)
+		}
 		return false
-	}, 30*time.Second, 1*time.Second, "agent config should include client %s", client.CYOANetworkIP)
+	}, 60*time.Second, 1*time.Second, "agent config should include client %s for device %s (%s)", client.CYOANetworkIP, device.Spec.Code, device.ID)
 }

--- a/e2e/ibrl_test.go
+++ b/e2e/ibrl_test.go
@@ -306,19 +306,6 @@ func checkIBRLPostConnect(t *testing.T, dn *TestDevnet, device *devnet.Device, c
 			t.Fail()
 		}
 
-		if !t.Run("only_one_tunnel_allowed", func(t *testing.T) {
-			dn.CreateMulticastGroupOnchain(t, client, "mg01")
-
-			// Set access pass for the client.
-			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
-			require.NoError(t, err)
-
-			_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast publisher mg01 --client-ip " + client.CYOANetworkIP})
-			require.Error(t, err, "User with different type already exists. Only one tunnel currently supported")
-		}) {
-			t.Fail()
-		}
-
 		dn.log.Info("--> IBRL post-connect requirements checked")
 	})
 }

--- a/e2e/internal/arista/commands.go
+++ b/e2e/internal/arista/commands.go
@@ -101,7 +101,19 @@ func ShowIPMrouteCmd() string {
 //             "169.254.0.3": {
 //               "address": "169.254.0.3",
 //               "intf": "Tunnel501",
-//               ...
+//               "creationTime": 1748812548.569936,
+//               "lastRefreshTime": 1748812548.5713866,
+//               "holdTime": 105,
+//               "mode": {
+//                 "mode": "Sparse",
+//                 "borderRouter": false
+//               },
+//               "bfdState": "disabled",
+//               "transport": "datagram",
+//               "detail": false,
+//               "secondaryAddress": [],
+//               "maintenanceReceived": null,
+//               "maintenanceSent": null
 //             }
 //           }
 //         }
@@ -110,17 +122,17 @@ func ShowIPMrouteCmd() string {
 //   }
 // }
 
-// ShowPIMNeighbors represents the top-level VRF-wrapped structure for PIM neighbor output.
+// ShowPIMNeighbors represents the top-level structure containing PIM neighbor details organized by VRF and interface.
 type ShowPIMNeighbors struct {
 	VRFs map[string]PIMNeighborVRF `json:"vrfs"`
 }
 
-// PIMNeighborVRF contains interfaces within a VRF.
+// PIMNeighborVRF holds the interfaces within a VRF that have PIM neighbors.
 type PIMNeighborVRF struct {
 	Interfaces map[string]PIMNeighborInterface `json:"interfaces"`
 }
 
-// PIMNeighborInterface contains neighbors on an interface.
+// PIMNeighborInterface holds the PIM neighbors on a specific interface.
 type PIMNeighborInterface struct {
 	Neighbors map[string]PIMNeighborDetail `json:"neighbors"`
 }

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -588,16 +588,6 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 			}
 		}
 
-		if !t.Run("only_one_tunnel_allowed", func(t *testing.T) {
-			_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
-			require.NoError(t, err)
-
-			_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect ibrl --client-ip " + client.CYOANetworkIP})
-			require.Error(t, err, "User with different type already exists. Only one tunnel currently supported")
-		}) {
-			t.Fail()
-		}
-
 		log.Info("--> Multicast post-connect requirements checked", "mode", mode)
 	})
 }


### PR DESCRIPTION
## Summary of Changes
This PR adds the ability from the CLI and the smart contract to add simultaneous tunnels: a single unicast and a single mulitcast tunnel (subscriber or publisher only). This also ensures that a second tunnel appears on a second device.

This also ensures that a mcast subscriber gets a device derived by tunnel_dst rather than dz_ip since subscribers aren't assigned a dz_ip.

This PR is split out from https://github.com/malbeclabs/doublezero/pull/2728 so that we can roll this out more safely and in two discrete steps (cli changes then activator,controller changes)

Closes https://github.com/malbeclabs/doublezero/issues/2725

## Testing Verification
* E2E tests were extended to include creating multiple tunnels for a single user
* The coexistence tests that were skipped are now enabled and pass
* This also adds tests to verify that `pubkey` is always the last deserialized field in both go and rust
* Claude helped extend the tests
