### PR TITLE
controller: publish getconfig metrics to clickhouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   - Add shared `borsh-incremental` library (Go, Python, TypeScript) for cursor-based Borsh deserialization with backward-compatible trailing field defaults
   - Add npm and PyPI publish workflows for serviceability and telemetry SDKs
   - DeleteUserCommand updated to wait for activator to process multicast user unsubscribe before deleting the user
+- Device controller
+  - Record successful GetConfig gRPC calls to ClickHouse for device telemetry tracking
 
 ## [v0.8.6](https://github.com/malbeclabs/doublezero/compare/client/v0.8.5...client/v0.8.6) – 2026-02-04
 
@@ -60,7 +62,6 @@ All notable changes to this project will be documented in this file.
   - fix(smartcontract): reserve first IP of DzPrefixBlock for device ([#2753](https://github.com/malbeclabs/doublezero/pull/2753))
 - Client
   - Fix race in bgp status handling on peer deletion
-
 
 ## [v0.8.4](https://github.com/malbeclabs/doublezero/compare/client/v0.8.3...client/v0.8.4) – 2026-01-28
 

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -222,6 +222,28 @@ func (c *ControllerCommand) Run() error {
 
 	options = append(options, controller.WithDeviceLocalASN(deviceLocalASN))
 
+	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {
+		chDB := os.Getenv("CLICKHOUSE_DB")
+		if chDB == "" {
+			chDB = "default"
+		}
+		chUser := os.Getenv("CLICKHOUSE_USER")
+		if chUser == "" {
+			chUser = "default"
+		}
+		chPass := os.Getenv("CLICKHOUSE_PASS")
+		chTLSDisabled := os.Getenv("CLICKHOUSE_TLS_DISABLED") == "true"
+		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled)
+		if err != nil {
+			log.Error("error creating clickhouse writer", "error", err)
+			os.Exit(1)
+		}
+		options = append(options, controller.WithClickhouse(cw))
+		log.Info("clickhouse enabled", "addr", chAddr, "db", chDB, "user", chUser)
+	} else {
+		log.Info("clickhouse disabled (CLICKHOUSE_ADDR not set)")
+	}
+
 	if c.noHardware {
 		options = append(options, controller.WithNoHardware())
 	}

--- a/controlplane/controller/internal/controller/clickhouse.go
+++ b/controlplane/controller/internal/controller/clickhouse.go
@@ -1,0 +1,127 @@
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+type getConfigEvent struct {
+	Timestamp    time.Time
+	DevicePubkey string
+}
+
+type ClickhouseWriter struct {
+	conn   clickhouse.Conn
+	log    *slog.Logger
+	db     string
+	mu     sync.Mutex
+	events []getConfigEvent
+}
+
+func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableTLS bool) (*ClickhouseWriter, error) {
+	chOpts := &clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: db,
+			Username: user,
+			Password: pass,
+		},
+	}
+	if !disableTLS {
+		chOpts.TLS = &tls.Config{}
+	}
+	conn, err := clickhouse.Open(chOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error opening clickhouse connection: %w", err)
+	}
+	if err := conn.Ping(context.Background()); err != nil {
+		return nil, fmt.Errorf("error pinging clickhouse: %w", err)
+	}
+	return &ClickhouseWriter{
+		conn: conn,
+		log:  log,
+		db:   db,
+	}, nil
+}
+
+func (cw *ClickhouseWriter) CreateTable(ctx context.Context) error {
+	err := cw.conn.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.controller_grpc_getconfig_success (
+			timestamp DateTime64(3),
+			device_pubkey LowCardinality(String)
+		) ENGINE = MergeTree
+		PARTITION BY toYYYYMM(timestamp)
+		ORDER BY (timestamp, device_pubkey)
+	`, cw.db))
+	if err != nil {
+		return fmt.Errorf("error creating table: %w", err)
+	}
+	return nil
+}
+
+func (cw *ClickhouseWriter) Record(event getConfigEvent) {
+	cw.mu.Lock()
+	cw.events = append(cw.events, event)
+	cw.mu.Unlock()
+}
+
+func (cw *ClickhouseWriter) Run(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			cw.flush(context.Background())
+			return
+		case <-ticker.C:
+			cw.flush(ctx)
+		}
+	}
+}
+
+func (cw *ClickhouseWriter) flush(ctx context.Context) {
+	cw.mu.Lock()
+	if len(cw.events) == 0 {
+		cw.mu.Unlock()
+		return
+	}
+	events := cw.events
+	cw.events = nil
+	cw.mu.Unlock()
+
+	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
+		`INSERT INTO %s.controller_grpc_getconfig_success (timestamp, device_pubkey)`, cw.db,
+	))
+	if err != nil {
+		cw.log.Error("error preparing clickhouse batch", "error", err)
+		return
+	}
+	for _, e := range events {
+		if err := batch.Append(e.Timestamp, e.DevicePubkey); err != nil {
+			cw.log.Error("error appending to clickhouse batch", "error", err)
+		}
+	}
+	if err := batch.Send(); err != nil {
+		_ = batch.Close()
+		cw.log.Error("error sending clickhouse batch", "error", err)
+		return
+	}
+	if err := batch.Close(); err != nil {
+		cw.log.Error("error closing clickhouse batch", "error", err)
+		return
+	}
+	cw.log.Debug("flushed getconfig events to clickhouse", "count", len(events))
+}
+
+func (cw *ClickhouseWriter) Close() {
+	cw.flush(context.Background())
+	if err := cw.conn.Close(); err != nil {
+		cw.log.Error("error closing clickhouse connection", "error", err)
+	}
+}


### PR DESCRIPTION
 ## Summary of Changes
* Add ClickHouse integration to the controller to record successful `GetConfig` gRPC calls for device health tracking as per rfc12
* New `ClickhouseWriter` batches events every 10 seconds and writes to a `controller_grpc_getconfig_success` table partitioned by month
* ClickHouse is opt-in, configured via environment variables: `CLICKHOUSE_ADDR`, `CLICKHOUSE_DB`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASS`, `CLICKHOUSE_TLS_DISABLED`
* CLICKHOUSE_TLS_DISABLED is only intended for use in e2e tests and testing with a local clickhouse instance
* Logs on startup whether ClickHouse is enabled or disabled, including connection details (addr, db, user)
* Table is auto-created with `CREATE TABLE IF NOT EXISTS` so it's safe across restarts

## Testing Verification
* Tested by hand in devnet
