### PR TITLE
bugfix(cli): add version to output (#1314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project will be documented in this file.
   - Support simultaneous unicast and multicast tunnels in doublezerod
   - Support publishing and subscribing to multiple multicast groups simultaneously
 - CLI
+  - add `version` field to json output so no longer breaks the json output if the version is out of date
   - Support publishing and subscribing a user to multiple multicast groups via `--group` flag
 - SDK
   - Go SDK can now perform batch writes to device.health and link.health as per rfc12

--- a/client/doublezero/src/command/latency.rs
+++ b/client/doublezero/src/command/latency.rs
@@ -1,11 +1,16 @@
 use crate::command::util;
 use clap::Args;
-use doublezero_cli::doublezerocommand::CliCommand;
-use doublezero_sdk::commands::device::list::ListDeviceCommand;
+use doublezero_cli::{
+    checkversion::{get_version_status, VersionStatus},
+    doublezerocommand::CliCommand,
+};
+use doublezero_sdk::{commands::device::list::ListDeviceCommand, ProgramVersion};
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    dzd_latency::retrieve_latencies, requirements::check_doublezero,
-    servicecontroller::ServiceControllerImpl,
+    dzd_latency::retrieve_latencies,
+    requirements::check_doublezero,
+    servicecontroller::{LatencyRecord, ServiceControllerImpl},
 };
 
 #[derive(Args, Debug)]
@@ -15,14 +20,39 @@ pub struct LatencyCliCommand {
     json: bool,
 }
 
+/// JSON response wrapper that includes version status information
+#[derive(Debug, Serialize, Deserialize)]
+struct LatencyJsonResponse {
+    version: VersionStatus,
+    latencies: Vec<LatencyRecord>,
+}
+
 impl LatencyCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         check_doublezero(&controller, client, None).await?;
 
+        // Get version status for JSON output
+        let version_status = get_version_status(client, ProgramVersion::current());
+
         let devices = client.list_device(ListDeviceCommand)?;
         let latencies = retrieve_latencies(&controller, &devices, false, None).await?;
-        util::show_output(latencies, self.json)?;
+
+        if self.json {
+            // For JSON output, include version status in the response
+            let json_response = LatencyJsonResponse {
+                version: version_status,
+                latencies,
+            };
+            let output = serde_json::to_string_pretty(&json_response)?;
+            println!("{output}");
+        } else {
+            // For table output, print version warning to stderr if needed
+            if let Some(msg) = version_status.message() {
+                eprintln!("{msg}");
+            }
+            util::show_output(latencies, false)?;
+        }
 
         Ok(())
     }

--- a/client/doublezero/src/command/routes.rs
+++ b/client/doublezero/src/command/routes.rs
@@ -1,10 +1,16 @@
 use crate::command::util;
 use clap::Args;
-use doublezero_cli::doublezerocommand::CliCommand;
+use doublezero_cli::{
+    checkversion::{get_version_status, VersionStatus},
+    doublezerocommand::CliCommand,
+};
+use doublezero_sdk::ProgramVersion;
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    requirements::check_doublezero, routes::retrieve_routes,
-    servicecontroller::ServiceControllerImpl,
+    requirements::check_doublezero,
+    routes::retrieve_routes,
+    servicecontroller::{RouteRecord, ServiceControllerImpl},
 };
 
 #[derive(Args, Debug)]
@@ -14,13 +20,38 @@ pub struct RoutesCliCommand {
     json: bool,
 }
 
+/// JSON response wrapper that includes version status information
+#[derive(Debug, Serialize, Deserialize)]
+struct RoutesJsonResponse {
+    version: VersionStatus,
+    routes: Vec<RouteRecord>,
+}
+
 impl RoutesCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         check_doublezero(&controller, client, None).await?;
 
+        // Get version status for JSON output
+        let version_status = get_version_status(client, ProgramVersion::current());
+
         let routes = retrieve_routes(&controller, None).await?;
-        util::show_output(routes, self.json)?;
+
+        if self.json {
+            // For JSON output, include version status in the response
+            let json_response = RoutesJsonResponse {
+                version: version_status,
+                routes,
+            };
+            let output = serde_json::to_string_pretty(&json_response)?;
+            println!("{output}");
+        } else {
+            // For table output, print version warning to stderr if needed
+            if let Some(msg) = version_status.message() {
+                eprintln!("{msg}");
+            }
+            util::show_output(routes, false)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary of Changes
This PR fixes a json rendering issue when the client is out of date. If the client was out of date and the user tried to return the status as json the json would be malformed as the version warning would be stuffed in.

Now it looks like this:
current:
```
{
  "version": {
    "status": "current"
  },
  "statuses": [...]
}
```

compatible:
```
{
  "version": {
    "status": "outdated",
    "current_version": "0.8.5",
    "latest_version": "0.9.0",
    "message": "A new version of the client is available: 0.8.5 → 0.9.0\nWe recommend updating to the latest version for the best experience."
  },
  "statuses": [...]
}
```

incompatible:
```
{
  "version": {
    "status": "incompatible",
    "current_version": "0.7.0",
    "min_required_version": "0.8.0",
    "message": "A new version of the client is available: 0.7.0 → 0.8.0\nYour client version is no longer up to date. Please update it before continuing to use the client."
  },
  "statuses": [...]
}
```

Closes https://github.com/malbeclabs/doublezero/issues/1314

## Testing Verification
Unit tests have been added that show the output conforms to the expected result.
