### PR TITLE
dependabot: add groups to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,44 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directories: 
-    - "**/*"
+  - package-ecosystem: "gomod"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      go-testing:
+        patterns:
+          - "github.com/stretchr/testify"
+          - "github.com/golang/mock"
+          - "go.uber.org/mock"
+
   - package-ecosystem: "cargo"
     directories:
-    - "**/*"
+      - "**/*"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      rust-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      solana:
+        patterns:
+          - "solana-*"
+          - "spl-*"
+      anchor:
+        patterns:
+          - "anchor-*"
+      tokio:
+        patterns:
+          - "tokio*"
+      serde:
+        patterns:
+          - "serde*"


### PR DESCRIPTION
## Summary of Changes
- Add dependency groups to bundle related updates into single PRs (minor/patch updates, Solana/Anchor packages, tokio/serde ecosystem)
- Limit open PRs to 10 per ecosystem to avoid overwhelming the repo
- Group Go testing dependencies (testify, mock) together

## Testing Verification
- Config syntax validated against Dependabot schema
- Changes will take effect on next scheduled Dependabot run