### PR TITLE
e2e: fix airdrop race condition by explicitly passing RPC URL

### DIFF
--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -245,11 +245,13 @@ func (c *Client) Start(ctx context.Context) error {
 
 	// Fund the client account via airdrop.
 	// Retry a couple times to avoid the observed intermittent failures, even on the first airdrop request.
+	// We explicitly pass the RPC URL via -u flag to avoid a race condition where the solana CLI
+	// config may not be set up yet by the entrypoint script, which would cause it to default to mainnet.
 	funded := false
 	var output []byte
 	for range 3 {
 		c.log.Info("--> Funding client account", "clientPubkey", c.Pubkey)
-		output, err = c.Exec(ctx, []string{"solana", "airdrop", "10", c.Pubkey}, docker.NoPrintOnError())
+		output, err = c.Exec(ctx, []string{"solana", "airdrop", "-u", c.dn.Ledger.InternalRPCURL, "10", c.Pubkey}, docker.NoPrintOnError())
 		if err != nil {
 			if strings.Contains(string(output), "rate limit") {
 				c.log.Info("--> Solana airdrop request failed with rate limit message, retrying")


### PR DESCRIPTION
## Summary
- Fix race condition where `solana airdrop` runs before client container's entrypoint configures the Solana CLI, causing it to default to mainnet and fail with 429 rate limiting
- Explicitly pass `-u` flag with local ledger URL to the airdrop command

## Root Cause
When the client container starts, `entrypoint.sh` first waits for the solana validator to be healthy before running `solana config set --url`. However, `client.go:Start()` immediately executes `solana airdrop` after container startup without waiting for the entrypoint to complete. Since the Solana CLI config hasn't been set yet, it defaults to `https://api.mainnet-beta.solana.com/`.

## Testing Verification
CI e2e tests pass and `TestE2E_MultiClient` no longer fails with mainnet rate limiting errors.