### PR TITLE
monitor: add sol-balance watcher for tracking account balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
   - Record successful GetConfig gRPC calls to ClickHouse for device telemetry tracking
 - Onchain programs
   - Enforce that `CloseAccessPass` only closes AccessPass accounts when `connection_count == 0`, preventing closure while active connections are present.
+- Monitor
+  - Add sol-balance watcher to track SOL balances for configured accounts and export Prometheus metrics for alerting
 
 ## [v0.8.6](https://github.com/malbeclabs/doublezero/compare/client/v0.8.5...client/v0.8.6) – 2026-02-04
 
@@ -32,7 +34,6 @@ All notable changes to this project will be documented in this file.
 - None for this release
 
 ### Changes
-
 - CLI
   - Remove log noise on resolve route
   - `doublezero resource verify` command added to verify onchain resources

--- a/controlplane/monitor/internal/sol-balance/config.go
+++ b/controlplane/monitor/internal/sol-balance/config.go
@@ -1,0 +1,39 @@
+package solbalance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+)
+
+type SolBalanceRPCClient interface {
+	GetBalance(ctx context.Context, pubkey solana.PublicKey, commitment solanarpc.CommitmentType) (*solanarpc.GetBalanceResult, error)
+}
+
+type Config struct {
+	Logger    *slog.Logger
+	Interval  time.Duration
+	RPCClient SolBalanceRPCClient
+	Accounts  map[string]solana.PublicKey
+	Threshold float64
+}
+
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if c.Interval <= 0 {
+		return errors.New("interval must be greater than 0")
+	}
+	if c.RPCClient == nil {
+		return errors.New("rpc client is required")
+	}
+	if len(c.Accounts) == 0 {
+		return errors.New("at least one account is required")
+	}
+	return nil
+}

--- a/controlplane/monitor/internal/sol-balance/metrics.go
+++ b/controlplane/monitor/internal/sol-balance/metrics.go
@@ -1,0 +1,49 @@
+package solbalance
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Metric names.
+	MetricNameBalanceLamports = "doublezero_monitor_sol_balance_lamports"
+	MetricNameBalanceSOL      = "doublezero_monitor_sol_balance_sol"
+	MetricNameErrors          = "doublezero_monitor_sol_balance_errors_total"
+
+	// Labels.
+	MetricLabelAccount   = "account"
+	MetricLabelErrorType = "error_type"
+
+	// Error types.
+	MetricErrorTypeGetBalance = "get_balance"
+
+	// Lamports per SOL.
+	LamportsPerSOL = 1_000_000_000
+)
+
+var (
+	MetricBalanceLamports = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameBalanceLamports,
+			Help: "SOL balance in lamports",
+		},
+		[]string{MetricLabelAccount},
+	)
+
+	MetricBalanceSOL = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricNameBalanceSOL,
+			Help: "SOL balance in SOL",
+		},
+		[]string{MetricLabelAccount},
+	)
+
+	MetricErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameErrors,
+			Help: "Number of errors encountered",
+		},
+		[]string{MetricLabelErrorType},
+	)
+)

--- a/controlplane/monitor/internal/sol-balance/watcher.go
+++ b/controlplane/monitor/internal/sol-balance/watcher.go
@@ -1,0 +1,82 @@
+package solbalance
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+)
+
+const (
+	watcherName = "sol-balance"
+)
+
+type SolBalanceWatcher struct {
+	log *slog.Logger
+	cfg *Config
+}
+
+func NewSolBalanceWatcher(cfg *Config) (*SolBalanceWatcher, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &SolBalanceWatcher{
+		log: cfg.Logger.With("watcher", watcherName),
+		cfg: cfg,
+	}, nil
+}
+
+func (w *SolBalanceWatcher) Name() string {
+	return watcherName
+}
+
+func (w *SolBalanceWatcher) Run(ctx context.Context) error {
+	ticker := time.NewTicker(w.cfg.Interval)
+	defer ticker.Stop()
+
+	err := w.Tick(ctx)
+	if err != nil {
+		w.log.Error("failed to tick", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.log.Debug("context done, stopping")
+			return nil
+		case <-ticker.C:
+			err := w.Tick(ctx)
+			if err != nil {
+				w.log.Error("failed to tick", "error", err)
+			}
+		}
+	}
+}
+
+func (w *SolBalanceWatcher) Tick(ctx context.Context) error {
+	w.log.Debug("ticking sol-balance")
+
+	for label, pubkey := range w.cfg.Accounts {
+		result, err := w.cfg.RPCClient.GetBalance(ctx, pubkey, solanarpc.CommitmentFinalized)
+		if err != nil {
+			MetricErrors.WithLabelValues(MetricErrorTypeGetBalance).Inc()
+			w.log.Info("failed to get balance", "account", label, "pubkey", pubkey.String(), "error", err)
+			continue
+		}
+
+		lamports := float64(result.Value)
+		sol := lamports / LamportsPerSOL
+
+		MetricBalanceLamports.WithLabelValues(label).Set(lamports)
+		MetricBalanceSOL.WithLabelValues(label).Set(sol)
+
+		w.log.Debug("balance", "account", label, "pubkey", pubkey.String(), "lamports", lamports, "sol", sol)
+
+		if sol < w.cfg.Threshold {
+			w.log.Warn("balance below threshold", "account", label, "pubkey", pubkey.String(), "sol", sol, "threshold", w.cfg.Threshold)
+		}
+	}
+
+	return nil
+}

--- a/controlplane/monitor/internal/sol-balance/watcher_test.go
+++ b/controlplane/monitor/internal/sol-balance/watcher_test.go
@@ -1,0 +1,208 @@
+package solbalance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRPCClient struct {
+	balances map[solana.PublicKey]uint64
+	err      error
+}
+
+func (m *mockRPCClient) GetBalance(ctx context.Context, pubkey solana.PublicKey, commitment solanarpc.CommitmentType) (*solanarpc.GetBalanceResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	balance, ok := m.balances[pubkey]
+	if !ok {
+		balance = 0
+	}
+	return &solanarpc.GetBalanceResult{
+		Value: balance,
+	}, nil
+}
+
+func TestTick_UpdatesMetrics(t *testing.T) {
+	// Reset metrics before test
+	MetricBalanceLamports.Reset()
+	MetricBalanceSOL.Reset()
+	MetricErrors.Reset()
+
+	// Use well-known Solana program addresses for testing
+	pubkey1 := solana.SystemProgramID // 11111111111111111111111111111111
+	pubkey2 := solana.TokenProgramID  // TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+
+	mockClient := &mockRPCClient{
+		balances: map[solana.PublicKey]uint64{
+			pubkey1: 500_000_000,   // 0.5 SOL
+			pubkey2: 1_000_000_000, // 1.0 SOL
+		},
+	}
+
+	cfg := &Config{
+		Logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		Interval:  1,
+		RPCClient: mockClient,
+		Accounts: map[string]solana.PublicKey{
+			"debt_accountant":    pubkey1,
+			"rewards_accountant": pubkey2,
+		},
+		Threshold: 0.1,
+	}
+
+	watcher, err := NewSolBalanceWatcher(cfg)
+	require.NoError(t, err)
+
+	err = watcher.Tick(context.Background())
+	require.NoError(t, err)
+
+	// Verify metrics
+	debtLamports := getGaugeValue(t, MetricBalanceLamports, "debt_accountant")
+	assert.Equal(t, float64(500_000_000), debtLamports)
+
+	debtSOL := getGaugeValue(t, MetricBalanceSOL, "debt_accountant")
+	assert.Equal(t, 0.5, debtSOL)
+
+	rewardsLamports := getGaugeValue(t, MetricBalanceLamports, "rewards_accountant")
+	assert.Equal(t, float64(1_000_000_000), rewardsLamports)
+
+	rewardsSOL := getGaugeValue(t, MetricBalanceSOL, "rewards_accountant")
+	assert.Equal(t, 1.0, rewardsSOL)
+}
+
+func TestTick_HandlesRPCErrors(t *testing.T) {
+	// Reset metrics before test
+	MetricBalanceLamports.Reset()
+	MetricBalanceSOL.Reset()
+	MetricErrors.Reset()
+
+	pubkey1 := solana.SystemProgramID
+
+	mockClient := &mockRPCClient{
+		err: errors.New("rpc error"),
+	}
+
+	cfg := &Config{
+		Logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		Interval:  1,
+		RPCClient: mockClient,
+		Accounts: map[string]solana.PublicKey{
+			"debt_accountant": pubkey1,
+		},
+		Threshold: 0.1,
+	}
+
+	watcher, err := NewSolBalanceWatcher(cfg)
+	require.NoError(t, err)
+
+	// Tick should not return error even if RPC fails
+	err = watcher.Tick(context.Background())
+	require.NoError(t, err)
+
+	// Verify error metric was incremented
+	errorCount := getCounterValue(t, MetricErrors, MetricErrorTypeGetBalance)
+	assert.Equal(t, float64(1), errorCount)
+}
+
+func TestValidate(t *testing.T) {
+	pubkey := solana.SystemProgramID
+	mockClient := &mockRPCClient{}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			cfg: &Config{
+				Logger:    logger,
+				Interval:  1,
+				RPCClient: mockClient,
+				Accounts:  map[string]solana.PublicKey{"test": pubkey},
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing logger",
+			cfg: &Config{
+				Interval:  1,
+				RPCClient: mockClient,
+				Accounts:  map[string]solana.PublicKey{"test": pubkey},
+			},
+			wantErr: "logger is required",
+		},
+		{
+			name: "invalid interval",
+			cfg: &Config{
+				Logger:    logger,
+				Interval:  0,
+				RPCClient: mockClient,
+				Accounts:  map[string]solana.PublicKey{"test": pubkey},
+			},
+			wantErr: "interval must be greater than 0",
+		},
+		{
+			name: "missing rpc client",
+			cfg: &Config{
+				Logger:   logger,
+				Interval: 1,
+				Accounts: map[string]solana.PublicKey{"test": pubkey},
+			},
+			wantErr: "rpc client is required",
+		},
+		{
+			name: "empty accounts",
+			cfg: &Config{
+				Logger:    logger,
+				Interval:  1,
+				RPCClient: mockClient,
+				Accounts:  map[string]solana.PublicKey{},
+			},
+			wantErr: "at least one account is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func getGaugeValue(t *testing.T, vec *prometheus.GaugeVec, labelValue string) float64 {
+	t.Helper()
+	gauge, err := vec.GetMetricWithLabelValues(labelValue)
+	require.NoError(t, err)
+	var m io_prometheus_client.Metric
+	err = gauge.Write(&m)
+	require.NoError(t, err)
+	return m.GetGauge().GetValue()
+}
+
+func getCounterValue(t *testing.T, vec *prometheus.CounterVec, labelValue string) float64 {
+	t.Helper()
+	counter, err := vec.GetMetricWithLabelValues(labelValue)
+	require.NoError(t, err)
+	var m io_prometheus_client.Metric
+	err = counter.Write(&m)
+	require.NoError(t, err)
+	return m.GetCounter().GetValue()
+}

--- a/controlplane/monitor/internal/worker/config.go
+++ b/controlplane/monitor/internal/worker/config.go
@@ -32,6 +32,10 @@ type InfluxWriter interface {
 	Flush()
 }
 
+type SolBalanceRPCClient interface {
+	GetBalance(ctx context.Context, pubkey solana.PublicKey, commitment solanarpc.CommitmentType) (*solanarpc.GetBalanceResult, error)
+}
+
 type Config struct {
 	Logger                     *slog.Logger
 	LedgerRPCClient            LedgerRPCClient
@@ -45,6 +49,10 @@ type Config struct {
 	TwoZOracleInterval         time.Duration
 	InfluxWriter               InfluxWriter
 	Env                        string
+	SolBalanceRPCClient        SolBalanceRPCClient
+	SolBalanceAccounts         map[string]solana.PublicKey
+	SolBalanceThreshold        float64
+	SolBalanceInterval         time.Duration
 }
 
 func (c *Config) Validate() error {

--- a/controlplane/monitor/internal/worker/worker.go
+++ b/controlplane/monitor/internal/worker/worker.go
@@ -8,6 +8,7 @@ import (
 	devicetelemetry "github.com/malbeclabs/doublezero/controlplane/monitor/internal/device-telemetry"
 	internettelemetry "github.com/malbeclabs/doublezero/controlplane/monitor/internal/internet-telemetry"
 	"github.com/malbeclabs/doublezero/controlplane/monitor/internal/serviceability"
+	solbalance "github.com/malbeclabs/doublezero/controlplane/monitor/internal/sol-balance"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -87,6 +88,20 @@ func New(cfg *Config) (*Worker, error) {
 			return nil, err
 		}
 		watchers = append(watchers, twoZOracleWatcher)
+	}
+
+	if len(cfg.SolBalanceAccounts) > 0 {
+		solBalanceWatcher, err := solbalance.NewSolBalanceWatcher(&solbalance.Config{
+			Logger:    cfg.Logger,
+			Interval:  cfg.SolBalanceInterval,
+			RPCClient: cfg.SolBalanceRPCClient,
+			Accounts:  cfg.SolBalanceAccounts,
+			Threshold: cfg.SolBalanceThreshold,
+		})
+		if err != nil {
+			return nil, err
+		}
+		watchers = append(watchers, solBalanceWatcher)
 	}
 
 	return &Worker{


### PR DESCRIPTION
## Summary of Changes
- Add new sol-balance watcher that monitors SOL balances for configured Solana accounts (e.g., debt accountant, rewards accountant)
- Export Prometheus metrics `doublezero_monitor_sol_balance_lamports` and `doublezero_monitor_sol_balance_sol` with account labels for Grafana alerting
- Log warnings when account balances drop below a configurable threshold
- Add CLI flags: `--sol-balance-accounts` (label:pubkey pairs), `--sol-balance-threshold` (default 0.5 SOL), `--sol-balance-interval` (default 30s)
- Closes https://github.com/malbeclabs/doublezero/issues/2812

## Testing Verification
- Unit tests added covering metric updates, RPC error handling, and config validation