### PR TITLE
client/liveness: fix flaky soft-loss fault test under parallel load

### DIFF
--- a/client/doublezerod/internal/liveness/faults_test.go
+++ b/client/doublezerod/internal/liveness/faults_test.go
@@ -886,7 +886,7 @@ func newFakeUDPConn(sw *fakeUDPSwitch, ip string, port int, ifname string) *fake
 		sw:     sw,
 		local:  &net.UDPAddr{IP: net.ParseIP(ip), Port: port},
 		ifname: ifname,
-		in:     make(chan fakeUDPPacket, 1024),
+		in:     make(chan fakeUDPPacket, 8192),
 	}
 	sw.register(c)
 	return c


### PR DESCRIPTION
## Summary
- Increase fakeUDPConn channel buffer from 1024 to 8192 to prevent silent packet drops during fault tests with 100 clients
- Fixes flaky `TestClient_Liveness_Faults_SoftLoss_PartialPacketLoss` that was failing due to buffer overflow adding unintended packet loss on top of the configured 1%

## Testing Verification
- Verified the change only affects infrastructure buffering, not the actual soft loss injection mechanism