### PR TITLE
Show refrence_count

### DIFF
--- a/smartcontract/cli/src/device/get.rs
+++ b/smartcontract/cli/src/device/get.rs
@@ -31,6 +31,7 @@ mgmt_vrf: {}\r\n\
 interfaces: {:?}\r\n\
 max_users: {}\r\n\
 users_count: {}\r\n\
+reference_count: {}\r\n\
 desired_status: {}\r\n\
 status: {}\r\n\
 health: {}\r\n\
@@ -48,6 +49,7 @@ owner: {}",
             device.interfaces,
             device.max_users,
             device.users_count,
+            device.reference_count,
             device.desired_status,
             device.status,
             device.device_health,
@@ -129,6 +131,6 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok(), "I should find a item by pubkey");
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\ndesired_status: activated\r\nstatus: activated\r\nhealth: ready-for-users\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
+        assert_eq!(output_str, "account: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\r\ncode: test\r\ncontributor: HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nlocation: HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx\r\nexchange: GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc\r\ndevice_type: hybrid\r\npublic_ip: 1.2.3.4\r\ndz_prefixes: 1.2.3.4/32\r\nmetrics_publisher: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\r\nmgmt_vrf: default\r\ninterfaces: []\r\nmax_users: 255\r\nusers_count: 0\r\nreference_count: 0\r\ndesired_status: activated\r\nstatus: activated\r\nhealth: ready-for-users\r\nowner: BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB\n");
     }
 }

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -88,6 +88,8 @@ pub struct DeviceDisplay {
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(skip)]
     pub metrics_publisher_pk: Pubkey,
+    #[tabled(skip)]
+    pub reference_count: u32,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
@@ -212,6 +214,7 @@ impl ListDeviceCliCommand {
                     mgmt_vrf: device.mgmt_vrf.clone(),
                     users: device.users_count,
                     max_users: device.max_users,
+                    reference_count: device.reference_count,
                     health: device.device_health,
                     desired_status: device.desired_status,
                     metrics_publisher_pk: device.metrics_publisher_pk,
@@ -386,7 +389,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\",\"code\":\"device1_code\",\"bump_seed\":2,\"location_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"contributor_code\":\"contributor1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"exchange_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPA\",\"exchange_code\":\"exchange1_code\",\"exchange_name\":\"exchange1_name\",\"device_type\":\"Hybrid\",\"public_ip\":\"1.2.3.4\",\"dz_prefixes\":\"1.2.3.4/32\",\"users\":0,\"max_users\":255,\"status\":\"Activated\",\"health\":\"ReadyForUsers\",\"desired_status\":\"Activated\",\"mgmt_vrf\":\"default\",\"metrics_publisher_pk\":\"11111111111111111111111111111111\",\"owner\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\",\"code\":\"device1_code\",\"bump_seed\":2,\"location_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"contributor_code\":\"contributor1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"exchange_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPA\",\"exchange_code\":\"exchange1_code\",\"exchange_name\":\"exchange1_name\",\"device_type\":\"Hybrid\",\"public_ip\":\"1.2.3.4\",\"dz_prefixes\":\"1.2.3.4/32\",\"users\":0,\"max_users\":255,\"status\":\"Activated\",\"health\":\"ReadyForUsers\",\"desired_status\":\"Activated\",\"mgmt_vrf\":\"default\",\"metrics_publisher_pk\":\"11111111111111111111111111111111\",\"reference_count\":0,\"owner\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\"}]\n");
     }
 
     #[test]

--- a/smartcontract/cli/src/device/update.rs
+++ b/smartcontract/cli/src/device/update.rs
@@ -57,6 +57,9 @@ pub struct UpdateDeviceCliCommand {
     /// Desired status for the device (optional)
     #[arg(long)]
     pub desired_status: Option<DeviceDesiredStatus>,
+    /// Reference count for the device (optional, foundation only)
+    #[arg(long)]
+    pub reference_count: Option<u32>,
     /// Wait for the device to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -170,6 +173,7 @@ impl UpdateDeviceCliCommand {
             users_count: self.users_count,
             status: self.status,
             desired_status: self.desired_status,
+            reference_count: self.reference_count,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -329,6 +333,7 @@ mod tests {
                 users_count: Some(0),
                 status: None,
                 desired_status: None,
+                reference_count: None,
             }))
             .times(1)
             .returning(move |_| Ok(signature));
@@ -349,6 +354,7 @@ mod tests {
             users_count: Some(0),
             status: None,
             desired_status: None,
+            reference_count: None,
             wait: false,
         }
         .execute(&client, &mut output);
@@ -449,6 +455,7 @@ mod tests {
             users_count: Some(0),
             status: None,
             desired_status: None,
+            reference_count: None,
             wait: false,
         }
         .execute(&client, &mut output);
@@ -548,6 +555,7 @@ mod tests {
             users_count: None,
             status: None,
             desired_status: None,
+            reference_count: None,
             wait: false,
         }
         .execute(&client, &mut output);

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -664,6 +664,7 @@ mod tests {
                 users_count: None,
                 status: None,
                 desired_status: None,
+                reference_count: None,
                 resource_count: 0,
             }),
             "UpdateDevice",

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
@@ -34,6 +34,7 @@ pub struct DeviceUpdateArgs {
     pub status: Option<DeviceStatus>,
     pub desired_status: Option<DeviceDesiredStatus>,
     pub resource_count: usize,
+    pub reference_count: Option<u32>,
 }
 
 impl fmt::Debug for DeviceUpdateArgs {
@@ -72,6 +73,9 @@ impl fmt::Debug for DeviceUpdateArgs {
             write!(f, "desired_status: {:?}, ", self.desired_status)?;
         }
         write!(f, "resource_count: {:?}, ", self.resource_count)?;
+        if self.reference_count.is_some() {
+            write!(f, "reference_count: {:?}, ", self.reference_count)?;
+        }
         Ok(())
     }
 }
@@ -184,6 +188,9 @@ pub fn process_update_device(
         }
         if let Some(users_count) = value.users_count {
             device.users_count = users_count;
+        }
+        if let Some(reference_count) = value.reference_count {
+            device.reference_count = reference_count;
         }
     }
 

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -414,6 +414,7 @@ async fn test_device() {
             status: None,
             desired_status: Some(DeviceDesiredStatus::Activated),
             resource_count: 2,
+            reference_count: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),
@@ -673,6 +674,7 @@ async fn test_device_update_metrics_publisher_by_foundation_allowlist_account() 
             status: None,
             desired_status: None,
             resource_count: 0,
+            reference_count: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
@@ -362,6 +362,7 @@ async fn device_update_location_test() {
             status: None,
             desired_status: None,
             resource_count: 0,
+            reference_count: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),
@@ -404,6 +405,7 @@ async fn device_update_location_test() {
             status: None,
             desired_status: None,
             resource_count: 0,
+            reference_count: None,
         }),
         vec![
             AccountMeta::new(device_pubkey, false),

--- a/smartcontract/sdk/rs/src/commands/device/sethealth.rs
+++ b/smartcontract/sdk/rs/src/commands/device/sethealth.rs
@@ -118,6 +118,7 @@ mod tests {
                     status: None,
                     desired_status: None,
                     resource_count: 2,
+                    reference_count: None,
                 })),
                 predicate::always(),
             )
@@ -138,6 +139,7 @@ mod tests {
             users_count: None,
             status: None,
             desired_status: None,
+            reference_count: None,
         };
 
         let update_invalid = UpdateDeviceCommand {

--- a/smartcontract/sdk/rs/src/commands/device/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/update.rs
@@ -35,6 +35,7 @@ pub struct UpdateDeviceCommand {
     pub users_count: Option<u16>,
     pub status: Option<DeviceStatus>,
     pub desired_status: Option<DeviceDesiredStatus>,
+    pub reference_count: Option<u32>,
 }
 
 impl UpdateDeviceCommand {
@@ -89,6 +90,7 @@ impl UpdateDeviceCommand {
                 status: self.status,
                 desired_status: self.desired_status,
                 resource_count,
+                reference_count: self.reference_count,
             }),
             [
                 vec![
@@ -193,6 +195,7 @@ mod tests {
                     status: None,
                     desired_status: None,
                     resource_count: 2,
+                    reference_count: None,
                 })),
                 predicate::always(),
             )
@@ -213,6 +216,7 @@ mod tests {
             users_count: None,
             status: None,
             desired_status: None,
+            reference_count: None,
         };
 
         let update_invalid = UpdateDeviceCommand {


### PR DESCRIPTION
This pull request adds support for a new `reference_count` field to device-related data structures, CLI commands, and smart contract logic. The changes ensure that `reference_count` can be viewed and updated via the CLI, is handled correctly in the backend, and is covered by tests throughout the codebase.

**Device reference count support:**

* Added a `reference_count` field to device display and update structures in the CLI (`DeviceDisplay`, `UpdateDeviceCliCommand`) and included it in output and test assertions. [[1]](diffhunk://#diff-69138b28bf84ce525ad21f83f3811592e6b42112dcd96251d4bbbff25e2dd4edR91-R92) [[2]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R60-R62) [[3]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36R34) [[4]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36R52) [[5]](diffhunk://#diff-836a1783ff55b101a3d39336dd1fec74f0d18184972fc832b0c5a1e6202ecd36L132-R134) [[6]](diffhunk://#diff-69138b28bf84ce525ad21f83f3811592e6b42112dcd96251d4bbbff25e2dd4edR217) [[7]](diffhunk://#diff-69138b28bf84ce525ad21f83f3811592e6b42112dcd96251d4bbbff25e2dd4edL389-R392) [[8]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R176)
* Updated the smart contract processor to accept and process an optional `reference_count` in device update arguments (`DeviceUpdateArgs`) and logic. [[1]](diffhunk://#diff-49878e14f25954be64bfe154e5918a4fd67b5959476b40b84c5e6c4ebf981958R37) [[2]](diffhunk://#diff-49878e14f25954be64bfe154e5918a4fd67b5959476b40b84c5e6c4ebf981958R76-R78) [[3]](diffhunk://#diff-49878e14f25954be64bfe154e5918a4fd67b5959476b40b84c5e6c4ebf981958R192-R194)
* Updated the SDK and CLI command structures and logic to include `reference_count` in device update commands and their serialization. [[1]](diffhunk://#diff-59095b10487144697056cba7979266640634c74d920c6e492add4b30db476b7bR38) [[2]](diffhunk://#diff-59095b10487144697056cba7979266640634c74d920c6e492add4b30db476b7bR93)
* Ensured all relevant tests in CLI, SDK, and smart contract programs cover the new `reference_count` field, including its presence in test data and assertions. [[1]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R336) [[2]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R357) [[3]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R458) [[4]](diffhunk://#diff-5887bb80e16a3f2882fd495476d15b6ce2324edea81569dc1d169f76921e5531R558) [[5]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dR667) [[6]](diffhunk://#diff-0e714508dd5cb19e85f22402253b839fd4a2725253f54ceec1088c878fdd2265R417) [[7]](diffhunk://#diff-0e714508dd5cb19e85f22402253b839fd4a2725253f54ceec1088c878fdd2265R677) [[8]](diffhunk://#diff-92dce804b8ff57779ab3e855183c98c38aff6c9f5866094f3b0b7a0082427109R365) [[9]](diffhunk://#diff-92dce804b8ff57779ab3e855183c98c38aff6c9f5866094f3b0b7a0082427109R408) [[10]](diffhunk://#diff-8e6ad849849fe36c8398a55ef839274ac9a24443e34c6ad0249507181fdebaa3R121) [[11]](diffhunk://#diff-8e6ad849849fe36c8398a55ef839274ac9a24443e34c6ad0249507181fdebaa3R142) [[12]](diffhunk://#diff-59095b10487144697056cba7979266640634c74d920c6e492add4b30db476b7bR198) [[13]](diffhunk://#diff-59095b10487144697056cba7979266640634c74d920c6e492add4b30db476b7bR219)

## Testing Verification
* Show evidence of testing the change
