### PR TITLE
e2e: fix multicast test flake caused by hardcoded link IPs

### DIFF
--- a/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
+++ b/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.17/31
+   ip address {{.Ethernet2IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.28/31
+   ip address {{.Ethernet4IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address {{.Ethernet5IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address {{.Ethernet6IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -120,7 +120,7 @@ interface Loopback256
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.18/31
+   ip address {{.Vlan4001IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2

--- a/e2e/fixtures/multicast/doublezero_agent_config_both_users_removed.tmpl
+++ b/e2e/fixtures/multicast/doublezero_agent_config_both_users_removed.tmpl
@@ -60,7 +60,7 @@ system control-plane
 interface Ethernet2
    mtu 2048
    no switchport
-   ip address 172.16.0.17/31
+   ip address {{.Ethernet2IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -73,7 +73,7 @@ interface Ethernet2
 interface Ethernet4
    mtu 2048
    no switchport
-   ip address 172.16.0.28/31
+   ip address {{.Ethernet4IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -86,7 +86,7 @@ interface Ethernet4
 interface Ethernet5
    mtu 2048
    no switchport
-   ip address 172.16.0.30/31
+   ip address {{.Ethernet5IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -99,7 +99,7 @@ interface Ethernet5
 interface Ethernet6
    mtu 2048
    no switchport
-   ip address 172.16.0.32/31
+   ip address {{.Ethernet6IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2
@@ -120,7 +120,7 @@ interface Loopback256
 !
 interface Vlan4001
    mtu 2048
-   ip address 172.16.0.18/31
+   ip address {{.Vlan4001IP}}
    pim ipv4 sparse-mode
    isis enable 1
    isis circuit-type level-2

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -295,6 +295,10 @@ func checkMulticastBothUsersAgentConfig(t *testing.T, dn *TestDevnet, device *de
 		pubTunnelBGPNeighbor := fmt.Sprintf("169.254.0.%d", 2*(pubTunnel-controllerconfig.StartUserTunnelNum)+1)
 		subTunnelBGPNeighbor := fmt.Sprintf("169.254.0.%d", 2*(subTunnel-controllerconfig.StartUserTunnelNum)+1)
 
+		// Fetch the link interface IPs dynamically from the ledger
+		linkIPs, err := dn.GetDeviceLinkInterfaceIPs(t, device.Spec.Code)
+		require.NoError(t, err, "error getting device link interface IPs")
+
 		config, err := fixtures.Render("fixtures/multicast/doublezero_agent_config_both_users_added.tmpl", map[string]any{
 			"PublisherClientIP":            publisherClient.CYOANetworkIP,
 			"SubscriberClientIP":           subscriberClient.CYOANetworkIP,
@@ -308,6 +312,11 @@ func checkMulticastBothUsersAgentConfig(t *testing.T, dn *TestDevnet, device *de
 			"SubscriberTunnelBGPNeighbor":  subTunnelBGPNeighbor,
 			"StartTunnel":                  controllerconfig.StartUserTunnelNum,
 			"EndTunnel":                    controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+			"Ethernet2IP":                  linkIPs["Ethernet2"],
+			"Ethernet4IP":                  linkIPs["Ethernet4"],
+			"Ethernet5IP":                  linkIPs["Ethernet5"],
+			"Ethernet6IP":                  linkIPs["Ethernet6"],
+			"Vlan4001IP":                   linkIPs["Vlan4001"],
 		})
 		require.NoError(t, err, "error reading agent configuration fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -319,10 +328,19 @@ func checkMulticastBothUsersAgentConfig(t *testing.T, dn *TestDevnet, device *de
 // publisher and subscriber tunnels removed.
 func checkMulticastBothUsersRemovedAgentConfig(t *testing.T, dn *TestDevnet, device *devnet.Device) {
 	t.Run("wait_for_agent_config_both_users_removed", func(t *testing.T) {
+		// Fetch the link interface IPs dynamically from the ledger
+		linkIPs, err := dn.GetDeviceLinkInterfaceIPs(t, device.Spec.Code)
+		require.NoError(t, err, "error getting device link interface IPs")
+
 		config, err := fixtures.Render("fixtures/multicast/doublezero_agent_config_both_users_removed.tmpl", map[string]any{
 			"DeviceIP":    device.CYOANetworkIP,
 			"StartTunnel": controllerconfig.StartUserTunnelNum,
 			"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+			"Ethernet2IP": linkIPs["Ethernet2"],
+			"Ethernet4IP": linkIPs["Ethernet4"],
+			"Ethernet5IP": linkIPs["Ethernet5"],
+			"Ethernet6IP": linkIPs["Ethernet6"],
+			"Vlan4001IP":  linkIPs["Vlan4001"],
 		})
 		require.NoError(t, err, "error reading agent configuration fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))


### PR DESCRIPTION
## Summary
- Fix flaky multicast E2E test caused by hardcoded Ethernet/Vlan interface IPs in fixtures
- Add `GetDeviceLinkInterfaceIPs` helper to dynamically fetch link IPs from ledger after activation
- Template the interface IPs instead of hardcoding them

## Context
The multicast test fixtures had hardcoded IP addresses for Ethernet interfaces (e.g., `172.16.0.17/31`). These IPs come from link IP allocation during activation. When link activation order varies or IP allocation happens in a different order than expected, the allocated IPs can differ from the hardcoded values, causing flaky failures like:
```
expected 172.16.0.17 but got 172.16.0.19
```

## Testing Verification
- Fix follows same pattern as existing dynamic value templating (tunnel IPs, device IPs)