### PR TITLE
ci: increase e2e workflow timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: "e2e/"
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       packages: read
       contents: read


### PR DESCRIPTION
## Summary of Changes
- Increase the e2e workflow timeout since we've added a bunch of new e2e tests recently and reduced parallelism a bit
