### PR TITLE
e2e: fix flaky bgp neighbor removal check in IBRL tests

### DIFF
--- a/e2e/ibrl_test.go
+++ b/e2e/ibrl_test.go
@@ -402,7 +402,7 @@ func checkIBRLPostDisconnect(t *testing.T, dn *TestDevnet, device *devnet.Device
 		if !t.Run("check_user_tunnel_is_removed_from_agent", func(t *testing.T) {
 			t.Parallel()
 
-			deadline := time.Now().Add(30 * time.Second)
+			deadline := time.Now().Add(60 * time.Second)
 			for time.Now().Before(deadline) {
 				neighbors, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPBGPSummary](t.Context(), device, arista.ShowIPBGPSummaryCmd("vrf1"))
 				require.NoError(t, err, "error fetching neighbors from doublezero device")

--- a/e2e/ibrl_with_allocated_ip_test.go
+++ b/e2e/ibrl_with_allocated_ip_test.go
@@ -393,7 +393,7 @@ func checkIBRLWithAllocatedIPPostDisconnect(t *testing.T, dn *TestDevnet, device
 		if !t.Run("check_user_tunnel_is_removed_from_agent", func(t *testing.T) {
 			t.Parallel()
 
-			deadline := time.Now().Add(30 * time.Second)
+			deadline := time.Now().Add(60 * time.Second)
 			for time.Now().Before(deadline) {
 				neighbors, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPBGPSummary](t.Context(), device, arista.ShowIPBGPSummaryCmd("vrf1"))
 				require.NoError(t, err, "error fetching neighbors from doublezero device")


### PR DESCRIPTION
## Summary of Changes
- Increase timeout for `check_user_tunnel_is_removed_from_agent` from 30s to 60s in both `TestE2E_IBRL` and `TestE2E_IBRLWithAllocatedIP`
- Fixes flaky test failure where BGP neighbor wasn't removed within 30s under CI load

## Testing Verification
- Fix addresses failure seen in CI: https://github.com/malbeclabs/doublezero/actions/runs/21770894943/job/62818116247
- Timeout aligns with similar device state checks in `ibrl_multicast_coexistence_test.go` which use 60s