### PR TITLE
ci: skip rfc slack notification for draft PRs

### DIFF
--- a/.github/workflows/rfc-notification.yml
+++ b/.github/workflows/rfc-notification.yml
@@ -2,13 +2,14 @@ name: RFC Slack Notification
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
     paths:
       - 'rfcs/rfc[0-9]*-*.md'
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- RFC Slack notifications now only trigger when PRs are ready for review
- Added `ready_for_review` event type to also notify when draft PRs become ready
- Added condition to skip job when PR is still in draft state

## Testing Verification

- Verified workflow syntax is valid