### PR TITLE
ci: add Docker Hub login to workflows that pull images

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Login to docker
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -126,12 +126,17 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Login to docker
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull pre-built images
         run: |
           pull_with_retry() {

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,6 +50,11 @@ jobs:
           go-version-file: go.mod
           cache: true
       - uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: make go-container-test
   go-fuzz:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add Docker Hub authentication to e2e and go workflows to avoid [rate limiting](https://docs.docker.com/docker-hub/usage/) when pulling public images (prometheus, influxdb, redpanda)
- Rename existing GHCR login steps for clarity

Fixes issues like: https://github.com/malbeclabs/doublezero/actions/runs/21784591098/job/62853956887?pr=2864

## Testing Verification
- Verify DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets are configured in repo settings
- Run e2e workflow to confirm Docker Hub images pull successfully