### PR TITLE
activator/client/controller: use DzPrefixFirstIP as multicast tunnel endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Activator
   - Assign multicast publisher IPs from global pool in serviceability GlobalConfig instead of per-device blocks
+  - Multicast tunnels now use the device's DZ prefix first IP (network address of dz_prefixes[0]) as both tunnel source (device side) and tunnel destination (client side), instead of the device's public IP
 - E2E tests
   - Add daily devnet QA test for device provisioning lifecycle (RFC12) — deletes/recreates device and links, restarts daemons with new pubkey via Ansible
 

--- a/activator/src/activator_metrics.rs
+++ b/activator/src/activator_metrics.rs
@@ -77,13 +77,14 @@ mod tests {
         let mut device = DeviceState::new(&device);
 
         let (assigned, total) = ip_count(&device);
-        assert_eq!(assigned, 0);
+        // 2 reserved IPs (one per prefix, the network address used as multicast tunnel endpoint)
+        assert_eq!(assigned, 2);
         assert_eq!(total, 512);
 
         for expected in 0..510 {
             let _ = device.get_next_dz_ip();
             let (assigned, total) = ip_count(&device);
-            assert_eq!(assigned, expected + 1);
+            assert_eq!(assigned, expected + 3); // 2 reserved + (expected + 1) allocated
             assert_eq!(total, 512);
         }
     }

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -888,7 +888,7 @@ mod tests {
         do_test_process_user_event_pending_to_activated(
             UserType::IBRL,
             Some([192, 168, 1, 1].into()),
-            0,
+            1, // 1 reserved (dz_prefix network address), IBRL doesn't allocate from prefix
         );
     }
 
@@ -897,7 +897,7 @@ mod tests {
         do_test_process_user_event_pending_to_activated(
             UserType::IBRLWithAllocatedIP,
             Some([10, 0, 0, 1].into()),
-            1,
+            2, // 1 reserved + 1 allocated
         );
     }
 
@@ -906,7 +906,7 @@ mod tests {
         do_test_process_user_event_pending_to_activated(
             UserType::EdgeFiltering,
             Some([10, 0, 0, 1].into()),
-            1,
+            2, // 1 reserved + 1 allocated
         );
     }
 
@@ -1065,7 +1065,7 @@ mod tests {
                         ("device_pk", device_pk_str.as_str()),
                         ("code", "TestDevice"),
                     ],
-                    0, // publisher IP comes from global pool, not device
+                    1, // 1 reserved (dz_prefix network address); publisher IP comes from global pool
                 )
                 .expect_counter(
                     "doublezero_activator_device_total_ips",
@@ -1246,11 +1246,8 @@ mod tests {
             let device2 = device.clone();
             devices.insert(device_pubkey, DeviceState::new(&device2));
 
-            // allocate the only ip
-            assert_ne!(
-                devices.get_mut(&device_pubkey).unwrap().dz_ips[0].next_available_block(1, 1),
-                None
-            );
+            // The /32 prefix only has one IP (the network address), which is
+            // reserved for the multicast tunnel endpoint, so no dz_ip can be allocated.
 
             let locations = HashMap::<Pubkey, Location>::new();
             let exchanges = HashMap::<Pubkey, Exchange>::new();
@@ -1495,7 +1492,7 @@ mod tests {
                         ("device_pk", device_pk_str.as_str()),
                         ("code", "TestDevice"),
                     ],
-                    0,
+                    1, // 1 reserved (dz_prefix network address)
                 )
                 .expect_counter(
                     "doublezero_activator_device_total_ips",
@@ -1736,7 +1733,7 @@ mod tests {
                         ("device_pk", device_pk_str.as_str()),
                         ("code", "TestDevice"),
                     ],
-                    0,
+                    1, // 1 reserved (dz_prefix network address)
                 )
                 .expect_counter(
                     "doublezero_activator_device_total_ips",
@@ -1977,7 +1974,7 @@ mod tests {
                         ("device_pk", device_pk_str.as_str()),
                         ("code", "TestDevice"),
                     ],
-                    0,
+                    1, // 1 reserved (dz_prefix network address)
                 )
                 .expect_counter(
                     "doublezero_activator_device_total_ips",
@@ -2133,7 +2130,7 @@ mod tests {
                         ("device_pk", device_pk_str.as_str()),
                         ("code", "TestDevice"),
                     ],
-                    0, // publisher IP comes from global pool, not device
+                    1, // 1 reserved (dz_prefix network address); publisher IP comes from global pool
                 )
                 .expect_counter(
                     "doublezero_activator_device_total_ips",

--- a/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
+++ b/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
@@ -151,7 +151,7 @@ interface Tunnel{{.PublisherTunnelNum}}
    mtu 9216
    ip address {{.PublisherTunnelDeviceIP}}
    tunnel mode gre
-   tunnel source {{.DeviceIP}}
+   tunnel source {{.DzPrefixFirstIP}}
    tunnel destination {{.PublisherClientIP}}
    tunnel path-mtu-discovery
    tunnel ttl 32
@@ -165,7 +165,7 @@ interface Tunnel{{.SubscriberTunnelNum}}
    mtu 9216
    ip address {{.SubscriberTunnelDeviceIP}}
    tunnel mode gre
-   tunnel source {{.DeviceIP}}
+   tunnel source {{.DzPrefixFirstIP}}
    tunnel destination {{.SubscriberClientIP}}
    tunnel path-mtu-discovery
    tunnel ttl 32

--- a/e2e/fixtures/multicast/doublezero_status_connected_publisher.tmpl
+++ b/e2e/fixtures/multicast/doublezero_status_connected_publisher.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} | {{.ExpectedAllocatedClientIP}} | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DzPrefixFirstIP}} | {{.ExpectedAllocatedClientIP}} | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/fixtures/multicast/doublezero_status_connected_subscriber.tmpl
+++ b/e2e/fixtures/multicast/doublezero_status_connected_subscriber.tmpl
@@ -1,2 +1,2 @@
  Tunnel Status | Last Session Update     | Tunnel Name | Tunnel Src   | Tunnel Dst   | Doublezero IP | User Type | Current Device | Lowest Latency Device | Metro    | Network
- BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DeviceIP}} |             | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local
+ BGP Session Up | 2025-06-03 19:58:21 UTC | doublezero1 | {{.ClientIP}} | {{.DzPrefixFirstIP}} |             | Multicast | ny5-dz01       | ✅ ny5-dz01           | New York | local

--- a/e2e/internal/devnet/device.go
+++ b/e2e/internal/devnet/device.go
@@ -185,9 +185,10 @@ type Device struct {
 	// It's the primary key of the devices dataset in the ledger.
 	ID string
 
-	ContainerID   string
-	CYOANetworkIP string
-	DZPrefix      string // The dz_prefix registered onchain for this device
+	ContainerID     string
+	CYOANetworkIP   string
+	DZPrefix        string // The dz_prefix registered onchain for this device
+	DZPrefixFirstIP string // The first IP (network address) of DZPrefix, used as multicast tunnel endpoint
 
 	// ExternalEAPIHTTPPort is the port on which the device's EAPI HTTP server is exposed.
 	ExternalEAPIHTTPPort int
@@ -333,6 +334,7 @@ func (d *Device) Start(ctx context.Context) error {
 	}
 	dzPrefix := dzPrefixBytes.String() + "/29"
 	d.DZPrefix = dzPrefix
+	d.DZPrefixFirstIP = dzPrefixBytes.String()
 
 	// Compute a second dz_prefix for UTE loopback interfaces when needed.
 	// This prefix lives in a different /24 than the CYOA subnet (third octet incremented by 1)
@@ -633,6 +635,7 @@ func (d *Device) Start(ctx context.Context) error {
 		"TelemetryMetricsEnable":   spec.Telemetry.MetricsEnable,
 		"TelemetryMetricsPort":     telemetryMetricsPort,
 		"CYOANetworkIP":            cyoaNetworkIP,
+		"DzPrefixFirstIP":          d.DZPrefixFirstIP,
 		"CYOANetworkCIDRPrefix":    strconv.Itoa(d.dn.Spec.CYOANetwork.CIDRPrefix),
 		"DefaultNetworkIP":         defaultNetworkIP,
 		"DefaultNetworkCIDRPrefix": strconv.Itoa(defaultNetworkCIDRPrefix),

--- a/e2e/internal/devnet/device/startup-config.tmpl
+++ b/e2e/internal/devnet/device/startup-config.tmpl
@@ -154,6 +154,9 @@ interface Loopback0
 interface Ethernet1
    no switchport
    ip address {{.CYOANetworkIP}}/{{.CYOANetworkCIDRPrefix}}
+{{- if .DzPrefixFirstIP }}
+   ip address {{.DzPrefixFirstIP}}/32 secondary
+{{- end }}
 !
 interface Management0
 {{- if .ManagementNS }}

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -283,6 +283,7 @@ func checkMulticastBothUsersAgentConfig(t *testing.T, dn *TestDevnet, device *de
 			"PublisherClientIP":            publisherClient.CYOANetworkIP,
 			"SubscriberClientIP":           subscriberClient.CYOANetworkIP,
 			"DeviceIP":                     device.CYOANetworkIP,
+			"DzPrefixFirstIP":              device.DZPrefixFirstIP,
 			"ExpectedAllocatedPublisherIP": expectedAllocatedPublisherIP,
 			"PublisherTunnelNum":           pubTunnel,
 			"SubscriberTunnelNum":          subTunnel,
@@ -370,7 +371,7 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 				fixturePath: "fixtures/multicast/doublezero_status_connected_" + mode + ".tmpl",
 				data: map[string]any{
 					"ClientIP":                  client.CYOANetworkIP,
-					"DeviceIP":                  device.CYOANetworkIP,
+					"DzPrefixFirstIP":           device.DZPrefixFirstIP,
 					"ExpectedAllocatedClientIP": expectedAllocatedClientIP,
 				},
 				cmd: []string{"doublezero", "status"},
@@ -422,7 +423,7 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 				"link_type":         "gre",
 				"address":           client.CYOANetworkIP,
 				"link_pointtopoint": true,
-				"broadcast":         device.CYOANetworkIP,
+				"broadcast":         device.DZPrefixFirstIP,
 			}, links[0])
 		}) {
 			t.Fail()


### PR DESCRIPTION
Resolves: malbeclabs/infra#522

## Summary
- Multicast tunnels now use the device's DZ prefix first IP (network address of `dz_prefixes[0]`) as both tunnel source (device side) and tunnel destination (client side), instead of the device's public IP — enabling simultaneous IBRL and multicast tunnels on the same device with unique GRE (src, dst) pairs
- Client sets multicast `tunnel_endpoint` to `DzPrefixFirstIP`; when IBRL already exists, multicast reuses the same device instead of excluding it
- Activator validates `DzPrefixFirstIP` as a valid tunnel endpoint and explicitly reserves the network address of each `dz_prefix` block so it cannot be allocated as a user `dz_ip`
- E2E infrastructure configures `DzPrefixFirstIP` as a secondary IP on device Ethernet1; single-client tests now verify same-device IBRL+multicast coexistence

## Backward Compatibility
- Standalone multicast (no IBRL) with `DzPrefixFirstIP` available: uses `DzPrefixFirstIP`
- Standalone multicast on old devices without `dz_prefixes`: falls back to `PublicIP`
- Controller logic unchanged — already uses `user.TunnelEndpoint` when set, falling back to `PublicIP`

## Testing Verification
- Activator unit tests (55 pass): `test_is_valid_tunnel_endpoint_matches_dz_prefix`, `test_dz_prefix_first_ip_reserved_at_init`, updated IP count expectations for reservation
- Client unit tests (62 pass): multicast tests updated for same-device behavior with `DzPrefixFirstIP`, IBRL+multicast coexistence on same device
- Controller unit tests (6 pass): `multicast_uses_dz_prefix_first_ip_as_tunnel_source` verifying `UnderlaySrcIP` matches `DzPrefixFirstIP`
- E2E: `TestE2E_Multicast`, `TestE2E_IBRL_Multicast_Coexistence`, `TestE2E_MultiTunnel_SameDevice`

```
## Devnet Verification (chi-dn-dzd1 + chi-dn-bm2)                                                                                                                                            
                                                                                                                                                                                               
  ### Device onchain state                                                                                                                                                                     
  $ doublezero device list   
   code        | public_ip | dz_prefixes
   chi-dn-dzd1 | 100.0.0.1 | 198.18.0.0/24

  ### Client: both tunnels up on same device
  $ doublezero status
   Tunnel Status  | Tunnel Name | Tunnel Src      | Tunnel Dst | User Type | Current Device
   BGP Session Up | doublezero0 | 137.174.145.145 | 100.0.0.1  | IBRL      | chi-dn-dzd1
   BGP Session Up | doublezero1 | 137.174.145.145 | 198.18.0.0 | Multicast | chi-dn-dzd1

  ### Device: distinct GRE (src, dst) pairs — no demux collision
  chi-dn-dzd1# show running-config section Tunnel50
  interface Tunnel501
     description USER-MCAST-501
     tunnel source 198.18.0.0        ← DzPrefixFirstIP
     tunnel destination 137.174.145.145

  interface Tunnel502
     description USER-UCAST-502
     tunnel source 100.0.0.1         ← public_ip
     tunnel destination 137.174.145.145

  ### PIM adjacency established over multicast tunnel
  chi-dn-dzd1# show ip pim neighbor
  Neighbor Address  Interface     Uptime
  169.254.0.1       Tunnel501     00:08:10
```