### PR TITLE
ci: fix flaky go-fuzz timeout

### DIFF
--- a/client/doublezerod/Makefile
+++ b/client/doublezerod/Makefile
@@ -31,5 +31,5 @@ FUZZTIME ?= 10s
 fuzz:
 	@for f in $$(go test ./internal/liveness -list=Fuzz | grep '^Fuzz'); do \
 		echo "==> Fuzzing $$f"; \
-		go test ./internal/liveness -run=^$$ -fuzz=$$f -fuzztime=$(FUZZTIME) || exit 1; \
+		go test ./internal/liveness -run=^$$ -fuzz=$$f -fuzztime=$(FUZZTIME) -timeout=60s || exit 1; \
 	done

--- a/tools/twamp/Makefile
+++ b/tools/twamp/Makefile
@@ -21,7 +21,7 @@ bench: docker-build-reflector
 
 .PHONY: fuzz
 fuzz:
-	go test -fuzz=FuzzTWAMP_NTPTimestamp -fuzztime=10s ./pkg/light
+	go test -fuzz=FuzzTWAMP_NTPTimestamp -fuzztime=10s -timeout=60s ./pkg/light
 
 .PHONY: docker-build-reflector
 docker-build-reflector:


### PR DESCRIPTION
## Summary of Changes
- Add explicit `-timeout=60s` to fuzz test commands in `client/doublezerod` and `tools/twamp` Makefiles to prevent `context deadline exceeded` flakes when fuzz worker shutdown races against the internal `-fuzztime` deadline on busy CI runners

## Testing Verification
- Verified the fuzz targets still run correctly with the added timeout flag