### PR TITLE
e2e: add telemetry diagnostic dumps and fix flaky liveness test

### DIFF
--- a/e2e/multi_client_ibrl_liveness_test.go
+++ b/e2e/multi_client_ibrl_liveness_test.go
@@ -289,8 +289,8 @@ func runMultiClientIBRLRouteLivenessTest(t *testing.T, log *slog.Logger, dn *dev
 
 	// --- Route liveness block matrix ---
 	log.Debug("==> Route liveness: block each client independently and require expected route behavior")
-	const wait = 30 * time.Second
-	const tick = 5 * time.Second
+	const wait = 60 * time.Second
+	const tick = 3 * time.Second
 
 	doRouteLivenessBaseline := func() {
 		t.Helper()


### PR DESCRIPTION
## Summary of Changes
- Add on-failure diagnostic dump to `TestE2E_DeviceTelemetry` that captures telemetry agent logs, launcher logs, tunnel interface state, and EOS interface status from each device — the test intermittently sees all-zero TWAMP samples despite manual probes succeeding, and we need agent-side visibility to identify the root cause
- Increase route liveness convergence window in `TestE2E_MultiClientIBRL_RouteLiveness` from 30s/5s to 60s/3s — after iptables unblock, liveness detection plus cross-device BGP re-advertisement can exceed 30s under CI load, and 6 polling attempts was insufficient

## Testing Verification
- Verified e2e tests compile with `go build -tags e2e ./e2e/...`
- Diagnostic dump only fires on test failure via `t.Cleanup` with a fresh context (won't affect passing runs or hang on expired test contexts)