### PR TITLE
fix default desired status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ All notable changes to this project will be documented in this file.
   - Deprecated the user suspend status, as it is no longer used.
   - Serviceability: enforce that CloseAccountUser instructions verify the target user has no multicast publishers or subscribers (both `publishers` and `subscribers` are empty) before closing, and add regression coverage for this behavior.
   - Enhance access pass functionality with new Solana-specific types
+  - fix default desired status
 - Telemetry
   - Fix goroutine leak in TWAMP sender — `cleanUpReceived` goroutines now exit on `Close()` instead of living until process shutdown
 - Client

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/create.rs
@@ -160,7 +160,9 @@ pub fn process_create_device(
         // TODO: This line show be change when the health oracle is implemented
         // device_health: DeviceHealth::Pending,
         device_health: DeviceHealth::ReadyForUsers, // Force the device to be ready for users until the health oracle is implemented
-        desired_status: value.desired_status.unwrap_or(DeviceDesiredStatus::Pending),
+        desired_status: value
+            .desired_status
+            .unwrap_or(DeviceDesiredStatus::Activated),
     };
 
     device.check_status_transition();

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -184,7 +184,7 @@ pub fn process_create_link(
         // TODO: This line show be change when the health oracle is implemented
         // link_health: LinkHealth::Pending,
         link_health: LinkHealth::ReadyForService, // Force the link to be ready for service until the health oracle is implemented,
-        desired_status: value.desired_status.unwrap_or(LinkDesiredStatus::Pending),
+        desired_status: value.desired_status.unwrap_or(LinkDesiredStatus::Activated),
     };
 
     link.check_status_transition();


### PR DESCRIPTION
This pull request fixes the default desired status for newly created devices and links in the serviceability smart contract. Previously, if no desired status was provided, the default was incorrectly set to `Pending`. This change updates the default to `Activated`, which better aligns with the intended initial state while the health oracle is not yet implemented.

Default status fixes:

* Updated `process_create_device` in `create.rs` to set the default `desired_status` to `DeviceDesiredStatus::Activated` instead of `Pending`.
* Updated `process_create_link` in `create.rs` to set the default `desired_status` to `LinkDesiredStatus::Activated` instead of `Pending`.

Documentation:

* Added a changelog entry documenting the fix for the default desired status.


