### PR TITLE
ci: skip regular tests during twamp fuzz to fix flake

### DIFF
--- a/tools/twamp/Makefile
+++ b/tools/twamp/Makefile
@@ -21,7 +21,7 @@ bench: docker-build-reflector
 
 .PHONY: fuzz
 fuzz:
-	go test -fuzz=FuzzTWAMP_NTPTimestamp -fuzztime=10s -timeout=60s ./pkg/light
+	go test -run=^$$ -fuzz=FuzzTWAMP_NTPTimestamp -fuzztime=10s -timeout=60s ./pkg/light
 
 .PHONY: docker-build-reflector
 docker-build-reflector:


### PR DESCRIPTION
## Summary
- Add `-run=^$` to the twamp fuzz Makefile target to skip running regular tests before fuzzing, avoiding redundant work (already covered by `make test`) and eliminating a timing-sensitive `context deadline exceeded` failure caused by the Go fuzz engine's shutdown race when `-fuzztime` expires
- Matches the pattern already used in `client/doublezerod/Makefile` for its fuzz targets

## Testing Verification
- Verified the fuzz target still runs correctly with the added flag
- Confirmed `client/doublezerod/Makefile` already uses this pattern successfully