### PR TITLE
e2e: improve QA multicast test diagnostics and reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - E2E tests
   - e2e: add multi-tenancy VRF isolation test ([#2891](https://github.com/malbeclabs/doublezero/pull/2891))
   - Add backward compatibility test that validates older CLI versions against the current onchain program by cloning live state from testnet and mainnet-beta
+  - QA multicast tests: add diagnostic dumps on failure (status, routes, latency, multicast reports, onchain user/device state), cleanup stale test groups at test start, and fix disconnect blocking on stuck daemon status
 
 ## [v0.8.6](https://github.com/malbeclabs/doublezero/compare/client/v0.8.5...client/v0.8.6) – 2026-02-04
 

--- a/e2e/internal/qa/client_multicast.go
+++ b/e2e/internal/qa/client_multicast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -50,7 +51,10 @@ func (c *Client) ConnectUserMulticast_Subscriber_NoWait(ctx context.Context, mul
 }
 
 func (c *Client) ConnectUserMulticast(ctx context.Context, multicastGroupCodes []string, mode pb.ConnectMulticastRequest_MulticastMode, waitForStatus bool) error {
-	err := c.DisconnectUser(ctx, true, true)
+	// Don't wait for daemon status — the daemon may be stuck in "BGP Session Failed" if a
+	// previous disconnect failed to clean up the tunnel state. Waiting for onchain deletion
+	// is sufficient; the next connect will overwrite the daemon's stale tunnel state.
+	err := c.DisconnectUser(ctx, false, true)
 	if err != nil {
 		return fmt.Errorf("failed to ensure disconnected on host %s: %w", c.Host, err)
 	}
@@ -273,4 +277,29 @@ func (c *Client) AddToMulticastGroupAllowlist(ctx context.Context, code string, 
 	}
 	c.log.Debug("Added to multicast group allowlist", "host", c.Host, "code", code, "pubkey", pubkey, "clientIP", clientIP)
 	return nil
+}
+
+// CleanupStaleTestGroups deletes all multicast groups matching the qa-test-group-* pattern.
+// This cleans up leftovers from previous test runs. Individual deletion failures are logged
+// but do not stop the cleanup. Returns the number of groups deleted.
+func (c *Client) CleanupStaleTestGroups(ctx context.Context) (int, error) {
+	data, err := getProgramDataWithRetry(ctx, c.serviceability)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get program data: %w", err)
+	}
+
+	deleted := 0
+	for _, group := range data.MulticastGroups {
+		if !strings.HasPrefix(group.Code, "qa-test-group-") {
+			continue
+		}
+		pk := solana.PublicKeyFromBytes(group.PubKey[:])
+		c.log.Debug("Deleting stale test group", "code", group.Code, "pubkey", pk)
+		if err := c.DeleteMulticastGroup(ctx, pk); err != nil {
+			c.log.Info("Failed to delete stale test group", "code", group.Code, "error", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
 }


### PR DESCRIPTION
## Summary of Changes
- Add diagnostic dumps on test failure: tunnel status, BGP routes, device latency, multicast packet counts, and onchain user/device state
- Clean up stale `qa-test-group-*` multicast groups at the start of each test to prevent accumulation from previous failed runs
- Fix disconnect timeout in `ConnectUserMulticast` by skipping daemon status wait — only wait for onchain deletion, since the daemon may be stuck in "BGP Session Failed" from stale tunnel state

## Testing Verification
- Ran QA multicast tests against bare-metal devnet; confirmed diagnostic output appears on failure and stale group cleanup works
- Verified disconnect no longer blocks on stuck daemon status