### PR TITLE
fix access-pass tenant

### DIFF
--- a/client/doublezero/src/cli/accesspass.rs
+++ b/client/doublezero/src/cli/accesspass.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use doublezero_cli::accesspass::{
-    close::CloseAccessPassCliCommand, list::ListAccessPassCliCommand, set::SetAccessPassCliCommand,
+    close::CloseAccessPassCliCommand, get::GetAccessPassCliCommand, list::ListAccessPassCliCommand,
+    set::SetAccessPassCliCommand,
 };
 
 #[derive(Args, Debug)]
@@ -20,4 +21,7 @@ pub enum AccessPassCommands {
     /// List access passes
     #[clap()]
     List(ListAccessPassCliCommand),
+    /// Get access pass details
+    #[clap()]
+    Get(GetAccessPassCliCommand),
 }

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -215,6 +215,7 @@ async fn main() -> eyre::Result<()> {
             cli::accesspass::AccessPassCommands::Set(args) => args.execute(&client, &mut handle),
             cli::accesspass::AccessPassCommands::Close(args) => args.execute(&client, &mut handle),
             cli::accesspass::AccessPassCommands::List(args) => args.execute(&client, &mut handle),
+            cli::accesspass::AccessPassCommands::Get(args) => args.execute(&client, &mut handle),
         },
         Command::User(command) => match command.command {
             UserCommands::Create(args) => args.execute(&client, &mut handle),

--- a/controlplane/doublezero-admin/src/cli/accesspass.rs
+++ b/controlplane/doublezero-admin/src/cli/accesspass.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use doublezero_cli::accesspass::{
-    close::CloseAccessPassCliCommand, list::ListAccessPassCliCommand, set::SetAccessPassCliCommand,
+    close::CloseAccessPassCliCommand, get::GetAccessPassCliCommand, list::ListAccessPassCliCommand,
+    set::SetAccessPassCliCommand,
 };
 
 #[derive(Args, Debug)]
@@ -20,4 +21,7 @@ pub enum AccessPassCommands {
     /// List access passes
     #[clap()]
     List(ListAccessPassCliCommand),
+    /// Get access pass details
+    #[clap()]
+    Get(GetAccessPassCliCommand),
 }

--- a/controlplane/doublezero-admin/src/main.rs
+++ b/controlplane/doublezero-admin/src/main.rs
@@ -164,6 +164,7 @@ async fn main() -> eyre::Result<()> {
             cli::accesspass::AccessPassCommands::Set(args) => args.execute(&client, &mut handle),
             cli::accesspass::AccessPassCommands::Close(args) => args.execute(&client, &mut handle),
             cli::accesspass::AccessPassCommands::List(args) => args.execute(&client, &mut handle),
+            cli::accesspass::AccessPassCommands::Get(args) => args.execute(&client, &mut handle),
         },
         Command::User(command) => match command.command {
             UserCommands::Create(args) => args.execute(&client, &mut handle),

--- a/smartcontract/cli/src/accesspass/get.rs
+++ b/smartcontract/cli/src/accesspass/get.rs
@@ -1,0 +1,202 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_sdk::commands::{
+    accesspass::get::GetAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
+    tenant::list::ListTenantCommand,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, net::Ipv4Addr};
+
+#[derive(Args, Debug)]
+pub struct GetAccessPassCliCommand {
+    /// Client IP address
+    #[arg(long)]
+    pub client_ip: Ipv4Addr,
+    /// User payer public key
+    #[arg(long)]
+    pub user_payer: Pubkey,
+}
+
+impl GetAccessPassCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let epoch = client.get_epoch()?;
+
+        let (pubkey, accesspass) = client.get_accesspass(GetAccessPassCommand {
+            client_ip: self.client_ip,
+            user_payer: self.user_payer,
+        })?;
+
+        let mgroups = client.list_multicastgroup(ListMulticastGroupCommand {})?;
+        let tenants = client.list_tenant(ListTenantCommand {})?;
+
+        let tenant_display: Vec<String> = accesspass
+            .tenant_allowlist
+            .iter()
+            .filter(|pk| **pk != Pubkey::default())
+            .map(|pk| tenants.get(pk).map_or(pk.to_string(), |t| t.code.clone()))
+            .collect();
+
+        let pub_display: Vec<String> = accesspass
+            .mgroup_pub_allowlist
+            .iter()
+            .map(|pk| mgroups.get(pk).map_or(pk.to_string(), |mg| mg.code.clone()))
+            .collect();
+
+        let sub_display: Vec<String> = accesspass
+            .mgroup_sub_allowlist
+            .iter()
+            .map(|pk| mgroups.get(pk).map_or(pk.to_string(), |mg| mg.code.clone()))
+            .collect();
+
+        let remaining_epoch = if accesspass.last_access_epoch == u64::MAX {
+            "MAX".to_string()
+        } else {
+            accesspass
+                .last_access_epoch
+                .saturating_sub(epoch)
+                .to_string()
+        };
+
+        let last_access_epoch = if accesspass.last_access_epoch == u64::MAX {
+            "MAX".to_string()
+        } else {
+            accesspass.last_access_epoch.to_string()
+        };
+
+        writeln!(out, "account: {pubkey}")?;
+        writeln!(out, "type: {}", accesspass.accesspass_type)?;
+        writeln!(out, "client_ip: {}", accesspass.client_ip)?;
+        writeln!(out, "user_payer: {}", accesspass.user_payer)?;
+        writeln!(out, "tenant: {}", tenant_display.join(", "))?;
+        writeln!(out, "multicast_pub: {}", pub_display.join(", "))?;
+        writeln!(out, "multicast_sub: {}", sub_display.join(", "))?;
+        writeln!(out, "last_access_epoch: {last_access_epoch}")?;
+        writeln!(out, "remaining_epoch: {remaining_epoch}")?;
+        writeln!(out, "flags: {}", accesspass.flags_string())?;
+        writeln!(out, "connections: {}", accesspass.connection_count)?;
+        writeln!(out, "status: {}", accesspass.status)?;
+        writeln!(out, "owner: {}", accesspass.owner)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{accesspass::get::GetAccessPassCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::{
+        commands::{
+            accesspass::get::GetAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
+            tenant::list::ListTenantCommand,
+        },
+        AccountType, MulticastGroup,
+    };
+    use doublezero_serviceability::state::{
+        accesspass::{AccessPass, AccessPassStatus, AccessPassType},
+        tenant::{Tenant, TenantPaymentStatus},
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+    use std::{collections::HashMap, net::Ipv4Addr};
+
+    #[test]
+    fn test_cli_accesspass_get() {
+        let mut client = create_test_client();
+
+        let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let user_payer = Pubkey::new_unique();
+        let accesspass_pubkey = Pubkey::new_unique();
+
+        let tenant_pubkey = Pubkey::new_unique();
+        let tenant = Tenant {
+            account_type: AccountType::Tenant,
+            owner: Pubkey::new_unique(),
+            bump_seed: 0,
+            code: "my-tenant".to_string(),
+            vrf_id: 100,
+            reference_count: 1,
+            administrators: vec![],
+            token_account: Pubkey::default(),
+            payment_status: TenantPaymentStatus::Paid,
+            metro_route: false,
+            route_aliveness: false,
+        };
+
+        let mgroup_pubkey = Pubkey::new_unique();
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 1,
+            owner: Pubkey::new_unique(),
+            tenant_pk: tenant_pubkey,
+            multicast_ip: [239, 0, 0, 1].into(),
+            max_bandwidth: 1000000000,
+            status: doublezero_sdk::MulticastGroupStatus::Activated,
+            code: "mcast-test".to_string(),
+            publisher_count: 1,
+            subscriber_count: 5,
+        };
+
+        let accesspass = AccessPass {
+            account_type: AccountType::AccessPass,
+            bump_seed: 255,
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            user_payer,
+            last_access_epoch: 200,
+            connection_count: 3,
+            status: AccessPassStatus::Connected,
+            mgroup_pub_allowlist: vec![mgroup_pubkey],
+            mgroup_sub_allowlist: vec![],
+            tenant_allowlist: vec![tenant_pubkey],
+            owner: Pubkey::new_unique(),
+            flags: 0,
+        };
+
+        let accesspass_clone = accesspass.clone();
+
+        client
+            .expect_get_accesspass()
+            .with(predicate::eq(GetAccessPassCommand {
+                client_ip,
+                user_payer,
+            }))
+            .returning(move |_| Ok((accesspass_pubkey, accesspass_clone.clone())));
+        client
+            .expect_list_multicastgroup()
+            .with(predicate::eq(ListMulticastGroupCommand {}))
+            .returning(move |_| {
+                let mut map = HashMap::new();
+                map.insert(mgroup_pubkey, mgroup.clone());
+                Ok(map)
+            });
+        client
+            .expect_list_tenant()
+            .with(predicate::eq(ListTenantCommand {}))
+            .returning(move |_| {
+                let mut map = HashMap::new();
+                map.insert(tenant_pubkey, tenant.clone());
+                Ok(map)
+            });
+
+        let mut output = Vec::new();
+        let res = GetAccessPassCliCommand {
+            client_ip,
+            user_payer,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains(&format!("account: {accesspass_pubkey}")));
+        assert!(output_str.contains("type: prepaid"));
+        assert!(output_str.contains("client_ip: 10.0.0.1"));
+        assert!(output_str.contains(&format!("user_payer: {user_payer}")));
+        assert!(output_str.contains("tenant: my-tenant"));
+        assert!(output_str.contains("multicast_pub: mcast-test"));
+        assert!(output_str.contains("last_access_epoch: 200"));
+        assert!(output_str.contains("remaining_epoch: 190"));
+        assert!(output_str.contains("connections: 3"));
+        assert!(output_str.contains("status: connected"));
+        assert!(output_str.contains(&format!("owner: {}", accesspass.owner)));
+    }
+}

--- a/smartcontract/cli/src/accesspass/mod.rs
+++ b/smartcontract/cli/src/accesspass/mod.rs
@@ -1,3 +1,4 @@
 pub mod close;
+pub mod get;
 pub mod list;
 pub mod set;

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -587,13 +587,15 @@ mod tests {
             Ok(mgroups)
         });
 
+        let tenant_pk = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9");
+
         let user1 = User {
             account_type: AccountType::User,
             index: 1,
             bump_seed: 2,
             owner: user1_pubkey,
             user_type: IBRL,
-            tenant_pk: Pubkey::default(),
+            tenant_pk,
             device_pk: Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9"),
             cyoa_type: GREOverDIA,
             client_ip: [1, 2, 3, 4].into(),
@@ -630,7 +632,7 @@ mod tests {
             bump_seed: 3,
             owner: user2_pubkey,
             user_type: UserType::Multicast,
-            tenant_pk: Pubkey::default(),
+            tenant_pk,
             device_pk: device1_pubkey,
             cyoa_type: GREOverDIA,
             client_ip: [1, 2, 3, 4].into(),
@@ -704,7 +706,7 @@ mod tests {
         .execute(&client, &mut output);
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, " account                                   | tenant                           | user_type | groups   | device       | location       | cyoa_type  | client_ip | dz_ip   | accesspass                  | tunnel_id | tunnel_net | status    | owner                                     \n 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo | 11111111111111111111111111111111 | Multicast | S:m_code | device1_code | location1_name | GREOverDIA | 1.2.3.4   | 2.3.4.5 | Prepaid: (expires epoch 10) | 500       | 1.2.3.5/32 | activated | 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo \n");
+        assert_eq!(output_str, " account                                   | tenant                                    | user_type | groups   | device       | location       | cyoa_type  | client_ip | dz_ip   | accesspass                  | tunnel_id | tunnel_net | status    | owner                                     \n 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9 | Multicast | S:m_code | device1_code | location1_name | GREOverDIA | 1.2.3.4   | 2.3.4.5 | Prepaid: (expires epoch 10) | 500       | 1.2.3.5/32 | activated | 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo \n");
 
         let mut output = Vec::new();
         let res = ListUserCliCommand {
@@ -730,7 +732,7 @@ mod tests {
         assert!(res.is_ok());
 
         let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(output_str, "[{\"account\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\",\"tenant\":\"11111111111111111111111111111111\",\"user_type\":\"Multicast\",\"device_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"multicast\":\"S:m_code\",\"publishers\":\"\",\"subscribers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8\",\"device_name\":\"device1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"cyoa_type\":\"GREOverDIA\",\"client_ip\":\"1.2.3.4\",\"dz_ip\":\"2.3.4.5\",\"accesspass\":\"Prepaid: (expires epoch 10)\",\"tunnel_id\":500,\"tunnel_net\":\"1.2.3.5/32\",\"status\":\"Activated\",\"owner\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\"}]\n");
+        assert_eq!(output_str, "[{\"account\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\",\"tenant\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"user_type\":\"Multicast\",\"device_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"multicast\":\"S:m_code\",\"publishers\":\"\",\"subscribers\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo8\",\"device_name\":\"device1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"cyoa_type\":\"GREOverDIA\",\"client_ip\":\"1.2.3.4\",\"dz_ip\":\"2.3.4.5\",\"accesspass\":\"Prepaid: (expires epoch 10)\",\"tunnel_id\":500,\"tunnel_net\":\"1.2.3.5/32\",\"status\":\"Activated\",\"owner\":\"11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo\"}]\n");
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -191,6 +191,13 @@ pub fn process_create_user(
             );
             return Err(DoubleZeroError::TenantNotInAccessPassAllowlist.into());
         }
+    } else if let Some(tenant_account) = tenant_account {
+        let tenant = Tenant::try_from(tenant_account)?;
+        msg!(
+            "Access-pass has no tenant_allowlist, but user creation specifies tenant {}",
+            tenant.code
+        );
+        return Err(DoubleZeroError::TenantNotInAccessPassAllowlist.into());
     }
 
     // Check Initial epoch

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -5,6 +5,7 @@ use doublezero_serviceability::{
         accesspass::set::SetAccessPassArgs,
         contributor::create::ContributorCreateArgs,
         device::update::DeviceUpdateArgs,
+        tenant::create::TenantCreateArgs,
         user::{activate::*, ban::*, create::*, delete::*, requestban::*, update::*},
         *,
     },
@@ -821,4 +822,334 @@ async fn test_user_ban_requires_pendingban() {
         .get_user()
         .unwrap();
     assert_eq!(user.status, UserStatus::Banned);
+}
+
+#[tokio::test]
+async fn test_user_create_tenant_allowlist_validation() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    println!("🟢  Start test_user_create_tenant_allowlist_validation");
+
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // --- Common infrastructure setup ---
+
+    // Create location
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(location::create::LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create exchange
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(exchange::create::ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create contributor
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) =
+        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create device
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "la".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "100.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Update device max_users
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Activate device
+    let (tunnel_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(device::activate::DeviceActivateArgs {
+            resource_count: 2,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(tunnel_ids_pda, false),
+            AccountMeta::new(dz_prefix_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create tenant_a
+    let tenant_a_code = "tenant-a";
+    let (tenant_a_pubkey, _) = get_tenant_pda(&program_id, tenant_a_code);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTenant(TenantCreateArgs {
+            code: tenant_a_code.to_string(),
+            administrator: Pubkey::new_unique(),
+            token_account: None,
+            metro_route: true,
+            route_aliveness: false,
+        }),
+        vec![
+            AccountMeta::new(tenant_a_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create tenant_b
+    let tenant_b_code = "tenant-b";
+    let (tenant_b_pubkey, _) = get_tenant_pda(&program_id, tenant_b_code);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTenant(TenantCreateArgs {
+            code: tenant_b_code.to_string(),
+            administrator: Pubkey::new_unique(),
+            token_account: None,
+            metro_route: true,
+            route_aliveness: false,
+        }),
+        vec![
+            AccountMeta::new(tenant_b_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // ==========================================
+    // Scenario 1: Access pass with no tenant, user creation with tenant
+    // The access pass has tenant_allowlist = [Pubkey::default()] (empty/no tenant).
+    // Creating a user that specifies a tenant should fail.
+    // ==========================================
+    println!("🟢 Scenario 1: Access pass without tenant, user specifies tenant...");
+
+    let user_ip_1 = [100, 0, 0, 1].into();
+    let (accesspass_1_pubkey, _) = get_accesspass_pda(&program_id, &user_ip_1, &payer.pubkey());
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip_1,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            tenant: Pubkey::default(),
+        }),
+        vec![
+            AccountMeta::new(accesspass_1_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (user_1_pubkey, _) = get_user_pda(&program_id, &user_ip_1, UserType::IBRL);
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateUser(UserCreateArgs {
+            client_ip: user_ip_1,
+            user_type: UserType::IBRL,
+            cyoa_type: UserCYOA::GREOverDIA,
+        }),
+        vec![
+            AccountMeta::new(user_1_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(accesspass_1_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(tenant_a_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(result.is_err());
+    let error_string = format!("{:?}", result.unwrap_err());
+    assert!(
+        error_string.contains("Custom(79)"),
+        "Expected TenantNotInAccessPassAllowlist error (Custom(79)), got: {}",
+        error_string
+    );
+
+    println!("✅ Scenario 1 passed: correctly rejected tenant when access pass has no tenant");
+
+    // ==========================================
+    // Scenario 2: Access pass with tenant_a, user creation with tenant_b
+    // The access pass has tenant_allowlist = [tenant_a_pubkey].
+    // Creating a user that specifies tenant_b should fail.
+    // ==========================================
+    println!("🟢 Scenario 2: Access pass with tenant_a, user specifies tenant_b...");
+
+    let user_ip_2 = [100, 0, 0, 2].into();
+    let (accesspass_2_pubkey, _) = get_accesspass_pda(&program_id, &user_ip_2, &payer.pubkey());
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip_2,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            tenant: tenant_a_pubkey,
+        }),
+        vec![
+            AccountMeta::new(accesspass_2_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (user_2_pubkey, _) = get_user_pda(&program_id, &user_ip_2, UserType::IBRL);
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateUser(UserCreateArgs {
+            client_ip: user_ip_2,
+            user_type: UserType::IBRL,
+            cyoa_type: UserCYOA::GREOverDIA,
+        }),
+        vec![
+            AccountMeta::new(user_2_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(accesspass_2_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(tenant_b_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(result.is_err());
+    let error_string = format!("{:?}", result.unwrap_err());
+    assert!(
+        error_string.contains("Custom(79)"),
+        "Expected TenantNotInAccessPassAllowlist error (Custom(79)), got: {}",
+        error_string
+    );
+
+    println!("✅ Scenario 2 passed: correctly rejected mismatched tenant");
+    println!("🟢🟢🟢  End test_user_create_tenant_allowlist_validation  🟢🟢🟢");
 }


### PR DESCRIPTION
This pull request adds a new CLI command for retrieving details of a single access pass and enhances the access pass listing functionality with tenant filtering and improved output. The changes also update the admin and client CLIs to support the new command.

**New CLI command for access pass details:**

* Added `GetAccessPassCliCommand` to fetch and display detailed information about a specific access pass, including tenant and multicast group names, with a corresponding test. (`smartcontract/cli/src/accesspass/get.rs`)
* Integrated the new `get` command into both the client and admin CLIs, updating enums and command dispatch logic. (`client/doublezero/src/cli/accesspass.rs`, `client/doublezero/src/main.rs`, `controlplane/doublezero-admin/src/cli/accesspass.rs`, `controlplane/doublezero-admin/src/main.rs`) [[1]](diffhunk://#diff-5d7cee8fff4cb44fdce89bb05c8f33f16320a5f8c628b044fafb5431db6e6d40L3-R4) [[2]](diffhunk://#diff-5d7cee8fff4cb44fdce89bb05c8f33f16320a5f8c628b044fafb5431db6e6d40R24-R26) [[3]](diffhunk://#diff-9b18c350b4f1b096b7187215002603fceaaa72368cbe6b66dacfd105ea8eace2R218) [[4]](diffhunk://#diff-901dffbcc0f09778ec585863ab718fec67ebd602c6fb8a98c47907d6bbf71f0cR167)

**Enhancements to access pass listing:**

* Added a `tenant` filter to the `ListAccessPassCliCommand`, allowing users to filter access passes by tenant code. (`smartcontract/cli/src/accesspass/list.rs`) [[1]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abL30-R33) [[2]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR99-R117)
* Updated the access pass display output to include a new `tenant` field, showing tenant names in both table and JSON outputs. (`smartcontract/cli/src/accesspass/list.rs`) [[1]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR50) [[2]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR126-R136)
* Updated tests to cover the new tenant field and filtering logic in both table and JSON output formats. (`smartcontract/cli/src/accesspass/list.rs`) [[1]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR282-R284) [[2]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR298) [[3]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abL268-R314) [[4]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abL283-R323)

**Dependency updates:**

* The access pass listing command now fetches tenants to support name display and filtering. (`smartcontract/cli/src/accesspass/list.rs`) [[1]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR6) [[2]](diffhunk://#diff-49622a8ec624eea6e893b5e01e9b19c0868b2807a1b9f901d251feca47bf32abR66)

These changes improve the usability and flexibility of the CLI tools for managing and inspecting access passes.
