### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - Onchain programs
   - feat(smartcontract): add payment_status, token_account fields and UpdatePaymentStatus instruction ([#2880](https://github.com/malbeclabs/doublezero/pull/2880))
   - fix(smartcontract): correctly ser/deser ops_manager_pk ([#2887](https://github.com/malbeclabs/doublezero/pull/2887))
-  - Serviceability: add metro_route and route_aliveness boolean fields to Tenant for routing configuration
+  - Serviceability: add metro_route and route_liveness boolean fields to Tenant for routing configuration
   - Serviceability: add Tenant account type with immutable code-based PDA derivation, VRF ID, administrator management, and reference counting for safe deletion
   - Serviceability: add TenantAddAdministrator and TenantRemoveAdministrator instructions for foundation-managed administrator lists
   - Serviceability: extend UserUpdate instruction to support tenant_pk field updates with automatic reference count management on old and new tenants (backward compatible with old format)
@@ -32,7 +32,7 @@ All notable changes to this project will be documented in this file.
   - Serviceability: fix multicast group closeaccount to use InvalidStatus error and remove redundant publisher/subscriber count check
   - Serviceability: add tenant_allowlist field to AccessPass to restrict which tenants can use specific access passes (backward compatible with existing accounts)
 - SDK
-  - Add metro_route and route_aliveness fields to CreateTenantCommand and UpdateTenantCommand
+  - Add metro_route and route_liveness fields to CreateTenantCommand and UpdateTenantCommand
   - Add CreateTenant, UpdateTenant (vrf_id only), DeleteTenant, GetTenant, and ListTenant commands with support for code or pubkey lookup
   - Add AddAdministratorTenant and RemoveAdministratorTenant commands for tenant administrator management
   - UpdateUserCommand extended with tenant_pk field and automatic tenant account resolution for reference counting

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -993,7 +993,7 @@ mod tests {
                 payment_status: TenantPaymentStatus::Paid,
                 token_account: Pubkey::default(),
                 metro_route: false,
-                route_aliveness: false,
+                route_liveness: false,
             };
 
             let mut tenants = HashMap::new();
@@ -1239,7 +1239,7 @@ mod tests {
                 payment_status: TenantPaymentStatus::Paid,
                 token_account: Pubkey::default(),
                 metro_route: false,
-                route_aliveness: false,
+                route_liveness: false,
             };
             tenants.insert(pk, tenant.clone());
             (pk, tenant)

--- a/smartcontract/cli/src/accesspass/get.rs
+++ b/smartcontract/cli/src/accesspass/get.rs
@@ -119,7 +119,7 @@ mod tests {
             token_account: Pubkey::default(),
             payment_status: TenantPaymentStatus::Paid,
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let mgroup_pubkey = Pubkey::new_unique();

--- a/smartcontract/cli/src/tenant/create.rs
+++ b/smartcontract/cli/src/tenant/create.rs
@@ -24,7 +24,7 @@ pub struct CreateTenantCliCommand {
     pub metro_route: bool,
     /// Enable route aliveness checks for this tenant
     #[arg(long, default_value = "false")]
-    pub route_aliveness: bool,
+    pub route_liveness: bool,
 }
 
 impl CreateTenantCliCommand {
@@ -58,7 +58,7 @@ impl CreateTenantCliCommand {
             administrator,
             token_account,
             metro_route: self.metro_route,
-            route_aliveness: self.route_aliveness,
+            route_liveness: self.route_liveness,
         })?;
 
         writeln!(out, "Signature: {signature}")?;

--- a/smartcontract/cli/src/tenant/get.rs
+++ b/smartcontract/cli/src/tenant/get.rs
@@ -20,7 +20,7 @@ impl GetTenantCliCommand {
         writeln!(out, "code: {}", tenant.code)?;
         writeln!(out, "vrf_id: {}", tenant.vrf_id)?;
         writeln!(out, "metro_route: {}", tenant.metro_route)?;
-        writeln!(out, "route_aliveness: {}", tenant.route_aliveness)?;
+        writeln!(out, "route_liveness: {}", tenant.route_liveness)?;
         writeln!(out, "owner: {}", tenant.owner)?;
 
         Ok(())

--- a/smartcontract/cli/src/tenant/list.rs
+++ b/smartcontract/cli/src/tenant/list.rs
@@ -24,7 +24,7 @@ pub struct TenantDisplay {
     pub code: String,
     pub vrf_id: u16,
     pub metro_route: bool,
-    pub route_aliveness: bool,
+    pub route_liveness: bool,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
@@ -40,7 +40,7 @@ impl ListTenantCliCommand {
                 code: tenant.code,
                 vrf_id: tenant.vrf_id,
                 metro_route: tenant.metro_route,
-                route_aliveness: tenant.route_aliveness,
+                route_liveness: tenant.route_liveness,
                 owner: tenant.owner,
             })
             .collect();

--- a/smartcontract/cli/src/tenant/update.rs
+++ b/smartcontract/cli/src/tenant/update.rs
@@ -24,7 +24,7 @@ pub struct UpdateTenantCliCommand {
     pub metro_route: Option<bool>,
     /// Enable/disable route aliveness checks
     #[arg(long)]
-    pub route_aliveness: Option<bool>,
+    pub route_liveness: Option<bool>,
 }
 
 impl UpdateTenantCliCommand {
@@ -46,7 +46,7 @@ impl UpdateTenantCliCommand {
             vrf_id: self.vrf_id,
             token_account,
             metro_route: self.metro_route,
-            route_aliveness: self.route_aliveness,
+            route_liveness: self.route_liveness,
         })?;
 
         writeln!(out, "Signature: {signature}")?;

--- a/smartcontract/cli/src/user/get.rs
+++ b/smartcontract/cli/src/user/get.rs
@@ -129,7 +129,7 @@ mod tests {
             token_account: Pubkey::default(),
             payment_status: TenantPaymentStatus::Paid,
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let device_pubkey = Pubkey::new_unique();

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -1359,7 +1359,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Paid,
             token_account: Pubkey::default(),
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let tenant2 = Tenant {
@@ -1373,7 +1373,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Paid,
             token_account: Pubkey::default(),
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let user1_pubkey = Pubkey::from_str_const("11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo");
@@ -1520,7 +1520,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Paid,
             token_account: Pubkey::default(),
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let tenant2 = Tenant {
@@ -1534,7 +1534,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Paid,
             token_account: Pubkey::default(),
             metro_route: false,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let user1_pubkey = Pubkey::from_str_const("11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo");

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -1158,7 +1158,7 @@ mod tests {
                 administrator: Pubkey::new_unique(),
                 token_account: None,
                 metro_route: true,
-                route_aliveness: false,
+                route_liveness: false,
             }),
             "CreateTenant",
         );
@@ -1167,7 +1167,7 @@ mod tests {
                 vrf_id: Some(200),
                 token_account: Some(Pubkey::new_unique()),
                 metro_route: Some(true),
-                route_aliveness: Some(false),
+                route_liveness: Some(false),
             }),
             "UpdateTenant",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/tenant/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/tenant/create.rs
@@ -33,14 +33,14 @@ pub struct TenantCreateArgs {
     pub administrator: Pubkey,
     pub token_account: Option<Pubkey>,
     pub metro_route: bool,
-    pub route_aliveness: bool,
+    pub route_liveness: bool,
 }
 impl fmt::Debug for TenantCreateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "code: {}, token_account: {:?}, metro_route: {}, route_aliveness: {}",
-            self.code, self.token_account, self.metro_route, self.route_aliveness
+            "code: {}, token_account: {:?}, metro_route: {}, route_liveness: {}",
+            self.code, self.token_account, self.metro_route, self.route_liveness
         )
     }
 }
@@ -146,7 +146,7 @@ pub fn process_create_tenant(
         payment_status: TenantPaymentStatus::default(),
         token_account: value.token_account.unwrap_or_default(),
         metro_route: value.metro_route,
-        route_aliveness: value.route_aliveness,
+        route_liveness: value.route_liveness,
     };
 
     let deposit = Rent::get()

--- a/smartcontract/programs/doublezero-serviceability/src/processors/tenant/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/tenant/update.rs
@@ -20,15 +20,15 @@ pub struct TenantUpdateArgs {
     pub vrf_id: Option<u16>,
     pub token_account: Option<Pubkey>,
     pub metro_route: Option<bool>,
-    pub route_aliveness: Option<bool>,
+    pub route_liveness: Option<bool>,
 }
 
 impl fmt::Debug for TenantUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "vrf_id: {:?}, token_account: {:?}, metro_route: {:?}, route_aliveness: {:?}",
-            self.vrf_id, self.token_account, self.metro_route, self.route_aliveness
+            "vrf_id: {:?}, token_account: {:?}, metro_route: {:?}, route_liveness: {:?}",
+            self.vrf_id, self.token_account, self.metro_route, self.route_liveness
         )
     }
 }
@@ -84,8 +84,8 @@ pub fn process_update_tenant(
     if let Some(metro_route) = value.metro_route {
         tenant.metro_route = metro_route;
     }
-    if let Some(route_aliveness) = value.route_aliveness {
-        tenant.route_aliveness = route_aliveness;
+    if let Some(route_liveness) = value.route_liveness {
+        tenant.route_liveness = route_liveness;
     }
     try_acc_write(&tenant, tenant_account, payer_account, accounts)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/tenant.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/tenant.rs
@@ -69,15 +69,15 @@ pub struct Tenant {
     )]
     pub token_account: Pubkey, // 32 bytes — Solana 2Z token account to monitor
     pub metro_route: bool, // 1 byte - enables tenant to be routed through metro for VRF requests
-    pub route_aliveness: bool, // 1 byte - enables tenant to be check for aliveness before routing
+    pub route_liveness: bool, // 1 byte - enables tenant to be check for aliveness before routing
 }
 
 impl fmt::Display for Tenant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "account_type: {}, owner: {}, bump_seed: {}, code: {}, vrf_id: {}, administrators: {:?}, payment_status: {}, token_account: {}, metro_route: {}, route_aliveness: {}",
-            self.account_type, self.owner, self.bump_seed, self.code, self.vrf_id, self.administrators, self.payment_status, self.token_account, self.metro_route, self.route_aliveness
+            "account_type: {}, owner: {}, bump_seed: {}, code: {}, vrf_id: {}, administrators: {:?}, payment_status: {}, token_account: {}, metro_route: {}, route_liveness: {}",
+            self.account_type, self.owner, self.bump_seed, self.code, self.vrf_id, self.administrators, self.payment_status, self.token_account, self.metro_route, self.route_liveness
         )
     }
 }
@@ -97,7 +97,7 @@ impl TryFrom<&[u8]> for Tenant {
             payment_status: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             token_account: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             metro_route: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
-            route_aliveness: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            route_liveness: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::Tenant {
@@ -170,7 +170,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Paid,
             token_account: Pubkey::default(),
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -211,7 +211,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Delinquent,
             token_account: Pubkey::default(),
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -231,7 +231,7 @@ mod tests {
             payment_status: TenantPaymentStatus::Delinquent,
             token_account: Pubkey::default(),
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         };
         let err = val.validate();
         assert!(err.is_err());

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -314,7 +314,7 @@ async fn test_accesspass_with_tenant() {
             administrator: administrator_acme,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_acme, false),
@@ -338,7 +338,7 @@ async fn test_accesspass_with_tenant() {
             administrator: administrator_corp,
             token_account: None,
             metro_route: false,
-            route_aliveness: true,
+            route_liveness: true,
         }),
         vec![
             AccountMeta::new(tenant_corp, false),
@@ -362,7 +362,7 @@ async fn test_accesspass_with_tenant() {
             administrator: administrator_validator,
             token_account: None,
             metro_route: true,
-            route_aliveness: true,
+            route_liveness: true,
         }),
         vec![
             AccountMeta::new(tenant_validator, false),
@@ -972,7 +972,7 @@ async fn setup_device_and_tenants() -> (BanksClient, Keypair, Pubkey, Pubkey, Pu
             administrator: Pubkey::new_unique(),
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_a, false),
@@ -993,7 +993,7 @@ async fn setup_device_and_tenants() -> (BanksClient, Keypair, Pubkey, Pubkey, Pu
             administrator: Pubkey::new_unique(),
             token_account: None,
             metro_route: false,
-            route_aliveness: true,
+            route_liveness: true,
         }),
         vec![
             AccountMeta::new(tenant_b, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/tenant_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/tenant_test.rs
@@ -43,7 +43,7 @@ async fn test_tenant() {
             administrator,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_pubkey, false),
@@ -66,7 +66,7 @@ async fn test_tenant() {
     assert_eq!(tenant.administrators.len(), 1);
     assert_eq!(tenant.administrators[0], administrator);
     assert!(tenant.metro_route);
-    assert!(!tenant.route_aliveness);
+    assert!(!tenant.route_liveness);
 
     println!("✅ Tenant created successfully");
 
@@ -80,7 +80,7 @@ async fn test_tenant() {
             vrf_id: Some(200),
             token_account: None,
             metro_route: Some(false),
-            route_aliveness: Some(true),
+            route_liveness: Some(true),
         }),
         vec![
             AccountMeta::new(tenant_pubkey, false),
@@ -99,7 +99,7 @@ async fn test_tenant() {
     assert_eq!(tenant.code, "test-tenant".to_string()); // Code unchanged (immutable)
     assert_eq!(tenant.vrf_id, 200); // VRF ID updated
     assert!(!tenant.metro_route); // Metro route updated
-    assert!(tenant.route_aliveness); // Route aliveness updated
+    assert!(tenant.route_liveness); // Route aliveness updated
 
     let _initial_vrf_id = tenant.vrf_id; // Save for later comparison
 
@@ -244,7 +244,7 @@ async fn test_tenant_delete_with_nonzero_reference_count_fails() {
             administrator,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_pubkey, false),
@@ -318,7 +318,7 @@ async fn test_tenant_add_duplicate_administrator_fails() {
             administrator,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_pubkey, false),
@@ -408,7 +408,7 @@ async fn test_tenant_remove_nonexistent_administrator_fails() {
             administrator,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -991,7 +991,7 @@ async fn test_user_create_tenant_allowlist_validation() {
             administrator: Pubkey::new_unique(),
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_a_pubkey, false),
@@ -1015,7 +1015,7 @@ async fn test_user_create_tenant_allowlist_validation() {
             administrator: Pubkey::new_unique(),
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }),
         vec![
             AccountMeta::new(tenant_b_pubkey, false),

--- a/smartcontract/sdk/rs/src/commands/tenant/create.rs
+++ b/smartcontract/sdk/rs/src/commands/tenant/create.rs
@@ -14,7 +14,7 @@ pub struct CreateTenantCommand {
     pub administrator: Pubkey,
     pub token_account: Option<Pubkey>,
     pub metro_route: bool,
-    pub route_aliveness: bool,
+    pub route_liveness: bool,
 }
 
 impl CreateTenantCommand {
@@ -36,7 +36,7 @@ impl CreateTenantCommand {
                     administrator: self.administrator,
                     token_account: self.token_account,
                     metro_route: self.metro_route,
-                    route_aliveness: self.route_aliveness,
+                    route_liveness: self.route_liveness,
                 }),
                 vec![
                     AccountMeta::new(pda_pubkey, false),
@@ -71,7 +71,7 @@ mod tests {
                     administrator,
                     token_account: None,
                     metro_route: true,
-                    route_aliveness: false,
+                    route_liveness: false,
                 })),
                 predicate::always(),
             )
@@ -82,7 +82,7 @@ mod tests {
             administrator: Pubkey::default(),
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }
         .execute(&client);
 
@@ -93,7 +93,7 @@ mod tests {
             administrator,
             token_account: None,
             metro_route: true,
-            route_aliveness: false,
+            route_liveness: false,
         }
         .execute(&client);
 

--- a/smartcontract/sdk/rs/src/commands/tenant/update.rs
+++ b/smartcontract/sdk/rs/src/commands/tenant/update.rs
@@ -11,7 +11,7 @@ pub struct UpdateTenantCommand {
     pub vrf_id: Option<u16>,
     pub token_account: Option<Pubkey>,
     pub metro_route: Option<bool>,
-    pub route_aliveness: Option<bool>,
+    pub route_liveness: Option<bool>,
 }
 
 impl UpdateTenantCommand {
@@ -23,7 +23,7 @@ impl UpdateTenantCommand {
                 vrf_id: self.vrf_id,
                 token_account: self.token_account,
                 metro_route: self.metro_route,
-                route_aliveness: self.route_aliveness,
+                route_liveness: self.route_liveness,
             }),
             vec![
                 AccountMeta::new(self.tenant_pubkey, false),


### PR DESCRIPTION
This pull request standardizes the naming of a tenant configuration field throughout the codebase, changing all occurrences of `route_aliveness` to `route_liveness`. This update affects the core program logic, CLI commands, tests, and documentation to ensure consistency and clarity regarding the tenant routing feature.

Field renaming and code consistency:

* Renamed the `route_aliveness` field to `route_liveness` in the `Tenant` struct and all related program logic, including serialization, deserialization, display, and validation in `smartcontract/programs/doublezero-serviceability/src/state/tenant.rs`. [[1]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L72-R80) [[2]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L100-R100)
* Updated the corresponding argument and field names in tenant creation and update processors, including `TenantCreateArgs`, `TenantUpdateArgs`, and their debug implementations, as well as in the processing functions. [[1]](diffhunk://#diff-0246aa0a0714fdfa1a280c3b1b71db28d3276b7d0a9418f8e443b0007bb92e6aL36-R43) [[2]](diffhunk://#diff-0246aa0a0714fdfa1a280c3b1b71db28d3276b7d0a9418f8e443b0007bb92e6aL149-R149) [[3]](diffhunk://#diff-510a80446e738453fbed75c0aa27ee9384941c0aac14a85118953cd650eaa3a6L23-R31) [[4]](diffhunk://#diff-510a80446e738453fbed75c0aa27ee9384941c0aac14a85118953cd650eaa3a6L87-R88)
* Modified CLI command structures and implementations to use `route_liveness` instead of `route_aliveness` for creating, updating, listing, and displaying tenants (`smartcontract/cli/src/tenant/create.rs`, `update.rs`, `list.rs`, `get.rs`). [[1]](diffhunk://#diff-341a09d7dc626850864d3090b56010c027cfb25663b71a952de00c6f25c15d76L27-R27) [[2]](diffhunk://#diff-341a09d7dc626850864d3090b56010c027cfb25663b71a952de00c6f25c15d76L61-R61) [[3]](diffhunk://#diff-5f5463b50e7bc8e0be7e0a1d96216b501c58d88571bff97f0b2febd407b1875fL27-R27) [[4]](diffhunk://#diff-5f5463b50e7bc8e0be7e0a1d96216b501c58d88571bff97f0b2febd407b1875fL49-R49) [[5]](diffhunk://#diff-f4015f6540131a468bfb7e1e295238b7fcdc5e75abd23c814ae0af1798f2fba9L27-R27) [[6]](diffhunk://#diff-f4015f6540131a468bfb7e1e295238b7fcdc5e75abd23c814ae0af1798f2fba9L43-R43) [[7]](diffhunk://#diff-9ce3a30cd9d0ab7437886e9ddc3e7fad980e26313ccfa678c9f9ad20d2c9b2deL23-R23)

Documentation and SDK updates:

* Updated all documentation references and changelog entries to use `route_liveness`, including in `CHANGELOG.md` and SDK command descriptions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL26-R26) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL35-R35)

Test coverage:

* Refactored all test cases across multiple files to use `route_liveness` for tenant creation, update, and validation scenarios, ensuring tests accurately reflect the new field name. [[1]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L996-R996) [[2]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L1242-R1242) [[3]](diffhunk://#diff-5b1a0a2f93933b3628890f158677c9ae03a911817a3ff6ab198c4a71f4f7538fL122-R122) [[4]](diffhunk://#diff-6ba64689de33aa0b385c0714d87b84a411782cc37c0e1a605ec6b275b73c8dc8L132-R132) [[5]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1362-R1362) [[6]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1376-R1376) [[7]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1523-R1523) [[8]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1537-R1537) [[9]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL1161-R1161) [[10]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL1170-R1170) [[11]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L173-R173) [[12]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L214-R214) [[13]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L234-R234) [[14]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL317-R317) [[15]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL341-R341) [[16]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL365-R365)