### PR TITLE
e2e: fix QA multicast connectivity test flakiness

### DIFF
--- a/e2e/qa_multicast_test.go
+++ b/e2e/qa_multicast_test.go
@@ -41,7 +41,7 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 	clients := test.Clients()
 
 	// Cleanup stale test groups from previous runs.
-	deleted, err := clients[0].CleanupStaleTestGroups(ctx)
+	deleted, err := clients[0].CleanupStaleTestGroups(ctx, clients)
 	require.NoError(t, err, "failed to cleanup stale test groups")
 	if deleted > 0 {
 		log.Info("Cleaned up stale test groups", "count", deleted)
@@ -156,9 +156,11 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 		require.NoError(t, err, "failed to join multicast group %s", group.Code)
 	}
 
-	// Send multicast data from publisher to the multicast group.
-	err = publisher.MulticastSend(ctx, group, 60*time.Second)
-	require.NoError(t, err, "failed to send multicast data to group %s", group.Code)
+	// Send multicast data from publisher in background while we poll for reports.
+	// This avoids the race where PIM convergence takes longer than the send window.
+	go func() {
+		_ = publisher.MulticastSend(ctx, group, 120*time.Second)
+	}()
 
 	// Get multicast report from each subscriber.
 	for _, subscriber := range subscribers {
@@ -174,7 +176,7 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 			report, err := subscriber.WaitForMulticastReport(subCtx, group)
 			require.NoError(t, err, "failed to get multicast report for group %s", group.Code)
 			require.NotNil(t, report, "multicast report not found for group %s", group.Code)
-			log.Debug("Got multicast report", "subscriber", subscriber.Host, "group", group.Code, "report", report)
+			log.Info("Received multicast packets", "subscriber", subscriber.Host, "group", group.Code, "packetCount", report.PacketCount)
 		})
 	}
 
@@ -197,7 +199,7 @@ func TestQA_MulticastMultiGroupSimultaneous(t *testing.T) {
 	require.GreaterOrEqual(t, len(clients), 2, "need at least 2 clients for this test")
 
 	// Cleanup stale test groups from previous runs.
-	deleted, err := clients[0].CleanupStaleTestGroups(ctx)
+	deleted, err := clients[0].CleanupStaleTestGroups(ctx, clients)
 	require.NoError(t, err, "failed to cleanup stale test groups")
 	if deleted > 0 {
 		log.Info("Cleaned up stale test groups", "count", deleted)
@@ -315,10 +317,10 @@ func TestQA_MulticastMultiGroupSimultaneous(t *testing.T) {
 		report := reports[group.IP.String()]
 		require.NotNil(t, report, "no report for group %s", group.Code)
 		require.Greater(t, report.PacketCount, uint64(0), "no packets received for group %s", group.Code)
-		log.Debug("Verified packets received", "group", group.Code, "packetCount", report.PacketCount)
+		log.Info("Received multicast packets", "subscriber", subscriber.Host, "group", group.Code, "packetCount", report.PacketCount)
 	}
 
-	log.Debug("Test passed: subscriber received traffic from all 3 groups")
+	log.Info("All subscribers received traffic from all groups")
 }
 
 // TestQA_MulticastAddGroupToExistingUser tests adding a new multicast group subscription
@@ -335,7 +337,7 @@ func TestQA_MulticastAddGroupToExistingUser(t *testing.T) {
 	require.GreaterOrEqual(t, len(clients), 2, "need at least 2 clients for this test")
 
 	// Cleanup stale test groups from previous runs.
-	deleted, err := clients[0].CleanupStaleTestGroups(ctx)
+	deleted, err := clients[0].CleanupStaleTestGroups(ctx, clients)
 	require.NoError(t, err, "failed to cleanup stale test groups")
 	if deleted > 0 {
 		log.Info("Cleaned up stale test groups", "count", deleted)
@@ -444,7 +446,7 @@ func TestQA_MulticastAddGroupToExistingUser(t *testing.T) {
 	reportA, err := subscriber.WaitForMulticastReport(ctx, groupA)
 	require.NoError(t, err, "failed to get report for group A")
 	require.Greater(t, reportA.PacketCount, uint64(0), "no packets received for group A")
-	log.Debug("Verified packets received from group A", "packetCount", reportA.PacketCount)
+	log.Info("Received multicast packets", "subscriber", subscriber.Host, "group", groupA.Code, "packetCount", reportA.PacketCount)
 
 	// Step 4: Add group B to existing subscriber (without disconnecting).
 	// Note: ConnectUserMulticast calls DisconnectUser internally, but the CLI behavior
@@ -487,8 +489,9 @@ func TestQA_MulticastAddGroupToExistingUser(t *testing.T) {
 	require.NotNil(t, reportB, "no report for group B")
 	require.Greater(t, reportB.PacketCount, uint64(0), "no packets from group B")
 
-	log.Debug("Test passed: successfully added group B to existing user and received traffic from both groups",
-		"groupA_packets", reportA.PacketCount, "groupB_packets", reportB.PacketCount)
+	log.Info("Received multicast packets from both groups",
+		"subscriber", subscriber.Host, "groupA", groupA.Code, "groupA_packets", reportA.PacketCount,
+		"groupB", groupB.Code, "groupB_packets", reportB.PacketCount)
 }
 
 // TestQA_MulticastPublisherMultipleGroups tests a single publisher sending to multiple
@@ -505,7 +508,7 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	require.GreaterOrEqual(t, len(clients), 3, "need at least 3 clients for this test (1 publisher + 2 subscribers)")
 
 	// Cleanup stale test groups from previous runs.
-	deleted, err := clients[0].CleanupStaleTestGroups(ctx)
+	deleted, err := clients[0].CleanupStaleTestGroups(ctx, clients)
 	require.NoError(t, err, "failed to cleanup stale test groups")
 	if deleted > 0 {
 		log.Info("Cleaned up stale test groups", "count", deleted)
@@ -636,15 +639,12 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	reportA, err := subscriberA.WaitForMulticastReport(ctx, groupA)
 	require.NoError(t, err, "failed to get report for group A from subscriberA")
 	require.Greater(t, reportA.PacketCount, uint64(0), "subscriberA received no packets from group A")
-	log.Debug("SubscriberA verified", "group", groupA.Code, "packetCount", reportA.PacketCount)
+	log.Info("Received multicast packets", "subscriber", subscriberA.Host, "group", groupA.Code, "packetCount", reportA.PacketCount)
 
 	// Verify subscriberB receives from group B.
 	log.Debug("Waiting for subscriberB to receive from group B")
 	reportB, err := subscriberB.WaitForMulticastReport(ctx, groupB)
 	require.NoError(t, err, "failed to get report for group B from subscriberB")
 	require.Greater(t, reportB.PacketCount, uint64(0), "subscriberB received no packets from group B")
-	log.Debug("SubscriberB verified", "group", groupB.Code, "packetCount", reportB.PacketCount)
-
-	log.Debug("Test passed: publisher successfully sent to multiple groups with different subscribers",
-		"groupA_packets", reportA.PacketCount, "groupB_packets", reportB.PacketCount)
+	log.Info("Received multicast packets", "subscriber", subscriberB.Host, "group", groupB.Code, "packetCount", reportB.PacketCount)
 }


### PR DESCRIPTION
## Summary
- Send multicast data in a background goroutine while polling for reports in `TestQA_MulticastConnectivity`, matching the pattern used by the other multicast tests. The previous synchronous send blocked for 60s before checking reports, so if PIM convergence took longer than the send window, no packets were delivered and the report poll timed out.
- Fix stale group cleanup to disconnect users that block group deletion (groups with active publishers/subscribers from previous failed runs), and treat `AccountNotFound` as success to suppress noise from duplicate cleanup attempts.
- Log multicast packet receipt at Info level so test output shows which subscribers received packets.

## Testing Verification
```
doublezero ms/go-routine-mg-send  ❯ go test -tags=qa -short -v -run 'TestQA_MulticastConnectivity|TestQA_MulticastMultiGroupSimultaneous' ./e2e --args -hosts=chi-dn-bm2,chi-dn-bm3,chi-dn-bm4 -env devnet
=== RUN   TestQA_MulticastConnectivity
=== RUN   TestQA_MulticastConnectivity/subscriber_chi-dn-bm3
    qa_test.go:67: 2026-02-11T16:16:09.708Z INF Received multicast packets subscriber=chi-dn-bm3 group=qa-test-group-482177 packetCount=4
=== RUN   TestQA_MulticastConnectivity/subscriber_chi-dn-bm4
    qa_test.go:67: 2026-02-11T16:16:09.754Z INF Received multicast packets subscriber=chi-dn-bm4 group=qa-test-group-482177 packetCount=6
--- PASS: TestQA_MulticastConnectivity (75.37s)
    --- PASS: TestQA_MulticastConnectivity/subscriber_chi-dn-bm3 (1.01s)
    --- PASS: TestQA_MulticastConnectivity/subscriber_chi-dn-bm4 (0.05s)
=== RUN   TestQA_MulticastMultiGroupSimultaneous
    qa_test.go:67: 2026-02-11T16:16:42.473Z INF Cleaned up stale test groups count=1
    qa_test.go:67: 2026-02-11T16:18:00.183Z INF Received multicast packets subscriber=chi-dn-bm4 group=qa-test-group-349096 packetCount=105
    qa_test.go:67: 2026-02-11T16:18:00.183Z INF Received multicast packets subscriber=chi-dn-bm4 group=qa-test-group-428332 packetCount=9
    qa_test.go:67: 2026-02-11T16:18:00.183Z INF Received multicast packets subscriber=chi-dn-bm4 group=qa-test-group-552465 packetCount=9
    qa_test.go:67: 2026-02-11T16:18:00.183Z INF All subscribers received traffic from all groups
--- PASS: TestQA_MulticastMultiGroupSimultaneous (116.66s)
PASS
ok      github.com/malbeclabs/doublezero/e2e    192.037s
```