### PR TITLE
change to metro routing

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/tests/tenant_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/tenant_test.rs
@@ -43,7 +43,6 @@ async fn test_tenant() {
             administrator,
             token_account: None,
             metro_routing: true,
-            metro_routing: true,
             route_liveness: false,
         }),
         vec![
@@ -67,7 +66,6 @@ async fn test_tenant() {
     assert_eq!(tenant.administrators.len(), 1);
     assert_eq!(tenant.administrators[0], administrator);
     assert!(tenant.metro_routing);
-    assert!(tenant.metro_routing);
     assert!(!tenant.route_liveness);
 
     println!("✅ Tenant created successfully");
@@ -81,7 +79,6 @@ async fn test_tenant() {
         DoubleZeroInstruction::UpdateTenant(TenantUpdateArgs {
             vrf_id: Some(200),
             token_account: None,
-            metro_routing: Some(false),
             metro_routing: Some(false),
             route_liveness: Some(true),
             billing: None,


### PR DESCRIPTION
This pull request standardizes the naming of a configuration field across the codebase by renaming all instances of `metro_route` to `metro_routing`. This change affects the smart contract state, CLI commands, SDK, test cases, and documentation to ensure consistency and clarity.

**Field renaming for consistency:**

* Renamed the `metro_route` field to `metro_routing` in the `Tenant` struct and all related smart contract logic, including serialization/deserialization, display, and validation (`smartcontract/programs/doublezero-serviceability/src/state/tenant.rs`, `smartcontract/programs/doublezero-serviceability/src/processors/tenant/create.rs`, `smartcontract/programs/doublezero-serviceability/src/processors/tenant/update.rs`) [[1]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L71-R80) [[2]](diffhunk://#diff-0246aa0a0714fdfa1a280c3b1b71db28d3276b7d0a9418f8e443b0007bb92e6aL35-R43) [[3]](diffhunk://#diff-0246aa0a0714fdfa1a280c3b1b71db28d3276b7d0a9418f8e443b0007bb92e6aL148-R148) [[4]](diffhunk://#diff-510a80446e738453fbed75c0aa27ee9384941c0aac14a85118953cd650eaa3a6L22-R31) [[5]](diffhunk://#diff-510a80446e738453fbed75c0aa27ee9384941c0aac14a85118953cd650eaa3a6L84-R85).

* Updated CLI command argument and struct field names from `metro_route` to `metro_routing` in `CreateTenantCliCommand`, `UpdateTenantCliCommand`, and related display and list logic (`smartcontract/cli/src/tenant/create.rs`, `smartcontract/cli/src/tenant/update.rs`, `smartcontract/cli/src/tenant/list.rs`, `smartcontract/cli/src/tenant/get.rs`) [[1]](diffhunk://#diff-341a09d7dc626850864d3090b56010c027cfb25663b71a952de00c6f25c15d76L24-R24) [[2]](diffhunk://#diff-341a09d7dc626850864d3090b56010c027cfb25663b71a952de00c6f25c15d76L60-R60) [[3]](diffhunk://#diff-5f5463b50e7bc8e0be7e0a1d96216b501c58d88571bff97f0b2febd407b1875fL24-R24) [[4]](diffhunk://#diff-5f5463b50e7bc8e0be7e0a1d96216b501c58d88571bff97f0b2febd407b1875fL48-R48) [[5]](diffhunk://#diff-f4015f6540131a468bfb7e1e295238b7fcdc5e75abd23c814ae0af1798f2fba9L26-R26) [[6]](diffhunk://#diff-f4015f6540131a468bfb7e1e295238b7fcdc5e75abd23c814ae0af1798f2fba9L42-R42) [[7]](diffhunk://#diff-9ce3a30cd9d0ab7437886e9ddc3e7fad980e26313ccfa678c9f9ad20d2c9b2deL22-R22).

* Modified all related test cases and test data to use the new `metro_routing` field name instead of `metro_route` across the CLI, SDK, and smart contract test files (`smartcontract/cli/src/user/get.rs`, `smartcontract/cli/src/user/list.rs`, `client/doublezero/src/command/connect.rs`, `smartcontract/programs/doublezero-serviceability/src/instructions.rs`, `smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs`, `smartcontract/programs/doublezero-serviceability/src/state/tenant.rs`) [[1]](diffhunk://#diff-6ba64689de33aa0b385c0714d87b84a411782cc37c0e1a605ec6b275b73c8dc8L131-R131) [[2]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1361-R1361) [[3]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1375-R1375) [[4]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1522-R1522) [[5]](diffhunk://#diff-f3488267bea84e657ab59113babdd80812985a6494792daa91bcbab5ad95b450L1536-R1536) [[6]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L995-R995) [[7]](diffhunk://#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184L1241-R1241) [[8]](diffhunk://#diff-5b1a0a2f93933b3628890f158677c9ae03a911817a3ff6ab198c4a71f4f7538fL121-R121) [[9]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL1160-R1160) [[10]](diffhunk://#diff-3aed842c99767fc5c576e142220dab61652c1872588c96ccbe1476ec39b8db3dL1169-R1169) [[11]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL316-R316) [[12]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL340-R340) [[13]](diffhunk://#diff-27037a2a93a0de599ec37406cb49d1762958fb87432edcd7620599b728eedfbbL364-R364) [[14]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L172-R172) [[15]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L213-R213) [[16]](diffhunk://#diff-94058fcb7d79bbd6d0ed858d4137f792c1965a528f44ebf76742099abddd0603L233-R233).

**Documentation and changelog updates:**

* Updated all references to `metro_route` to `metro_routing` in the `CHANGELOG.md` and SDK documentation to reflect the new field name and maintain accurate documentation (`CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL26-R26) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL35-R35).