### PR TITLE
telemetry: fix flaky flow-ingest e2e test on redpanda container exit

### DIFF
--- a/telemetry/flow-ingest/internal/e2e/server_test.go
+++ b/telemetry/flow-ingest/internal/e2e/server_test.go
@@ -279,6 +279,7 @@ func isRetryableContainerStartErr(err error) bool {
 		strings.Contains(s, "context deadline exceeded") ||
 		strings.Contains(s, "TLS handshake") ||
 		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "container exited") ||
 		strings.Contains(s, "/containers/") && strings.Contains(s, "json") ||
 		strings.Contains(s, "Get \"http")
 }


### PR DESCRIPTION
## Summary of Changes
- Add `"container exited"` to the retryable error patterns in `isRetryableContainerStartErr` so that Redpanda container startup failures (exit code 1) trigger retry logic instead of immediately failing the test
- Fixes https://github.com/malbeclabs/doublezero/actions/runs/21921314620/job/63302196184?pr=2882

## Testing Verification
- Existing retry logic (up to 5 attempts with backoff) handles the transient failure