### PR TITLE
doublezerod: add multicast publisher heartbeat sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - Activator
   - Assign multicast publisher IPs from global pool in serviceability GlobalConfig instead of per-device blocks
+- Client
+  - Add multicast publisher heartbeat sender — sends periodic UDP packets to each multicast group to keep PIM (S,G) mroute state alive on devices
 - E2E tests
   - Add daily devnet QA test for device provisioning lifecycle (RFC12) — deletes/recreates device and links, restarts daemons with new pubkey via Ansible
 

--- a/client/doublezerod/internal/manager/http_test.go
+++ b/client/doublezerod/internal/manager/http_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -108,7 +109,8 @@ func TestHttpStatus(t *testing.T) {
 	b := &MockBgpServer{}
 	db := &MockDb{state: nil}
 	pim := &MockPIMServer{}
-	manager := manager.NewNetlinkManager(m, b, db, pim)
+	heartbeat := &MockHeartbeatSender{}
+	manager := manager.NewNetlinkManager(m, b, db, pim, heartbeat)
 
 	f, err := os.CreateTemp("/tmp", "doublezero.sock")
 	if err != nil {
@@ -220,7 +222,8 @@ func TestNetlinkManager_HttpEndpoints(t *testing.T) {
 	b := &MockBgpServer{}
 	db := &MockDb{state: []*api.ProvisionRequest{}}
 	pim := &MockPIMServer{}
-	manager := manager.NewNetlinkManager(m, b, db, pim)
+	heartbeat := &MockHeartbeatSender{}
+	manager := manager.NewNetlinkManager(m, b, db, pim, heartbeat)
 
 	f, err := os.CreateTemp("/tmp", "doublezero.sock")
 	if err != nil {
@@ -401,6 +404,16 @@ func (m *MockPIMServer) Start(conn pim.RawConner, iface string, tunnelAddr net.I
 }
 
 func (m *MockPIMServer) Close() error {
+	return nil
+}
+
+type MockHeartbeatSender struct{}
+
+func (m *MockHeartbeatSender) Start(iface string, srcIP net.IP, groups []net.IP, ttl int, interval time.Duration) error {
+	return nil
+}
+
+func (m *MockHeartbeatSender) Close() error {
 	return nil
 }
 

--- a/client/doublezerod/internal/multicast/heartbeat.go
+++ b/client/doublezerod/internal/multicast/heartbeat.go
@@ -1,0 +1,118 @@
+package multicast
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/net/ipv4"
+)
+
+const (
+	// HeartbeatPort is the well-known UDP port for multicast heartbeat packets.
+	HeartbeatPort = 5765
+
+	// DefaultHeartbeatTTL is the default IP TTL for heartbeat packets,
+	// matching the GRE tunnel TTL configured on devices.
+	DefaultHeartbeatTTL = 32
+
+	// DefaultHeartbeatInterval is the default interval between heartbeat packets.
+	DefaultHeartbeatInterval = 10 * time.Second
+)
+
+// heartbeatPayload is the fixed payload sent in each heartbeat packet.
+// 0x44, 0x5A = "DZ", followed by a 2-byte version (0x00, 0x01).
+var heartbeatPayload = []byte{0x44, 0x5A, 0x00, 0x01}
+
+// PacketConner abstracts the UDP multicast connection for testing.
+type PacketConner interface {
+	WriteTo(b []byte, cm *ipv4.ControlMessage, dst net.Addr) (int, error)
+	SetMulticastTTL(ttl int) error
+	SetMulticastInterface(intf *net.Interface) error
+	Close() error
+}
+
+// HeartbeatSender sends periodic UDP heartbeat packets to multicast groups
+// to keep PIM (S, G) state and MSDP SA caches alive in the network.
+type HeartbeatSender struct {
+	done chan struct{}
+	wg   *sync.WaitGroup
+}
+
+func NewHeartbeatSender() *HeartbeatSender {
+	return &HeartbeatSender{done: make(chan struct{})}
+}
+
+// Start begins sending heartbeat packets to each multicast group at the given interval.
+// srcIP is the source address to bind (the publisher's allocated DZ IP).
+func (h *HeartbeatSender) Start(iface string, srcIP net.IP, groups []net.IP, ttl int, interval time.Duration) error {
+	intf, err := net.InterfaceByName(iface)
+	if err != nil {
+		return fmt.Errorf("failed to get interface %s: %v", iface, err)
+	}
+
+	conn, err := net.ListenPacket("udp4", net.JoinHostPort(srcIP.String(), "0"))
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %v", srcIP, err)
+	}
+
+	p := ipv4.NewPacketConn(conn)
+	return h.startWithConn(p, intf, groups, ttl, interval)
+}
+
+// startWithConn is the internal start method that accepts a pre-built connection for testing.
+func (h *HeartbeatSender) startWithConn(p PacketConner, intf *net.Interface, groups []net.IP, ttl int, interval time.Duration) error {
+	if err := p.SetMulticastTTL(ttl); err != nil {
+		p.Close()
+		return fmt.Errorf("failed to set multicast TTL: %v", err)
+	}
+	if err := p.SetMulticastInterface(intf); err != nil {
+		p.Close()
+		return fmt.Errorf("failed to set multicast interface: %v", err)
+	}
+
+	dsts := make([]*net.UDPAddr, len(groups))
+	for i, group := range groups {
+		dsts[i] = &net.UDPAddr{IP: group, Port: HeartbeatPort}
+	}
+
+	h.wg = &sync.WaitGroup{}
+	h.wg.Add(1)
+	go func() {
+		defer p.Close()
+		defer h.wg.Done()
+
+		// Send immediately before starting ticker so we don't delay by the interval.
+		sendHeartbeats(p, dsts)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				sendHeartbeats(p, dsts)
+			case <-h.done:
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func sendHeartbeats(p PacketConner, dsts []*net.UDPAddr) {
+	for _, dst := range dsts {
+		if _, err := p.WriteTo(heartbeatPayload, nil, dst); err != nil {
+			slog.Error("failed to send heartbeat", "dst", dst, "error", err)
+		}
+	}
+}
+
+func (h *HeartbeatSender) Close() error {
+	close(h.done)
+	if h.wg != nil {
+		h.wg.Wait()
+	}
+	return nil
+}

--- a/client/doublezerod/internal/multicast/heartbeat_test.go
+++ b/client/doublezerod/internal/multicast/heartbeat_test.go
@@ -1,0 +1,240 @@
+package multicast
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/ipv4"
+)
+
+type mockPacketConn struct {
+	mu      sync.Mutex
+	writes  []mockWrite
+	ttl     int
+	ifIndex int
+	closed  bool
+	writeCh chan mockWrite
+}
+
+type mockWrite struct {
+	payload []byte
+	dst     net.Addr
+}
+
+func newMockPacketConn() *mockPacketConn {
+	return &mockPacketConn{
+		writeCh: make(chan mockWrite, 100),
+	}
+}
+
+func (m *mockPacketConn) WriteTo(b []byte, _ *ipv4.ControlMessage, dst net.Addr) (int, error) {
+	cp := make([]byte, len(b))
+	copy(cp, b)
+	w := mockWrite{payload: cp, dst: dst}
+	m.mu.Lock()
+	m.writes = append(m.writes, w)
+	m.mu.Unlock()
+	m.writeCh <- w
+	return len(b), nil
+}
+
+func (m *mockPacketConn) SetMulticastTTL(ttl int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ttl = ttl
+	return nil
+}
+
+func (m *mockPacketConn) SetMulticastInterface(intf *net.Interface) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ifIndex = intf.Index
+	return nil
+}
+
+func (m *mockPacketConn) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *mockPacketConn) getWrites() []mockWrite {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]mockWrite, len(m.writes))
+	copy(cp, m.writes)
+	return cp
+}
+
+func (m *mockPacketConn) getTTL() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ttl
+}
+
+func TestHeartbeatSender_SendsImmediately(t *testing.T) {
+	conn := newMockPacketConn()
+	sender := NewHeartbeatSender()
+
+	groups := []net.IP{net.IPv4(239, 0, 0, 1)}
+	intf := &net.Interface{Index: 1, Name: "lo0"}
+
+	err := sender.startWithConn(conn, intf, groups, 32, 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	// Wait for the immediate send.
+	select {
+	case w := <-conn.writeCh:
+		udpAddr, ok := w.dst.(*net.UDPAddr)
+		if !ok {
+			t.Fatalf("expected *net.UDPAddr, got %T", w.dst)
+		}
+		if !udpAddr.IP.Equal(net.IPv4(239, 0, 0, 1)) {
+			t.Errorf("expected dst 239.0.0.1, got %s", udpAddr.IP)
+		}
+		if udpAddr.Port != HeartbeatPort {
+			t.Errorf("expected port %d, got %d", HeartbeatPort, udpAddr.Port)
+		}
+		if len(w.payload) != len(heartbeatPayload) {
+			t.Errorf("expected payload len %d, got %d", len(heartbeatPayload), len(w.payload))
+		}
+		for i, b := range w.payload {
+			if b != heartbeatPayload[i] {
+				t.Errorf("payload[%d] = 0x%02x, want 0x%02x", i, b, heartbeatPayload[i])
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for immediate heartbeat")
+	}
+
+	sender.Close()
+}
+
+func TestHeartbeatSender_SetsTTL(t *testing.T) {
+	conn := newMockPacketConn()
+	sender := NewHeartbeatSender()
+
+	intf := &net.Interface{Index: 1, Name: "lo0"}
+	err := sender.startWithConn(conn, intf, []net.IP{net.IPv4(239, 0, 0, 1)}, 42, 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	if got := conn.getTTL(); got != 42 {
+		t.Errorf("TTL = %d, want 42", got)
+	}
+
+	sender.Close()
+}
+
+func TestHeartbeatSender_MultipleGroups(t *testing.T) {
+	conn := newMockPacketConn()
+	sender := NewHeartbeatSender()
+
+	groups := []net.IP{net.IPv4(239, 0, 0, 1), net.IPv4(239, 0, 0, 2)}
+	intf := &net.Interface{Index: 1, Name: "lo0"}
+
+	err := sender.startWithConn(conn, intf, groups, 32, 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	// Wait for both immediate sends.
+	for i := range 2 {
+		select {
+		case <-conn.writeCh:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for heartbeat %d", i)
+		}
+	}
+
+	writes := conn.getWrites()
+	if len(writes) < 2 {
+		t.Fatalf("expected at least 2 writes, got %d", len(writes))
+	}
+
+	seen := map[string]bool{}
+	for _, w := range writes[:2] {
+		udpAddr := w.dst.(*net.UDPAddr)
+		seen[udpAddr.IP.String()] = true
+	}
+	if !seen["239.0.0.1"] {
+		t.Error("missing heartbeat to 239.0.0.1")
+	}
+	if !seen["239.0.0.2"] {
+		t.Error("missing heartbeat to 239.0.0.2")
+	}
+
+	sender.Close()
+}
+
+func TestHeartbeatSender_SendsAtInterval(t *testing.T) {
+	conn := newMockPacketConn()
+	sender := NewHeartbeatSender()
+
+	groups := []net.IP{net.IPv4(239, 0, 0, 1)}
+	intf := &net.Interface{Index: 1, Name: "lo0"}
+
+	// Use a short interval for testing.
+	err := sender.startWithConn(conn, intf, groups, 32, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	// Wait for at least 3 sends (1 immediate + 2 ticker).
+	for i := range 3 {
+		select {
+		case <-conn.writeCh:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for heartbeat %d", i)
+		}
+	}
+
+	writes := conn.getWrites()
+	if len(writes) < 3 {
+		t.Errorf("expected at least 3 writes, got %d", len(writes))
+	}
+
+	sender.Close()
+}
+
+func TestHeartbeatSender_CloseStopsSending(t *testing.T) {
+	conn := newMockPacketConn()
+	sender := NewHeartbeatSender()
+
+	groups := []net.IP{net.IPv4(239, 0, 0, 1)}
+	intf := &net.Interface{Index: 1, Name: "lo0"}
+
+	err := sender.startWithConn(conn, intf, groups, 32, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	// Drain the immediate send.
+	<-conn.writeCh
+
+	sender.Close()
+
+	// Record count after close.
+	countAfterClose := len(conn.getWrites())
+
+	// Wait a bit and verify no more sends.
+	time.Sleep(200 * time.Millisecond)
+	countLater := len(conn.getWrites())
+
+	if countLater != countAfterClose {
+		t.Errorf("writes continued after Close: %d -> %d", countAfterClose, countLater)
+	}
+
+	conn.mu.Lock()
+	closed := conn.closed
+	conn.mu.Unlock()
+	if !closed {
+		t.Error("connection was not closed")
+	}
+}

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/latency"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/liveness"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/manager"
+	"github.com/malbeclabs/doublezero/client/doublezerod/internal/multicast"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/pim"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
 	"github.com/malbeclabs/doublezero/config"
@@ -68,7 +69,8 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 	}
 
 	pim := pim.NewPIMServer()
-	nlm := manager.NewNetlinkManager(nlr, bgp, db, pim)
+	heartbeat := multicast.NewHeartbeatSender()
+	nlm := manager.NewNetlinkManager(nlr, bgp, db, pim, heartbeat)
 
 	errCh := make(chan error)
 

--- a/client/doublezerod/internal/services/base.go
+++ b/client/doublezerod/internal/services/base.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"slices"
+	"time"
 
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/api"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/bgp"
@@ -15,6 +16,11 @@ import (
 
 type PIMWriter interface {
 	Start(conn pim.RawConner, iface string, tunnelAddr net.IP, group []net.IP) error
+	Close() error
+}
+
+type HeartbeatWriter interface {
+	Start(iface string, srcIP net.IP, groups []net.IP, ttl int, interval time.Duration) error
 	Close() error
 }
 

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -487,10 +487,9 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 
 				mGroups := []string{"233.84.178.0", "233.84.178.1"}
 
-				for _, mGroup := range mGroups {
-					_, _ = client.Exec(t.Context(), []string{"bash", "-c", "ping -c 1 -w 1 " + mGroup}, docker.NoPrintOnError())
-				}
-
+				// The publisher's heartbeat sender automatically sends UDP heartbeat
+				// packets to each multicast group every 10 seconds. This creates (S, G)
+				// mroute state on the device without requiring an explicit ping or send.
 				for _, mGroup := range mGroups {
 					require.Eventually(t, func() bool {
 						mroutes, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPMroute](t.Context(), device, arista.ShowIPMrouteCmd())
@@ -512,7 +511,7 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 						}
 
 						return true
-					}, 5*time.Second, 1*time.Second, "multicast group %s not found in mroutes", mGroup)
+					}, 30*time.Second, 1*time.Second, "multicast group %s not found in mroutes", mGroup)
 				}
 			}) {
 				t.Fail()


### PR DESCRIPTION
## Summary
- Add a `HeartbeatSender` that sends periodic UDP heartbeat packets (every 10s) to each multicast group, keeping PIM (S,G) mroute state and MSDP SA caches alive on devices
- Heartbeat uses a 4-byte payload (`DZ` + version) on UDP port 5765 with TTL 32, matching the GRE tunnel TTL
- Wire `HeartbeatWriter` interface through the service layer alongside the existing `PIMWriter` pattern — started on publisher `Setup()`, stopped on `Teardown()`
- E2E test no longer relies on an explicit `ping` to trigger (S,G) mroute creation; heartbeat packets now create this state automatically

## Testing Verification
- 5 unit tests added for `HeartbeatSender`: immediate send, TTL configuration, multiple groups, interval sends, close stops sending — all passing
- Existing service tests updated with `MockHeartbeatSender` — all passing
- Full e2e multicast test suite passing (`TestE2E_Multicast`, `TestE2E_MulticastGroup_AllocationLifecycle`, `TestE2E_Multicast_ReactivationPreservesAllocations`, `TestE2E_Multicast_PublisherXorSubscriber`)
- `check_s_comma_g_is_created` subtest confirms heartbeat creates (S,G) mroute state on the device without any explicit multicast send
- `golangci-lint` clean on all modified packages