### PR TITLE
e2e: fix flaky WaitForLatencyResults by retrying on curl errors

### DIFF
--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -588,7 +588,11 @@ func (c *Client) WaitForLatencyResults(ctx context.Context, wantDevicePK string,
 	err := poll.Until(ctx, func() (bool, error) {
 		results, err := c.ExecReturnJSONList(ctx, []string{"curl", "-s", "--unix-socket", "/var/run/doublezerod/doublezerod.sock", "http://doublezero/latency"})
 		if err != nil {
-			return false, fmt.Errorf("failed to get latency results: %w", err)
+			if attempts == 1 || attempts%5 == 0 {
+				c.log.Debug("--> Waiting for latency results (curl not ready yet)", "wantDevicePK", wantDevicePK, "err", err, "attempts", attempts)
+			}
+			attempts++
+			return false, nil
 		}
 
 		if len(results) > 0 {


### PR DESCRIPTION
## Summary of Changes
- Treat curl connection errors in `WaitForLatencyResults` as retryable instead of immediately failing the poll loop
- When doublezerod hasn't started yet, curl exits with code 7 on the unix socket. Previously this error propagated to `poll.Until` which stops on any error, causing the test to fail instantly instead of retrying within the 90s timeout window.

## Testing Verification
- Verified the fix is consistent with how `WaitForPing` handles transient exec errors (returns `(false, nil)` to retry)
- Confirmed `poll.Until` semantics: errors cause immediate stop, `(false, nil)` causes retry