### PR TITLE
ci: move release validation pipeline to k8s runners

### DIFF
--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate_pipeline:
-    runs-on: ubuntu-24.04-16c-64gb
+    runs-on: doublezero-k8s-ci
     strategy:
       matrix:
         include:
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies for rpm packaging
         run: |
           sudo apt update
-          sudo apt-get install squashfs-tools rpm -y
+          sudo apt-get install build-essential pkg-config libssl-dev squashfs-tools rpm -y
 
       - name: Set env vars
         run: ./scripts/env.sh >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Move the release pipeline validation workflow from GitHub-hosted `ubuntu-24.04-16c-64gb` runners to `doublezero-k8s-ci` kubernetes runners for cost reduction and infrastructure consolidation

## Testing Verification
- The workflow triggers on PRs to main, so this PR itself will validate the change runs successfully on the k8s runners