### PR TITLE
e2e: stop cancelling in-progress runs on main branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,8 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   SHARD_COUNT: "4"


### PR DESCRIPTION
## Summary of Changes
- Use per-commit (`github.sha`) concurrency groups instead of per-ref (`github.ref`) so main branch e2e runs don't share a single group
- Only enable `cancel-in-progress` for pull request events, allowing all main branch runs to complete independently

Previously, merging two PRs to main in quick succession would cancel the first merge's e2e run because all main branch pushes shared the concurrency group `e2e-refs/heads/main` with `cancel-in-progress: true`. This masked failures introduced by specific merges.

## Testing Verification
- Verified the concurrency group expression resolves to unique values per commit on main (`e2e-<sha>`) and per PR number on pull requests (`e2e-<pr_number>`)
- Confirmed `cancel-in-progress` evaluates to `false` for push events and `true` for pull_request events