### PR TITLE
serviceability: prevent linking interfaces with CYOA or DIA assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ All notable changes to this project will be documented in this file.
   - Fix panic in heartbeat sender when concurrent teardown requests race on close
 - E2E tests
   - Add daily devnet QA test for device provisioning lifecycle (RFC12) — deletes/recreates device and links, restarts daemons with new pubkey via Ansible
+- Serviceability: prevent creating or activating links on interfaces with CYOA or DIA assignments, and prevent setting CYOA/DIA on interfaces that are already linked
+- CLI: add early validation in `link wan-create` and `link dzx-create` to reject interfaces with CYOA or DIA assignments
 
 ## [v0.8.7](https://github.com/malbeclabs/doublezero/compare/client/v0.8.6...client/v0.8.7) – 2026-02-10
 

--- a/smartcontract/cli/src/link/wan_create.rs
+++ b/smartcontract/cli/src/link/wan_create.rs
@@ -18,7 +18,10 @@ use doublezero_sdk::{
     },
     *,
 };
-use doublezero_serviceability::state::link::LinkDesiredStatus;
+use doublezero_serviceability::state::{
+    interface::{InterfaceCYOA, InterfaceDIA},
+    link::LinkDesiredStatus,
+};
 use eyre::eyre;
 use std::io::Write;
 
@@ -117,6 +120,15 @@ impl CreateWANLinkCliCommand {
             ));
         }
 
+        if side_a_iface.interface_cyoa != InterfaceCYOA::None
+            || side_a_iface.interface_dia != InterfaceDIA::None
+        {
+            return Err(eyre!(
+                "Interface '{}' on side A device has a CYOA or DIA assignment and cannot be used for links",
+                self.side_a_interface
+            ));
+        }
+
         let side_z_iface = side_z_dev
             .interfaces
             .iter()
@@ -139,6 +151,15 @@ impl CreateWANLinkCliCommand {
         if side_z_iface.status != InterfaceStatus::Unlinked {
             return Err(eyre!(
                 "Interface '{}' on side Z device must be unlinked",
+                self.side_z_interface
+            ));
+        }
+
+        if side_z_iface.interface_cyoa != InterfaceCYOA::None
+            || side_z_iface.interface_dia != InterfaceDIA::None
+        {
+            return Err(eyre!(
+                "Interface '{}' on side Z device has a CYOA or DIA assignment and cannot be used for links",
                 self.side_z_interface
             ));
         }
@@ -196,7 +217,7 @@ mod tests {
         Link, LinkLinkType, LinkStatus,
     };
     use doublezero_serviceability::state::interface::{
-        InterfaceStatus, InterfaceType, LoopbackType,
+        InterfaceCYOA, InterfaceStatus, InterfaceType, LoopbackType,
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
@@ -461,5 +482,137 @@ mod tests {
         );
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "");
+    }
+
+    #[test]
+    fn test_cli_wan_link_create_rejects_cyoa_interface() {
+        let mut client = create_test_client();
+
+        let (pda_pubkey, _bump_seed) = get_device_pda(&client.get_program_id(), 1);
+
+        let contributor_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+        let location1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+        let exchange1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkca");
+        let device1_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcb");
+        let device1 = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 255,
+            reference_count: 0,
+            code: "test".to_string(),
+            contributor_pk,
+            location_pk: location1_pk,
+            exchange_pk: exchange1_pk,
+            device_type: DeviceType::Hybrid,
+            public_ip: [10, 0, 0, 1].into(),
+            dz_prefixes: "10.1.0.0/16".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            status: DeviceStatus::Activated,
+            owner: pda_pubkey,
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![CurrentInterfaceVersion {
+                status: InterfaceStatus::Unlinked,
+                name: "Ethernet1/1".to_string(),
+                interface_type: InterfaceType::Physical,
+                loopback_type: LoopbackType::None,
+                vlan_id: 16,
+                ip_net: "10.2.0.1/24".parse().unwrap(),
+                node_segment_idx: 0,
+                user_tunnel_endpoint: true,
+                interface_cyoa: InterfaceCYOA::GREOverDIA,
+                ..Default::default()
+            }
+            .to_interface()],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_users_count: 0,
+            max_unicast_users: 0,
+            max_multicast_users: 0,
+        };
+        let location2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+        let exchange2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkce");
+        let device2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");
+        let device2 = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 255,
+            reference_count: 0,
+            code: "test".to_string(),
+            contributor_pk,
+            location_pk: location2_pk,
+            exchange_pk: exchange2_pk,
+            device_type: DeviceType::Hybrid,
+            public_ip: [10, 0, 0, 1].into(),
+            dz_prefixes: "10.1.0.0/16".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            status: DeviceStatus::Activated,
+            owner: pda_pubkey,
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![CurrentInterfaceVersion {
+                status: InterfaceStatus::Unlinked,
+                name: "Ethernet1/2".to_string(),
+                interface_type: InterfaceType::Physical,
+                loopback_type: LoopbackType::None,
+                vlan_id: 16,
+                ip_net: "10.2.0.2/24".parse().unwrap(),
+                node_segment_idx: 0,
+                user_tunnel_endpoint: true,
+                ..Default::default()
+            }
+            .to_interface()],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_users_count: 0,
+            max_unicast_users: 0,
+            max_multicast_users: 0,
+        };
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_device()
+            .with(predicate::eq(GetDeviceCommand {
+                pubkey_or_code: device1_pk.to_string(),
+            }))
+            .returning(move |_| Ok((device1_pk, device1.clone())));
+        client
+            .expect_get_device()
+            .with(predicate::eq(GetDeviceCommand {
+                pubkey_or_code: device2_pk.to_string(),
+            }))
+            .returning(move |_| Ok((device2_pk, device2.clone())));
+
+        let mut output = Vec::new();
+        let res = CreateWANLinkCliCommand {
+            code: "test".to_string(),
+            contributor: contributor_pk.to_string(),
+            desired_status: None,
+            side_a: device1_pk.to_string(),
+            side_z: device2_pk.to_string(),
+            bandwidth: 1000000000,
+            mtu: 1500,
+            delay_ms: 10000.0,
+            jitter_ms: 5000.0,
+            side_a_interface: "Ethernet1/1".to_string(),
+            side_z_interface: "Ethernet1/2".to_string(),
+            wait: false,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("CYOA or DIA assignment"),);
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -170,6 +170,8 @@ pub enum DoubleZeroError {
     MaxUnicastUsersExceeded, // variant 81
     #[error("Max multicast users exceeded")]
     MaxMulticastUsersExceeded, // variant 82
+    #[error("Interface cannot have both a link and a CYOA or DIA assignment")]
+    InterfaceHasEdgeAssignment, // variant 83
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -258,6 +260,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::InvalidTunnelEndpoint => ProgramError::Custom(80),
             DoubleZeroError::MaxUnicastUsersExceeded => ProgramError::Custom(81),
             DoubleZeroError::MaxMulticastUsersExceeded => ProgramError::Custom(82),
+            DoubleZeroError::InterfaceHasEdgeAssignment => ProgramError::Custom(83),
         }
     }
 }
@@ -347,6 +350,7 @@ impl From<u32> for DoubleZeroError {
             80 => DoubleZeroError::InvalidTunnelEndpoint,
             81 => DoubleZeroError::MaxUnicastUsersExceeded,
             82 => DoubleZeroError::MaxMulticastUsersExceeded,
+            83 => DoubleZeroError::InterfaceHasEdgeAssignment,
             _ => DoubleZeroError::Custom(e),
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
@@ -8,7 +8,9 @@ use crate::{
         contributor::Contributor,
         device::*,
         globalstate::GlobalState,
-        interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus, LoopbackType, RoutingMode},
+        interface::{
+            InterfaceCYOA, InterfaceDIA, InterfaceStatus, InterfaceType, LoopbackType, RoutingMode,
+        },
     },
 };
 use borsh::BorshSerialize;
@@ -124,9 +126,21 @@ pub fn process_update_device_interface(
         iface.loopback_type = *loopback_type;
     }
     if let Some(interface_cyoa) = &value.interface_cyoa {
+        if *interface_cyoa != InterfaceCYOA::None
+            && iface.status == InterfaceStatus::Activated
+            && iface.interface_type == InterfaceType::Physical
+        {
+            return Err(DoubleZeroError::InterfaceHasEdgeAssignment.into());
+        }
         iface.interface_cyoa = *interface_cyoa;
     }
     if let Some(interface_dia) = &value.interface_dia {
+        if *interface_dia != InterfaceDIA::None
+            && iface.status == InterfaceStatus::Activated
+            && iface.interface_type == InterfaceType::Physical
+        {
+            return Err(DoubleZeroError::InterfaceHasEdgeAssignment.into());
+        }
         iface.interface_dia = *interface_dia;
     }
     if let Some(bandwidth) = value.bandwidth {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
@@ -4,7 +4,10 @@ use crate::{
     resource::ResourceType,
     serializer::try_acc_write,
     state::{
-        device::*, globalstate::GlobalState, interface::InterfaceStatus, link::*,
+        device::*,
+        globalstate::GlobalState,
+        interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus},
+        link::*,
         resource_extension::ResourceExtensionBorrowed,
     },
 };
@@ -134,6 +137,14 @@ pub fn process_activate_link(
         || side_z_iface.status != InterfaceStatus::Unlinked
     {
         return Err(DoubleZeroError::InvalidStatus.into());
+    }
+
+    if side_a_iface.interface_cyoa != InterfaceCYOA::None
+        || side_a_iface.interface_dia != InterfaceDIA::None
+        || side_z_iface.interface_cyoa != InterfaceCYOA::None
+        || side_z_iface.interface_dia != InterfaceDIA::None
+    {
+        return Err(DoubleZeroError::InterfaceHasEdgeAssignment.into());
     }
 
     // Allocate resources from ResourceExtension or use provided values

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -3,7 +3,7 @@ use doublezero_serviceability::{
     pda::*,
     processors::{
         contributor::create::ContributorCreateArgs,
-        device::interface::DeviceInterfaceUnlinkArgs,
+        device::interface::{update::DeviceInterfaceUpdateArgs, DeviceInterfaceUnlinkArgs},
         link::{activate::*, create::*, delete::*, sethealth::LinkSetHealthArgs, update::*},
         *,
     },
@@ -840,6 +840,995 @@ async fn test_wan_link() {
 
     println!("✅ Link deleted successfully");
     println!("🟢🟢🟢  End test_link  🟢🟢🟢");
+}
+
+#[tokio::test]
+async fn test_wan_link_rejects_cyoa_interface() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    // 1. Init global state
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (config_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+            user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+            multicastgroup_block: "10.0.0.0/24".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block_pda, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block_pda, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 2. Create location and exchange
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(location::create::LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(exchange::create::ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 3. Create contributor
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) =
+        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 4. Create device A with a physical interface that has CYOA set
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_a_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "A".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [110, 0, 0, 1].into(),
+            dz_prefixes: "100.1.0.0/24".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create interface with CYOA assignment
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(
+            device::interface::create::DeviceInterfaceCreateArgs {
+                name: "Ethernet0".to_string(),
+                interface_dia: InterfaceDIA::None,
+                loopback_type: LoopbackType::None,
+                interface_cyoa: InterfaceCYOA::GREOverDIA,
+                bandwidth: 0,
+                ip_net: None,
+                cir: 0,
+                mtu: 1500,
+                routing_mode: RoutingMode::Static,
+                vlan_id: 0,
+                user_tunnel_endpoint: false,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Activate and unlink the interface so it's in Unlinked status
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(
+            device::interface::activate::DeviceInterfaceActivateArgs {
+                name: "Ethernet0".to_string(),
+                ip_net: "10.0.0.0/31".parse().unwrap(),
+                node_segment_idx: 0,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UnlinkDeviceInterface(DeviceInterfaceUnlinkArgs {
+            name: "Ethernet0".to_string(),
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 5. Create device Z with a normal interface
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_z_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "Z".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [11, 0, 0, 1].into(),
+            dz_prefixes: "11.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(
+            device::interface::create::DeviceInterfaceCreateArgs {
+                name: "Ethernet1".to_string(),
+                interface_dia: InterfaceDIA::None,
+                loopback_type: LoopbackType::None,
+                interface_cyoa: InterfaceCYOA::None,
+                bandwidth: 0,
+                ip_net: None,
+                cir: 0,
+                mtu: 1500,
+                routing_mode: RoutingMode::Static,
+                vlan_id: 0,
+                user_tunnel_endpoint: false,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(
+            device::interface::activate::DeviceInterfaceActivateArgs {
+                name: "Ethernet1".to_string(),
+                ip_net: "10.0.0.1/31".parse().unwrap(),
+                node_segment_idx: 0,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UnlinkDeviceInterface(DeviceInterfaceUnlinkArgs {
+            name: "Ethernet1".to_string(),
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 6. Attempt to create a WAN link using the CYOA interface - should fail
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (link_pubkey, _) = get_link_pda(&program_id, globalstate_account.account_index + 1);
+
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "cyoa-link".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 20000000000,
+            mtu: 9000,
+            delay_ns: 1000000,
+            jitter_ns: 100000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(81)"),
+        "Expected InterfaceHasEdgeAssignment error (Custom(81)), got: {}",
+        error_string
+    );
+
+    // 7. Now clear CYOA on device A and set it on device Z, then try again
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet0".to_string(),
+            interface_cyoa: Some(InterfaceCYOA::None),
+            interface_dia: None,
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet1".to_string(),
+            interface_cyoa: None,
+            interface_dia: Some(InterfaceDIA::DIA),
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "dia-link".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 20000000000,
+            mtu: 9000,
+            delay_ns: 1000000,
+            jitter_ns: 100000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(81)"),
+        "Expected InterfaceHasEdgeAssignment error (Custom(81)), got: {}",
+        error_string
+    );
+
+    // 8. Clear DIA on device Z, create link successfully, then try to activate
+    //    with CYOA set on side A
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet1".to_string(),
+            interface_cyoa: None,
+            interface_dia: Some(InterfaceDIA::None),
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create the link (should succeed now that both interfaces are clean)
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "clean-link".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 20000000000,
+            mtu: 9000,
+            delay_ns: 1000000,
+            jitter_ns: 100000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Now set CYOA on side A interface (simulating a race condition)
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet0".to_string(),
+            interface_cyoa: Some(InterfaceCYOA::GREOverDIA),
+            interface_dia: None,
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Attempt to activate the link - should fail because side A now has CYOA
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateLink(LinkActivateArgs {
+            tunnel_id: 500,
+            tunnel_net: "10.0.0.0/21".parse().unwrap(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(81)"),
+        "Expected InterfaceHasEdgeAssignment error (Custom(81)), got: {}",
+        error_string
+    );
+}
+
+#[tokio::test]
+async fn test_cannot_set_cyoa_on_linked_interface() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (config_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+            user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+            multicastgroup_block: "10.0.0.0/24".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block_pda, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block_pda, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create location, exchange, contributor
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(location::create::LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(exchange::create::ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) =
+        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create device A with clean interface
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_a_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "A".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [110, 0, 0, 1].into(),
+            dz_prefixes: "100.1.0.0/24".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(
+            device::interface::create::DeviceInterfaceCreateArgs {
+                name: "Ethernet0".to_string(),
+                interface_dia: InterfaceDIA::None,
+                loopback_type: LoopbackType::None,
+                interface_cyoa: InterfaceCYOA::None,
+                bandwidth: 0,
+                ip_net: None,
+                cir: 0,
+                mtu: 1500,
+                routing_mode: RoutingMode::Static,
+                vlan_id: 0,
+                user_tunnel_endpoint: false,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(
+            device::interface::activate::DeviceInterfaceActivateArgs {
+                name: "Ethernet0".to_string(),
+                ip_net: "10.0.0.0/31".parse().unwrap(),
+                node_segment_idx: 0,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UnlinkDeviceInterface(DeviceInterfaceUnlinkArgs {
+            name: "Ethernet0".to_string(),
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create device Z with clean interface
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_z_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "Z".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [11, 0, 0, 1].into(),
+            dz_prefixes: "11.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(
+            device::interface::create::DeviceInterfaceCreateArgs {
+                name: "Ethernet1".to_string(),
+                interface_dia: InterfaceDIA::None,
+                loopback_type: LoopbackType::None,
+                interface_cyoa: InterfaceCYOA::None,
+                bandwidth: 0,
+                ip_net: None,
+                cir: 0,
+                mtu: 1500,
+                routing_mode: RoutingMode::Static,
+                vlan_id: 0,
+                user_tunnel_endpoint: false,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDeviceInterface(
+            device::interface::activate::DeviceInterfaceActivateArgs {
+                name: "Ethernet1".to_string(),
+                ip_net: "10.0.0.1/31".parse().unwrap(),
+                node_segment_idx: 0,
+            },
+        ),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UnlinkDeviceInterface(DeviceInterfaceUnlinkArgs {
+            name: "Ethernet1".to_string(),
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate a link (both interfaces become Activated)
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (link_pubkey, _) = get_link_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "test-link".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 20000000000,
+            mtu: 9000,
+            delay_ns: 1000000,
+            jitter_ns: 100000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateLink(LinkActivateArgs {
+            tunnel_id: 500,
+            tunnel_net: "10.0.0.0/21".parse().unwrap(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify interfaces are now Activated (linked)
+    let device_a = get_account_data(&mut banks_client, device_a_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_device()
+        .unwrap();
+    let iface_a = device_a.find_interface("Ethernet0").unwrap().1;
+    assert_eq!(iface_a.status, InterfaceStatus::Activated);
+
+    // Attempt to set CYOA on linked interface — should fail
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet0".to_string(),
+            interface_cyoa: Some(InterfaceCYOA::GREOverDIA),
+            interface_dia: None,
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(81)"),
+        "Expected InterfaceHasEdgeAssignment error (Custom(81)), got: {}",
+        error_string
+    );
+
+    // Attempt to set DIA on linked side Z interface — should also fail
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "Ethernet1".to_string(),
+            interface_cyoa: None,
+            interface_dia: Some(InterfaceDIA::DIA),
+            loopback_type: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+            node_segment_idx: None,
+        }),
+        vec![
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(81)"),
+        "Expected InterfaceHasEdgeAssignment error (Custom(81)), got: {}",
+        error_string
+    );
 }
 
 /// Helper that sets up a full link environment and returns all relevant pubkeys.


### PR DESCRIPTION
Interfaces with CYOA or DIA assignments are edge-facing and should not be used for device-to-device links. This adds guardrails at multiple layers:

- Smart contract: reject CreateLink and ActivateLink when either interface has CYOA or DIA set
- Smart contract: reject UpdateDeviceInterface from setting CYOA or DIA on an already-linked (Activated) interface
- CLI: early validation in wan-create and dzx-create commands

Code and tests in this change were produced by Claude.