### PR TITLE
doublezerod: fix heartbeat sender broken after first close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Client
+  - Fix heartbeat sender not restarting after disconnect due to poisoned done channel
 - Onchain Programs
   - bugfix(serviceability): contributors can now update their interfaces, CYOA interfaces saved on create, physical interfaces remain after unlink ([#2993](https://github.com/malbeclabs/doublezero/pull/2993))
 

--- a/e2e/ibrl_multicast_coexistence_test.go
+++ b/e2e/ibrl_multicast_coexistence_test.go
@@ -1195,14 +1195,11 @@ func verifyConcurrentMulticastPublisherMrouteState(t *testing.T, log *slog.Logge
 	log.Info("Addresses on doublezero1", "output", string(addrOut))
 
 	// Verify mroute state on device - poll for 60 seconds (longer for concurrent case).
-	// Each iteration pings the multicast group to trigger S,G creation. The ping is
-	// inside the loop because the device may still be applying PIM border-router config
-	// when we first start checking, and a ping sent before that config is active will
-	// be ignored.
+	// The heartbeat sender creates (S,G) state by sending periodic UDP heartbeat
+	// packets to the multicast group, so no explicit ping is needed.
 	mGroup := "233.84.178.0"
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		_, _ = client.Exec(t.Context(), []string{"bash", "-c", "ping -c 1 -w 1 -I " + expectedAllocatedIP + " " + mGroup}, docker.NoPrintOnError())
 
 		mroutes, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPMroute](t.Context(), device, arista.ShowIPMrouteCmd())
 		if err != nil {
@@ -1254,13 +1251,11 @@ func verifyMulticastPublisherMrouteState(t *testing.T, log *slog.Logger, device 
 	log.Info("==> Using client's actual allocated IP", "expectedAllocatedIP", expectedAllocatedIP)
 
 	// Verify mroute state on device - poll for 30 seconds.
-	// Each iteration pings the multicast group to trigger S,G creation. The ping is
-	// inside the loop because the device may still be applying PIM border-router config
-	// when we first start checking.
+	// The heartbeat sender creates (S,G) state by sending periodic UDP heartbeat
+	// packets to the multicast group, so no explicit ping is needed.
 	mGroup := "233.84.178.0"
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
-		_, _ = client.Exec(t.Context(), []string{"bash", "-c", "ping -c 1 -w 1 -I " + expectedAllocatedIP + " " + mGroup}, docker.NoPrintOnError())
 
 		mroutes, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPMroute](t.Context(), device, arista.ShowIPMrouteCmd())
 		if err != nil {


### PR DESCRIPTION
## Summary

- Fix HeartbeatSender singleton becoming permanently broken after the first `Close()` by sending a value into the `done` channel instead of closing it, matching the PIM server pattern
- Remove explicit `ping` workarounds from E2E publisher mroute verification that were masking the broken heartbeat behavior

## Context

`HeartbeatSender` is created once at daemon startup and reused across connect/disconnect cycles. After the first `Close()`, the `done` channel was permanently closed via `sync.Once`, causing every subsequent `Start()` to exit immediately — the goroutine's `select` on `<-h.done` returns instantly because reads from a closed channel always succeed in Go.

The PIM server (`pim/server.go`) uses the same singleton pattern but does **not** have this bug because it sends a value into the `done` channel (`s.done <- struct{}{}`) instead of closing it.

## Testing Verification

- 8/8 heartbeat unit tests pass with race detector, including new `RestartAfterClose`, `DoubleClose`, and `CloseBeforeStart` tests
- Full `doublezerod` test suite passes with race detector
- All E2E publisher mroute tests pass without the ping workaround, confirming the heartbeat sender correctly creates (S,G) state across reconnect cycles