### PR TITLE
e2e: fix panic in SDK serviceability test

### DIFF
--- a/e2e/sdk_serviceability_test.go
+++ b/e2e/sdk_serviceability_test.go
@@ -59,7 +59,10 @@ func TestE2E_SDK_Serviceability(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			data, err := client.GetProgramData(ctx)
-			require.NoError(t, err, "error while reloading onchain state to verify update")
+			if err != nil {
+				log.Debug("--> Error reloading onchain state to verify update", "error", err)
+				return false
+			}
 
 			got := data.GlobalConfig.RemoteASN
 			if got == newAsn {


### PR DESCRIPTION
## Summary of Changes
- Replace `require.NoError` with an error check inside `assert.Eventually` callback to prevent panic when the condition goroutine outlives the subtest
- `require.NoError` calls `t.FailNow()` which panics when called from a goroutine after the test has completed; returning `false` on error lets `Eventually` fail gracefully instead

## Testing Verification
- The panic in CI (`Fail in goroutine after TestE2E_SDK_Serviceability/update_global_config has completed`) is directly caused by this `require.NoError` call — the fix eliminates the panic path