### PR TITLE
doublezerod: set link scope on tunnel overlay addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be documented in this file.
   - Serviceability: allow contributors to update prefixes when for IBRL when no users are allocated
 - CLI
   - `doublezero status` now shows a `Tenant` column (between `User Type` and `Current Device`) with the tenant code associated with the user; empty when no tenant is assigned
+- Client
+  - Fix tunnel overlay address scope to prevent kernel from selecting link-local /31 as source for routed traffic
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
   - Backward compatibility test: use `--status` instead of `--desired-status` for drain commands; fix version ranges (link drain compatible since v0.7.2, device drain since v0.8.1)

--- a/client/doublezerod/internal/api/resolve_route_test.go
+++ b/client/doublezerod/internal/api/resolve_route_test.go
@@ -20,15 +20,15 @@ type mockNetlinker struct {
 	mu           sync.Mutex
 }
 
-func (m *mockNetlinker) TunnelAdd(*routing.Tunnel) error               { return nil }
-func (m *mockNetlinker) TunnelDelete(*routing.Tunnel) error            { return nil }
-func (m *mockNetlinker) TunnelAddrAdd(*routing.Tunnel, string) error   { return nil }
-func (m *mockNetlinker) TunnelUp(*routing.Tunnel) error                { return nil }
-func (m *mockNetlinker) RouteAdd(*routing.Route) error                 { return nil }
-func (m *mockNetlinker) RouteDelete(*routing.Route) error              { return nil }
-func (m *mockNetlinker) RuleAdd(*routing.IPRule) error                 { return nil }
-func (m *mockNetlinker) RuleDel(*routing.IPRule) error                 { return nil }
-func (m *mockNetlinker) RouteByProtocol(int) ([]*routing.Route, error) { return nil, nil }
+func (m *mockNetlinker) TunnelAdd(*routing.Tunnel) error                  { return nil }
+func (m *mockNetlinker) TunnelDelete(*routing.Tunnel) error               { return nil }
+func (m *mockNetlinker) TunnelAddrAdd(*routing.Tunnel, string, int) error { return nil }
+func (m *mockNetlinker) TunnelUp(*routing.Tunnel) error                   { return nil }
+func (m *mockNetlinker) RouteAdd(*routing.Route) error                    { return nil }
+func (m *mockNetlinker) RouteDelete(*routing.Route) error                 { return nil }
+func (m *mockNetlinker) RuleAdd(*routing.IPRule) error                    { return nil }
+func (m *mockNetlinker) RuleDel(*routing.IPRule) error                    { return nil }
+func (m *mockNetlinker) RouteByProtocol(int) ([]*routing.Route, error)    { return nil, nil }
 
 func (m *mockNetlinker) RouteGet(ip net.IP) ([]*routing.Route, error) {
 	m.mu.Lock()

--- a/client/doublezerod/internal/manager/http_test.go
+++ b/client/doublezerod/internal/manager/http_test.go
@@ -455,7 +455,7 @@ func (m *MockNetlink) TunnelDelete(n *routing.Tunnel) error {
 	return nil
 }
 
-func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string) error {
+func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string, scope int) error {
 	m.tunAddrAdded = append(m.tunAddrAdded, ip)
 	return nil
 }

--- a/client/doublezerod/internal/routing/config_test.go
+++ b/client/doublezerod/internal/routing/config_test.go
@@ -248,7 +248,7 @@ func newMockNetlinker() *MockNetlinker {
 	m.Update(func(nl *MockNetlinker) {
 		nl.TunnelAddFunc = func(*Tunnel) error { return nil }
 		nl.TunnelDeleteFunc = func(*Tunnel) error { return nil }
-		nl.TunnelAddrAddFunc = func(*Tunnel, string) error { return nil }
+		nl.TunnelAddrAddFunc = func(*Tunnel, string, int) error { return nil }
 		nl.TunnelUpFunc = func(*Tunnel) error { return nil }
 		nl.RouteAddFunc = func(*Route) error { return nil }
 		nl.RouteDeleteFunc = func(*Route) error { return nil }
@@ -263,7 +263,7 @@ func newMockNetlinker() *MockNetlinker {
 type MockNetlinker struct {
 	TunnelAddFunc       func(*Tunnel) error
 	TunnelDeleteFunc    func(*Tunnel) error
-	TunnelAddrAddFunc   func(*Tunnel, string) error
+	TunnelAddrAddFunc   func(*Tunnel, string, int) error
 	TunnelUpFunc        func(*Tunnel) error
 	RouteAddFunc        func(*Route) error
 	RouteDeleteFunc     func(*Route) error
@@ -286,10 +286,10 @@ func (m *MockNetlinker) TunnelDelete(t *Tunnel) error {
 	defer m.mu.Unlock()
 	return m.TunnelDeleteFunc(t)
 }
-func (m *MockNetlinker) TunnelAddrAdd(t *Tunnel, ip string) error {
+func (m *MockNetlinker) TunnelAddrAdd(t *Tunnel, ip string, scope int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.TunnelAddrAddFunc(t, ip)
+	return m.TunnelAddrAddFunc(t, ip, scope)
 }
 func (m *MockNetlinker) TunnelUp(t *Tunnel) error {
 	m.mu.Lock()

--- a/client/doublezerod/internal/routing/netlink.go
+++ b/client/doublezerod/internal/routing/netlink.go
@@ -14,7 +14,8 @@ type Netlink struct{}
 type Netlinker interface {
 	TunnelAdd(*Tunnel) error
 	TunnelDelete(*Tunnel) error
-	TunnelAddrAdd(*Tunnel, string) error
+	// TunnelAddrAdd adds an address to a tunnel interface with the given scope (syscall.RT_SCOPE_*).
+	TunnelAddrAdd(*Tunnel, string, int) error
 	TunnelUp(*Tunnel) error
 	RouteAdd(*Route) error
 	RouteDelete(*Route) error
@@ -54,7 +55,7 @@ func (n Netlink) TunnelDelete(t *Tunnel) error {
 }
 func (n Netlink) TunnelGet(t *Tunnel) error { return nil }
 
-func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string) error {
+func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string, scope int) error {
 	gre := &nl.Gretun{
 		LinkAttrs: nl.LinkAttrs{
 			Name:      t.Name,
@@ -67,6 +68,7 @@ func (n Netlink) TunnelAddrAdd(t *Tunnel, prefix string) error {
 	if err != nil {
 		return fmt.Errorf("tunnel: error parsing addr: %v", err)
 	}
+	addr.Scope = scope
 
 	err = nl.AddrAdd(gre, addr)
 	if err != nil && errors.Is(err, syscall.EEXIST) {

--- a/client/doublezerod/internal/services/base.go
+++ b/client/doublezerod/internal/services/base.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"slices"
+	"syscall"
 	"time"
 
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/api"
@@ -74,7 +75,7 @@ func createBaseTunnel(nl routing.Netlinker, tun *routing.Tunnel) error {
 		}
 	}
 	slog.Info("tunnel: adding address to tunnel interface", "address", tun.LocalOverlay)
-	err = nl.TunnelAddrAdd(tun, tun.LocalOverlay.String()+"/31")
+	err = nl.TunnelAddrAdd(tun, tun.LocalOverlay.String()+"/31", syscall.RT_SCOPE_LINK)
 	if err != nil {
 		if errors.Is(err, routing.ErrAddressExists) {
 			slog.Error("tunnel: address already present on tunnel")
@@ -96,7 +97,7 @@ func createTunnelWithIP(nl routing.Netlinker, tun *routing.Tunnel, dzIp net.IP) 
 	}
 
 	slog.Info("tunnel: adding dz address to tunnel interface", "dz address", dzIp.String()+"/32")
-	err = nl.TunnelAddrAdd(tun, dzIp.String()+"/32")
+	err = nl.TunnelAddrAdd(tun, dzIp.String()+"/32", syscall.RT_SCOPE_UNIVERSE)
 	if err != nil {
 		if errors.Is(err, routing.ErrAddressExists) {
 			slog.Error("tunnel: address already present on tunnel")

--- a/client/doublezerod/internal/services/services_test.go
+++ b/client/doublezerod/internal/services/services_test.go
@@ -49,7 +49,8 @@ type MockNetlink struct {
 }
 
 type MockTunAddr struct {
-	IP string
+	IP    string
+	Scope int
 }
 
 func (m *MockNetlink) TunnelAdd(t *routing.Tunnel) error {
@@ -63,8 +64,8 @@ func (m *MockNetlink) TunnelDelete(n *routing.Tunnel) error {
 	return nil
 }
 
-func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string) error {
-	m.tunAddrAdded = append(m.tunAddrAdded, MockTunAddr{IP: ip})
+func (m *MockNetlink) TunnelAddrAdd(t *routing.Tunnel, ip string, scope int) error {
+	m.tunAddrAdded = append(m.tunAddrAdded, MockTunAddr{IP: ip, Scope: scope})
 	return nil
 }
 
@@ -190,7 +191,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			wantRoutesAdded:  nil,
@@ -242,7 +243,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}, {IP: "192.168.1.0/32"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}, {IP: "192.168.1.0/32", Scope: syscall.RT_SCOPE_UNIVERSE}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			wantRoutesAdded:  nil,
@@ -296,7 +297,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}, {IP: "7.7.7.7/32"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}, {IP: "7.7.7.7/32", Scope: syscall.RT_SCOPE_UNIVERSE}},
 			wantTunUp:        true,
 			wantRulesAdded: []*routing.IPRule{
 				{
@@ -391,7 +392,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			wantRoutesAdded: []*routing.Route{
@@ -448,7 +449,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}, {IP: "7.7.7.7/32"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}, {IP: "7.7.7.7/32", Scope: syscall.RT_SCOPE_UNIVERSE}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			wantRoutesAdded: []*routing.Route{
@@ -513,7 +514,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}, {IP: "7.7.7.7/32"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}, {IP: "7.7.7.7/32", Scope: syscall.RT_SCOPE_UNIVERSE}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			// Only one route — the publisher route with Src set. The subscriber
@@ -572,7 +573,7 @@ func TestServices(t *testing.T) {
 				RemoteOverlay:  net.IPv4(169, 254, 0, 0),
 				MTU:            routing.GREMTU,
 			},
-			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31"}, {IP: "7.7.7.7/32"}},
+			wantTunAddrAdded: []MockTunAddr{{IP: "169.254.0.1/31", Scope: syscall.RT_SCOPE_LINK}, {IP: "7.7.7.7/32", Scope: syscall.RT_SCOPE_UNIVERSE}},
 			wantTunUp:        true,
 			wantRulesAdded:   nil,
 			wantRoutesAdded: []*routing.Route{


### PR DESCRIPTION
## Summary
- Fix kernel source address selection in allocated address mode by setting `RT_SCOPE_LINK` on the `/31` overlay address added to the tunnel interface
- Previously both the `/31` overlay (169.254.x.x) and the `/32` allocated address were added with global scope, allowing the kernel to pick the link-local address as source for routed traffic
- The `/32` allocated address is now explicitly set to `RT_SCOPE_UNIVERSE` to ensure it is always preferred for source address selection

## Testing Verification
- All doublezerod packages compile cleanly for linux/amd64 (production target)
- All test packages (`services`, `routing`, `manager`, `api`) compile cleanly for linux/amd64
- Existing unit tests unchanged in behavior; mock `Netlinker` implementations updated to match new `TunnelAddrAdd` signature