### PR TITLE
activator: fix multicast publisher dz_ip leak on user deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Activator
   - Fail to start if any global config network blocks (`device_tunnel_block`, `user_tunnel_block`, `multicastgroup_block`, `multicast_publisher_block`) are unset (0.0.0.0/0)
+  - Fix multicast publisher dz_ip leak in offchain deallocation — IPs from the global publisher pool were never freed on user deletion because the check required non-empty publishers, which the smartcontract already clears before allowing deletion
 - Client
   - Fix heartbeat sender not restarting after disconnect due to poisoned done channel
 - Onchain Programs


### PR DESCRIPTION
Context: https://malbeclabs.slack.com/archives/C0ADT8N21A9/p1771030951954659

## Summary
- Fix publisher IP address leak in offchain deallocation path — `deallocate_publisher_dz_ip` checked `!user.publishers.is_empty()` before freeing the IP, but the smartcontract requires publishers to be cleared before a user can reach `Deleting` status, making the deallocation dead code
- Publisher IPs from the global `multicast_publisher_block` pool were never returned, causing monotonically increasing addresses on each connect/disconnect cycle
- The onchain deallocation path was not affected (it checks `dz_ip != client_ip && dz_ip != UNSPECIFIED` without referencing publishers)

## Testing Verification
- Added activator unit tests for `deallocate_publisher_dz_ip`: verifies IP is freed when publishers list is empty (the real-world state at deletion time), and verifies deallocation is skipped for non-Multicast/subscriber users
- Added onchain integration test `test_multicast_publisher_block_deallocation_and_reuse`: full cycle activate → subscribe as publisher → reactivate → unsubscribe → delete → close with deallocation → re-create → verify same IP is reused from MulticastPublisherBlock bitmap