### PR TITLE
geoprobe: fix flaky TestPinger_MeasureAll_LargeScale on CI

### DIFF
--- a/controlplane/telemetry/internal/geoprobe/pinger_test.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger_test.go
@@ -365,6 +365,7 @@ func TestPinger_MeasureAll_ConcurrencyLimit(t *testing.T) {
 	}
 
 	pinger := NewPinger(cfg)
+	t.Cleanup(func() { pinger.Close() })
 	ctx := context.Background()
 
 	numProbes := 2000
@@ -431,9 +432,10 @@ func TestPinger_MeasureAll_LargeScale(t *testing.T) {
 	}
 
 	pinger := NewPinger(cfg)
+	t.Cleanup(func() { pinger.Close() })
 	ctx := context.Background()
 
-	numProbes := 5000
+	numProbes := 1000
 	t.Logf("Testing with %d probes (validates worker pool batching)", numProbes)
 
 	for i := 0; i < numProbes; i++ {


### PR DESCRIPTION
## Summary

- Fix flaky `TestPinger_MeasureAll_LargeScale` caused by ephemeral port exhaustion on CI runners — [example failure](https://github.com/malbeclabs/doublezero/actions/runs/22038534325/job/63675490755?pr=3003)
- Reduce probe count from 5000 to 1000 (sufficient for worker pool batching validation) and add `t.Cleanup` to close sockets deterministically instead of relying on GC

## Testing Verification

- Ran both `TestPinger_MeasureAll_LargeScale` and `TestPinger_MeasureAll_ConcurrencyLimit` in parallel — both pass with "Closed all probes" cleanup confirmed