### PR TITLE
chore: bump version to 0.8.9 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- N/A
+
+## [v0.8.9](https://github.com/malbeclabs/doublezero/compare/client/v0.8.8...client/v0.8.9) – 2026-02-16
+
+### Breaking
+
+- N/A
+
+### Changes
+
 - Activator
   - Fail to start if any global config network blocks (`device_tunnel_block`, `user_tunnel_block`, `multicastgroup_block`, `multicast_publisher_block`) are unset (0.0.0.0/0)
   - Fix multicast publisher dz_ip leak in offchain deallocation — IPs from the global publisher pool were never freed on user deletion because the check required non-empty publishers, which the smartcontract already clears before allowing deletion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.8.8 to 0.8.9 in Cargo.toml
- Move unreleased changelog entries into new v0.8.9 section dated 2026-02-16