### PR TITLE
e2e: fix QA unicast test flake from RPC 429 rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- N/A
+- E2E / QA Tests
+  - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
 
 ## [v0.8.9](https://github.com/malbeclabs/doublezero/compare/client/v0.8.8...client/v0.8.9) – 2026-02-16
 


### PR DESCRIPTION
## Summary
- `TestQA_UnicastConnectivity` cleanup disconnects all clients concurrently, each polling `getProgramDataWithRetry` every second to confirm onchain user deletion. This hammers the Solana RPC endpoint, triggering 429 rate limiting.
- `poll.Until` treated any error from the condition function as fatal, so a single rate-limited RPC failure would immediately abort the entire deletion wait — even with 90 seconds of timeout remaining.
- Treat transient RPC errors as non-fatal in both the initial onchain check (log and fall through to polling) and the polling loop (return `false, nil` to keep trying).

## Testing Verification
- Verified the fix addresses the exact error path seen in CI: `timed out waiting for user deletion ... Too many requests from your IP`