### PR TITLE
config: update multicast publisher IP block to 148.51.120.0/21

### DIFF
--- a/activator/src/activator.rs
+++ b/activator/src/activator.rs
@@ -400,7 +400,7 @@ mod tests {
             device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "1.0.1.0/24".parse().unwrap(),
             multicastgroup_block: "239.239.239.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: 65535,
         };
         mock_client

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -1029,7 +1029,7 @@ mod tests {
                     predicate::eq(DoubleZeroInstruction::ActivateUser(UserActivateArgs {
                         tunnel_id: 500,
                         tunnel_net: "10.0.0.1/29".parse().unwrap(),
-                        dz_ip: [147, 51, 126, 1].into(),
+                        dz_ip: [148, 51, 120, 1].into(),
                         dz_prefix_count: 0, // legacy path
                         tunnel_endpoint: Ipv4Addr::new(192, 168, 1, 2),
                     })),
@@ -1044,7 +1044,7 @@ mod tests {
             let exchanges = HashMap::<Pubkey, Exchange>::new();
 
             let mut publisher_dz_ips =
-                Some(IPBlockAllocator::new("147.51.126.0/23".parse().unwrap()));
+                Some(IPBlockAllocator::new("148.51.120.0/21".parse().unwrap()));
 
             process_user_event(
                 &client,
@@ -1587,7 +1587,7 @@ mod tests {
     /// causing publisher IPs to leak on every connect/disconnect cycle.
     #[test]
     fn test_publisher_dz_ip_deallocated_on_delete() {
-        let mut publisher_dz_ips = Some(IPBlockAllocator::new("147.51.126.0/23".parse().unwrap()));
+        let mut publisher_dz_ips = Some(IPBlockAllocator::new("148.51.120.0/21".parse().unwrap()));
 
         // Allocate a publisher IP (simulates what happens during Pending → Activated)
         let allocated_ip = publisher_dz_ips
@@ -1596,7 +1596,7 @@ mod tests {
             .next_available_block(1, 1)
             .map(|net| net.ip())
             .unwrap();
-        assert_eq!(allocated_ip, Ipv4Addr::new(147, 51, 126, 1));
+        assert_eq!(allocated_ip, Ipv4Addr::new(148, 51, 120, 1));
         assert!(publisher_dz_ips.as_ref().unwrap().assigned_ips[1]);
 
         // Simulate the user at deletion time: Multicast type, dz_ip set,
@@ -1646,7 +1646,7 @@ mod tests {
     /// and for users whose dz_ip matches client_ip (subscribers).
     #[test]
     fn test_publisher_dz_ip_deallocation_skipped_for_non_publishers() {
-        let mut publisher_dz_ips = Some(IPBlockAllocator::new("147.51.126.0/23".parse().unwrap()));
+        let mut publisher_dz_ips = Some(IPBlockAllocator::new("148.51.120.0/21".parse().unwrap()));
 
         // Allocate an IP so we can verify it's NOT freed
         let allocated_ip = publisher_dz_ips
@@ -2235,7 +2235,7 @@ mod tests {
                     predicate::eq(DoubleZeroInstruction::ActivateUser(UserActivateArgs {
                         tunnel_id: 500,
                         tunnel_net: "10.0.0.1/29".parse().unwrap(),
-                        dz_ip: [147, 51, 126, 1].into(),
+                        dz_ip: [148, 51, 120, 1].into(),
                         dz_prefix_count: 0,
                         tunnel_endpoint: demanded_endpoint,
                     })),
@@ -2250,7 +2250,7 @@ mod tests {
             let exchanges = HashMap::<Pubkey, Exchange>::new();
 
             let mut publisher_dz_ips =
-                Some(IPBlockAllocator::new("147.51.126.0/23".parse().unwrap()));
+                Some(IPBlockAllocator::new("148.51.120.0/21".parse().unwrap()));
 
             process_user_event(
                 &client,

--- a/activator/src/processor.rs
+++ b/activator/src/processor.rs
@@ -302,7 +302,7 @@ mod tests {
             device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "239.239.239.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: 0,
         }
     }

--- a/activator/src/tests.rs
+++ b/activator/src/tests.rs
@@ -47,7 +47,7 @@ pub mod utils {
             device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: 0,
         };
 

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -1141,7 +1141,7 @@ mod tests {
                     device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
                     user_tunnel_block: "10.0.1.0/24".parse().unwrap(),
                     multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
-                    multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                    multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: 10000,
                 },
                 client: create_test_client(),

--- a/controlplane/controller/internal/controller/models_test.go
+++ b/controlplane/controller/internal/controller/models_test.go
@@ -33,7 +33,7 @@ func TestIsBgpMartian(t *testing.T) {
 		{"valid public 1", "1.1.1.1", false},
 		{"valid public 8", "8.8.8.8", false},
 		{"valid public 100", "100.128.0.1", false},
-		{"valid public 147", "147.51.126.1", false},
+		{"valid public 148", "148.51.120.1", false},
 		{"valid public 172.15", "172.15.255.255", false},
 		{"valid public 172.32", "172.32.0.0", false},
 		{"valid public 192.0.3", "192.0.3.1", false},

--- a/e2e/compatibility_test.go
+++ b/e2e/compatibility_test.go
@@ -71,7 +71,10 @@ var knownIncompatibilities = map[string]string{
 	// global_config_set: The SetGlobalConfig instruction added new required accounts
 	// (MulticastPublisherBlock, VrfIds) that released CLIs (through v0.8.7) don't
 	// include, causing "insufficient account keys for instruction".
-	"write/global_config_set": "0.8.8",
+	// Updated to 0.8.10: The multicast publisher IP block changed from 147.51.126.0/23
+	// to 148.51.120.0/21. CLIs v0.8.9 and older have the old IP block hardcoded,
+	// causing "Immutable Field" errors when trying to update other global config fields.
+	"write/global_config_set": "0.8.10",
 }
 
 // =============================================================================
@@ -641,7 +644,7 @@ func createAndStartVersionDevnet(
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
 		set -euo pipefail
 		doublezero init
-		doublezero global-config set --local-asn 65000 --remote-asn 65342 --device-tunnel-block 172.16.0.0/16 --user-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24 --multicast-publisher-block 147.51.126.0/23
+		doublezero global-config set --local-asn 65000 --remote-asn 65342 --device-tunnel-block 172.16.0.0/16 --user-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24 --multicast-publisher-block 148.51.120.0/21
 	`})
 	require.NoError(t, err)
 

--- a/e2e/internal/devnet/smartcontract_init.go
+++ b/e2e/internal/devnet/smartcontract_init.go
@@ -80,7 +80,7 @@ func (dn *Devnet) InitSmartContract(ctx context.Context) error {
 
 		doublezero global-config authority set --activator-authority me --sentinel-authority me
 
-		doublezero global-config set --local-asn 65000 --remote-asn 65342 --device-tunnel-block ` + dn.Spec.DeviceTunnelNet + ` --user-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24 --multicast-publisher-block 147.51.126.0/23
+		doublezero global-config set --local-asn 65000 --remote-asn 65342 --device-tunnel-block ` + dn.Spec.DeviceTunnelNet + ` --user-tunnel-block 169.254.0.0/16 --multicastgroup-block 233.84.178.0/24 --multicast-publisher-block 148.51.120.0/21
 
 		doublezero global-config authority set --activator-authority me --sentinel-authority me
 

--- a/e2e/multicast_publisher_ip_test.go
+++ b/e2e/multicast_publisher_ip_test.go
@@ -39,7 +39,7 @@ func parsePublisherUserInfo(output []byte) []publisherUserInfo {
 }
 
 // TestE2E_MulticastPublisher_MultipleAllocations verifies that multiple publishers
-// get unique sequential IPs from the global multicast_publisher_block (147.51.126.0/23).
+// get unique sequential IPs from the global multicast_publisher_block (148.51.120.0/21).
 func TestE2E_MulticastPublisher_MultipleAllocations(t *testing.T) {
 	t.Parallel()
 
@@ -97,12 +97,12 @@ func TestE2E_MulticastPublisher_MultipleAllocations(t *testing.T) {
 		publishers := parsePublisherUserInfo(userListOutput)
 		require.Len(t, publishers, 3, "should have 3 multicast publisher users")
 
-		// Verify all IPs are from global multicast_publisher_block (147.51.126.0/23)
+		// Verify all IPs are from global multicast_publisher_block (148.51.120.0/21)
 		// and are sequential
 		dzIPs := []string{}
 		for _, pub := range publishers {
-			require.True(t, netutil.IPInRange(pub.DzIP, "147.51.126.0/23"),
-				"publisher dz_ip %s should be in global multicast_publisher_block 147.51.126.0/23", pub.DzIP)
+			require.True(t, netutil.IPInRange(pub.DzIP, "148.51.120.0/21"),
+				"publisher dz_ip %s should be in global multicast_publisher_block 148.51.120.0/21", pub.DzIP)
 			dzIPs = append(dzIPs, pub.DzIP)
 		}
 
@@ -205,8 +205,8 @@ func TestE2E_MulticastPublisher_MixedUsers(t *testing.T) {
 		require.NotEmpty(t, ibrlDzIP, "IBRL user should have dz_ip")
 
 		// Verify publisher uses global multicast_publisher_block
-		require.True(t, netutil.IPInRange(publisherDzIP, "147.51.126.0/23"),
-			"publisher dz_ip %s should be from global block 147.51.126.0/23", publisherDzIP)
+		require.True(t, netutil.IPInRange(publisherDzIP, "148.51.120.0/21"),
+			"publisher dz_ip %s should be from global block 148.51.120.0/21", publisherDzIP)
 
 		// Verify IBRL user uses device DzPrefixBlock
 		require.True(t, netutil.IPInRange(ibrlDzIP, device.DZPrefix),
@@ -217,7 +217,7 @@ func TestE2E_MulticastPublisher_MixedUsers(t *testing.T) {
 			"publisher and IBRL user should have different IPs")
 
 		dn.log.Info("✓ Publisher and IBRL user coexist with separate IP pools",
-			"publisher_dz_ip", publisherDzIP, "publisher_pool", "147.51.126.0/23",
+			"publisher_dz_ip", publisherDzIP, "publisher_pool", "148.51.120.0/21",
 			"ibrl_dz_ip", ibrlDzIP, "ibrl_pool", device.DZPrefix)
 	}) {
 		t.Fail()
@@ -281,7 +281,7 @@ func TestE2E_MulticastPublisher_IPDeallocation(t *testing.T) {
 		require.Len(t, publishers, 1, "should have 1 publisher")
 		firstPublisherIP = publishers[0].DzIP
 
-		require.True(t, netutil.IPInRange(firstPublisherIP, "147.51.126.0/23"),
+		require.True(t, netutil.IPInRange(firstPublisherIP, "148.51.120.0/21"),
 			"first publisher dz_ip %s should be from global block", firstPublisherIP)
 
 		dn.log.Info("✓ First publisher connected", "dz_ip", firstPublisherIP)
@@ -399,7 +399,7 @@ func TestE2E_MulticastPublisher_BothAllocationPaths(t *testing.T) {
 		// Collect allocated IPs
 		dzIPs := []string{}
 		for _, pub := range publishers {
-			require.True(t, netutil.IPInRange(pub.DzIP, "147.51.126.0/23"),
+			require.True(t, netutil.IPInRange(pub.DzIP, "148.51.120.0/21"),
 				"publisher dz_ip %s should be in global multicast_publisher_block", pub.DzIP)
 			dzIPs = append(dzIPs, pub.DzIP)
 		}
@@ -440,7 +440,7 @@ func TestE2E_MulticastPublisher_BothAllocationPaths(t *testing.T) {
 				return false
 			}
 			// Bitmap should be empty after deallocation
-			return !strings.Contains(string(resourceOutput), "147.51.126")
+			return !strings.Contains(string(resourceOutput), "148.51.120")
 		}, 30*time.Second, 2*time.Second, "IPs should be deallocated from on-chain bitmap")
 
 		dn.log.Info("✓ Off-chain deallocations synced to on-chain bitmap")

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -332,7 +332,7 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 				}
 			}
 			require.NotEmpty(t, expectedAllocatedClientIP, "publisher should have allocated dz_ip")
-			require.True(t, netutil.IPInRange(expectedAllocatedClientIP, "147.51.126.0/23"), "publisher dz_ip %s should be from global multicast_publisher_block", expectedAllocatedClientIP)
+			require.True(t, netutil.IPInRange(expectedAllocatedClientIP, "148.51.120.0/21"), "publisher dz_ip %s should be from global multicast_publisher_block", expectedAllocatedClientIP)
 		}
 
 		tests := []struct {

--- a/rfcs/rfc13-simultaneous_tunnels.md
+++ b/rfcs/rfc13-simultaneous_tunnels.md
@@ -36,7 +36,7 @@ N/A
 
 This design enables simultaneous tunnels by provisioning a second tunnel endpoint on each DZD device, allowing users to maintain both a unicast tunnel and a multicast tunnel concurrently. The approach requires changes across four areas:
 
-1. **Activator**: Assigns multicast publishers an IP from a new global address pool (proposed: 147.51.126.0/23) rather than the per-device dz_prefix ranges, which are too small for anticipated multicast volume.
+1. **Activator**: Assigns multicast publishers an IP from a new global address pool (proposed: 148.51.120.0/21) rather than the per-device dz_prefix ranges, which are too small for anticipated multicast volume.
 
 2. **Client**: Updates the CLI to provision a second tunnel by locating an available tunnel endpoint on the user's current device, or falling back to a nearby device within a 5ms latency threshold. The existing check preventing multiple tunnels will be removed.
 
@@ -71,7 +71,7 @@ This design enables simultaneous tunnels by provisioning a second tunnel endpoin
 * `user-tunnel-endpoint` IP addresses should be configured on Loopback interfaces to reduce the risk of an outage if a physical interface goes down.  However, if there is only a single CYOA interface, a `user-tunnel-endpoint` may be configured on a physical interface.
 * To support capacity planning, the smart-contract should support distinct max-user counts for unicast and multicast.  By default, both values should be set to 48.
 * Policing of user-tunnels, particularly important for multicast tunnels, will be addressed in a separate RFC.
-* Multicast publishers should be assigned an IP address from a global pool of address space defined in `global-config`.  It is proposed that this is set to 147.51.126.0/23, allowing 512 distinct multicast publishers.  If required to expand this block, there should be an option for including additional ranges.
+* Multicast publishers should be assigned an IP address from a global pool of address space defined in `global-config`.  It is proposed that this is set to 148.51.120.0/21, allowing 512 distinct multicast publishers.  If required to expand this block, there should be an option for including additional ranges.
 
 ## Impact
 

--- a/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
+++ b/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
@@ -155,7 +155,7 @@ fn generate_global_config(dir: &Path) {
         user_tunnel_block: "10.200.0.0/16".parse().unwrap(),
         multicastgroup_block: "239.0.0.0/8".parse().unwrap(),
         next_bgp_community: 10042,
-        multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+        multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
     };
 
     let data = borsh::to_vec(&val).unwrap();
@@ -173,7 +173,7 @@ fn generate_global_config(dir: &Path) {
             FieldValue { name: "UserTunnelBlock".into(), value: "10.200.0.0/16".into(), typ: "networkv4".into() },
             FieldValue { name: "MulticastGroupBlock".into(), value: "239.0.0.0/8".into(), typ: "networkv4".into() },
             FieldValue { name: "NextBgpCommunity".into(), value: "10042".into(), typ: "u16".into() },
-            FieldValue { name: "MulticastPublisherBlock".into(), value: "147.51.126.0/23".into(), typ: "networkv4".into() },
+            FieldValue { name: "MulticastPublisherBlock".into(), value: "148.51.120.0/21".into(), typ: "networkv4".into() },
         ],
     };
 

--- a/sdk/serviceability/testdata/fixtures/global_config.json
+++ b/sdk/serviceability/testdata/fixtures/global_config.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "MulticastPublisherBlock",
-      "value": "147.51.126.0/23",
+      "value": "148.51.120.0/21",
       "typ": "networkv4"
     }
   ]

--- a/smartcontract/cli/src/globalconfig/authority/get.rs
+++ b/smartcontract/cli/src/globalconfig/authority/get.rs
@@ -61,7 +61,7 @@ mod tests {
             device_tunnel_block: "10.1.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.5.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.2.0.0/4".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: 10000,
         };
 
@@ -76,7 +76,7 @@ mod tests {
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(
-            output_str, " local asn | remote asn | device tunnel block | user tunnel block | multicast group block | multicast publisher block | next bgp community \n 1234      | 5678       | 10.1.0.0/24         | 10.5.0.0/24       | 224.2.0.0/4           | 147.51.126.0/23           | 10000              \n"
+            output_str, " local asn | remote asn | device tunnel block | user tunnel block | multicast group block | multicast publisher block | next bgp community \n 1234      | 5678       | 10.1.0.0/24         | 10.5.0.0/24       | 224.2.0.0/4           | 148.51.120.0/21           | 10000              \n"
         );
     }
 }

--- a/smartcontract/cli/src/globalconfig/get.rs
+++ b/smartcontract/cli/src/globalconfig/get.rs
@@ -73,7 +73,7 @@ mod tests {
             device_tunnel_block: "10.1.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.5.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.2.0.0/4".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: 10000,
         };
 
@@ -88,7 +88,7 @@ mod tests {
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(
-            output_str, " local asn | remote asn | device tunnel block | user tunnel block | multicast group block | multicast publisher block | next bgp community \n 1234      | 5678       | 10.1.0.0/24         | 10.5.0.0/24       | 224.2.0.0/4           | 147.51.126.0/23           | 10000              \n"
+            output_str, " local asn | remote asn | device tunnel block | user tunnel block | multicast group block | multicast publisher block | next bgp community \n 1234      | 5678       | 10.1.0.0/24         | 10.5.0.0/24       | 224.2.0.0/4           | 148.51.120.0/21           | 10000              \n"
         );
     }
 }

--- a/smartcontract/cli/src/globalconfig/set.rs
+++ b/smartcontract/cli/src/globalconfig/set.rs
@@ -30,7 +30,7 @@ pub struct SetGlobalConfigCliCommand {
     #[arg(long)]
     pub next_bgp_community: Option<u16>,
     /// Multicast publisher block in CIDR format
-    #[arg(long, default_value = "147.51.126.0/23")]
+    #[arg(long, default_value = "148.51.120.0/21")]
     multicast_publisher_block: Option<NetworkV4>,
 }
 

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -599,7 +599,7 @@ mod tests {
                 device_tunnel_block: "1.2.3.4/1".parse().unwrap(),
                 user_tunnel_block: "1.2.3.4/1".parse().unwrap(),
                 multicastgroup_block: "1.2.3.4/1".parse().unwrap(),
-                multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                 next_bgp_community: None,
             }),
             "SetGlobalConfig",

--- a/smartcontract/programs/doublezero-serviceability/src/state/globalconfig.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/globalconfig.rs
@@ -149,7 +149,7 @@ mod tests {
             user_tunnel_block: "10.0.0.2/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/4".parse().unwrap(),
             next_bgp_community: BGP_COMMUNITY_MIN,
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -192,7 +192,7 @@ mod tests {
             user_tunnel_block: "10.0.0.2/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/4".parse().unwrap(),
             next_bgp_community: BGP_COMMUNITY_MIN,
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
         };
         let err = val.validate();
         assert!(err.is_err());
@@ -211,7 +211,7 @@ mod tests {
             user_tunnel_block: "10.0.0.2/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/4".parse().unwrap(),
             next_bgp_community: BGP_COMMUNITY_MIN,
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
         };
         let err_zero = val_zero.validate();
         assert!(err_zero.is_err());
@@ -238,7 +238,7 @@ mod tests {
             user_tunnel_block: "10.0.0.2/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/4".parse().unwrap(),
             next_bgp_community: BGP_COMMUNITY_MIN,
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
         };
         let err_zero = val_zero.validate();
         assert!(err_zero.is_err());

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
@@ -74,7 +74,7 @@ async fn test_accesspass_allow_multiple_ip() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "9.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_test.rs
@@ -85,7 +85,7 @@ async fn test_device() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(), // Private tunnel block
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),   // Private tunnel block
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(), // Multicast block
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -761,7 +761,7 @@ async fn setup_program_with_location_and_exchange(
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_update_location_test.rs
@@ -74,7 +74,7 @@ async fn device_update_location_test() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(), // Private tunnel block
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),   // Private tunnel block
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(), // Multicast block
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/exchange_setdevice.rs
@@ -67,7 +67,7 @@ async fn exchange_setdevice() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/exchange_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/exchange_test.rs
@@ -66,7 +66,7 @@ async fn test_exchange() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -296,7 +296,7 @@ async fn test_exchange_owner_and_foundation_can_update_status() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -453,7 +453,7 @@ async fn test_exchange_bgp_community_autoassignment() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -610,7 +610,7 @@ async fn test_exchange_bgp_community_autoassignment() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: Some(10999),
         }),
         vec![
@@ -760,7 +760,7 @@ async fn test_suspend_exchange_from_suspended_fails() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/global_test.rs
@@ -85,7 +85,7 @@ async fn test_doublezero_program() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/interface_test.rs
@@ -79,7 +79,7 @@ async fn test_device_interfaces() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(), // Private tunnel block
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),   // Private tunnel block
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(), // Multicast block
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_dzx_test.rs
@@ -75,7 +75,7 @@ async fn test_dzx_link() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "10.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -74,7 +74,7 @@ async fn test_wan_link() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "10.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_subscribe_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_subscribe_test.rs
@@ -94,7 +94,7 @@ async fn setup_fixture() -> TestFixture {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
@@ -415,7 +415,7 @@ pub async fn setup_program_with_globalconfig() -> (BanksClient, Keypair, Pubkey,
             device_tunnel_block: "10.100.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.200.0.0/24".parse().unwrap(),
             multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/user_migration.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_migration.rs
@@ -70,7 +70,7 @@ async fn test_user_migration() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/user_old_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_old_test.rs
@@ -74,7 +74,7 @@ async fn test_old_user() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
@@ -128,7 +128,7 @@ async fn setup_user_onchain_allocation_test(
             device_tunnel_block: "10.100.0.0/24".parse().unwrap(),
             user_tunnel_block: "169.254.0.0/24".parse().unwrap(), // Link-local for user tunnel_net
             multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -1480,12 +1480,12 @@ async fn test_multicast_publisher_block_deallocation_and_reuse() {
     assert_eq!(user.status, UserStatus::Activated);
 
     let first_dz_ip = user.dz_ip;
-    // dz_ip should be from MulticastPublisherBlock (147.51.126.0/23), not client_ip
+    // dz_ip should be from MulticastPublisherBlock (148.51.120.0/21), not client_ip
     assert_ne!(first_dz_ip, Ipv4Addr::from(client_ip));
     assert_eq!(
         first_dz_ip.octets()[0..2],
         [147, 51],
-        "dz_ip should be from MulticastPublisherBlock (147.51.126.0/23)"
+        "dz_ip should be from MulticastPublisherBlock (148.51.120.0/21)"
     );
     println!("  First publisher dz_ip: {}", first_dz_ip);
 

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -75,7 +75,7 @@ async fn test_user() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![
@@ -566,7 +566,7 @@ async fn test_user_ban_requires_pendingban() {
             device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
             next_bgp_community: None,
         }),
         vec![

--- a/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
@@ -793,7 +793,7 @@ impl ServiceabilityProgramHelper {
                     device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
                     user_tunnel_block: "10.0.0.0/24".parse().unwrap(),
                     multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-                    multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                    multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: None,
                 }),
                 vec![

--- a/smartcontract/sdk/rs/src/commands/device/activate.rs
+++ b/smartcontract/sdk/rs/src/commands/device/activate.rs
@@ -110,7 +110,7 @@ mod tests {
                     device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
                     user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
                     multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-                    multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                    multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: 0,
                 }))
             });

--- a/smartcontract/sdk/rs/src/commands/device/sethealth.rs
+++ b/smartcontract/sdk/rs/src/commands/device/sethealth.rs
@@ -102,7 +102,7 @@ mod tests {
                     device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
                     user_tunnel_block: "10.1.0.0/24".parse().unwrap(),
                     multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-                    multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                    multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: 1,
                 }))
             });

--- a/smartcontract/sdk/rs/src/commands/device/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/update.rs
@@ -179,7 +179,7 @@ mod tests {
                     device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
                     user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
                     multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-                    multicast_publisher_block: "147.51.126.0/23".parse().unwrap(),
+                    multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: 0,
                 }))
             });

--- a/smartcontract/sdk/rs/src/commands/user/closeaccount.rs
+++ b/smartcontract/sdk/rs/src/commands/user/closeaccount.rs
@@ -269,7 +269,7 @@ mod tests {
             device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(), // dz_ip 10.0.0.1 NOT in this range
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(), // dz_ip 10.0.0.1 NOT in this range
             next_bgp_community: 0,
         };
         client
@@ -437,7 +437,7 @@ mod tests {
             device_tunnel_block: "1.0.0.0/24".parse().unwrap(),
             user_tunnel_block: "2.0.0.0/24".parse().unwrap(),
             multicastgroup_block: "224.0.0.0/24".parse().unwrap(),
-            multicast_publisher_block: "147.51.126.0/23".parse().unwrap(), // dz_ip 10.0.0.1 NOT in this range
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(), // dz_ip 10.0.0.1 NOT in this range
             next_bgp_community: 0,
         };
         client


### PR DESCRIPTION
## Summary
- Update multicast publisher IP block from 147.51.126.0/23 to 148.51.120.0/21 across all code, tests, and documentation
- Changes affect global configuration in smart contracts, activator, client, controller, and e2e tests
- The larger /21 block provides increased address space for multicast publisher allocations

## Testing Verification
- All 37 affected files updated consistently across Rust and Go codebases
- Updated test fixtures and SDK test data to reflect new IP block
- RFC documentation updated to match new configuration