### PR TITLE
rust: update cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "backon",
  "base64 0.22.1",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "backon",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "eyre",
  "serde",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "async-trait",
  "backon",
@@ -2078,7 +2078,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",


### PR DESCRIPTION
## Summary of Changes
- Cargo.lock update missing from Cargo.toml v0.8.9 update

## Testing Verification
- N/A
