### PR TITLE
e2e: fix flaky ny5 metrics fetch in DeviceTelemetry test

### DIFF
--- a/e2e/internal/prometheus/metrics.go
+++ b/e2e/internal/prometheus/metrics.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"time"
@@ -66,6 +67,18 @@ func (m *MetricsClient) Fetch(ctx context.Context) error {
 		return err
 	}
 
+	m.families = families
+	return nil
+}
+
+// ParseMetrics parses raw Prometheus exposition-format text and stores the
+// metric families, just like Fetch does but without making an HTTP request.
+func (m *MetricsClient) ParseMetrics(data []byte) error {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
 	m.families = families
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fix `TestE2E_DeviceTelemetry` flake where ny5's metrics endpoint times out because Docker port-mapped traffic enters the root namespace but the listener is in ns-management, and the cross-namespace route cEOS sets up during boot isn't ready in time on CI
- For ny5, exec into the container and fetch metrics from within ns-management where the listener is directly reachable on localhost
- Add `Device.FetchTelemetryMetricsViaExec()` and `MetricsClient.ParseMetrics()` helpers

## Testing Verification
- `go test -tags e2e -run TestE2E_DeviceTelemetry -v -count=1 ./e2e/...`