### PR TITLE
e2e: fix UserLimits and UserBan test flakes

### DIFF
--- a/e2e/internal/devnet/devnet.go
+++ b/e2e/internal/devnet/devnet.go
@@ -598,6 +598,14 @@ func (d *Devnet) AddClient(ctx context.Context, spec ClientSpec) (*Client, error
 		return nil, fmt.Errorf("failed to start client: %w", err)
 	}
 
+	// The container entrypoint starts doublezerod as its last step, so there
+	// is a window after the container is "running" where the socket does not
+	// yet exist. Wait for the daemon to be accepting requests before
+	// returning the client to the caller.
+	if err := client.WaitForDaemonReady(ctx, 30*time.Second); err != nil {
+		return nil, fmt.Errorf("failed to wait for client daemon: %w", err)
+	}
+
 	return client, nil
 }
 


### PR DESCRIPTION
## Summary
- Fix `TestE2E_UserLimits/unicast_limit_enforcement` flake: `AddClient` returned before `doublezerod` was ready — the container entrypoint starts the daemon as its last step, leaving a window where the Unix socket doesn't exist. Add `WaitForDaemonReady()` at the end of `AddClient` so all callers get a ready daemon.
- Fix `TestE2E_UserBan/user-ban-ibrl` flake: cross-exchange client route checks used 60s/1s (timeout/poll), but the full propagation path (device iBGP → client daemon → kernel route install) can exceed 60s on CI. Increase to 120s/5s, matching `multi_client_ibrl_test.go`.

Failures observed in https://github.com/malbeclabs/doublezero/actions/runs/22078692369 (shards 3 and 6).

## Testing Verification
- `go test -tags e2e -run TestE2E_UserLimits -v -count=1 ./e2e/...`
- `go test -tags e2e -run TestE2E_UserBan -v -count=1 ./e2e/...`