### PR TITLE
Serviceability: validate limits before incrementing counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain Programs
+  - Refactor user creation to validate all limits (max_users, max_multicast_users, max_unicast_users) before incrementing counters — improves efficiency by avoiding wasted work on validation failures and follows fail-fast best practice
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -214,9 +214,6 @@ pub fn process_create_user(
         return Err(DoubleZeroError::AccessPassUnauthorized.into());
     }
 
-    accesspass.connection_count += 1;
-    accesspass.status = AccessPassStatus::Connected;
-
     // Read validator_pubkey from AccessPass
     let validator_pubkey = match &accesspass.accesspass_type {
         AccessPassType::SolanaValidator(pk) => *pk,
@@ -270,6 +267,10 @@ pub fn process_create_user(
             }
         }
     }
+
+    // All validations passed - now update counters
+    accesspass.connection_count += 1;
+    accesspass.status = AccessPassStatus::Connected;
 
     device.reference_count += 1;
     device.users_count += 1;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -168,12 +168,6 @@ pub fn process_create_subscribe_user(
         return Err(DoubleZeroError::AccessPassUnauthorized.into());
     }
 
-    accesspass.connection_count += 1;
-    accesspass.status = AccessPassStatus::Connected;
-    if accesspass.is_dynamic() && accesspass.client_ip == Ipv4Addr::UNSPECIFIED {
-        accesspass.client_ip = value.client_ip; // lock to the first used IP
-    }
-
     // Read validator_pubkey from AccesPass
     let validator_pubkey = match &accesspass.accesspass_type {
         AccessPassType::SolanaValidator(pk) => *pk,
@@ -239,6 +233,13 @@ pub fn process_create_subscribe_user(
                 return Err(DoubleZeroError::MaxUnicastUsersExceeded.into());
             }
         }
+    }
+
+    // All validations passed - now update counters
+    accesspass.connection_count += 1;
+    accesspass.status = AccessPassStatus::Connected;
+    if accesspass.is_dynamic() && accesspass.client_ip == Ipv4Addr::UNSPECIFIED {
+        accesspass.client_ip = value.client_ip; // lock to the first used IP
     }
 
     device.reference_count += 1;


### PR DESCRIPTION
Move counter increments (connection_count, users_count, etc) to occur after all validations pass in user creation. Previously, counters were incremented early, then validations checked limits. While Solana's atomic transactions ensure consistency, this order was inefficient (doing work that would be reverted on validation failure) and less clear.

Changes:
- create.rs: move accesspass.connection_count increment after device limit validations (max_users, max_multicast_users, max_unicast_users)
- create_subscribe.rs: same pattern for multicast subscribe flow

Benefits:
- More efficient: no wasted work if validation fails
- Clearer logic: validate first, update state after
- Follows "fail fast" best practice