### PR TITLE
bugfix(serviceability): update ibrl dz-prefixes when no users allocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
   - Refactor user creation to validate all limits (max_users, max_multicast_users, max_unicast_users) before incrementing counters — improves efficiency by avoiding wasted work on validation failures and follows fail-fast best practice
   - Serviceability: `UnlinkDeviceInterface` now only allows `Activated` or `Pending` interfaces; when an associated link account is provided for an `Activated` interface, the link must be in `Deleting` status
   - SDK: `UnlinkDeviceInterfaceCommand` automatically discovers and passes associated link accounts
+  - Serviceability: allow contributors to update prefixes when for IBRL when no users are allocated
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/resource_extension.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/resource_extension.rs
@@ -249,6 +249,13 @@ impl<'a> ResourceExtensionBorrowed<'a> {
             }
         }
     }
+
+    pub fn count_allocated(&self) -> usize {
+        match &self.allocator {
+            Allocator::Ip(ip_allocator) => ip_allocator.iter_allocated(self.storage).count(),
+            Allocator::Id(id_allocator) => id_allocator.iter_allocated(self.storage).count(),
+        }
+    }
 }
 
 impl fmt::Display for ResourceExtensionBorrowed<'_> {

--- a/smartcontract/programs/doublezero-serviceability/tests/resource_extension_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/resource_extension_test.rs
@@ -1068,8 +1068,15 @@ async fn update_device_dz_prefixes(
 
     let dz_prefixes_list: NetworkV4List = dz_prefixes.parse().unwrap();
 
+    let device = get_device(banks_client, device_pubkey)
+        .await
+        .expect("Device should exist");
+    let old_count = device.dz_prefixes.len();
+    let new_count = dz_prefixes_list.len();
+    let max_count = old_count.max(new_count);
+
     let mut resource_accounts = vec![];
-    for idx in 0..dz_prefixes_list.len() + 1 {
+    for idx in 0..max_count + 1 {
         let resource_type = match idx {
             0 => ResourceType::TunnelIds(device_pubkey, 0),
             _ => ResourceType::DzPrefixBlock(device_pubkey, idx - 1),

--- a/smartcontract/sdk/rs/src/commands/device/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/update.rs
@@ -66,7 +66,10 @@ impl UpdateDeviceCommand {
         let mut resource_count = 0;
         if let Some(dz_prefixes) = &self.dz_prefixes {
             extra_accounts.push(AccountMeta::new(globalconfig_pubkey, false));
-            for idx in 0..dz_prefixes.len() + 1 {
+            let old_count = device.dz_prefixes.len();
+            let new_count = dz_prefixes.len();
+            let max_count = old_count.max(new_count);
+            for idx in 0..max_count + 1 {
                 let resource_type = match idx {
                     0 => ResourceType::TunnelIds(device_pubkey, 0),
                     _ => ResourceType::DzPrefixBlock(device_pubkey, idx - 1),
@@ -75,7 +78,7 @@ impl UpdateDeviceCommand {
                     get_resource_extension_pda(&client.get_program_id(), resource_type);
                 extra_accounts.push(AccountMeta::new(pda, false));
             }
-            resource_count += dz_prefixes.len() + 1;
+            resource_count += max_count + 1;
         }
 
         client.execute_transaction(


### PR DESCRIPTION
## Summary of Changes
This PR enables network contributors to update (add, remove) their dz_prefixes vec for IBRL users. This change is only allowed when there are no users allocated.

Closes https://github.com/malbeclabs/doublezero/issues/3027


## Testing Verification
* Added test to verify behavior 