### PR TITLE
feat(serviceability): Ensure prefixes are cleaned up when removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
   - `doublezero status` now shows a `Tenant` column (between `User Type` and `Current Device`) with the tenant code associated with the user; empty when no tenant is assigned
 - Client
   - Fix tunnel overlay address scope to prevent kernel from selecting link-local /31 as source for routed traffic
+  - Serviceability: close orphaned blocks when dz_prefixes shrink
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
   - Backward compatibility test: use `--status` instead of `--desired-status` for drain commands; fix version ranges (link drain compatible since v0.7.2, device drain since v0.8.1)


### PR DESCRIPTION
## Summary of Changes

This is a followup to https://github.com/malbeclabs/doublezero/pull/3029 to ensure that when vec of prefixes shrink, they are properly cleaned up.

Closes https://github.com/malbeclabs/doublezero/issues/3030

## Testing Verification
* Added unit tests to show shrinking works as expected
* Added e2e test that allocated additional grows and shrinks allocated dz-prefixes vec
