### PR TITLE
bugfix(serviceability): require ip-net for CYOA interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - Client
   - Fix tunnel overlay address scope to prevent kernel from selecting link-local /31 as source for routed traffic
   - Serviceability: close orphaned blocks when dz_prefixes shrink
+  - Serviceability: require ip-net for CYOA interfaces
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
   - Backward compatibility test: use `--status` instead of `--desired-status` for drain commands; fix version ranges (link drain compatible since v0.7.2, device drain since v0.8.1)

--- a/e2e/dz_prefix_rollover_test.go
+++ b/e2e/dz_prefix_rollover_test.go
@@ -386,6 +386,7 @@ func TestE2E_DzPrefix_GrowAndShrink(t *testing.T) {
 		set -euo pipefail
 		doublezero device create --code test-dz01 --contributor co01 --location lax --exchange xlax --public-ip "45.33.100.1" --dz-prefixes "45.33.101.0/30" --mgmt-vrf mgmt --desired-status activated 2>&1
 		doublezero device update --pubkey test-dz01 --max-users 128 2>&1
+		doublezero device interface create test-dz01 "Ethernet1" --interface-cyoa gre-over-dia --ip-net "45.33.100.62/31" 2>&1
 		doublezero device interface create test-dz01 "Loopback255" --loopback-type vpnv4 -w
 		doublezero device interface create test-dz01 "Loopback256" --loopback-type ipv4 -w
 	`})

--- a/e2e/interface_validation_test.go
+++ b/e2e/interface_validation_test.go
@@ -61,6 +61,7 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 			"doublezero", "device", "interface", "create",
 			testDeviceCode, testInterfaceName,
 			"--interface-cyoa", "gre-over-dia",
+			"--ip-net", "45.33.100.50/31",
 		})
 		require.NoError(t, err, "failed to create physical interface with CYOA")
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
@@ -108,12 +108,22 @@ pub fn process_create_device_interface(
         interface_type = InterfaceType::Loopback;
     }
 
+    // CYOA can only be set on physical interfaces
+    if value.interface_cyoa != InterfaceCYOA::None && interface_type != InterfaceType::Physical {
+        return Err(DoubleZeroError::CyoaRequiresPhysical.into());
+    }
+
     // ip_net can only be set on CYOA, DIA, or user-tunnel-endpoint interfaces
     if value.ip_net.is_some()
         && value.interface_cyoa == InterfaceCYOA::None
         && value.interface_dia == InterfaceDIA::None
         && !value.user_tunnel_endpoint
     {
+        return Err(DoubleZeroError::InvalidInterfaceIp.into());
+    }
+
+    // CYOA interfaces must have an ip_net
+    if value.interface_cyoa != InterfaceCYOA::None && value.ip_net.is_none() {
         return Err(DoubleZeroError::InvalidInterfaceIp.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
@@ -180,6 +180,13 @@ pub fn process_update_device_interface(
         }
         iface.node_segment_idx = node_segment_idx;
     }
+
+    // CYOA interfaces must have an ip_net — prevent setting CYOA without ip_net
+    // or clearing ip_net from a CYOA interface via update
+    if iface.interface_cyoa != InterfaceCYOA::None && iface.ip_net == NetworkV4::default() {
+        return Err(DoubleZeroError::InvalidInterfaceIp.into());
+    }
+
     // until we have release V2 version for interfaces, always convert to v1
     let updated_interface = iface.to_interface();
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/interface.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/interface.rs
@@ -448,6 +448,14 @@ impl Validate for Interface {
             return Err(DoubleZeroError::CyoaRequiresPhysical);
         }
 
+        // CYOA interfaces must have an ip_net
+        if interface.interface_cyoa != InterfaceCYOA::None
+            && interface.ip_net == NetworkV4::default()
+        {
+            msg!("CYOA interfaces must have an ip_net set");
+            return Err(DoubleZeroError::InvalidInterfaceIp);
+        }
+
         // Only allow private and link-local IPs for non-CYOA and non-DIA interfaces,
         // unless it's a loopback interface with user_tunnel_endpoint set to true.
         if interface.ip_net != NetworkV4::default()
@@ -615,6 +623,7 @@ mod test_interface_validate {
         let mut iface = base_interface();
         iface.interface_type = InterfaceType::Physical;
         iface.interface_cyoa = InterfaceCYOA::GREOverDIA;
+        iface.ip_net = "38.104.127.117/31".parse().unwrap();
         assert!(Interface::V2(iface).validate().is_ok());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_wan_test.rs
@@ -1013,7 +1013,7 @@ async fn test_wan_link_rejects_cyoa_interface() {
                 loopback_type: LoopbackType::None,
                 interface_cyoa: InterfaceCYOA::GREOverDIA,
                 bandwidth: 0,
-                ip_net: None,
+                ip_net: Some("100.1.0.0/31".parse().unwrap()),
                 cir: 0,
                 mtu: 1500,
                 routing_mode: RoutingMode::Static,


### PR DESCRIPTION
## Summary of Changes

This PR adds the requirement to have an ip_net when a CYOA interface is created.  Previously one could create a CYOA interface without an ip_net which would default to `0.0.0.0` which doesn't seem like desired behavior. 

Closes https://github.com/malbeclabs/doublezero/issues/3032

## Testing Verification
* E2E tests have been updated to include the `ip-net` flag for CYOA interfaces 
