### PR TITLE
rfc19-user-bgp-status

### DIFF
--- a/rfcs/rfc19-user-bgp-status.md
+++ b/rfcs/rfc19-user-bgp-status.md
@@ -1,8 +1,8 @@
-# RFC 17 — User BGP Status
+# RFC 19 — User BGP Status
 
 ## Summary
 
-**Status: `Draft`**
+**Status: `Approved`**
 
 This RFC closes the loop between Serviceability, DZD configuration, and the doublezerod
 client connection by persisting the real BGP session state of each user onchain.


### PR DESCRIPTION
This pull request introduces RFC 17, which proposes a new onchain mechanism to track the real BGP session status for each user, closing the gap between configuration and actual client connectivity. The RFC details new fields to be added to the User account, a new instruction for updating BGP status, and changes to telemetry collection and SDKs. This enhancement will enable more accurate diagnostics and user lifecycle management by making BGP session state observable onchain.

**User account and onchain status tracking:**

* Adds three new fields to the `User` struct: `bgp_status` (session state), `last_bgp_up_at` (last time session was Up), and `last_bgp_reported_at` (last time status changed), requiring a 17-byte account reallocation on first write.
* Introduces a new instruction, `SetUserBGPStatus`, allowing authorized metrics publishers to update BGP status for each user, with strict validation.

**Telemetry and agent changes:**

* Updates the telemetry collector to determine each user's BGP state after every collection tick and enqueue onchain status updates via the new instruction, using a background worker for reliability.

**SDK and compatibility:**

* Requires updates to SDKs (Go, TypeScript, Python) to handle the new fields, ensuring backward compatibility by treating missing fields as
