### PR TITLE
e2e: remove devnet/testnet filter from TestQA_MulticastPublisherMultipleGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - E2E / QA Tests
   - Fix QA unicast test flake caused by RPC 429 rate limiting during concurrent user deletion — treat transient RPC errors as non-fatal in the deletion polling loop
   - Backward compatibility test: use `--status` instead of `--desired-status` for drain commands; fix version ranges (link drain compatible since v0.7.2, device drain since v0.8.1)
+  - Remove devnet/testnet environment filter from `TestQA_MulticastPublisherMultipleGroups` — test now runs against all environments
 
 ## [v0.8.9](https://github.com/malbeclabs/doublezero/compare/client/v0.8.8...client/v0.8.9) – 2026-02-16
 

--- a/e2e/qa_multicast_test.go
+++ b/e2e/qa_multicast_test.go
@@ -201,9 +201,6 @@ func validateMulticastConnectivity(t *testing.T, ctx context.Context, log *slog.
 // TestQA_MulticastPublisherMultipleGroups tests a single publisher sending to multiple
 // multicast groups, with different subscribers for each group.
 func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
-	if envArg != "devnet" && envArg != "testnet" {
-		t.Skip("Skipping: requires QA agent support for multi-group multicast")
-	}
 	log := newTestLogger(t)
 	ctx := t.Context()
 	test, err := qa.NewTest(ctx, log, hostsArg, portArg, networkConfig, nil)


### PR DESCRIPTION
## Summary
- `TestQA_MulticastPublisherMultipleGroups` was previously skipped on all environments except devnet and testnet
- Remove the environment guard so the test runs against all QA environments

## Testing Verification
- Test now executes on all environments without the skip guard