### PR TITLE
claude: add /diff-breakdown skill and update /pr-text

### DIFF
--- a/.claude/commands/diff-breakdown.md
+++ b/.claude/commands/diff-breakdown.md
@@ -1,0 +1,45 @@
+Analyze the diff between the current branch and origin/main and produce a categorized breakdown.
+
+Steps:
+1. Run `git fetch origin` to ensure remote tracking is up to date
+2. Run `git diff origin/main...HEAD --numstat` to get per-file added/removed line counts
+3. Categorize each changed file using these heuristics (applied in order, first match wins):
+   - **Tests**: files matching `*_test.go`, `*_test.rs`, `tests/`, `e2e/`, `*_test.py`, `*.test.ts`, `*.test.js`
+   - **Fixtures/snapshots**: paths containing `fixtures/`, `snapshots/`, or `.bin`/`.json` files within those directories
+   - **Config/build**: `Cargo.toml`, `go.mod`, `go.sum`, `Makefile`, `*.toml`, `*.yml`, `*.yaml`, `Dockerfile`, `*.lock`
+   - **Docs**: `*.md`, paths under `rfcs/`
+   - **Generated**: lock files (`Cargo.lock`, `go.sum`, `bun.lockb`, `package-lock.json`), protobuf generated output (`*.pb.go`, `*.pb.rs`)
+   - **Scaffolding**: code that wires things together but contains little logic of its own:
+     - Metrics/instrumentation definitions (`metrics.go`, prometheus boilerplate)
+     - Thin CLI wrappers — files that are mostly clap/cobra struct definitions + a single function call (e.g. `enable.rs`, `disable.rs` that just call one controller method)
+     - Subcommand/route registration (`mod.rs` adding a `pub mod`, `command.rs` adding a variant, `main.go` wiring a new dependency)
+     - Interface/trait definitions that are pure signatures with no logic
+   - **Core logic**: everything else — the files where the real business logic and algorithms live
+4. Tally lines added and removed per category, and count distinct files per category
+5. Omit categories with zero changes
+
+Output the breakdown as plain text (NOT inside a code block) so it's readable in the terminal. Use this format:
+
+## Diff Breakdown (origin/main...HEAD)
+
+| Category          | Files | Lines (+/-) | Net    |
+|-------------------|-------|-------------|--------|
+| Core logic        |     4 | +680 / -30  |   +650 |
+| Scaffolding       |     5 | +200 / -10  |   +190 |
+| Tests             |     3 | +820 / -10  |   +810 |
+| Fixtures          |     7 | +14 / -14   |      0 |
+| Config/build      |     1 | +2 / -0     |     +2 |
+| **Total**         |    20 | +1716 / -64 |  +1652 |
+
+### Core changes
+- `client/doublezerod/internal/reconciler/reconciler.go` — +396/-0 (reconciliation loop, onchain state polling)
+- `client/doublezero/src/command/status.rs` — +95/-12 (v2 status endpoint, synthetic disconnected entry)
+
+Summary: ~680 lines of core logic across 4 files, supported by ~200 lines of scaffolding, ~820 lines of tests, and 7 fixture updates.
+
+Guidelines:
+- For the "Core changes" section, list only core logic files, sorted by lines changed (descending). Include a brief parenthetical note about what changed in each file (read the diff to understand).
+- If there are more than 8 core logic files, show the top 8 and add a "... and N more files" line.
+- The summary line should give a quick characterization of the branch's substance — how much is core logic vs supporting changes.
+- Round line counts in the summary (use ~ prefix) for readability.
+- When classifying scaffolding vs core logic, read the diff to understand the file's content. A file with real conditional logic, state management, or algorithms is core logic even if it's small. A file that's mostly declarations, registrations, or one-liner delegations is scaffolding.

--- a/.claude/commands/pr-text.md
+++ b/.claude/commands/pr-text.md
@@ -19,6 +19,24 @@ Resolves: #<issue number if known, otherwise omit this line>
 -
 -
 
+## Diff Breakdown
+| Category     | Files | Lines (+/-) | Net  |
+|--------------|-------|-------------|------|
+| Core logic   |     X | +N / -N     |  +N  |
+| Scaffolding  |     X | +N / -N     |  +N  |
+| Tests        |     X | +N / -N     |  +N  |
+| ...          |       |             |      |
+
+<one-line summary>
+
+<details>
+<summary>Key files (click to expand)</summary>
+
+- [`path/to/file.go`](PR_FILES_URL#diff-HASH) — brief description of what changed
+- [`path/to/other.rs`](PR_FILES_URL#diff-HASH) — brief description of what changed
+
+</details>
+
 ## Testing Verification
 -
 -
@@ -32,6 +50,9 @@ PR Title guidelines:
 Guidelines:
 - Summary should describe the net result: what does this branch add or change compared to origin/main?
 - Ignore commit history - only describe what the final diff shows
+- Include a Diff Breakdown table categorizing changes using `git diff origin/main...HEAD --numstat`. Categorize files as: Core logic, Scaffolding (metrics, thin CLI wrappers, subcommand registration, interface-only files), Tests, Fixtures, Config/build, Docs, Generated. Omit categories with zero changes. Add a one-line summary below the table characterizing the balance of changes.
+- Include a "Key files" list after the diff breakdown showing the most important core logic files (up to 8), sorted by lines changed descending. Each entry should have a brief description of what changed. This helps reviewers know where to focus.
+- Link each key file to its diff in the PR. Use `gh pr view --json number,url` to get the PR URL, then link to `<PR_URL>/files#diff-<SHA256_OF_FILE_PATH>` where the hash is `echo -n "path/to/file" | shasum -a 256`. If no PR exists yet, use plain backtick paths instead.
 - Testing Verification should describe how the changes were tested (e.g., unit tests added/passing, manual testing performed, build verified)
 - Focus on the "what" and "why", not the "how"
 - Group related changes together


### PR DESCRIPTION
## Summary of Changes
- Add a new `/diff-breakdown` skill that categorizes `git diff origin/main...HEAD` output into core logic, scaffolding, tests, fixtures, config, docs, and generated code
- Update `/pr-text` to include a diff breakdown table, collapsible key files list with links to PR diff, and scaffolding as a distinct category

## Diff Breakdown
| Category | Files | Lines (+/-) | Net  |
|----------|-------|-------------|------|
| Docs     |     2 | +66 / -0    |  +66 |

~66 lines across 2 skill definition files.

## Testing Verification
- Ran `/diff-breakdown` on an active branch and verified categorization output
- Ran `/pr-text` on an active branch and verified breakdown section and key file links appear in generated description