### PR TITLE
chore: bump version to 0.8.10 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+## [v0.8.10](https://github.com/malbeclabs/doublezero/compare/client/v0.8.9...client/v0.8.10) – 2026-02-19
+
+### Breaking
+
+- N/A
+
+### Changes
+
 - Activator
   - removes accesspass monitor task (that expires access passes)
 - Monitor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "backon",
  "base64 0.22.1",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "backon",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "eyre",
  "serde",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "async-trait",
  "backon",
@@ -2088,7 +2088,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.9"
+version = "0.8.10"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
- Bump workspace version from 0.8.9 to 0.8.10 in Cargo.toml
- Move unreleased changelog entries into new v0.8.10 section dated 2026-02-19