### PR TITLE
qaagent: avoid parsing errors by removing stderr from --json output

### DIFF
--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -732,7 +732,7 @@ func (q *QAAgent) GetPublicIP(ctx context.Context, req *emptypb.Empty) (*pb.GetP
 // the `doublezero status --json` command.
 func (q *QAAgent) fetchStatus(ctx context.Context) ([]StatusResponse, error) {
 	cmd := exec.CommandContext(ctx, "doublezero", "status", "--json")
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute doublezero status command: %w, output: %s", err, string(output))
 	}
@@ -748,7 +748,7 @@ func (q *QAAgent) fetchStatus(ctx context.Context) ([]StatusResponse, error) {
 // the `doublezero latency --json` command.
 func (q *QAAgent) fetchLatency(ctx context.Context) ([]LatencyResponse, error) {
 	cmd := exec.CommandContext(ctx, "doublezero", "latency", "--json")
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute doublezero latency command: %w, output: %s", err, string(output))
 	}


### PR DESCRIPTION
## Summary of Changes
* qaagent: avoid parsing errors by removing stderr from --json output
* Prevents QA test failures in case the client recommends a version upgrade:
```
2026-02-20T17:34:39.7173092Z     qa_test.go:68: [2m2026-02-20T17:34:39.715Z[0m DBG Collect `doublezero latency` for each client
2026-02-20T17:34:40.0577082Z     qa_alldevices_unicast_test.go:107: 
2026-02-20T17:34:40.0578365Z         	Error Trace:	/home/runner/_work/infra/infra/doublezero/e2e/qa_alldevices_unicast_test.go:107
2026-02-20T17:34:40.0579340Z         	Error:      	Received unexpected error:
2026-02-20T17:34:40.0583686Z         	            	failed to get latency on host <qa-hostname>: rpc error: code = Unknown desc = failed to unmarshal latency response: error: invalid character 'A' looking for beginning of value, output: A new version of the client is available: 0.8.9 → 0.8.10
2026-02-20T17:34:40.0586209Z         	            	We recommend updating to the latest version for the best experience.
2026-02-20T17:34:40.0586945Z         	            	[
2026-02-20T17:34:40.0587389Z         	            	  {
2026-02-20T17:34:40.0588589Z         	            	    "device_pk": "6HDniG2dEQuuGGz14G4DxJ3J1WQRauARCTT18ckh5mpP",
```

## Testing Verification
* Tested in devnet
