### PR TITLE
client: remove redundant connect ibrl unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - Remove redundant `connect ibrl` unit tests that were duplicates of hybrid-device equivalents
+
 ## [v0.8.10](https://github.com/malbeclabs/doublezero/compare/client/v0.8.9...client/v0.8.10) – 2026-02-19
 
 ### Breaking


### PR DESCRIPTION
## Summary

Three unit tests in the `connect ibrl` flow were removed because they covered
no code paths beyond what sibling tests already exercise.

### `test_connect_command_ibrl_edge` (removed)

This test was structurally identical to `test_connect_command_ibrl_hybrid`: it
ran IBRL connect followed by a multicast coexistence check, asserting success in
both cases. The only difference was the device type (`Edge` vs `Hybrid`). The
connect command has no branching logic on `DeviceType` — that attribute is an
onchain concept handled by the activator. `execute_ibrl` selects an eligible
device and runs the same provisioning path regardless of device type. Running the
same test against an Edge device adds no coverage.

### `test_connect_command_ibrl_allocate_edge` (removed)

Same situation as above for the `allocate_addr: true` variant. This test was
byte-for-byte equivalent to `test_connect_command_ibrl_allocate_hybrid` except
for the device type. The route-resolution and allocated-address provisioning path
(`resolve_tunnel_src` → `IBRLWithAllocatedIP` provision) is independent of
device type.

### `test_connect_command_ibrl_allocate_resolve_route_failure` (removed)

This test verified that when `resolve_tunnel_src` returns `None` (no route
found), the command fails with `"Unable to resolve route"`. The same assertion is
already made by `test_connect_command_ibrl_allocate_existing_user_resolve_failure`.
The only difference was setup: the removed test had no existing onchain user (new
user path), while the kept test has an `Activated` user. Both paths call the same
`resolve_tunnel_src` function at the same point in `find_or_create_user`, and the
error is propagated identically. The kept test covers the more realistic scenario
(a user already exists but route resolution fails on reconnect), making the simpler
variant redundant.

## Testing Verification

- All 59 remaining unit tests pass after removal