### PR TITLE
client: fix current device showing N/A for multicast subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - CLI
+  - Fix `doublezero status` showing "Current Device" and "Metro" as N/A for multicast subscribers when the tunnel destination is a `user_tunnel_endpoint` loopback interface IP rather than the device's `public_ip`
   - Remove redundant `connect ibrl` unit tests that were duplicates of hybrid-device equivalents
   - `doublezero global-config feature-flags` commands added
   - Fix multicast subscriber tunnel source resolution for NAT environments — resolve local interface IP instead of using public IP

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, net::Ipv4Addr, str::FromStr, time::Duration};
 
 /// Get all tunnel endpoints for a device.
 /// Returns the device's public_ip plus any UserTunnelEndpoint interface IPs.
-fn get_device_tunnel_endpoints(device: &Device) -> Vec<Ipv4Addr> {
+pub(crate) fn get_device_tunnel_endpoints(device: &Device) -> Vec<Ipv4Addr> {
     let mut endpoints = vec![device.public_ip];
 
     // Add all UserTunnelEndpoint interfaces


### PR DESCRIPTION
## Summary of Changes
* Fix a bug where `doublezero status` showed "Current Device" and "Metro" as N/A for multicast subscribers even when a tunnel was connected
* Root cause: the tunnel destination IP for multicast subscribers can be a device's `user_tunnel_endpoint` loopback interface IP rather than its `public_ip`, but the fallback matching logic only checked `public_ip`
* Reuse `get_device_tunnel_endpoints` from `dzd_latency.rs` (now `pub(crate)`) in the status command's fallback path, which already correctly checks both `public_ip` and `user_tunnel_endpoint` interface IPs
* Refactor status test module to use shared helpers (`make_device`, `make_exchange`, `make_user`, `make_latency`, `setup_mocks`, `run_status`), reducing boilerplate across all tests (net -162 lines)

## Testing Verification
* 9 unit tests pass in the status command module (`cargo test -p doublezero status`), covering all device-resolution paths:
  - Primary path: `doublezero_ip` matched against onchain user `dz_ip`
  - Fallback: `tunnel_dst` matched against device `public_ip`
  - Fallback: `tunnel_dst` matched against device `user_tunnel_endpoint` interface IP (new)
  - No match with tunnel connected: displays N/A (new)
  - No match with tunnel disconnected: displays N/A