### PR TITLE
cli: add multicast group filters to access-pass list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
   - Remove redundant `connect ibrl` unit tests that were duplicates of hybrid-device equivalents
   - `doublezero global-config feature-flags` commands added
   - Fix multicast subscriber tunnel source resolution for NAT environments — resolve local interface IP instead of using public IP
+  - Added multicast filters to access-pass list, enabling filtering by publisher/subscriber role and identifying access passes not authorized for a specific multicast group.
 - Client
   - Reject BGP martian addresses (CGNAT, multicast, reserved, benchmarking, etc.) as client IP during `connect`
 - Controller


### PR DESCRIPTION
## Summary of Changes
- Added four new CLI flags to `doublezero accesspass list`: `--multicast-group-publisher`, `--not-multicast-group-publisher`, `--multicast-group-subscriber`, and `--not-multicast-group-subscriber`
- These allow operators to find access passes that authorize (or do not authorize) a specific multicast group publisher or subscriber, identified by group code
- Added 4 unit tests covering each filter, including positive and negative cases

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net  |
|-------------|-------|-------------|------|
| Core logic  |     1 | +50 / -0    |  +50 |
| Scaffolding |     1 | +21 / -0    |  +21 |
| Tests       |     1 | +173 / -0   | +173 |
| Docs        |     1 | +1 / -0     |   +1 |

Heavily test-weighted change; core filter logic is small and focused.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/accesspass/list.rs` — added four `Option<String>` fields to `ListAccessPassCliCommand`, four corresponding `retain` filter blocks in `execute`, and 4 unit tests with a shared `setup_multicast_client` helper

</details>

## Testing Verification
- All 4 new unit tests pass (`test_filter_multicast_group_publisher`, `test_filter_multicast_group_subscriber`, `test_filter_not_multicast_group_publisher`, `test_filter_not_multicast_group_subscriber`)
- Each test verifies both inclusion of matching passes and exclusion of non-matching passes by pubkey