### PR TITLE
devcontainer: run as non-root user to fix file ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
             "version": "1.90.0"
         },
     },
-    "postCreateCommand": "rustup component add --toolchain nightly rustfmt",
+    "postCreateCommand": "sudo chown vscode:vscode /workspaces/doublezero/target && rustup component add --toolchain nightly rustfmt",
+    "postStartCommand": "sudo chmod 666 /var/run/docker.sock && sudo chown -R vscode:vscode /home/vscode/.docker",
     "customizations": {
         "vscode": {
             "extensions": [
@@ -53,7 +54,8 @@
             }
         }
     },
-    "remoteUser": "root",
+    "remoteUser": "vscode",
+    "updateRemoteUserUID": true,
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
         "source=devcontainer-target,target=/workspaces/doublezero/target,type=volume"


### PR DESCRIPTION
## Summary
- Switch `remoteUser` from `root` to `vscode` so files created inside the container are owned by the host user instead of root, fixing permission issues on Windows/WSL
- Add `updateRemoteUserUID` to remap container UID to match the host user
- Use `postStartCommand` to chmod the docker socket and fix `~/.docker` ownership on every container start
- Take ownership of the volume-mounted `target/` directory in `postCreateCommand`

## Testing Verification
- `docker ps` works without sudo from VS Code terminal
- Files created inside the container are owned by the host user
- Rust and Go toolchains function correctly under the `vscode` user