### PR TITLE
internet-latency-collector: remove packet size from RIPE Atlas measurements

### DIFF
--- a/controlplane/internet-latency-collector/internal/ripeatlas/client.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client.go
@@ -60,7 +60,6 @@ type MeasurementDefinition struct {
 	AF             int      `json:"af"`
 	Interval       int      `json:"interval"`
 	Packets        int      `json:"packets"`
-	Size           int      `json:"size"`
 	PacketInterval int      `json:"packet_interval"`
 	Target         string   `json:"target"`
 	Description    string   `json:"description"`

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -1046,7 +1046,6 @@ func (c *Collector) configureMeasurements(ctx context.Context, locationMatches [
 						AF:             4,
 						Interval:       int(samplingInterval.Seconds()),
 						Packets:        1,
-						Size:           1280,
 						PacketInterval: 1000, // Delay between packets; only matters when Packets > 1
 						Target:         spec.TargetProbe.Address,
 						Description:    description,


### PR DESCRIPTION
## Summary of Changes
* Remove the `Size` field from `MeasurementDefinition` struct in `client.go` and the `Size: 1280` assignment in `collector.go`
* The slc anchor probe (7549) does not support packets larger than 102 bytes, but the collector was requesting 1280-byte RIPE Atlas measurements, causing all 30 slc-related circuits to fail silently
* By omitting `size` from the JSON payload, RIPE Atlas uses its default packet size which all probes support

## Testing Verification
* Verified fix by running snapshot build in mainnet-beta