### PR TITLE
RFC16: Support Inbound Probing

### DIFF
--- a/rfcs/rfc16-geolocation-verification.md
+++ b/rfcs/rfc16-geolocation-verification.md
@@ -117,8 +117,8 @@ IP    │ │ Offset        Target IPs │  │ Measured             Offset │
 Inbound Probing Flow
 ```
   ┌──────────┐                  ┌───────────┐                  ┌───────────┐
-  │          │<─────Reply───────│           │───Signed Reply──>│           │
-  │   DZD    │──────TWAMP──────>│   Probe   │<──Signed Probe───│  Target   │
+  │          │<─────Reply───────│           │<──Signed Probe───│           │
+  │   DZD    │──────TWAMP──────>│   Probe   │───Signed Reply──>│  Target   │
   │          │──Signed Offset──>│           │                  │           │
   └──────────┘                  └───────────┘                  └───────────┘
       ^ │ Measured                 ^  │                             │


### PR DESCRIPTION
This updates RFC16 to add support for "inbound probing" required by some users who are behind NAT or running in a TEE. This inverts some of the security assumptions and requires the Target to be trusted to accurately report the RTTs.