### PR TITLE
ci: add hotfix branch triggers to test and validation workflows (#3121)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,9 @@
 name: e2e
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/flow_schema_migrations.yml
+++ b/.github/workflows/flow_schema_migrations.yml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - "telemetry/flow-enricher/clickhouse/**"
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
     paths:
       - "telemetry/flow-enricher/clickhouse/**"
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 jobs:
   validate:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,9 @@
 name: go
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 jobs:
   go-build:

--- a/.github/workflows/release.pipeline.validation.yml
+++ b/.github/workflows/release.pipeline.validation.yml
@@ -2,9 +2,9 @@ name: release pipeline validation
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 permissions:
   contents: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,9 @@
 name: rust
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 jobs:
   rust-build:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,9 +1,9 @@
 name: sdk
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'hotfix/**' ]
 
 jobs:
   sdk-version-check:


### PR DESCRIPTION
## Summary

* Add `hotfix/**` branch pattern to push and pull_request triggers on 6 CI workflows so tests and validation run on hotfix branches, not just main
* Affected workflows: `go.yml`, `rust.yml`, `sdk.yml`, `e2e.yml`, `release.pipeline.validation.yml`, `flow_schema_migrations.yml`

## Testing Verification

* Validated all 6 YAML files parse correctly
* Verified `hotfix/**` pattern appears exactly twice per file (push + pull_request triggers)