### PR TITLE
smartcontract: allow sentinel authority to update multicast allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - SDK
   - Fix multicast group deserialization in `smartcontract/sdk/go` to correctly read publisher and subscriber counts and align status enum with onchain definition
+- Smartcontract
+  - Allow sentinel authority to add/remove multicast publisher and subscriber allowlist entries
 - Telemetry
   - Fix global monitor crash when IBRL and multicast users share the same client IP but are on different devices, by preferring non-multicast users in client IP lookups to match status device selection
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
@@ -77,6 +77,7 @@ pub fn process_add_multicastgroup_pub_allowlist(
 
     // Check whether mgroup is authorized
     let is_authorized = (mgroup.owner == *payer_account.key)
+        || globalstate.sentinel_authority_pk == *payer_account.key
         || globalstate.foundation_allowlist.contains(payer_account.key);
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
@@ -78,6 +78,7 @@ pub fn process_remove_multicast_pub_allowlist(
 
     // Check whether mgroup is authorized
     let is_authorized = (mgroup.owner == *payer_account.key)
+        || globalstate.sentinel_authority_pk == *payer_account.key
         || globalstate.foundation_allowlist.contains(payer_account.key);
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
@@ -78,6 +78,7 @@ pub fn process_add_multicastgroup_sub_allowlist(
 
     // Check whether mgroup is authorized
     let is_authorized = (mgroup.owner == *payer_account.key)
+        || globalstate.sentinel_authority_pk == *payer_account.key
         || globalstate.foundation_allowlist.contains(payer_account.key);
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
@@ -78,6 +78,7 @@ pub fn process_remove_multicast_sub_allowlist(
 
     // Check whether mgroup is authorized
     let is_authorized = (mgroup.owner == *payer_account.key)
+        || globalstate.sentinel_authority_pk == *payer_account.key
         || globalstate.foundation_allowlist.contains(payer_account.key);
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -3,6 +3,7 @@ use doublezero_serviceability::{
     pda::*,
     processors::{
         accesspass::set::SetAccessPassArgs,
+        globalstate::setauthority::SetAuthorityArgs,
         multicastgroup::{
             activate::MulticastGroupActivateArgs,
             allowlist::publisher::{
@@ -17,7 +18,7 @@ use doublezero_serviceability::{
     },
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, signature::Keypair, signer::Signer};
 
 mod test_helpers;
 use test_helpers::*;
@@ -213,4 +214,212 @@ async fn test_multicast_publisher_allowlist() {
     println!("✅");
     /*****************************************************************************************************************************************************/
     println!("🟢🟢🟢  End test  🟢🟢🟢");
+}
+
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_sentinel_authority() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 2].into();
+    let user_payer = payer.pubkey();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    // 1. Initialize global state
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 2. Create a sentinel keypair and set it as sentinel authority
+    let sentinel = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &sentinel.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            sentinel_authority_pk: Some(sentinel.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // 3. Create and activate a multicast group (owned by payer, NOT sentinel)
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "sentinel-test".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 254, 0, 2].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 4. Set access pass (requires foundation allowlist, so use payer)
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 5. Sentinel (non-owner) adds publisher allowlist entry — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &sentinel,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Sentinel authority should be able to add publisher allowlist entry"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_pub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // 6. Sentinel removes publisher allowlist entry — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupPubAllowlist(
+            RemoveMulticastGroupPubAllowlistArgs {
+                client_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &sentinel,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Sentinel authority should be able to remove publisher allowlist entry"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_pub_allowlist.len(), 0);
+
+    // 7. Unauthorized keypair should fail
+    let unauthorized = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &unauthorized.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &unauthorized,
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "Unauthorized keypair should not be able to add publisher allowlist entry"
+    );
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -3,6 +3,7 @@ use doublezero_serviceability::{
     pda::*,
     processors::{
         accesspass::set::SetAccessPassArgs,
+        globalstate::setauthority::SetAuthorityArgs,
         multicastgroup::{
             activate::MulticastGroupActivateArgs,
             allowlist::subscriber::{
@@ -17,7 +18,7 @@ use doublezero_serviceability::{
     },
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, signature::Keypair, signer::Signer};
 
 mod test_helpers;
 use test_helpers::*;
@@ -213,4 +214,212 @@ async fn test_multicast_subscriber_allowlist() {
     println!("✅");
     /*****************************************************************************************************************************************************/
     println!("🟢🟢🟢  End test  🟢🟢🟢");
+}
+
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_sentinel_authority() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 2].into();
+    let user_payer = payer.pubkey();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    // 1. Initialize global state
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 2. Create a sentinel keypair and set it as sentinel authority
+    let sentinel = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &sentinel.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            sentinel_authority_pk: Some(sentinel.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // 3. Create and activate a multicast group (owned by payer, NOT sentinel)
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "sentinel-test".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 254, 0, 2].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 4. Set access pass (requires foundation allowlist, so use payer)
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 5. Sentinel (non-owner) adds subscriber allowlist entry — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &sentinel,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Sentinel authority should be able to add subscriber allowlist entry"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // 6. Sentinel removes subscriber allowlist entry — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupSubAllowlist(
+            RemoveMulticastGroupSubAllowlistArgs {
+                client_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &sentinel,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Sentinel authority should be able to remove subscriber allowlist entry"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_sub_allowlist.len(), 0);
+
+    // 7. Unauthorized keypair should fail
+    let unauthorized = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &unauthorized.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &unauthorized,
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "Unauthorized keypair should not be able to add subscriber allowlist entry"
+    );
 }


### PR DESCRIPTION
## Summary

- Allow `sentinel_authority_pk` to add/remove multicast publisher and subscriber allowlist entries, matching the pattern used by access pass and tenant payment status processors

## Diff Breakdown (origin/main...HEAD)

| Category          | Files | Lines (+/-) | Net    |
|-------------------|-------|-------------|--------|
| Core logic        |     4 | +4 / -0    |     +4 |
| Tests             |     2 | +428 / -2  |   +426 |
| Docs              |     1 | +2 / -0    |     +2 |
| **Total**         |     7 | +434 / -2  |   +432 |

### Core changes
- `allowlist/publisher/add.rs` — +1/-0 (add sentinel_authority_pk auth check)
- `allowlist/publisher/remove.rs` — +1/-0 (add sentinel_authority_pk auth check)
- `allowlist/subscriber/add.rs` — +1/-0 (add sentinel_authority_pk auth check)
- `allowlist/subscriber/remove.rs` — +1/-0 (add sentinel_authority_pk auth check)

Summary: ~4 lines of core logic across 4 allowlist processors, supported by ~430 lines of tests covering sentinel add/remove and unauthorized rejection.

## Testing Verification

- Added sentinel authority integration tests for both publisher and subscriber allowlist add/remove operations, including unauthorized keypair rejection