### PR TITLE
geolocation: add missing reservation_authority_pk to test helper

### DIFF
--- a/smartcontract/programs/doublezero-geolocation/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/test_helpers.rs
@@ -82,6 +82,7 @@ pub fn create_mock_globalstate_account_shared(
         health_oracle_pk: Pubkey::new_unique(),
         qa_allowlist: vec![],
         feature_flags: 0,
+        reservation_authority_pk: Pubkey::new_unique(),
     };
 
     let data = borsh::to_vec(&globalstate).unwrap();


### PR DESCRIPTION
## Summary
- PR #3086 added `reservation_authority_pk` to `GlobalState` but missed updating the geolocation test helper introduced in PR #3120, breaking `rust-lint` and `rust-test` on main.

## Testing Verification
- `make rust-lint` passes
- All `make rust-test` unit tests pass