### PR TITLE
changelog: move client onchain reconciler entries to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
   - Allow sentinel authority to add/remove multicast publisher and subscriber allowlist entries
 - Telemetry
   - Fix global monitor crash when IBRL and multicast users share the same client IP but are on different devices, by preferring non-multicast users in client IP lookups to match status device selection
+- Client
+  - Add onchain reconciler to daemon — automatically provisions/removes tunnels by polling onchain User state, replacing CLI-driven provisioning and the `doublezerod.json` state file ([RFC-17](rfcs/rfc17-client-onchain-reconciler.md))
+  - Add `doublezero enable` / `doublezero disable` CLI commands to toggle the reconciler at runtime
 - E2E tests
   - Publish `TestQA_AllDevices_UnicastConnectivity` results to ClickHouse (`qa_alldevices_results` and `qa_alldevices_metadata` tables) in addition to InfluxDB; configured via `CLICKHOUSE_ADDR` env var, skipped gracefully when not set
 
@@ -47,8 +50,6 @@ All notable changes to this project will be documented in this file.
   - Fix BGP `OnClose` deleting routes from all peers instead of only the closing peer, preventing multicast teardown from nuking unicast routes
   - Skip route deletion on `OnClose` for `NoInstall` peers (multicast) since they never install kernel routes
   - Reject BGP martian addresses (CGNAT, multicast, reserved, benchmarking, etc.) as client IP during `connect`
-  - Add onchain reconciler to daemon — automatically provisions/removes tunnels by polling onchain User state, replacing CLI-driven provisioning and the `doublezerod.json` state file ([RFC-17](rfcs/rfc17-client-onchain-reconciler.md))
-  - Add `doublezero enable` / `doublezero disable` CLI commands to toggle the reconciler at runtime
 - Controller
   - detect duplicate (UnderlaySrcIP, UnderlayDstIP) pairs for tunnels and only render the first to the device config and write a log error for the second
 - Onchain Programs


### PR DESCRIPTION
## Summary

- Move the onchain reconciler and `doublezero enable`/`disable` CLI changelog entries from the v0.9.0 section to Unreleased, where they belong since they were merged after that release

## Testing Verification

- Verified the entries appear in the Unreleased section and are removed from v0.9.0