### PR TITLE
e2e: remove devnet gatekeep from alldevices qa

### DIFF
--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -216,10 +216,8 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 	if err := qa.PublishMetrics(ctx, log, qa.MetricsConfigFromEnv(), envArg, results, time.Since(startTime)); err != nil {
 		log.Error("Failed to publish metrics", "error", err)
 	}
-	if envArg == "devnet" {
-		if err := qa.PublishToClickhouse(ctx, log, qa.ClickhouseConfigFromEnv(), envArg, results, time.Since(startTime)); err != nil {
-			log.Error("Failed to publish metrics to ClickHouse", "error", err)
-		}
+	if err := qa.PublishToClickhouse(ctx, log, qa.ClickhouseConfigFromEnv(), envArg, results, time.Since(startTime)); err != nil {
+		log.Error("Failed to publish metrics to ClickHouse", "error", err)
 	}
 }
 


### PR DESCRIPTION
Resolves: #3153

## Summary
- Remove the devnet-only condition around ClickHouse metric publishing in `TestQA_AllDevices_UnicastConnectivity` so results are published in all environments

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| e2e | +2 | -4 |

## Testing Verification
- Verified the conditional logic is correctly unwrapped while preserving the error handling behavior