### PR TITLE
devcontainer: skip Solana CLI install on Linux arm64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,10 +36,13 @@ RUN curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && \
     mv gotest /usr/local/bin/gotest
 
 # Install Solana CLI tools (provides cargo-build-sbf for onchain program compilation)
+# Skipped on arm64 — Solana does not publish arm64 binaries.
 ARG SOLANA_VERSION=v2.3.1
-RUN curl -sSfL "https://release.anza.xyz/${SOLANA_VERSION}/install" | bash && \
-    mv /root/.local/share/solana/install/active_release /usr/local/solana && \
-    rm -rf /root/.local/share/solana
+RUN if [ "$(uname -m)" != "aarch64" ]; then \
+        curl -sSfL "https://release.anza.xyz/${SOLANA_VERSION}/install" | bash && \
+        mv /root/.local/share/solana/install/active_release /usr/local/solana && \
+        rm -rf /root/.local/share/solana; \
+    fi
 
 ENV PATH="/usr/local/solana/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Skip Solana CLI tools installation on Linux arm64 in the devcontainer Dockerfile, since Anza does not publish Linux arm64 binaries

## Testing Verification
- Verified the `uname -m` guard correctly gates the install step