### PR TITLE
release: bump version to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+## [v0.10.0](https://github.com/malbeclabs/doublezero/compare/client/v0.9.0...client/v0.10.0) - 2026-03-04
+
+### Breaking
+
+### Changes
+
 - CLI
   - `doublezero resource verify` command will now suggest creating resources or create them with --fix
   - All `get` commands now display output as a formatted table and support a `--json` flag for machine-readable output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "backon",
  "base64 0.22.1",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "eyre",
  "serde",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -2105,7 +2105,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Bump workspace version from 0.9.0 to 0.10.0 in `Cargo.toml` and `Cargo.lock`
- Move all Unreleased changelog entries under a new v0.10.0 release section dated 2026-03-04

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Config/build |     2 | +13 / -13   |   0  |
| Docs         |     1 | +6 / -0     |  +6  |

Version bump across workspace crates plus changelog release cut.

<details>
<summary>Key files (click to expand)</summary>

- `Cargo.lock` — version bump for all 12 workspace crates (0.9.0 → 0.10.0)
- `Cargo.toml` — workspace package version 0.9.0 → 0.10.0
- `CHANGELOG.md` — cut Unreleased entries into v0.10.0 release section

</details>

## Testing Verification
- Verified `Cargo.lock` updated cleanly with `cargo update --workspace` (only workspace crates changed, no transitive dependency churn)