### PR TITLE
serviceability: replace uses of checked_sub with saturating_sub

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -249,10 +249,7 @@ pub fn process_set_access_pass(
                 "Tenant Remove Account is not writable"
             );
             let mut tenant_remove = Tenant::try_from(tenant_remove_acc)?;
-            tenant_remove.reference_count = tenant_remove
-                .reference_count
-                .checked_sub(1)
-                .ok_or(DoubleZeroError::InvalidIndex)?;
+            tenant_remove.reference_count = tenant_remove.reference_count.saturating_sub(1);
             try_acc_write(&tenant_remove, tenant_remove_acc, payer_account, accounts)?;
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -333,10 +333,7 @@ pub fn process_closeaccount_user(
         assert!(tenant_acc.is_writable, "Tenant Account is not writable");
 
         let mut tenant = Tenant::try_from(tenant_acc)?;
-        tenant.reference_count = tenant
-            .reference_count
-            .checked_sub(1)
-            .ok_or(DoubleZeroError::InvalidIndex)?;
+        tenant.reference_count = tenant.reference_count.saturating_sub(1);
 
         try_acc_write(&tenant, tenant_acc, payer_account, accounts)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
@@ -251,10 +251,7 @@ pub fn process_delete_user(
             assert!(tenant_acc.is_writable, "Tenant Account is not writable");
 
             let mut tenant = Tenant::try_from(tenant_acc)?;
-            tenant.reference_count = tenant
-                .reference_count
-                .checked_sub(1)
-                .ok_or(DoubleZeroError::InvalidIndex)?;
+            tenant.reference_count = tenant.reference_count.saturating_sub(1);
 
             try_acc_write(&tenant, tenant_acc, payer_account, accounts)?;
         }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
@@ -158,10 +158,7 @@ pub fn process_update_user(
             let mut new_tenant = Tenant::try_from(new_tenant_acc)?;
 
             // Decrement old tenant reference count
-            old_tenant.reference_count = old_tenant
-                .reference_count
-                .checked_sub(1)
-                .ok_or(DoubleZeroError::InvalidIndex)?;
+            old_tenant.reference_count = old_tenant.reference_count.saturating_sub(1);
 
             // Increment new tenant reference count
             new_tenant.reference_count = new_tenant


### PR DESCRIPTION
Closes #3181

## Summary of Changes
* replace uses of checked_sub with saturating_sub in serviceability instructions to prevent unnecessary errors

## Testing Verification
* Existing tests pass
