### PR TITLE
smartcontract: add Permission account and authorize() mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain Programs
+  - Serviceability: add `Permission` account with `CreatePermission`, `UpdatePermission`, `DeletePermission`, `SuspendPermission`, and `ResumePermission` instructions for managing per-keypair permission bitmasks onchain
+- SDK
+  - Split `execute_transaction` into `execute_transaction` (no auth) and `execute_authorized_transaction` (injects Permission PDA) to avoid breaking processors that use `accounts.len()` for optional-account detection
+- CLI
+  - Add `permission get`, `permission list`, and `permission set` commands with table and JSON output; `permission set` supports incremental `--add` / `--remove` flags and creates or updates the account as needed
 - Activator
   - Suppress noisy program log output from race conditions caused by dual event processing (websocket + snapshot poll). The SDK's new `execute_transaction_quiet` returns a `SimulationError` with program logs; the activator verifies suspected races by re-fetching user state before deciding whether to print logs ([#3197](https://github.com/malbeclabs/doublezero/pull/3197))
 - Telemetry

--- a/activator/src/process/user.rs
+++ b/activator/src/process/user.rs
@@ -1765,7 +1765,7 @@ mod tests {
             UserStatus::Deleting,
             |user_service, _, seq| {
                 user_service
-                    .expect_execute_transaction_quiet()
+                    .expect_execute_authorized_transaction()
                     .times(1)
                     .in_sequence(seq)
                     .with(
@@ -1789,7 +1789,7 @@ mod tests {
             UserStatus::PendingBan,
             |user_service, _, seq| {
                 user_service
-                    .expect_execute_transaction_quiet()
+                    .expect_execute_authorized_transaction()
                     .times(1)
                     .in_sequence(seq)
                     .with(
@@ -2837,7 +2837,7 @@ mod tests {
 
             // Stateless mode: use_onchain_deallocation=true
             client
-                .expect_execute_transaction_quiet()
+                .expect_execute_authorized_transaction()
                 .times(1)
                 .in_sequence(&mut seq)
                 .with(
@@ -2941,7 +2941,7 @@ mod tests {
                 .returning(move |_| Ok(AccountData::User(user2.clone())));
 
             client
-                .expect_execute_transaction_quiet()
+                .expect_execute_authorized_transaction()
                 .times(1)
                 .in_sequence(&mut seq)
                 .with(

--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -4,7 +4,8 @@ use crate::{
         accesspass::AccessPassCliCommand, config::ConfigCliCommand,
         contributor::ContributorCliCommand, device::DeviceCliCommand, exchange::ExchangeCliCommand,
         globalconfig::GlobalConfigCliCommand, link::LinkCliCommand, location::LocationCliCommand,
-        resource::ResourceCliCommand, tenant::TenantCliCommand, user::UserCliCommand,
+        permission::PermissionCliCommand, resource::ResourceCliCommand, tenant::TenantCliCommand,
+        user::UserCliCommand,
     },
     command::{
         connect::ProvisioningCliCommand, disable::DisableCliCommand,
@@ -74,6 +75,9 @@ pub enum Command {
     /// Manage contributors
     #[command()]
     Contributor(ContributorCliCommand),
+    /// Manage permissions
+    #[clap()]
+    Permission(PermissionCliCommand),
     /// Manage tenants
     #[command()]
     Tenant(TenantCliCommand),

--- a/client/doublezero/src/cli/mod.rs
+++ b/client/doublezero/src/cli/mod.rs
@@ -9,6 +9,7 @@ pub mod link;
 pub mod location;
 pub mod multicast;
 pub mod multicastgroup;
+pub mod permission;
 pub mod resource;
 pub mod tenant;
 pub mod user;

--- a/client/doublezero/src/cli/permission.rs
+++ b/client/doublezero/src/cli/permission.rs
@@ -1,0 +1,31 @@
+use clap::{Args, Subcommand};
+
+use doublezero_cli::permission::{delete::*, get::*, list::*, resume::*, set::*, suspend::*};
+
+#[derive(Args, Debug)]
+pub struct PermissionCliCommand {
+    #[command(subcommand)]
+    pub command: PermissionCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PermissionCommands {
+    /// Create or update a permission account for a pubkey
+    #[clap()]
+    Set(SetPermissionCliCommand),
+    /// Suspend a permission (disables authorization)
+    #[clap()]
+    Suspend(SuspendPermissionCliCommand),
+    /// Resume a suspended permission
+    #[clap()]
+    Resume(ResumePermissionCliCommand),
+    /// Delete a permission account
+    #[clap()]
+    Delete(DeletePermissionCliCommand),
+    /// Get details for a permission account
+    #[clap()]
+    Get(GetPermissionCliCommand),
+    /// List all permission accounts
+    #[clap()]
+    List(ListPermissionCliCommand),
+}

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -178,6 +178,16 @@ async fn main() -> eyre::Result<()> {
                 args.execute(&client, &mut handle)
             }
         },
+        Command::Permission(command) => match command.command {
+            cli::permission::PermissionCommands::Set(args) => args.execute(&client, &mut handle),
+            cli::permission::PermissionCommands::Suspend(args) => {
+                args.execute(&client, &mut handle)
+            }
+            cli::permission::PermissionCommands::Resume(args) => args.execute(&client, &mut handle),
+            cli::permission::PermissionCommands::Delete(args) => args.execute(&client, &mut handle),
+            cli::permission::PermissionCommands::Get(args) => args.execute(&client, &mut handle),
+            cli::permission::PermissionCommands::List(args) => args.execute(&client, &mut handle),
+        },
         Command::Tenant(command) => match command.command {
             cli::tenant::TenantCommands::Create(args) => args.execute(&client, &mut handle),
             cli::tenant::TenantCommands::Update(args) => args.execute(&client, &mut handle),

--- a/controlplane/doublezero-admin/src/cli/command.rs
+++ b/controlplane/doublezero-admin/src/cli/command.rs
@@ -2,8 +2,8 @@ use super::multicast::MulticastCliCommand;
 use crate::cli::{
     accesspass::AccessPassCliCommand, config::ConfigCliCommand, contributor::ContributorCliCommand,
     device::DeviceCliCommand, exchange::ExchangeCliCommand, globalconfig::GlobalConfigCliCommand,
-    link::LinkCliCommand, location::LocationCliCommand, tenant::TenantCliCommand,
-    user::UserCliCommand,
+    link::LinkCliCommand, location::LocationCliCommand, permission::PermissionCliCommand,
+    tenant::TenantCliCommand, user::UserCliCommand,
 };
 use clap::{Args, Subcommand};
 use clap_complete::Shell;
@@ -57,6 +57,9 @@ pub enum Command {
     #[command()]
     AccessPass(AccessPassCliCommand),
 
+    /// Manage permission accounts
+    #[command()]
+    Permission(PermissionCliCommand),
     /// Manage users
     #[command()]
     User(UserCliCommand),

--- a/controlplane/doublezero-admin/src/cli/mod.rs
+++ b/controlplane/doublezero-admin/src/cli/mod.rs
@@ -9,5 +9,6 @@ pub mod link;
 pub mod location;
 pub mod multicast;
 pub mod multicastgroup;
+pub mod permission;
 pub mod tenant;
 pub mod user;

--- a/controlplane/doublezero-admin/src/cli/permission.rs
+++ b/controlplane/doublezero-admin/src/cli/permission.rs
@@ -1,0 +1,31 @@
+use clap::{Args, Subcommand};
+
+use doublezero_cli::permission::{delete::*, get::*, list::*, resume::*, set::*, suspend::*};
+
+#[derive(Args, Debug)]
+pub struct PermissionCliCommand {
+    #[command(subcommand)]
+    pub command: PermissionCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PermissionCommands {
+    /// Create or update a permission account for a pubkey
+    #[clap()]
+    Set(SetPermissionCliCommand),
+    /// Suspend a permission (disables authorization)
+    #[clap()]
+    Suspend(SuspendPermissionCliCommand),
+    /// Resume a suspended permission
+    #[clap()]
+    Resume(ResumePermissionCliCommand),
+    /// Delete a permission account
+    #[clap()]
+    Delete(DeletePermissionCliCommand),
+    /// Get details for a permission account
+    #[clap()]
+    Get(GetPermissionCliCommand),
+    /// List all permission accounts
+    #[clap()]
+    List(ListPermissionCliCommand),
+}

--- a/controlplane/doublezero-admin/src/main.rs
+++ b/controlplane/doublezero-admin/src/main.rs
@@ -13,6 +13,7 @@ use crate::cli::{
     },
     link::LinkCommands,
     location::LocationCommands,
+    permission::PermissionCommands,
     tenant::TenantCommands,
     user::UserCommands,
 };
@@ -171,6 +172,14 @@ async fn main() -> eyre::Result<()> {
             cli::accesspass::AccessPassCommands::Fund(args) => {
                 args.execute(&client, &mut handle, &mut std::io::stdin().lock())
             }
+        },
+        Command::Permission(command) => match command.command {
+            PermissionCommands::Set(args) => args.execute(&client, &mut handle),
+            PermissionCommands::Suspend(args) => args.execute(&client, &mut handle),
+            PermissionCommands::Resume(args) => args.execute(&client, &mut handle),
+            PermissionCommands::Delete(args) => args.execute(&client, &mut handle),
+            PermissionCommands::Get(args) => args.execute(&client, &mut handle),
+            PermissionCommands::List(args) => args.execute(&client, &mut handle),
         },
         Command::User(command) => match command.command {
             UserCommands::Create(args) => args.execute(&client, &mut handle),

--- a/sdk/serviceability/go/client.go
+++ b/sdk/serviceability/go/client.go
@@ -28,6 +28,7 @@ type ProgramData struct {
 	ProgramConfig      *ProgramConfig
 	AccessPasses       []AccessPass
 	ResourceExtensions []ResourceExtension
+	Permissions        []Permission
 }
 
 // ProgramDataProvider is an interface for types that can provide program data.
@@ -138,6 +139,7 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 		MulticastGroups:    []MulticastGroup{},
 		AccessPasses:       []AccessPass{},
 		ResourceExtensions: []ResourceExtension{},
+		Permissions:        []Permission{},
 	}
 
 	for _, element := range out {
@@ -212,6 +214,11 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 			DeserializeTenant(reader, &tenant)
 			tenant.PubKey = element.Pubkey
 			pd.Tenants = append(pd.Tenants, tenant)
+		case PermissionType:
+			var perm Permission
+			DeserializePermission(reader, &perm)
+			perm.PubKey = element.Pubkey
+			pd.Permissions = append(pd.Permissions, perm)
 		}
 	}
 

--- a/sdk/serviceability/go/deserialize.go
+++ b/sdk/serviceability/go/deserialize.go
@@ -311,6 +311,17 @@ func DeserializeResourceExtension(reader *ByteReader, ext *ResourceExtension) {
 	}
 }
 
+func DeserializePermission(reader *ByteReader, perm *Permission) {
+	perm.AccountType = AccountType(reader.ReadU8())
+	perm.Owner = reader.ReadPubkey()
+	perm.BumpSeed = reader.ReadU8()
+	perm.Status = PermissionStatus(reader.ReadU8())
+	perm.UserPayer = reader.ReadPubkey()
+	u128 := reader.ReadU128()
+	perm.PermissionsLo = u128.Low
+	perm.PermissionsHi = u128.High
+}
+
 func DeserializeTenant(reader *ByteReader, tenant *Tenant) {
 	tenant.AccountType = AccountType(reader.ReadU8())
 	tenant.Owner = reader.ReadPubkey()

--- a/sdk/serviceability/go/pda.go
+++ b/sdk/serviceability/go/pda.go
@@ -15,6 +15,7 @@ var (
 	seedDeviceTunnelBlock       = []byte("devicetunnelblock")
 	seedMulticastGroupBlock     = []byte("multicastgroupblock")
 	seedMulticastPublisherBlock = []byte("multicastpublisherblock")
+	seedPermission              = []byte("permission")
 )
 
 func DeriveGlobalStatePDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
@@ -57,4 +58,9 @@ func GetMulticastGroupBlockPDA(programID solana.PublicKey) (solana.PublicKey, ui
 // GetMulticastPublisherBlockPDA derives the PDA for the global MulticastPublisherBlock resource extension
 func GetMulticastPublisherBlockPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
 	return solana.FindProgramAddress([][]byte{seedPrefix, seedMulticastPublisherBlock}, programID)
+}
+
+// GetPermissionPDA derives the PDA for a Permission account given the user_payer pubkey.
+func GetPermissionPDA(programID solana.PublicKey, userPayer solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{seedPrefix, seedPermission, userPayer[:]}, programID)
 }

--- a/sdk/serviceability/go/state.go
+++ b/sdk/serviceability/go/state.go
@@ -24,6 +24,7 @@ const (
 	AccessPassType        AccountType = 11
 	ResourceExtensionType AccountType = 12
 	TenantType            AccountType = 13
+	PermissionType        AccountType = 15
 )
 
 type LocationStatus uint8
@@ -1070,4 +1071,62 @@ func (t Tenant) MarshalJSON() ([]byte, error) {
 	jsonTenant.TokenAccount = base58.Encode(t.TokenAccount[:])
 
 	return json.Marshal(jsonTenant)
+}
+
+type PermissionStatus uint8
+
+const (
+	PermissionStatusNone      PermissionStatus = 0
+	PermissionStatusActivated PermissionStatus = 1
+	PermissionStatusSuspended PermissionStatus = 2
+	PermissionStatusDeleting  PermissionStatus = 3
+)
+
+func (s PermissionStatus) String() string {
+	switch s {
+	case PermissionStatusNone:
+		return "none"
+	case PermissionStatusActivated:
+		return "activated"
+	case PermissionStatusSuspended:
+		return "suspended"
+	case PermissionStatusDeleting:
+		return "deleting"
+	default:
+		return "unknown"
+	}
+}
+
+func (s PermissionStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// Permission flag bit positions (bitmask).
+const (
+	PermissionFlagFoundation       uint64 = 1 << 0
+	PermissionFlagPermissionAdmin  uint64 = 1 << 1
+	PermissionFlagGlobalstateAdmin uint64 = 1 << 13
+	PermissionFlagContributorAdmin uint64 = 1 << 14
+	PermissionFlagInfraAdmin       uint64 = 1 << 2
+	PermissionFlagNetworkAdmin     uint64 = 1 << 3
+	PermissionFlagTenantAdmin      uint64 = 1 << 4
+	PermissionFlagMulticastAdmin   uint64 = 1 << 5
+	PermissionFlagReservation      uint64 = 1 << 6
+	PermissionFlagActivator        uint64 = 1 << 7
+	PermissionFlagSentinel         uint64 = 1 << 8
+	PermissionFlagUserAdmin        uint64 = 1 << 9
+	PermissionFlagAccessPassAdmin  uint64 = 1 << 10
+	PermissionFlagHealthOracle     uint64 = 1 << 11
+	PermissionFlagQA               uint64 = 1 << 12
+)
+
+type Permission struct {
+	AccountType   AccountType
+	Owner         [32]byte
+	BumpSeed      uint8
+	Status        PermissionStatus
+	UserPayer     [32]byte
+	PermissionsLo uint64
+	PermissionsHi uint64
+	PubKey        [32]byte
 }

--- a/sdk/serviceability/python/serviceability/client.py
+++ b/sdk/serviceability/python/serviceability/client.py
@@ -19,6 +19,7 @@ from serviceability.state import (
     Link,
     Location,
     MulticastGroup,
+    Permission,
     ProgramConfig,
     User,
 )
@@ -43,6 +44,7 @@ class ProgramData:
         self.multicast_groups: list[MulticastGroup] = []
         self.contributors: list[Contributor] = []
         self.access_passes: list[AccessPass] = []
+        self.permissions: list[Permission] = []
 
 
 class Client:
@@ -133,5 +135,8 @@ class Client:
             elif account_type == AccountTypeEnum.ACCESS_PASS:
                 ap = AccessPass.from_bytes(data)
                 pd.access_passes.append(ap)
+            elif account_type == AccountTypeEnum.PERMISSION:
+                perm = Permission.from_bytes(data)
+                pd.permissions.append(perm)
 
         return pd

--- a/sdk/serviceability/python/serviceability/state.py
+++ b/sdk/serviceability/python/serviceability/state.py
@@ -41,6 +41,7 @@ class AccountTypeEnum(IntEnum):
     CONTRIBUTOR = 10
     ACCESS_PASS = 11
     TENANT = 13
+    PERMISSION = 15
 
 
 # ---------------------------------------------------------------------------
@@ -911,3 +912,62 @@ class AccessPass:
         ap.mgroup_sub_allowlist = _read_pubkey_vec(r)
         ap.flags = r.read_u8()
         return ap
+
+
+# ---------------------------------------------------------------------------
+# Permission
+# ---------------------------------------------------------------------------
+
+
+class PermissionStatus(IntEnum):
+    NONE = 0
+    ACTIVATED = 1
+    SUSPENDED = 2
+    DELETING = 3
+
+    def __str__(self) -> str:
+        _names = {0: "none", 1: "activated", 2: "suspended", 3: "deleting"}
+        return _names.get(self.value, "unknown")
+
+
+# Permission flag bitmask constants (bit positions in the u128 permissions field).
+PERMISSION_FLAG_FOUNDATION = 1 << 0
+PERMISSION_FLAG_PERMISSION_ADMIN = 1 << 1
+PERMISSION_FLAG_GLOBALSTATE_ADMIN = 1 << 13
+PERMISSION_FLAG_CONTRIBUTOR_ADMIN = 1 << 14
+PERMISSION_FLAG_INFRA_ADMIN = 1 << 2
+PERMISSION_FLAG_NETWORK_ADMIN = 1 << 3
+PERMISSION_FLAG_TENANT_ADMIN = 1 << 4
+PERMISSION_FLAG_MULTICAST_ADMIN = 1 << 5
+PERMISSION_FLAG_RESERVATION = 1 << 6
+PERMISSION_FLAG_ACTIVATOR = 1 << 7
+PERMISSION_FLAG_SENTINEL = 1 << 8
+PERMISSION_FLAG_USER_ADMIN = 1 << 9
+PERMISSION_FLAG_ACCESS_PASS_ADMIN = 1 << 10
+PERMISSION_FLAG_HEALTH_ORACLE = 1 << 11
+PERMISSION_FLAG_QA = 1 << 12
+
+
+@dataclass
+class Permission:
+    account_type: int = 0
+    owner: Pubkey = Pubkey.default()
+    bump_seed: int = 0
+    status: PermissionStatus = PermissionStatus.NONE
+    user_payer: Pubkey = Pubkey.default()
+    permissions: int = 0
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Permission:
+        r = DefensiveReader(data)
+        p = cls()
+        p.account_type = r.read_u8()
+        p.owner = _read_pubkey(r)
+        p.bump_seed = r.read_u8()
+        p.status = PermissionStatus(r.read_u8())
+        p.user_payer = _read_pubkey(r)
+        # u128 stored as two u64 little-endian: lo then hi
+        lo = r.read_u64()
+        hi = r.read_u64()
+        p.permissions = lo | (hi << 64)
+        return p

--- a/sdk/serviceability/typescript/serviceability/client.ts
+++ b/sdk/serviceability/typescript/serviceability/client.ts
@@ -15,6 +15,7 @@ import {
   ACCOUNT_TYPE_PROGRAM_CONFIG,
   ACCOUNT_TYPE_CONTRIBUTOR,
   ACCOUNT_TYPE_ACCESS_PASS,
+  ACCOUNT_TYPE_PERMISSION,
   deserializeGlobalState,
   deserializeGlobalConfig,
   deserializeLocation,
@@ -26,6 +27,7 @@ import {
   deserializeProgramConfig,
   deserializeContributor,
   deserializeAccessPass,
+  deserializePermission,
   type GlobalState,
   type GlobalConfig,
   type Location,
@@ -37,6 +39,7 @@ import {
   type ProgramConfig,
   type Contributor,
   type AccessPass,
+  type Permission,
 } from "./state.js";
 
 export interface ProgramData {
@@ -51,6 +54,7 @@ export interface ProgramData {
   multicastGroups: MulticastGroup[];
   contributors: Contributor[];
   accessPasses: AccessPass[];
+  permissions: Permission[];
 }
 
 export class Client {
@@ -102,6 +106,7 @@ export class Client {
       multicastGroups: [],
       contributors: [],
       accessPasses: [],
+      permissions: [],
     };
 
     for (const { account } of accounts) {
@@ -143,6 +148,9 @@ export class Client {
           break;
         case ACCOUNT_TYPE_ACCESS_PASS:
           pd.accessPasses.push(deserializeAccessPass(data));
+          break;
+        case ACCOUNT_TYPE_PERMISSION:
+          pd.permissions.push(deserializePermission(data));
           break;
       }
     }

--- a/sdk/serviceability/typescript/serviceability/state.ts
+++ b/sdk/serviceability/typescript/serviceability/state.ts
@@ -31,6 +31,7 @@ export const ACCOUNT_TYPE_PROGRAM_CONFIG = 9;
 export const ACCOUNT_TYPE_CONTRIBUTOR = 10;
 export const ACCOUNT_TYPE_ACCESS_PASS = 11;
 export const ACCOUNT_TYPE_TENANT = 13;
+export const ACCOUNT_TYPE_PERMISSION = 15;
 
 // ---------------------------------------------------------------------------
 // Enum string mappings
@@ -949,5 +950,66 @@ export function deserializeAccessPass(data: Uint8Array): AccessPass {
     mGroupSubAllowlist,
     flags,
     tenantAllowlist,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Permission
+// ---------------------------------------------------------------------------
+
+// Permission flag bitmask constants (bit positions in the u128 permissions field).
+export const PERMISSION_FLAG_FOUNDATION = 1n << 0n;
+export const PERMISSION_FLAG_PERMISSION_ADMIN = 1n << 1n;
+export const PERMISSION_FLAG_GLOBALSTATE_ADMIN = 1n << 13n;
+export const PERMISSION_FLAG_CONTRIBUTOR_ADMIN = 1n << 14n;
+export const PERMISSION_FLAG_INFRA_ADMIN = 1n << 2n;
+export const PERMISSION_FLAG_NETWORK_ADMIN = 1n << 3n;
+export const PERMISSION_FLAG_TENANT_ADMIN = 1n << 4n;
+export const PERMISSION_FLAG_MULTICAST_ADMIN = 1n << 5n;
+export const PERMISSION_FLAG_RESERVATION = 1n << 6n;
+export const PERMISSION_FLAG_ACTIVATOR = 1n << 7n;
+export const PERMISSION_FLAG_SENTINEL = 1n << 8n;
+export const PERMISSION_FLAG_USER_ADMIN = 1n << 9n;
+export const PERMISSION_FLAG_ACCESS_PASS_ADMIN = 1n << 10n;
+export const PERMISSION_FLAG_HEALTH_ORACLE = 1n << 11n;
+export const PERMISSION_FLAG_QA = 1n << 12n;
+
+const PERMISSION_STATUS_NAMES: Record<number, string> = {
+  0: "none",
+  1: "activated",
+  2: "suspended",
+  3: "deleting",
+};
+export function permissionStatusString(v: number): string {
+  return PERMISSION_STATUS_NAMES[v] ?? "unknown";
+}
+
+export interface Permission {
+  accountType: number;
+  owner: PublicKey;
+  bumpSeed: number;
+  status: number;
+  userPayer: PublicKey;
+  permissions: bigint;
+}
+
+export function deserializePermission(data: Uint8Array): Permission {
+  const r = new DefensiveReader(data);
+  const accountType = r.readU8();
+  const owner = readPubkey(r);
+  const bumpSeed = r.readU8();
+  const status = r.readU8();
+  const userPayer = readPubkey(r);
+  // u128 stored as two u64 little-endian: lo then hi
+  const lo = r.readU64();
+  const hi = r.readU64();
+  const permissions = lo | (hi << 64n);
+  return {
+    accountType,
+    owner,
+    bumpSeed,
+    status,
+    userPayer,
+    permissions,
   };
 }

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -81,6 +81,12 @@ use doublezero_sdk::{
             subscribe::SubscribeMulticastGroupCommand,
             update::UpdateMulticastGroupCommand,
         },
+        permission::{
+            create::CreatePermissionCommand, delete::DeletePermissionCommand,
+            get::GetPermissionCommand, list::ListPermissionCommand,
+            resume::ResumePermissionCommand, suspend::SuspendPermissionCommand,
+            update::UpdatePermissionCommand,
+        },
         programconfig::get::GetProgramConfigCommand,
         resource::{
             allocate::AllocateResourceCommand, closeaccount::CloseResourceCommand,
@@ -105,7 +111,7 @@ use doublezero_sdk::{
 };
 use doublezero_serviceability::state::{
     accesspass::AccessPass, accountdata::AccountData, contributor::Contributor,
-    programconfig::ProgramConfig, tenant::Tenant,
+    permission::Permission, programconfig::ProgramConfig, tenant::Tenant,
 };
 use mockall::automock;
 use solana_client::rpc_config::RpcProgramAccountsConfig;
@@ -176,6 +182,16 @@ pub trait CliCommand {
     fn update_contributor(&self, cmd: UpdateContributorCommand) -> eyre::Result<Signature>;
     fn delete_contributor(&self, cmd: DeleteContributorCommand) -> eyre::Result<Signature>;
 
+    fn create_permission(&self, cmd: CreatePermissionCommand) -> eyre::Result<(Signature, Pubkey)>;
+    fn get_permission(&self, cmd: GetPermissionCommand) -> eyre::Result<(Pubkey, Permission)>;
+    fn list_permission(
+        &self,
+        cmd: ListPermissionCommand,
+    ) -> eyre::Result<HashMap<Pubkey, Permission>>;
+    fn update_permission(&self, cmd: UpdatePermissionCommand) -> eyre::Result<Signature>;
+    fn suspend_permission(&self, cmd: SuspendPermissionCommand) -> eyre::Result<Signature>;
+    fn resume_permission(&self, cmd: ResumePermissionCommand) -> eyre::Result<Signature>;
+    fn delete_permission(&self, cmd: DeletePermissionCommand) -> eyre::Result<Signature>;
     fn create_tenant(&self, cmd: CreateTenantCommand) -> eyre::Result<(Signature, Pubkey)>;
     fn get_tenant(&self, cmd: GetTenantCommand) -> eyre::Result<(Pubkey, Tenant)>;
     fn list_tenant(&self, cmd: ListTenantCommand) -> eyre::Result<HashMap<Pubkey, Tenant>>;
@@ -479,6 +495,30 @@ impl CliCommand for CliCommandImpl<'_> {
         cmd.execute(self.client)
     }
 
+    fn create_permission(&self, cmd: CreatePermissionCommand) -> eyre::Result<(Signature, Pubkey)> {
+        cmd.execute(self.client)
+    }
+    fn get_permission(&self, cmd: GetPermissionCommand) -> eyre::Result<(Pubkey, Permission)> {
+        cmd.execute(self.client)
+    }
+    fn list_permission(
+        &self,
+        cmd: ListPermissionCommand,
+    ) -> eyre::Result<HashMap<Pubkey, Permission>> {
+        cmd.execute(self.client)
+    }
+    fn update_permission(&self, cmd: UpdatePermissionCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn suspend_permission(&self, cmd: SuspendPermissionCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn resume_permission(&self, cmd: ResumePermissionCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn delete_permission(&self, cmd: DeletePermissionCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
     fn create_tenant(&self, cmd: CreateTenantCommand) -> eyre::Result<(Signature, Pubkey)> {
         cmd.execute(self.client)
     }

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod location;
 pub mod logcommand;
 pub mod migrate;
 pub mod multicastgroup;
+pub mod permission;
 pub mod poll_for_activation;
 pub mod requirements;
 pub mod resource;

--- a/smartcontract/cli/src/permission/delete.rs
+++ b/smartcontract/cli/src/permission/delete.rs
@@ -1,0 +1,75 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::permission::delete::DeletePermissionCommand;
+use doublezero_serviceability::pda::get_permission_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct DeletePermissionCliCommand {
+    /// Pubkey to delete permissions for
+    #[arg(long)]
+    pub user_payer: String,
+}
+
+impl DeletePermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let user_payer = Pubkey::from_str(&self.user_payer)
+            .map_err(|e| eyre::eyre!("invalid user_payer pubkey: {e}"))?;
+
+        let program_id = client.get_program_id();
+        let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+        let signature = client.delete_permission(DeletePermissionCommand { permission_pda })?;
+
+        writeln!(out, "Signature: {signature}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        permission::delete::DeletePermissionCliCommand,
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_sdk::commands::permission::delete::DeletePermissionCommand;
+    use doublezero_serviceability::pda::get_permission_pda;
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    const TEST_PROGRAM_ID: Pubkey =
+        Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+
+    #[test]
+    fn test_cli_permission_delete() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_delete_permission()
+            .with(predicate::eq(DeletePermissionCommand { permission_pda }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = DeletePermissionCliCommand {
+            user_payer: user_payer.to_string(),
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        assert!(String::from_utf8(output).unwrap().contains("Signature:"));
+    }
+}

--- a/smartcontract/cli/src/permission/flags.rs
+++ b/smartcontract/cli/src/permission/flags.rs
@@ -1,0 +1,186 @@
+use clap::{builder::PossibleValue, ValueEnum};
+use doublezero_serviceability::state::permission::permission_flags;
+
+/// Named permission that can be passed to --add / --remove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionName {
+    Foundation,
+    PermissionAdmin,
+    GlobalstateAdmin,
+    ContributorAdmin,
+    InfraAdmin,
+    NetworkAdmin,
+    TenantAdmin,
+    MulticastAdmin,
+    Reservation,
+    Activator,
+    Sentinel,
+    UserAdmin,
+    AccessPassAdmin,
+    HealthOracle,
+    Qa,
+}
+
+impl PermissionName {
+    pub fn to_flag(self) -> u128 {
+        match self {
+            Self::Foundation => permission_flags::FOUNDATION,
+            Self::PermissionAdmin => permission_flags::PERMISSION_ADMIN,
+            Self::GlobalstateAdmin => permission_flags::GLOBALSTATE_ADMIN,
+            Self::ContributorAdmin => permission_flags::CONTRIBUTOR_ADMIN,
+            Self::InfraAdmin => permission_flags::INFRA_ADMIN,
+            Self::NetworkAdmin => permission_flags::NETWORK_ADMIN,
+            Self::TenantAdmin => permission_flags::TENANT_ADMIN,
+            Self::MulticastAdmin => permission_flags::MULTICAST_ADMIN,
+            Self::Reservation => permission_flags::RESERVATION,
+            Self::Activator => permission_flags::ACTIVATOR,
+            Self::Sentinel => permission_flags::SENTINEL,
+            Self::UserAdmin => permission_flags::USER_ADMIN,
+            Self::AccessPassAdmin => permission_flags::ACCESS_PASS_ADMIN,
+            Self::HealthOracle => permission_flags::HEALTH_ORACLE,
+            Self::Qa => permission_flags::QA,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Foundation => "foundation",
+            Self::PermissionAdmin => "permission-admin",
+            Self::GlobalstateAdmin => "globalstate-admin",
+            Self::ContributorAdmin => "contributor-admin",
+            Self::InfraAdmin => "infra-admin",
+            Self::NetworkAdmin => "network-admin",
+            Self::TenantAdmin => "tenant-admin",
+            Self::MulticastAdmin => "multicast-admin",
+            Self::Reservation => "reservation",
+            Self::Activator => "activator",
+            Self::Sentinel => "sentinel",
+            Self::UserAdmin => "user-admin",
+            Self::AccessPassAdmin => "access-pass-admin",
+            Self::HealthOracle => "health-oracle",
+            Self::Qa => "qa",
+        }
+    }
+}
+
+impl ValueEnum for PermissionName {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Self::Foundation,
+            Self::PermissionAdmin,
+            Self::GlobalstateAdmin,
+            Self::ContributorAdmin,
+            Self::InfraAdmin,
+            Self::NetworkAdmin,
+            Self::TenantAdmin,
+            Self::MulticastAdmin,
+            Self::Reservation,
+            Self::Activator,
+            Self::Sentinel,
+            Self::UserAdmin,
+            Self::AccessPassAdmin,
+            Self::HealthOracle,
+            Self::Qa,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.as_str()))
+    }
+}
+
+/// Build a bitmask from a list of `PermissionName`s.
+pub fn names_to_bitmask(names: &[PermissionName]) -> u128 {
+    names.iter().fold(0u128, |acc, n| acc | n.to_flag())
+}
+
+/// Return a list of permission names set in `mask`.
+pub fn bitmask_to_names(mask: u128) -> Vec<String> {
+    let all = [
+        (permission_flags::FOUNDATION, "foundation"),
+        (permission_flags::PERMISSION_ADMIN, "permission-admin"),
+        (permission_flags::GLOBALSTATE_ADMIN, "globalstate-admin"),
+        (permission_flags::CONTRIBUTOR_ADMIN, "contributor-admin"),
+        (permission_flags::INFRA_ADMIN, "infra-admin"),
+        (permission_flags::NETWORK_ADMIN, "network-admin"),
+        (permission_flags::TENANT_ADMIN, "tenant-admin"),
+        (permission_flags::MULTICAST_ADMIN, "multicast-admin"),
+        (permission_flags::RESERVATION, "reservation"),
+        (permission_flags::ACTIVATOR, "activator"),
+        (permission_flags::SENTINEL, "sentinel"),
+        (permission_flags::USER_ADMIN, "user-admin"),
+        (permission_flags::ACCESS_PASS_ADMIN, "access-pass-admin"),
+        (permission_flags::HEALTH_ORACLE, "health-oracle"),
+        (permission_flags::QA, "qa"),
+    ];
+    all.iter()
+        .filter(|(flag, _)| mask & flag != 0)
+        .map(|(_, name)| name.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_names_to_bitmask_single() {
+        assert_eq!(
+            names_to_bitmask(&[PermissionName::NetworkAdmin]),
+            permission_flags::NETWORK_ADMIN
+        );
+    }
+
+    #[test]
+    fn test_names_to_bitmask_multiple() {
+        assert_eq!(
+            names_to_bitmask(&[PermissionName::NetworkAdmin, PermissionName::UserAdmin]),
+            permission_flags::NETWORK_ADMIN | permission_flags::USER_ADMIN
+        );
+    }
+
+    #[test]
+    fn test_names_to_bitmask_empty() {
+        assert_eq!(names_to_bitmask(&[]), 0);
+    }
+
+    #[test]
+    fn test_bitmask_to_names_single() {
+        assert_eq!(
+            bitmask_to_names(permission_flags::NETWORK_ADMIN),
+            vec!["network-admin".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_bitmask_to_names_multiple() {
+        assert_eq!(
+            bitmask_to_names(permission_flags::NETWORK_ADMIN | permission_flags::USER_ADMIN),
+            vec!["network-admin".to_string(), "user-admin".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_bitmask_to_names_empty() {
+        let result = bitmask_to_names(0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let names = [
+            PermissionName::Activator,
+            PermissionName::Sentinel,
+            PermissionName::Qa,
+        ];
+        let mask = names_to_bitmask(&names);
+        assert_eq!(
+            bitmask_to_names(mask),
+            vec![
+                "activator".to_string(),
+                "sentinel".to_string(),
+                "qa".to_string()
+            ]
+        );
+    }
+}

--- a/smartcontract/cli/src/permission/get.rs
+++ b/smartcontract/cli/src/permission/get.rs
@@ -1,0 +1,128 @@
+use crate::{doublezerocommand::CliCommand, permission::flags::bitmask_to_names};
+use clap::Args;
+use doublezero_program_common::serializer;
+use doublezero_sdk::commands::permission::get::GetPermissionCommand;
+use doublezero_serviceability::pda::get_permission_pda;
+use serde::Serialize;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+use tabled::Tabled;
+
+#[derive(Args, Debug)]
+pub struct GetPermissionCliCommand {
+    /// Pubkey to look up permissions for
+    #[arg(long)]
+    pub user_payer: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Tabled, Serialize)]
+struct PermissionDisplay {
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub account: Pubkey,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub user_payer: Pubkey,
+    pub permissions: PermissionList,
+    pub status: String,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub owner: Pubkey,
+}
+
+/// Wraps `Vec<String>` to display as comma-separated in tables and as a JSON array.
+#[derive(Serialize)]
+#[serde(transparent)]
+struct PermissionList(Vec<String>);
+
+impl std::fmt::Display for PermissionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.join(", "))
+    }
+}
+
+impl GetPermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let user_payer = Pubkey::from_str(&self.user_payer)
+            .map_err(|e| eyre::eyre!("invalid user_payer pubkey: {e}"))?;
+
+        let program_id = client.get_program_id();
+        let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+        let (pubkey, permission) = client.get_permission(GetPermissionCommand {
+            pubkey: permission_pda.to_string(),
+        })?;
+
+        let display = PermissionDisplay {
+            account: pubkey,
+            user_payer: permission.user_payer,
+            permissions: PermissionList(bitmask_to_names(permission.permissions)),
+            status: permission.status.to_string(),
+            owner: permission.owner,
+        };
+
+        if self.json {
+            writeln!(out, "{}", serde_json::to_string_pretty(&display)?)?;
+        } else {
+            let headers = PermissionDisplay::headers();
+            let fields = display.fields();
+            let max_len = headers.iter().map(|h| h.len()).max().unwrap_or(0);
+            for (header, value) in headers.iter().zip(fields.iter()) {
+                writeln!(out, " {header:<max_len$} | {value}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{permission::get::GetPermissionCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::{commands::permission::get::GetPermissionCommand, AccountType};
+    use doublezero_serviceability::{
+        pda::get_permission_pda,
+        state::permission::{permission_flags, Permission, PermissionStatus},
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    const TEST_PROGRAM_ID: Pubkey =
+        Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+
+    #[test]
+    fn test_cli_permission_get() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: permission_pda,
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer,
+            permissions: permission_flags::NETWORK_ADMIN,
+        };
+
+        let p2 = permission.clone();
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(move |_| Ok((permission_pda, p2.clone())));
+
+        let mut output = Vec::new();
+        let res = GetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            json: false,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        let out = String::from_utf8(output).unwrap();
+        assert!(out.contains("activated"));
+        assert!(out.contains("network-admin"));
+    }
+}

--- a/smartcontract/cli/src/permission/list.rs
+++ b/smartcontract/cli/src/permission/list.rs
@@ -1,0 +1,119 @@
+use crate::{doublezerocommand::CliCommand, permission::flags::bitmask_to_names};
+use clap::Args;
+use doublezero_program_common::serializer;
+use doublezero_sdk::commands::permission::list::ListPermissionCommand;
+use serde::Serialize;
+use solana_sdk::pubkey::Pubkey;
+use std::io::Write;
+use tabled::{settings::Style, Table, Tabled};
+
+#[derive(Args, Debug)]
+pub struct ListPermissionCliCommand {
+    /// Output as pretty JSON
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+    /// Output as compact JSON
+    #[arg(long, default_value_t = false)]
+    pub json_compact: bool,
+}
+
+/// Wraps `Vec<String>` to display as comma-separated in tables and as a JSON array.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct PermissionList(pub Vec<String>);
+
+impl std::fmt::Display for PermissionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.join(", "))
+    }
+}
+
+#[derive(Tabled, Serialize)]
+pub struct PermissionDisplay {
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub account: Pubkey,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub user_payer: Pubkey,
+    pub permissions: PermissionList,
+    pub status: String,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    pub owner: Pubkey,
+}
+
+impl ListPermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let permissions = client.list_permission(ListPermissionCommand {})?;
+
+        let mut displays: Vec<PermissionDisplay> = permissions
+            .into_iter()
+            .map(|(pubkey, p)| PermissionDisplay {
+                account: pubkey,
+                user_payer: p.user_payer,
+                permissions: PermissionList(bitmask_to_names(p.permissions)),
+                status: p.status.to_string(),
+                owner: p.owner,
+            })
+            .collect();
+
+        displays.sort_by_key(|d| d.user_payer.to_string());
+
+        let res = if self.json {
+            serde_json::to_string_pretty(&displays)?
+        } else if self.json_compact {
+            serde_json::to_string(&displays)?
+        } else {
+            Table::new(displays)
+                .with(Style::psql().remove_horizontals())
+                .to_string()
+        };
+
+        writeln!(out, "{res}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{permission::list::ListPermissionCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::AccountType;
+    use doublezero_serviceability::state::permission::{
+        permission_flags, Permission, PermissionStatus,
+    };
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_cli_permission_list() {
+        let mut client = create_test_client();
+
+        let pda = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: pda,
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer,
+            permissions: permission_flags::NETWORK_ADMIN | permission_flags::ACTIVATOR,
+        };
+
+        let p2 = permission.clone();
+        client
+            .expect_list_permission()
+            .returning(move |_| Ok(HashMap::from([(pda, p2.clone())])));
+
+        let mut output = Vec::new();
+        let res = ListPermissionCliCommand {
+            json: false,
+            json_compact: false,
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        let out = String::from_utf8(output).unwrap();
+        assert!(out.contains("activated"));
+        assert!(out.contains("network-admin"));
+        assert!(out.contains("activator"));
+    }
+}

--- a/smartcontract/cli/src/permission/mod.rs
+++ b/smartcontract/cli/src/permission/mod.rs
@@ -1,0 +1,7 @@
+pub mod delete;
+pub mod flags;
+pub mod get;
+pub mod list;
+pub mod resume;
+pub mod set;
+pub mod suspend;

--- a/smartcontract/cli/src/permission/resume.rs
+++ b/smartcontract/cli/src/permission/resume.rs
@@ -1,0 +1,75 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::permission::resume::ResumePermissionCommand;
+use doublezero_serviceability::pda::get_permission_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct ResumePermissionCliCommand {
+    /// Pubkey to resume permissions for
+    #[arg(long)]
+    pub user_payer: String,
+}
+
+impl ResumePermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let user_payer = Pubkey::from_str(&self.user_payer)
+            .map_err(|e| eyre::eyre!("invalid user_payer pubkey: {e}"))?;
+
+        let program_id = client.get_program_id();
+        let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+        let signature = client.resume_permission(ResumePermissionCommand { permission_pda })?;
+
+        writeln!(out, "Signature: {signature}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        permission::resume::ResumePermissionCliCommand,
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_sdk::commands::permission::resume::ResumePermissionCommand;
+    use doublezero_serviceability::pda::get_permission_pda;
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    const TEST_PROGRAM_ID: Pubkey =
+        Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+
+    #[test]
+    fn test_cli_permission_resume() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_resume_permission()
+            .with(predicate::eq(ResumePermissionCommand { permission_pda }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = ResumePermissionCliCommand {
+            user_payer: user_payer.to_string(),
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        assert!(String::from_utf8(output).unwrap().contains("Signature:"));
+    }
+}

--- a/smartcontract/cli/src/permission/set.rs
+++ b/smartcontract/cli/src/permission/set.rs
@@ -1,0 +1,377 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    permission::flags::{bitmask_to_names, names_to_bitmask, PermissionName},
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::permission::{
+    create::CreatePermissionCommand, get::GetPermissionCommand, update::UpdatePermissionCommand,
+};
+use doublezero_serviceability::pda::get_permission_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct SetPermissionCliCommand {
+    /// Pubkey to grant/update permissions for
+    #[arg(long)]
+    pub user_payer: String,
+    /// Permission(s) to grant (repeat for multiple: --add network-admin --add user-admin)
+    #[arg(long = "add", value_name = "PERMISSION")]
+    pub add: Vec<PermissionName>,
+    /// Permission(s) to revoke — only valid when updating an existing account
+    #[arg(long = "remove", value_name = "PERMISSION")]
+    pub remove: Vec<PermissionName>,
+}
+
+impl SetPermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        if self.add.is_empty() && self.remove.is_empty() {
+            return Err(eyre::eyre!(
+                "at least one --add or --remove flag is required"
+            ));
+        }
+
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let user_payer = Pubkey::from_str(&self.user_payer)
+            .map_err(|e| eyre::eyre!("invalid user_payer pubkey: {e}"))?;
+
+        let program_id = client.get_program_id();
+        let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+        let existing = client
+            .get_permission(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            })
+            .ok();
+
+        let (signature, new_permissions) = match existing {
+            None => {
+                // Account does not exist — create it.
+                if !self.remove.is_empty() {
+                    return Err(eyre::eyre!(
+                        "cannot --remove permissions from an account that does not exist yet"
+                    ));
+                }
+                let permissions = names_to_bitmask(&self.add);
+                let (sig, _) = client.create_permission(CreatePermissionCommand {
+                    user_payer,
+                    permissions,
+                })?;
+                (sig, permissions)
+            }
+            Some((_, current)) => {
+                // Account exists — apply incremental delta.
+                let add_mask = names_to_bitmask(&self.add);
+                let remove_mask = names_to_bitmask(&self.remove);
+                let new_permissions = (current.permissions | add_mask) & !remove_mask;
+
+                if new_permissions == 0 {
+                    return Err(eyre::eyre!(
+                        "resulting permissions bitmask is zero — at least one permission is required"
+                    ));
+                }
+
+                let sig = client.update_permission(UpdatePermissionCommand {
+                    permission_pda,
+                    permissions: new_permissions,
+                })?;
+                (sig, new_permissions)
+            }
+        };
+
+        writeln!(out, "Signature:   {signature}")?;
+        writeln!(
+            out,
+            "Permissions: {}",
+            bitmask_to_names(new_permissions).join(", ")
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        permission::flags::PermissionName,
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_serviceability::state::{
+        accounttype::AccountType,
+        permission::{permission_flags, Permission, PermissionStatus},
+    };
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    // Fixed program_id set by create_test_client().
+    const TEST_PROGRAM_ID: Pubkey =
+        Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+
+    fn make_permission(permissions: u128) -> Permission {
+        Permission {
+            account_type: AccountType::Permission,
+            owner: Pubkey::new_unique(),
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer: Pubkey::new_unique(),
+            permissions,
+        }
+    }
+
+    // ── create path ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_creates_when_account_absent() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+        let permissions = permission_flags::NETWORK_ADMIN | permission_flags::USER_ADMIN;
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(|_| Err(eyre::eyre!("not found")));
+        client
+            .expect_create_permission()
+            .with(predicate::eq(CreatePermissionCommand {
+                user_payer,
+                permissions,
+            }))
+            .returning(move |_| Ok((Signature::new_unique(), permission_pda)));
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![PermissionName::NetworkAdmin, PermissionName::UserAdmin],
+            remove: vec![],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        let out = String::from_utf8(output).unwrap();
+        assert!(out.contains("Signature:"));
+        assert!(out.contains("network-admin"));
+        assert!(out.contains("user-admin"));
+    }
+
+    #[test]
+    fn test_set_remove_on_nonexistent_account_rejected() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(|_| Err(eyre::eyre!("not found")));
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![PermissionName::NetworkAdmin],
+            remove: vec![PermissionName::UserAdmin],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("cannot --remove permissions from an account that does not exist yet"));
+    }
+
+    // ── update path ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_updates_when_account_exists_add() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        let initial = permission_flags::NETWORK_ADMIN;
+        let expected = initial | permission_flags::SENTINEL;
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(move |_| Ok((permission_pda, make_permission(initial))));
+        client
+            .expect_update_permission()
+            .with(predicate::eq(UpdatePermissionCommand {
+                permission_pda,
+                permissions: expected,
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![PermissionName::Sentinel],
+            remove: vec![],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        let out = String::from_utf8(output).unwrap();
+        assert!(out.contains("network-admin"));
+        assert!(out.contains("sentinel"));
+    }
+
+    #[test]
+    fn test_set_updates_when_account_exists_remove() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        let initial = permission_flags::NETWORK_ADMIN | permission_flags::USER_ADMIN;
+        let expected = permission_flags::NETWORK_ADMIN;
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(move |_| Ok((permission_pda, make_permission(initial))));
+        client
+            .expect_update_permission()
+            .with(predicate::eq(UpdatePermissionCommand {
+                permission_pda,
+                permissions: expected,
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![],
+            remove: vec![PermissionName::UserAdmin],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        let out = String::from_utf8(output).unwrap();
+        assert!(out.contains("network-admin"));
+        assert!(!out.contains("user-admin"));
+    }
+
+    #[test]
+    fn test_set_updates_add_and_remove() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        let initial = permission_flags::NETWORK_ADMIN | permission_flags::USER_ADMIN;
+        let expected = permission_flags::NETWORK_ADMIN | permission_flags::SENTINEL;
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(move |_| Ok((permission_pda, make_permission(initial))));
+        client
+            .expect_update_permission()
+            .with(predicate::eq(UpdatePermissionCommand {
+                permission_pda,
+                permissions: expected,
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![PermissionName::Sentinel],
+            remove: vec![PermissionName::UserAdmin],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_set_remove_all_rejected() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_permission()
+            .with(predicate::eq(GetPermissionCommand {
+                pubkey: permission_pda.to_string(),
+            }))
+            .returning(move |_| {
+                Ok((
+                    permission_pda,
+                    make_permission(permission_flags::NETWORK_ADMIN),
+                ))
+            });
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![],
+            remove: vec![PermissionName::NetworkAdmin],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("resulting permissions bitmask is zero"));
+    }
+
+    #[test]
+    fn test_set_no_flags_rejected() {
+        let client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+
+        let mut output = Vec::new();
+        let res = SetPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+            add: vec![],
+            remove: vec![],
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("at least one --add or --remove flag is required"));
+    }
+}

--- a/smartcontract/cli/src/permission/suspend.rs
+++ b/smartcontract/cli/src/permission/suspend.rs
@@ -1,0 +1,75 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::permission::suspend::SuspendPermissionCommand;
+use doublezero_serviceability::pda::get_permission_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, str::FromStr};
+
+#[derive(Args, Debug)]
+pub struct SuspendPermissionCliCommand {
+    /// Pubkey to suspend permissions for
+    #[arg(long)]
+    pub user_payer: String,
+}
+
+impl SuspendPermissionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let user_payer = Pubkey::from_str(&self.user_payer)
+            .map_err(|e| eyre::eyre!("invalid user_payer pubkey: {e}"))?;
+
+        let program_id = client.get_program_id();
+        let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+        let signature = client.suspend_permission(SuspendPermissionCommand { permission_pda })?;
+
+        writeln!(out, "Signature: {signature}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        permission::suspend::SuspendPermissionCliCommand,
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_sdk::commands::permission::suspend::SuspendPermissionCommand;
+    use doublezero_serviceability::pda::get_permission_pda;
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    const TEST_PROGRAM_ID: Pubkey =
+        Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+
+    #[test]
+    fn test_cli_permission_suspend() {
+        let mut client = create_test_client();
+        let user_payer = Pubkey::new_unique();
+        let (permission_pda, _) = get_permission_pda(&TEST_PROGRAM_ID, &user_payer);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_suspend_permission()
+            .with(predicate::eq(SuspendPermissionCommand { permission_pda }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut output = Vec::new();
+        let res = SuspendPermissionCliCommand {
+            user_payer: user_payer.to_string(),
+        }
+        .execute(&client, &mut output);
+
+        assert!(res.is_ok());
+        assert!(String::from_utf8(output).unwrap().contains("Signature:"));
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/PERMISSION.md
+++ b/smartcontract/programs/doublezero-serviceability/PERMISSION.md
@@ -1,0 +1,237 @@
+# Permission System
+
+The Permission system grants named capabilities to specific pubkeys via onchain `Permission`
+accounts. It replaces the legacy `GlobalState` allowlist/authority model with a fine-grained,
+auditable permission layer. Both models coexist during the transition period; the legacy model is
+disabled by setting the `RequirePermissionAccounts` feature flag.
+
+---
+
+## Account Layout
+
+`Permission` is a PDA owned by the serviceability program.
+
+| Field          | Type               | Description                                               |
+|----------------|--------------------|-----------------------------------------------------------|
+| `account_type` | `u8`               | Discriminator — always `15` (`AccountType::Permission`)   |
+| `owner`        | `Pubkey`           | The key that created this account (foundation member)     |
+| `bump_seed`    | `u8`               | PDA bump                                                  |
+| `status`       | `PermissionStatus` | `Activated` or `Suspended`                                |
+| `user_payer`   | `Pubkey`           | The key being granted permissions                         |
+| `permissions`  | `u128`             | Bitmask of `permission_flags::*`                          |
+
+**PDA seeds:** `["doublezero", "permission", user_payer_bytes]`
+
+---
+
+## Permission Flags
+
+Flags are a `u128` bitmask. Authorization uses **OR semantics**: a single matching bit is
+sufficient.
+
+### Tier 1 — System governance
+
+| Constant             | Bit     | Description                                                         |
+|----------------------|---------|---------------------------------------------------------------------|
+| `FOUNDATION`         | `1<<0`  | Catch-all legacy flag (maps to `foundation_allowlist`)              |
+| `PERMISSION_ADMIN`   | `1<<1`  | Manage Permission accounts (create/update/suspend/resume/delete)    |
+| `GLOBALSTATE_ADMIN`  | `1<<13` | Manage GlobalState: feature flags, allowlists, authority keys       |
+| `CONTRIBUTOR_ADMIN`  | `1<<14` | Manage Contributors: create, update, delete                         |
+
+### Tier 2 — Infrastructure management
+
+| Constant          | Bit    | Description                                                |
+|-------------------|--------|------------------------------------------------------------|
+| `INFRA_ADMIN`     | `1<<2` | Manage locations and exchanges                             |
+| `NETWORK_ADMIN`   | `1<<3` | Manage devices and links                                   |
+| `TENANT_ADMIN`    | `1<<4` | Manage tenants                                             |
+| `MULTICAST_ADMIN` | `1<<5` | Manage multicast groups and their allowlists               |
+| `RESERVATION`     | `1<<6` | Manage reservations                                        |
+
+### Tier 3 — Operational roles
+
+| Constant            | Bit     | Description                                          |
+|---------------------|---------|------------------------------------------------------|
+| `ACTIVATOR`         | `1<<7`  | Activate/reject network entities                     |
+| `SENTINEL`          | `1<<8`  | Suspend network entities                             |
+| `USER_ADMIN`        | `1<<9`  | Administer users (ban, delete, close account)        |
+| `ACCESS_PASS_ADMIN` | `1<<10` | Create and modify access passes                      |
+
+### Tier 4 — Technical/automated roles
+
+| Constant        | Bit     | Description                    |
+|-----------------|---------|--------------------------------|
+| `HEALTH_ORACLE` | `1<<11` | Report device/link health      |
+| `QA`            | `1<<12` | QA operations                  |
+
+---
+
+## Authorization Model
+
+Authorization is resolved in `src/authorize.rs` via `authorize()`. Each instruction calls
+`authorize()` after consuming its expected accounts. An optional trailing account — the caller's
+`Permission` PDA — selects the path:
+
+### New path (Permission account provided)
+
+1. Validate the PDA matches `get_permission_pda(program_id, payer)`.
+2. Verify the account is owned by the program and non-empty.
+3. Check `permission.status == Activated`.
+4. Check `permission.permissions & any_of_flags \!= 0`.
+
+### Legacy path (no Permission account, `RequirePermissionAccounts` not set)
+
+Falls back to `GlobalState` fields:
+
+| Flag                | Legacy check                                                                       |
+|---------------------|------------------------------------------------------------------------------------|
+| `FOUNDATION`        | `foundation_allowlist.contains(payer)`                                             |
+| `QA`                | `qa_allowlist.contains(payer)`                                                     |
+| `ACTIVATOR`         | `activator_authority_pk == payer`                                                  |
+| `SENTINEL`          | `sentinel_authority_pk == payer`                                                   |
+| `HEALTH_ORACLE`     | `health_oracle_pk == payer`                                                        |
+| `RESERVATION`       | `reservation_authority_pk == payer`                                                |
+| `USER_ADMIN`        | `foundation_allowlist` OR `activator_authority_pk`                                 |
+| `ACCESS_PASS_ADMIN` | `foundation_allowlist` OR `sentinel_authority_pk`                                  |
+| `NETWORK_ADMIN`     | `foundation_allowlist` OR `activator_authority_pk`                                 |
+| `TENANT_ADMIN`      | `foundation_allowlist` OR `sentinel_authority_pk`                                  |
+| `MULTICAST_ADMIN`   | `foundation_allowlist` OR `activator_authority_pk` OR `sentinel_authority_pk`      |
+| `PERMISSION_ADMIN`  | `foundation_allowlist`                                                             |
+| `INFRA_ADMIN`       | `foundation_allowlist`                                                             |
+| `GLOBALSTATE_ADMIN` | `foundation_allowlist`                                                             |
+| `CONTRIBUTOR_ADMIN` | `foundation_allowlist`                                                             |
+
+### Foundation bypass for `PERMISSION_ADMIN`
+
+Even when `RequirePermissionAccounts` is set (legacy mode disabled), `foundation_allowlist` members
+can still call Permission instructions without a Permission account. This prevents the foundation
+from being locked out of the permission system when migrating to strict mode.
+
+---
+
+## Instructions
+
+All Permission instructions require `PERMISSION_ADMIN` authorization.
+
+### CreatePermission
+
+Creates a Permission PDA granting `permissions` to `user_payer`.
+
+**Args:** `PermissionCreateArgs { user_payer: Pubkey, permissions: u128 }`
+
+**Accounts:**
+```
+[0] permission_pda   (writable) — PDA for user_payer
+[1] globalstate      (readonly)
+[2] payer            (signer)
+[3] system_program
+[4] payer_permission (optional) — payer's own Permission PDA for new-path authorization
+```
+
+**Guards:**
+- `permissions \!= 0`
+- Account must not already be initialized
+
+### UpdatePermission
+
+Replaces the `permissions` bitmask on an existing Permission account.
+
+**Args:** `PermissionUpdateArgs { permissions: u128 }`
+
+**Accounts:** same layout as Create (without system_program allocation)
+
+**Guards:** `permissions \!= 0`
+
+### SuspendPermission
+
+Sets `status = Suspended`. While suspended, the holder cannot authorize any instruction.
+
+**Args:** `PermissionSuspendArgs {}`
+
+**Guards:** status must currently be `Activated`
+
+### ResumePermission
+
+Sets `status = Activated`.
+
+**Args:** `PermissionResumeArgs {}`
+
+**Guards:** status must currently be `Suspended`
+
+### DeletePermission
+
+Closes the account and refunds rent to the payer.
+
+**Args:** `PermissionDeleteArgs {}`
+
+---
+
+## Adding a New Permission Flag
+
+1. **Define the flag** in `src/state/permission.rs` inside `pub mod permission_flags`:
+
+   ```rust
+   /// Can manage Foo accounts: create, update, delete.
+   pub const FOO_ADMIN: u128 = 1 << 15;  // next available bit
+   ```
+
+   Place it in the appropriate tier with a doc comment describing what it gates.
+
+2. **Add the legacy mapping** in `src/authorize.rs` inside `check_legacy_any()`:
+
+   ```rust
+   // FOO_ADMIN in legacy = foundation (adjust to whichever legacy key applies).
+   if any_of & permission_flags::FOO_ADMIN \!= 0
+       && globalstate.foundation_allowlist.contains(payer)
+   {
+       return true;
+   }
+   ```
+
+   Also update the doc comment on `authorize()` to list the new mapping.
+
+3. **Guard the new instructions** by calling `authorize()` with the flag:
+
+   ```rust
+   authorize(
+       program_id,
+       accounts_iter,
+       payer_account.key,
+       &globalstate,
+       permission_flags::FOO_ADMIN,
+   )?;
+   ```
+
+4. **Update the SDKs:**
+
+   - **Go** (`sdk/serviceability/go/state.go`):
+     ```go
+     PermissionFlagFooAdmin uint64 = 1 << 15
+     ```
+
+   - **TypeScript** (`sdk/serviceability/typescript/serviceability/state.ts`):
+     ```ts
+     export const PERMISSION_FLAG_FOO_ADMIN = 1n << 15n;
+     ```
+
+   - **Python** (`sdk/serviceability/python/serviceability/state.py`):
+     ```python
+     PERMISSION_FLAG_FOO_ADMIN = 1 << 15
+     ```
+
+5. **Add tests:**
+   - A legacy-path unit test in `src/authorize.rs` (both allowed and denied cases).
+   - An integration test in `tests/` verifying the instruction rejects unauthorized callers.
+
+---
+
+## Migration from Legacy to Strict Mode
+
+1. Create `Permission` accounts for all operators currently using `GlobalState` keys.
+2. Verify each operator can authorize instructions via their Permission account (use the new path
+   by passing the Permission PDA as the trailing account on each transaction).
+3. Set `FeatureFlag::RequirePermissionAccounts` via `SetFeatureFlags`.
+
+Once the flag is set, all instructions require a Permission account. The only exception is
+`PERMISSION_ADMIN`: `foundation_allowlist` members can always manage Permission accounts, even in
+strict mode, to recover from misconfiguration.

--- a/smartcontract/programs/doublezero-serviceability/src/authorize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/authorize.rs
@@ -1,0 +1,1058 @@
+use crate::{
+    error::DoubleZeroError,
+    pda::get_permission_pda,
+    state::{
+        feature_flags::{is_feature_enabled, FeatureFlag},
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission, PermissionStatus},
+    },
+};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+/// Authorize `payer_key` for an instruction, using a Permission account (new path) or the
+/// legacy GlobalState allowlists/authority keys (legacy path).
+///
+/// Call this after all expected accounts have been consumed from `accounts_iter`.
+/// If an additional account is present in the iterator, it is treated as the Permission account.
+///
+/// `any_of_flags` uses OR semantics: the payer is authorized if their Permission account has
+/// at least one of the specified `permission_flags::*` bits set.
+///
+/// Legacy fallback mapping (used when no Permission account is provided and
+/// `FeatureFlag::RequirePermissionAccounts` is not set):
+///   FOUNDATION        → foundation_allowlist
+///   QA                → qa_allowlist
+///   ACTIVATOR         → activator_authority_pk
+///   SENTINEL          → sentinel_authority_pk
+///   HEALTH_ORACLE     → health_oracle_pk
+///   RESERVATION       → reservation_authority_pk
+///   USER_ADMIN        → foundation_allowlist OR activator_authority_pk
+///   ACCESS_PASS_ADMIN → foundation_allowlist OR sentinel_authority_pk
+///   NETWORK_ADMIN     → foundation_allowlist OR activator_authority_pk
+///   TENANT_ADMIN      → foundation_allowlist OR sentinel_authority_pk
+///   MULTICAST_ADMIN   → foundation_allowlist OR activator_authority_pk OR sentinel_authority_pk
+///   PERMISSION_ADMIN  → foundation_allowlist (also allowed even when RequirePermissionAccounts is set)
+///   INFRA_ADMIN       → foundation_allowlist
+///   GLOBALSTATE_ADMIN → foundation_allowlist
+///   CONTRIBUTOR_ADMIN → foundation_allowlist
+pub fn authorize<'a, 'b: 'a, I>(
+    program_id: &Pubkey,
+    accounts_iter: &mut I,
+    payer_key: &Pubkey,
+    globalstate: &GlobalState,
+    any_of_flags: u128,
+) -> ProgramResult
+where
+    I: Iterator<Item = &'a AccountInfo<'b>>,
+{
+    match next_account_info(accounts_iter).ok() {
+        Some(permission_account) => {
+            // New path: validate Permission PDA and bitmask.
+            let (expected_pda, _) = get_permission_pda(program_id, payer_key);
+            if permission_account.key != &expected_pda {
+                return Err(ProgramError::InvalidArgument);
+            }
+            if permission_account.data_is_empty() {
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+            if permission_account.owner != program_id {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            let permission = Permission::try_from(permission_account)?;
+            if permission.status != PermissionStatus::Activated {
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+            if permission.permissions & any_of_flags == 0 {
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+        }
+        None => {
+            // Legacy path: check GlobalState allowlists / authority keys.
+            if is_feature_enabled(
+                globalstate.feature_flags,
+                FeatureFlag::RequirePermissionAccounts,
+            ) {
+                // Even in strict mode, foundation members can manage permissions to
+                // prevent being locked out of the permission system.
+                if any_of_flags & permission_flags::PERMISSION_ADMIN != 0
+                    && globalstate.foundation_allowlist.contains(payer_key)
+                {
+                    return Ok(());
+                }
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+            if !check_legacy_any(payer_key, globalstate, any_of_flags) {
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Returns true if `payer` satisfies at least one of the requested flags using legacy
+/// GlobalState fields.
+fn check_legacy_any(payer: &Pubkey, globalstate: &GlobalState, any_of: u128) -> bool {
+    if any_of & permission_flags::FOUNDATION != 0
+        && globalstate.foundation_allowlist.contains(payer)
+    {
+        return true;
+    }
+    if any_of & permission_flags::QA != 0 && globalstate.qa_allowlist.contains(payer) {
+        return true;
+    }
+    if any_of & permission_flags::ACTIVATOR != 0 && globalstate.activator_authority_pk == *payer {
+        return true;
+    }
+    if any_of & permission_flags::SENTINEL != 0 && globalstate.sentinel_authority_pk == *payer {
+        return true;
+    }
+    if any_of & permission_flags::HEALTH_ORACLE != 0 && globalstate.health_oracle_pk == *payer {
+        return true;
+    }
+    if any_of & permission_flags::RESERVATION != 0 && globalstate.reservation_authority_pk == *payer
+    {
+        return true;
+    }
+    // USER_ADMIN in legacy = foundation or activator (historical user management authorities).
+    if any_of & permission_flags::USER_ADMIN != 0
+        && (globalstate.foundation_allowlist.contains(payer)
+            || globalstate.activator_authority_pk == *payer)
+    {
+        return true;
+    }
+    // ACCESS_PASS_ADMIN in legacy = foundation or sentinel.
+    if any_of & permission_flags::ACCESS_PASS_ADMIN != 0
+        && (globalstate.foundation_allowlist.contains(payer)
+            || globalstate.sentinel_authority_pk == *payer)
+    {
+        return true;
+    }
+    // NETWORK_ADMIN in legacy = foundation or activator.
+    if any_of & permission_flags::NETWORK_ADMIN != 0
+        && (globalstate.foundation_allowlist.contains(payer)
+            || globalstate.activator_authority_pk == *payer)
+    {
+        return true;
+    }
+    // TENANT_ADMIN in legacy = foundation or sentinel.
+    if any_of & permission_flags::TENANT_ADMIN != 0
+        && (globalstate.foundation_allowlist.contains(payer)
+            || globalstate.sentinel_authority_pk == *payer)
+    {
+        return true;
+    }
+    // MULTICAST_ADMIN in legacy = foundation, activator, or sentinel.
+    if any_of & permission_flags::MULTICAST_ADMIN != 0
+        && (globalstate.foundation_allowlist.contains(payer)
+            || globalstate.activator_authority_pk == *payer
+            || globalstate.sentinel_authority_pk == *payer)
+    {
+        return true;
+    }
+    // PERMISSION_ADMIN in legacy = foundation (only foundation can manage permissions).
+    if any_of & permission_flags::PERMISSION_ADMIN != 0
+        && globalstate.foundation_allowlist.contains(payer)
+    {
+        return true;
+    }
+    // INFRA_ADMIN in legacy = foundation.
+    if any_of & permission_flags::INFRA_ADMIN != 0
+        && globalstate.foundation_allowlist.contains(payer)
+    {
+        return true;
+    }
+    // GLOBALSTATE_ADMIN in legacy = foundation.
+    if any_of & permission_flags::GLOBALSTATE_ADMIN != 0
+        && globalstate.foundation_allowlist.contains(payer)
+    {
+        return true;
+    }
+    // CONTRIBUTOR_ADMIN in legacy = foundation.
+    if any_of & permission_flags::CONTRIBUTOR_ADMIN != 0
+        && globalstate.foundation_allowlist.contains(payer)
+    {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        pda::get_permission_pda,
+        state::{
+            accounttype::AccountType,
+            feature_flags::FeatureFlag,
+            permission::{Permission, PermissionStatus},
+        },
+    };
+    use solana_program::{account_info::AccountInfo, clock::Epoch, pubkey::Pubkey};
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn gs_with_foundation(member: &Pubkey) -> GlobalState {
+        GlobalState {
+            foundation_allowlist: vec![*member],
+            ..GlobalState::default()
+        }
+    }
+
+    fn gs_with_qa(member: &Pubkey) -> GlobalState {
+        GlobalState {
+            qa_allowlist: vec![*member],
+            ..GlobalState::default()
+        }
+    }
+
+    fn gs_with_activator(activator: &Pubkey) -> GlobalState {
+        GlobalState {
+            activator_authority_pk: *activator,
+            ..GlobalState::default()
+        }
+    }
+
+    fn gs_with_sentinel(sentinel: &Pubkey) -> GlobalState {
+        GlobalState {
+            sentinel_authority_pk: *sentinel,
+            ..GlobalState::default()
+        }
+    }
+
+    fn gs_with_health_oracle(oracle: &Pubkey) -> GlobalState {
+        GlobalState {
+            health_oracle_pk: *oracle,
+            ..GlobalState::default()
+        }
+    }
+
+    fn gs_with_reservation(authority: &Pubkey) -> GlobalState {
+        GlobalState {
+            reservation_authority_pk: *authority,
+            ..GlobalState::default()
+        }
+    }
+
+    /// Call `authorize` with NO trailing account (forces the legacy path).
+    fn authorize_legacy(
+        program_id: &Pubkey,
+        payer: &Pubkey,
+        globalstate: &GlobalState,
+        flags: u128,
+    ) -> ProgramResult {
+        let accounts: Vec<AccountInfo> = vec![];
+        let mut iter = accounts.iter();
+        authorize(program_id, &mut iter, payer, globalstate, flags)
+    }
+
+    // ── Legacy path: individual flags ────────────────────────────────────────
+
+    #[test]
+    fn test_legacy_foundation_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::FOUNDATION).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_foundation_not_member_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&Pubkey::new_unique()); // different pubkey
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::FOUNDATION).is_err());
+    }
+
+    #[test]
+    fn test_legacy_qa_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_qa(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::QA).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_qa_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = GlobalState::default();
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::QA).is_err());
+    }
+
+    #[test]
+    fn test_legacy_activator_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::ACTIVATOR).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_activator_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&Pubkey::new_unique());
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::ACTIVATOR).is_err());
+    }
+
+    #[test]
+    fn test_legacy_sentinel_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::SENTINEL).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_sentinel_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&Pubkey::new_unique());
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::SENTINEL).is_err());
+    }
+
+    #[test]
+    fn test_legacy_health_oracle_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_health_oracle(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::HEALTH_ORACLE).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_reservation_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_reservation(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::RESERVATION).is_ok());
+    }
+
+    // ── Legacy path: composite flags ─────────────────────────────────────────
+
+    #[test]
+    fn test_legacy_user_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::USER_ADMIN).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_user_admin_via_activator() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::USER_ADMIN).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_user_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = GlobalState::default();
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::USER_ADMIN).is_err());
+    }
+
+    #[test]
+    fn test_legacy_access_pass_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::ACCESS_PASS_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_legacy_access_pass_admin_via_sentinel() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&payer);
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::ACCESS_PASS_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_legacy_access_pass_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = GlobalState::default();
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::ACCESS_PASS_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_legacy_network_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::NETWORK_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_network_admin_via_activator() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::NETWORK_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_network_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&payer); // sentinel does NOT grant NETWORK_ADMIN
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::NETWORK_ADMIN).is_err()
+        );
+    }
+
+    #[test]
+    fn test_legacy_tenant_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::TENANT_ADMIN).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_tenant_admin_via_sentinel() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::TENANT_ADMIN).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_tenant_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer); // activator does NOT grant TENANT_ADMIN
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::TENANT_ADMIN).is_err()
+        );
+    }
+
+    #[test]
+    fn test_legacy_multicast_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::MULTICAST_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_multicast_admin_via_activator() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::MULTICAST_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_multicast_admin_via_sentinel() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_sentinel(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::MULTICAST_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_multicast_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_qa(&payer); // QA does NOT grant MULTICAST_ADMIN
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::MULTICAST_ADMIN).is_err()
+        );
+    }
+
+    #[test]
+    fn test_legacy_infra_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::INFRA_ADMIN).is_ok());
+    }
+
+    #[test]
+    fn test_legacy_infra_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer); // activator does NOT grant INFRA_ADMIN
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::INFRA_ADMIN).is_err());
+    }
+
+    #[test]
+    fn test_legacy_globalstate_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::GLOBALSTATE_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_legacy_globalstate_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer); // activator does NOT grant GLOBALSTATE_ADMIN
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::GLOBALSTATE_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_legacy_contributor_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::CONTRIBUTOR_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_legacy_contributor_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer); // activator does NOT grant CONTRIBUTOR_ADMIN
+        assert!(authorize_legacy(
+            &program_id,
+            &payer,
+            &gs,
+            permission_flags::CONTRIBUTOR_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_legacy_permission_admin_via_foundation() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_foundation(&payer);
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::PERMISSION_ADMIN).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_legacy_permission_admin_unauthorized() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let gs = gs_with_activator(&payer); // activator does NOT grant PERMISSION_ADMIN
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::PERMISSION_ADMIN).is_err()
+        );
+    }
+
+    // ── RequirePermissionAccounts feature flag ────────────────────────────────
+
+    #[test]
+    fn test_feature_flag_require_permission_accounts_blocks_legacy() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let mut gs = gs_with_foundation(&payer);
+        gs.feature_flags = FeatureFlag::RequirePermissionAccounts.to_mask();
+        // payer IS in foundation_allowlist but feature flag blocks the legacy path
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::FOUNDATION).is_err());
+    }
+
+    #[test]
+    fn test_feature_flag_without_require_does_not_block_legacy() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let mut gs = gs_with_foundation(&payer);
+        gs.feature_flags = FeatureFlag::OnChainAllocation.to_mask(); // unrelated flag
+        assert!(authorize_legacy(&program_id, &payer, &gs, permission_flags::FOUNDATION).is_ok());
+    }
+
+    #[test]
+    fn test_feature_flag_require_permission_accounts_foundation_can_still_manage_permissions() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let mut gs = gs_with_foundation(&payer);
+        gs.feature_flags = FeatureFlag::RequirePermissionAccounts.to_mask();
+        // Foundation member can still manage permissions even in strict mode
+        assert!(
+            authorize_legacy(&program_id, &payer, &gs, permission_flags::PERMISSION_ADMIN).is_ok()
+        );
+        // But non-foundation cannot
+        let other = Pubkey::new_unique();
+        assert!(
+            authorize_legacy(&program_id, &other, &gs, permission_flags::PERMISSION_ADMIN).is_err()
+        );
+    }
+
+    // ── Permission account path (new) ─────────────────────────────────────────
+
+    fn make_permission_data(
+        program_id: &Pubkey,
+        payer: &Pubkey,
+        status: PermissionStatus,
+        permissions: u128,
+    ) -> (Pubkey, u8, Vec<u8>) {
+        let (pda, bump) = get_permission_pda(program_id, payer);
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: *payer,
+            bump_seed: bump,
+            status,
+            user_payer: *payer,
+            permissions,
+        };
+        (pda, bump, borsh::to_vec(&permission).unwrap())
+    }
+
+    #[test]
+    fn test_permission_account_activated_with_matching_flag_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::USER_ADMIN,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_permission_account_or_semantics_any_matching_flag_allowed() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        // Permission has only ACCESS_PASS_ADMIN, but we require USER_ADMIN | ACCESS_PASS_ADMIN
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::ACCESS_PASS_ADMIN,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN | permission_flags::ACCESS_PASS_ADMIN
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_permission_account_multiple_flags_granted_all_work() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let all_flags = permission_flags::USER_ADMIN
+            | permission_flags::ACCESS_PASS_ADMIN
+            | permission_flags::NETWORK_ADMIN;
+        let (pda, _, mut data) =
+            make_permission_data(&program_id, &payer, PermissionStatus::Activated, all_flags);
+
+        let mut lamports = 100_000u64;
+        let gs = GlobalState::default();
+
+        for flag in [
+            permission_flags::USER_ADMIN,
+            permission_flags::ACCESS_PASS_ADMIN,
+            permission_flags::NETWORK_ADMIN,
+        ] {
+            let account = AccountInfo::new(
+                &pda,
+                false,
+                false,
+                &mut lamports,
+                &mut data,
+                &program_id,
+                false,
+                Epoch::default(),
+            );
+            let accounts = [account];
+            let mut iter = accounts.iter();
+            assert!(
+                authorize(&program_id, &mut iter, &payer, &gs, flag).is_ok(),
+                "flag {flag} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_permission_account_insufficient_flag_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        // Has QA only, but instruction requires USER_ADMIN
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::QA,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_permission_account_no_flags_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, mut data) =
+            make_permission_data(&program_id, &payer, PermissionStatus::Activated, 0);
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_permission_account_suspended_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Suspended,
+            permission_flags::USER_ADMIN,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_permission_account_deleting_status_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Deleting,
+            permission_flags::FOUNDATION,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::FOUNDATION
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_permission_account_wrong_pda_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let wrong_pda = Pubkey::new_unique(); // not the real PDA for payer
+
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: payer,
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer: payer,
+            permissions: permission_flags::USER_ADMIN,
+        };
+        let mut data = borsh::to_vec(&permission).unwrap();
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &wrong_pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert_eq!(
+            authorize(
+                &program_id,
+                &mut iter,
+                &payer,
+                &gs,
+                permission_flags::USER_ADMIN
+            )
+            .unwrap_err(),
+            ProgramError::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn test_permission_account_empty_data_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, _) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::USER_ADMIN,
+        );
+
+        let mut data = vec![]; // uninitialized
+        let mut lamports = 0u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_permission_account_wrong_owner_denied() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let wrong_owner = Pubkey::new_unique(); // not program_id
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::USER_ADMIN,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &wrong_owner,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        let gs = GlobalState::default();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::USER_ADMIN
+        )
+        .is_err());
+    }
+
+    // ── New path overrides feature flag enforcement ───────────────────────────
+
+    #[test]
+    fn test_permission_account_works_even_when_require_flag_set() {
+        let program_id = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (pda, _, mut data) = make_permission_data(
+            &program_id,
+            &payer,
+            PermissionStatus::Activated,
+            permission_flags::FOUNDATION,
+        );
+
+        let mut lamports = 100_000u64;
+        let account = AccountInfo::new(
+            &pda,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+        let accounts = [account];
+        let mut iter = accounts.iter();
+        // Feature flag is set — Permission account path should still work
+        let mut gs = gs_with_foundation(&payer);
+        gs.feature_flags = FeatureFlag::RequirePermissionAccounts.to_mask();
+
+        assert!(authorize(
+            &program_id,
+            &mut iter,
+            &payer,
+            &gs,
+            permission_flags::FOUNDATION
+        )
+        .is_ok());
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
@@ -80,6 +80,11 @@ use crate::{
             suspend::process_suspend_multicastgroup,
             update::process_update_multicastgroup,
         },
+        permission::{
+            create::process_create_permission, delete::process_delete_permission,
+            resume::process_resume_permission, suspend::process_suspend_permission,
+            update::process_update_permission,
+        },
         reservation::{close::process_close_reservation, reserve::process_reserve_connection},
         resource::{
             allocate::process_allocate_resource,
@@ -398,6 +403,21 @@ pub fn process_instruction(
         }
         DoubleZeroInstruction::CloseReservation(value) => {
             process_close_reservation(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::CreatePermission(value) => {
+            process_create_permission(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::UpdatePermission(value) => {
+            process_update_permission(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::SuspendPermission(value) => {
+            process_suspend_permission(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::ResumePermission(value) => {
+            process_resume_permission(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::DeletePermission(value) => {
+            process_delete_permission(program_id, accounts, &value)?
         }
     };
     Ok(())

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -66,6 +66,10 @@ use crate::processors::{
         suspend::MulticastGroupSuspendArgs,
         update::MulticastGroupUpdateArgs,
     },
+    permission::{
+        create::PermissionCreateArgs, delete::PermissionDeleteArgs, resume::PermissionResumeArgs,
+        suspend::PermissionSuspendArgs, update::PermissionUpdateArgs,
+    },
     reservation::{close::CloseReservationArgs, reserve::ReserveConnectionArgs},
     resource::{
         allocate::ResourceAllocateArgs, closeaccount::ResourceExtensionCloseAccountArgs,
@@ -206,6 +210,12 @@ pub enum DoubleZeroInstruction {
 
     ReserveConnection(ReserveConnectionArgs), // variant 95
     CloseReservation(CloseReservationArgs),   // variant 96
+
+    CreatePermission(PermissionCreateArgs),   // variant 97
+    UpdatePermission(PermissionUpdateArgs),   // variant 98
+    SuspendPermission(PermissionSuspendArgs), // variant 99
+    ResumePermission(PermissionResumeArgs),   // variant 100
+    DeletePermission(PermissionDeleteArgs),   // variant 101
 }
 
 impl DoubleZeroInstruction {
@@ -334,6 +344,12 @@ impl DoubleZeroInstruction {
             95 => Ok(Self::ReserveConnection(ReserveConnectionArgs::try_from(rest).unwrap())),
             96 => Ok(Self::CloseReservation(CloseReservationArgs::try_from(rest).unwrap())),
 
+            97 => Ok(Self::CreatePermission(PermissionCreateArgs::try_from(rest).unwrap())),
+            98 => Ok(Self::UpdatePermission(PermissionUpdateArgs::try_from(rest).unwrap())),
+            99 => Ok(Self::SuspendPermission(PermissionSuspendArgs::try_from(rest).unwrap())),
+            100 => Ok(Self::ResumePermission(PermissionResumeArgs::try_from(rest).unwrap())),
+            101 => Ok(Self::DeletePermission(PermissionDeleteArgs::try_from(rest).unwrap())),
+
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }
@@ -458,6 +474,12 @@ impl DoubleZeroInstruction {
 
             Self::ReserveConnection(_) => "ReserveConnection".to_string(), // variant 95
             Self::CloseReservation(_) => "CloseReservation".to_string(),   // variant 96
+
+            Self::CreatePermission(_) => "CreatePermission".to_string(), // variant 97
+            Self::UpdatePermission(_) => "UpdatePermission".to_string(), // variant 98
+            Self::SuspendPermission(_) => "SuspendPermission".to_string(), // variant 99
+            Self::ResumePermission(_) => "ResumePermission".to_string(), // variant 100
+            Self::DeletePermission(_) => "DeletePermission".to_string(), // variant 101
         }
     }
 
@@ -575,6 +597,12 @@ impl DoubleZeroInstruction {
 
             Self::ReserveConnection(args) => format!("{args:?}"), // variant 95
             Self::CloseReservation(args) => format!("{args:?}"),  // variant 96
+
+            Self::CreatePermission(args) => format!("{args:?}"), // variant 97
+            Self::UpdatePermission(args) => format!("{args:?}"), // variant 98
+            Self::SuspendPermission(args) => format!("{args:?}"), // variant 99
+            Self::ResumePermission(args) => format!("{args:?}"), // variant 100
+            Self::DeletePermission(args) => format!("{args:?}"), // variant 101
         }
     }
 }
@@ -588,6 +616,7 @@ mod tests {
             device::{DeviceHealth, DeviceType},
             interface::{LoopbackType, RoutingMode},
             link::{LinkHealth, LinkLinkType},
+            permission::permission_flags,
             user::{UserCYOA, UserType},
         },
     };
@@ -1226,6 +1255,31 @@ mod tests {
         test_instruction(
             DoubleZeroInstruction::CloseReservation(CloseReservationArgs {}),
             "CloseReservation",
+        );
+        test_instruction(
+            DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+                user_payer: Pubkey::new_unique(),
+                permissions: permission_flags::USER_ADMIN | permission_flags::NETWORK_ADMIN,
+            }),
+            "CreatePermission",
+        );
+        test_instruction(
+            DoubleZeroInstruction::UpdatePermission(PermissionUpdateArgs {
+                permissions: permission_flags::FOUNDATION,
+            }),
+            "UpdatePermission",
+        );
+        test_instruction(
+            DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+            "SuspendPermission",
+        );
+        test_instruction(
+            DoubleZeroInstruction::ResumePermission(PermissionResumeArgs {}),
+            "ResumePermission",
+        );
+        test_instruction(
+            DoubleZeroInstruction::DeletePermission(PermissionDeleteArgs {}),
+            "DeletePermission",
         );
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/lib.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 pub mod addresses;
+pub mod authorize;
 pub mod entrypoint;
 pub mod error;
 mod helper;

--- a/smartcontract/programs/doublezero-serviceability/src/pda.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/pda.rs
@@ -7,9 +7,9 @@ use crate::{
         SEED_ACCESS_PASS, SEED_CONFIG, SEED_CONTRIBUTOR, SEED_DEVICE, SEED_DEVICE_TUNNEL_BLOCK,
         SEED_DZ_PREFIX_BLOCK, SEED_EXCHANGE, SEED_GLOBALSTATE, SEED_LINK, SEED_LINK_IDS,
         SEED_LOCATION, SEED_MULTICASTGROUP_BLOCK, SEED_MULTICAST_GROUP,
-        SEED_MULTICAST_PUBLISHER_BLOCK, SEED_PREFIX, SEED_PROGRAM_CONFIG, SEED_RESERVATION,
-        SEED_SEGMENT_ROUTING_IDS, SEED_TENANT, SEED_TUNNEL_IDS, SEED_USER, SEED_USER_TUNNEL_BLOCK,
-        SEED_VRF_IDS,
+        SEED_MULTICAST_PUBLISHER_BLOCK, SEED_PERMISSION, SEED_PREFIX, SEED_PROGRAM_CONFIG,
+        SEED_RESERVATION, SEED_SEGMENT_ROUTING_IDS, SEED_TENANT, SEED_TUNNEL_IDS, SEED_USER,
+        SEED_USER_TUNNEL_BLOCK, SEED_VRF_IDS,
     },
     state::user::UserType,
 };
@@ -92,6 +92,13 @@ pub fn get_reservation_pda(
             device_pk.as_ref(),
             &client_ip.octets(),
         ],
+        program_id,
+    )
+}
+
+pub fn get_permission_pda(program_id: &Pubkey, user_payer: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[SEED_PREFIX, SEED_PERMISSION, user_payer.as_ref()],
         program_id,
     )
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/close.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/close.rs
@@ -1,7 +1,11 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_close,
-    state::{accesspass::AccessPass, accounttype::AccountType, globalstate::GlobalState},
+    state::{
+        accesspass::AccessPass, accounttype::AccountType, globalstate::GlobalState,
+        permission::permission_flags,
+    },
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -70,11 +74,15 @@ pub fn process_close_access_pass(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Parse the global state account & check authorization
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::ACCESS_PASS_ADMIN,
+    )?;
 
     if let Ok(data) = accesspass_account.try_borrow_data() {
         let account_type: AccountType = data[0].into();

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     pda::*,
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
@@ -7,6 +8,7 @@ use crate::{
         accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP, IS_DYNAMIC},
         accounttype::AccountType,
         globalstate::GlobalState,
+        permission::permission_flags,
         tenant::Tenant,
     },
 };
@@ -107,19 +109,15 @@ pub fn process_set_access_pass(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Parse the global state account & check authorization
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if globalstate.sentinel_authority_pk != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
-        msg!(
-            "sentinel_authority_pk: {} payer: {} foundation_allowlist: {:?}",
-            globalstate.sentinel_authority_pk,
-            payer_account.key,
-            globalstate.foundation_allowlist
-        );
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::ACCESS_PASS_ADMIN,
+    )?;
 
     if let AccessPassType::SolanaValidator(node_id) = value.accesspass_type {
         if node_id == Pubkey::default() {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/mod.rs
@@ -9,6 +9,7 @@ pub mod link;
 pub mod location;
 pub mod migrate;
 pub mod multicastgroup;
+pub mod permission;
 pub mod reservation;
 pub mod resource;
 pub mod tenant;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/create.rs
@@ -1,0 +1,110 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    pda::get_permission_pda,
+    seeds::{SEED_PERMISSION, SEED_PREFIX},
+    serializer::try_acc_create,
+    state::{
+        accounttype::AccountType,
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission, PermissionStatus},
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct PermissionCreateArgs {
+    /// The pubkey for which this Permission PDA is being created.
+    pub user_payer: Pubkey,
+    /// Bitmask of permission_flags to grant.
+    pub permissions: u128,
+}
+
+impl fmt::Debug for PermissionCreateArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "user_payer: {}, permissions: {}",
+            self.user_payer, self.permissions
+        )
+    }
+}
+
+pub fn process_create_permission(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &PermissionCreateArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let permission_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert!(
+        permission_account.is_writable,
+        "Permission Account is not writable"
+    );
+
+    let (expected_pda, bump_seed) = get_permission_pda(program_id, &value.user_payer);
+    if permission_account.key != &expected_pda {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    if *permission_account.owner != solana_system_interface::program::ID {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    }
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::PERMISSION_ADMIN,
+    )?;
+
+    let permission = Permission {
+        account_type: AccountType::Permission,
+        owner: *payer_account.key,
+        bump_seed,
+        status: PermissionStatus::Activated,
+        user_payer: value.user_payer,
+        permissions: value.permissions,
+    };
+
+    // Validate that at least one known flag is set
+    if value.permissions == 0 {
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
+    try_acc_create(
+        &permission,
+        permission_account,
+        payer_account,
+        system_program,
+        program_id,
+        &[
+            SEED_PREFIX,
+            SEED_PERMISSION,
+            value.user_payer.as_ref(),
+            &[bump_seed],
+        ],
+    )?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/delete.rs
@@ -1,0 +1,75 @@
+use crate::{
+    authorize::authorize,
+    pda::get_permission_pda,
+    serializer::try_acc_close,
+    state::{
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission},
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct PermissionDeleteArgs {}
+
+impl fmt::Debug for PermissionDeleteArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PermissionDeleteArgs")
+    }
+}
+
+pub fn process_delete_permission(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _value: &PermissionDeleteArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let permission_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        permission_account.owner, program_id,
+        "Invalid Permission Account Owner"
+    );
+    assert!(
+        permission_account.is_writable,
+        "Permission Account is not writable"
+    );
+
+    let permission = Permission::try_from(permission_account)?;
+
+    let (expected_pda, _) = get_permission_pda(program_id, &permission.user_payer);
+    if permission_account.key != &expected_pda {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::PERMISSION_ADMIN,
+    )?;
+
+    // Close and refund rent to payer
+    try_acc_close(permission_account, payer_account)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/mod.rs
@@ -1,0 +1,5 @@
+pub mod create;
+pub mod delete;
+pub mod resume;
+pub mod suspend;
+pub mod update;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/resume.rs
@@ -1,0 +1,80 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    pda::get_permission_pda,
+    serializer::try_acc_write,
+    state::{
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission, PermissionStatus},
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct PermissionResumeArgs {}
+
+impl fmt::Debug for PermissionResumeArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PermissionResumeArgs")
+    }
+}
+
+pub fn process_resume_permission(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _value: &PermissionResumeArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let permission_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        permission_account.owner, program_id,
+        "Invalid Permission Account Owner"
+    );
+    assert!(
+        permission_account.is_writable,
+        "Permission Account is not writable"
+    );
+
+    let mut permission = Permission::try_from(permission_account)?;
+
+    let (expected_pda, _) = get_permission_pda(program_id, &permission.user_payer);
+    if permission_account.key != &expected_pda {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    if permission.status != PermissionStatus::Suspended {
+        return Err(DoubleZeroError::InvalidStatus.into());
+    }
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::PERMISSION_ADMIN,
+    )?;
+
+    permission.status = PermissionStatus::Activated;
+    try_acc_write(&permission, permission_account, payer_account, accounts)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/suspend.rs
@@ -1,0 +1,80 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    pda::get_permission_pda,
+    serializer::try_acc_write,
+    state::{
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission, PermissionStatus},
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct PermissionSuspendArgs {}
+
+impl fmt::Debug for PermissionSuspendArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PermissionSuspendArgs")
+    }
+}
+
+pub fn process_suspend_permission(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _value: &PermissionSuspendArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let permission_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        permission_account.owner, program_id,
+        "Invalid Permission Account Owner"
+    );
+    assert!(
+        permission_account.is_writable,
+        "Permission Account is not writable"
+    );
+
+    let mut permission = Permission::try_from(permission_account)?;
+
+    let (expected_pda, _) = get_permission_pda(program_id, &permission.user_payer);
+    if permission_account.key != &expected_pda {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    if permission.status != PermissionStatus::Activated {
+        return Err(DoubleZeroError::InvalidStatus.into());
+    }
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::PERMISSION_ADMIN,
+    )?;
+
+    permission.status = PermissionStatus::Suspended;
+    try_acc_write(&permission, permission_account, payer_account, accounts)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/update.rs
@@ -1,0 +1,83 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    pda::get_permission_pda,
+    serializer::try_acc_write,
+    state::{
+        globalstate::GlobalState,
+        permission::{permission_flags, Permission},
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
+pub struct PermissionUpdateArgs {
+    /// New permissions bitmask to replace the existing one.
+    pub permissions: u128,
+}
+
+impl fmt::Debug for PermissionUpdateArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "permissions: {}", self.permissions)
+    }
+}
+
+pub fn process_update_permission(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &PermissionUpdateArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let permission_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert_eq!(
+        permission_account.owner, program_id,
+        "Invalid Permission Account Owner"
+    );
+    assert!(
+        permission_account.is_writable,
+        "Permission Account is not writable"
+    );
+
+    let mut permission = Permission::try_from(permission_account)?;
+
+    let (expected_pda, _) = get_permission_pda(program_id, &permission.user_payer);
+    if permission_account.key != &expected_pda {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    if value.permissions == 0 {
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::PERMISSION_ADMIN,
+    )?;
+
+    permission.permissions = value.permissions;
+    try_acc_write(&permission, permission_account, payer_account, accounts)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_write,
-    state::{globalstate::GlobalState, user::*},
+    state::{globalstate::GlobalState, permission::permission_flags, user::*},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -56,9 +57,13 @@ pub fn process_ban_user(
     assert!(user_account.is_writable, "PDA Account is not writable");
 
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if globalstate.activator_authority_pk != *payer_account.key {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::USER_ADMIN,
+    )?;
 
     let mut user: User = User::try_from(user_account)?;
     if user.status != UserStatus::PendingBan {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/closeaccount.rs
@@ -1,11 +1,11 @@
 use crate::{
-    error::DoubleZeroError,
+    authorize::authorize,
     pda::get_resource_extension_pda,
     resource::{IdOrIp, ResourceType},
     serializer::{try_acc_close, try_acc_write},
     state::{
-        device::Device, globalstate::GlobalState, resource_extension::ResourceExtensionBorrowed,
-        tenant::Tenant, user::*,
+        device::Device, globalstate::GlobalState, permission::permission_flags,
+        resource_extension::ResourceExtensionBorrowed, tenant::Tenant, user::*,
     },
 };
 use borsh::BorshSerialize;
@@ -133,12 +133,13 @@ pub fn process_closeaccount_user(
 
     let globalstate = GlobalState::try_from(globalstate_account)?;
 
-    // Authorization: allow activator_authority_pk OR foundation_allowlist (matching ActivateUser)
-    let is_activator = globalstate.activator_authority_pk == *payer_account.key;
-    let is_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
-    if !is_activator && !is_foundation {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::USER_ADMIN,
+    )?;
 
     let user = User::try_from(user_account)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     pda::get_accesspass_pda,
     serializer::{try_acc_close, try_acc_write},
@@ -6,6 +7,7 @@ use crate::{
         accesspass::{AccessPass, AccessPassStatus},
         device::Device,
         globalstate::GlobalState,
+        permission::permission_flags,
         tenant::Tenant,
         user::*,
     },
@@ -143,10 +145,15 @@ pub fn process_delete_user(
     let user: User = User::try_from(user_account)?;
 
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key)
-        && user.owner != *payer_account.key
-    {
-        return Err(DoubleZeroError::NotAllowed.into());
+    // The user owner can always delete their own account without a Permission account.
+    if user.owner != *payer_account.key {
+        authorize(
+            program_id,
+            accounts_iter,
+            payer_account.key,
+            &globalstate,
+            permission_flags::USER_ADMIN,
+        )?;
     }
 
     let (accesspass_pda, _) = get_accesspass_pda(program_id, &user.client_ip, &user.owner);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_write,
-    state::{globalstate::GlobalState, user::*},
+    state::{globalstate::GlobalState, permission::permission_flags, user::*},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -57,9 +58,13 @@ pub fn process_request_ban_user(
     assert!(user_account.is_writable, "PDA Account is not writable");
 
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::USER_ADMIN,
+    )?;
 
     let mut user: User = User::try_from(user_account)?;
     if !can_request_ban(user.status) {

--- a/smartcontract/programs/doublezero-serviceability/src/seeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/seeds.rs
@@ -21,3 +21,4 @@ pub const SEED_LINK_IDS: &[u8] = b"linkids";
 pub const SEED_SEGMENT_ROUTING_IDS: &[u8] = b"segmentroutingids";
 pub const SEED_VRF_IDS: &[u8] = b"vrfids";
 pub const SEED_RESERVATION: &[u8] = b"reservation";
+pub const SEED_PERMISSION: &[u8] = b"permission";

--- a/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accountdata.rs
@@ -3,9 +3,9 @@ use crate::{
     state::{
         accesspass::AccessPass, accounttype::AccountType, contributor::Contributor, device::Device,
         exchange::Exchange, globalconfig::GlobalConfig, globalstate::GlobalState, link::Link,
-        location::Location, multicastgroup::MulticastGroup, programconfig::ProgramConfig,
-        reservation::Reservation, resource_extension::ResourceExtensionOwned, tenant::Tenant,
-        user::User,
+        location::Location, multicastgroup::MulticastGroup, permission::Permission,
+        programconfig::ProgramConfig, reservation::Reservation,
+        resource_extension::ResourceExtensionOwned, tenant::Tenant, user::User,
     },
 };
 use solana_program::program_error::ProgramError;
@@ -29,6 +29,7 @@ pub enum AccountData {
     ResourceExtension(ResourceExtensionOwned),
     Tenant(Tenant),
     Reservation(Reservation),
+    Permission(Permission),
 }
 
 impl AccountData {
@@ -49,6 +50,7 @@ impl AccountData {
             AccountData::ResourceExtension(_) => "ResourceExtension",
             AccountData::Tenant(_) => "Tenant",
             AccountData::Reservation(_) => "Reservation",
+            AccountData::Permission(_) => "Permission",
         }
     }
 
@@ -69,6 +71,7 @@ impl AccountData {
             AccountData::ResourceExtension(resource_extension) => resource_extension.to_string(),
             AccountData::Tenant(tenant) => tenant.to_string(),
             AccountData::Reservation(reservation) => reservation.to_string(),
+            AccountData::Permission(permission) => permission.to_string(),
         }
     }
 
@@ -175,6 +178,14 @@ impl AccountData {
             Err(DoubleZeroError::InvalidAccountType)
         }
     }
+
+    pub fn get_permission(&self) -> Result<Permission, DoubleZeroError> {
+        if let AccountData::Permission(permission) = self {
+            Ok(permission.clone())
+        } else {
+            Err(DoubleZeroError::InvalidAccountType)
+        }
+    }
 }
 
 impl TryFrom<&[u8]> for AccountData {
@@ -214,6 +225,9 @@ impl TryFrom<&[u8]> for AccountData {
             )),
             AccountType::Tenant => Ok(AccountData::Tenant(Tenant::try_from(bytes as &[u8])?)),
             AccountType::Reservation => Ok(AccountData::Reservation(Reservation::try_from(
+                bytes as &[u8],
+            )?)),
+            AccountType::Permission => Ok(AccountData::Permission(Permission::try_from(
                 bytes as &[u8],
             )?)),
         }

--- a/smartcontract/programs/doublezero-serviceability/src/state/accounttype.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accounttype.rs
@@ -23,6 +23,7 @@ pub enum AccountType {
     ResourceExtension = 12,
     Tenant = 13,
     Reservation = 14,
+    Permission = 15,
 }
 
 pub trait AccountTypeInfo {
@@ -50,6 +51,7 @@ impl From<u8> for AccountType {
             12 => AccountType::ResourceExtension,
             13 => AccountType::Tenant,
             14 => AccountType::Reservation,
+            15 => AccountType::Permission,
             _ => AccountType::None,
         }
     }
@@ -73,6 +75,7 @@ impl fmt::Display for AccountType {
             AccountType::ResourceExtension => write!(f, "resourceextension"),
             AccountType::Tenant => write!(f, "tenant"),
             AccountType::Reservation => write!(f, "reservation"),
+            AccountType::Permission => write!(f, "permission"),
         }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs
@@ -4,11 +4,17 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeatureFlag {
     OnChainAllocation = 0,
+    /// When set, all instructions require a Permission account for authorization.
+    /// The legacy GlobalState allowlist/authority fallback is disabled.
+    RequirePermissionAccounts = 1,
 }
 
 impl FeatureFlag {
     pub fn all_variants() -> &'static [FeatureFlag] {
-        &[FeatureFlag::OnChainAllocation]
+        &[
+            FeatureFlag::OnChainAllocation,
+            FeatureFlag::RequirePermissionAccounts,
+        ]
     }
 
     pub fn to_mask(self) -> u128 {
@@ -20,6 +26,7 @@ impl fmt::Display for FeatureFlag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FeatureFlag::OnChainAllocation => write!(f, "onchain-allocation"),
+            FeatureFlag::RequirePermissionAccounts => write!(f, "require-permission-accounts"),
         }
     }
 }
@@ -30,6 +37,7 @@ impl std::str::FromStr for FeatureFlag {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "onchain-allocation" => Ok(FeatureFlag::OnChainAllocation),
+            "require-permission-accounts" => Ok(FeatureFlag::RequirePermissionAccounts),
             _ => Err(format!("unknown feature flag: {s}")),
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/state/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/mod.rs
@@ -11,6 +11,7 @@ pub mod interface;
 pub mod link;
 pub mod location;
 pub mod multicastgroup;
+pub mod permission;
 pub mod programconfig;
 pub mod reservation;
 pub mod resource_extension;

--- a/smartcontract/programs/doublezero-serviceability/src/state/permission.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/permission.rs
@@ -1,0 +1,158 @@
+use crate::{
+    error::{DoubleZeroError, Validate},
+    state::accounttype::AccountType,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
+use std::fmt;
+
+/// Permission flags stored in `Permission.permissions` as a u128 bitmask.
+/// Any single matching flag is sufficient for authorization (OR semantics).
+pub mod permission_flags {
+    // ── Tier 1: System governance ──────────────────────────────────────────
+    /// Can manage contributors, allowlists, and globalstate.
+    pub const FOUNDATION: u128 = 1 << 0;
+    /// Can manage Permission accounts: create, update, suspend, resume, delete.
+    pub const PERMISSION_ADMIN: u128 = 1 << 1;
+    /// Can manage GlobalState: feature flags, allowlists, authority keys.
+    pub const GLOBALSTATE_ADMIN: u128 = 1 << 13;
+    /// Can manage Contributors: create, update, delete.
+    pub const CONTRIBUTOR_ADMIN: u128 = 1 << 14;
+
+    // ── Tier 2: Infrastructure management ─────────────────────────────────
+    /// Can manage infrastructure: locations and exchanges.
+    pub const INFRA_ADMIN: u128 = 1 << 2;
+    /// Can manage network devices and links: create, activate, reject, update, delete, sethealth.
+    pub const NETWORK_ADMIN: u128 = 1 << 3;
+    /// Can manage tenants: create, update, delete, add/remove administrators, update payment status.
+    pub const TENANT_ADMIN: u128 = 1 << 4;
+    /// Can manage multicast groups: create, activate, reject, update, suspend, delete, allowlists.
+    pub const MULTICAST_ADMIN: u128 = 1 << 5;
+    /// Can manage reservations.
+    pub const RESERVATION: u128 = 1 << 6;
+
+    // ── Tier 3: Operational roles ──────────────────────────────────────────
+    /// Can activate/reject network entities.
+    pub const ACTIVATOR: u128 = 1 << 7;
+    /// Can suspend network entities.
+    pub const SENTINEL: u128 = 1 << 8;
+    /// Can administer users: ban, request ban, delete, close account.
+    pub const USER_ADMIN: u128 = 1 << 9;
+    /// Can create and modify access passes.
+    pub const ACCESS_PASS_ADMIN: u128 = 1 << 10;
+
+    // ── Tier 4: Technical/automated roles ─────────────────────────────────
+    /// Can report device/link health.
+    pub const HEALTH_ORACLE: u128 = 1 << 11;
+    /// QA operations.
+    pub const QA: u128 = 1 << 12;
+}
+
+#[repr(u8)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Copy, Clone, PartialEq, Default)]
+#[borsh(use_discriminant = true)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PermissionStatus {
+    #[default]
+    None = 0,
+    Activated = 1,
+    Suspended = 2,
+    Deleting = 3,
+}
+
+impl From<u8> for PermissionStatus {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => PermissionStatus::None,
+            1 => PermissionStatus::Activated,
+            2 => PermissionStatus::Suspended,
+            3 => PermissionStatus::Deleting,
+            _ => PermissionStatus::None,
+        }
+    }
+}
+
+impl fmt::Display for PermissionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PermissionStatus::None => write!(f, "none"),
+            PermissionStatus::Activated => write!(f, "activated"),
+            PermissionStatus::Suspended => write!(f, "suspended"),
+            PermissionStatus::Deleting => write!(f, "deleting"),
+        }
+    }
+}
+
+#[derive(BorshSerialize, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Permission {
+    pub account_type: AccountType, // 1
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "doublezero_program_common::serializer::serialize_pubkey_as_string",
+            deserialize_with = "doublezero_program_common::serializer::deserialize_pubkey_from_string"
+        )
+    )]
+    pub owner: Pubkey, // 32
+    pub bump_seed: u8,             // 1
+    pub status: PermissionStatus,  // 1
+    pub user_payer: Pubkey,        // 32
+    pub permissions: u128,         // 16 — bitmask of permission_flags
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "account_type: {}, owner: {}, bump_seed: {}, status: {}, user_payer: {}, permissions: {}",
+            self.account_type, self.owner, self.bump_seed, self.status, self.user_payer, self.permissions
+        )
+    }
+}
+
+impl TryFrom<&[u8]> for Permission {
+    type Error = ProgramError;
+
+    fn try_from(mut data: &[u8]) -> Result<Self, Self::Error> {
+        let out = Self {
+            account_type: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            owner: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            bump_seed: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            status: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            user_payer: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            permissions: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+        };
+
+        if out.account_type != AccountType::Permission {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(out)
+    }
+}
+
+impl TryFrom<&AccountInfo<'_>> for Permission {
+    type Error = ProgramError;
+
+    fn try_from(account: &AccountInfo) -> Result<Self, Self::Error> {
+        let data = account.try_borrow_data()?;
+        let res = Self::try_from(&data[..]);
+        if res.is_err() {
+            msg!("Failed to deserialize Permission: {:?}", res.as_ref().err());
+        }
+        res
+    }
+}
+
+impl Validate for Permission {
+    fn validate(&self) -> Result<(), DoubleZeroError> {
+        // Account type must be Permission
+        if self.account_type != AccountType::Permission {
+            msg!("Invalid account type: {}", self.account_type);
+            return Err(DoubleZeroError::InvalidAccountType);
+        }
+
+        Ok(())
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/permission_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/permission_test.rs
@@ -1,0 +1,455 @@
+use doublezero_serviceability::{
+    instructions::*,
+    pda::get_permission_pda,
+    processors::permission::{
+        create::PermissionCreateArgs, delete::PermissionDeleteArgs, resume::PermissionResumeArgs,
+        suspend::PermissionSuspendArgs, update::PermissionUpdateArgs,
+    },
+    state::{
+        accounttype::AccountType,
+        permission::{permission_flags, PermissionStatus},
+    },
+};
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::AccountMeta,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
+
+mod test_helpers;
+use test_helpers::*;
+
+async fn get_permission(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    user_payer: &Pubkey,
+) -> doublezero_serviceability::state::permission::Permission {
+    let (pda, _) = get_permission_pda(&program_id, user_payer);
+    get_account_data(banks_client, pda)
+        .await
+        .expect("Permission account not found")
+        .get_permission()
+        .expect("Not a Permission account")
+}
+
+#[tokio::test]
+async fn test_permission_crud() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    println!("1. Create Permission with USER_ADMIN flag");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::USER_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.account_type, AccountType::Permission);
+    assert_eq!(permission.status, PermissionStatus::Activated);
+    assert_eq!(permission.user_payer, user_payer);
+    assert_eq!(permission.permissions, permission_flags::USER_ADMIN);
+
+    println!("2. Update Permission to add NETWORK_ADMIN");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdatePermission(PermissionUpdateArgs {
+            permissions: permission_flags::USER_ADMIN | permission_flags::NETWORK_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(
+        permission.permissions,
+        permission_flags::USER_ADMIN | permission_flags::NETWORK_ADMIN
+    );
+
+    println!("3. Suspend Permission");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.status, PermissionStatus::Suspended);
+
+    println!("4. Resume Permission");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ResumePermission(PermissionResumeArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.status, PermissionStatus::Activated);
+
+    println!("5. Delete Permission");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::DeletePermission(PermissionDeleteArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let account = banks_client.get_account(permission_pda).await.unwrap();
+    assert!(account.is_none(), "Permission account should be closed");
+}
+
+#[tokio::test]
+async fn test_permission_create_requires_foundation() {
+    let (mut banks_client, _payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let unauthorized = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &_payer,
+        &unauthorized.pubkey(),
+        10_000_000,
+    )
+    .await;
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::USER_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &unauthorized,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Unauthorized payer should not be able to create permissions"
+    );
+}
+
+#[tokio::test]
+async fn test_permission_create_zero_flags_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: 0,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(result.is_err(), "Zero permissions should be rejected");
+}
+
+#[tokio::test]
+async fn test_permission_double_create_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::FOUNDATION,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Use different permissions so the second transaction has a distinct signature.
+    let recent_blockhash2 = banks_client.get_latest_blockhash().await.unwrap();
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash2,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::NETWORK_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(result.is_err(), "Creating a permission twice should fail");
+}
+
+#[tokio::test]
+async fn test_permission_suspend_already_suspended_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::ACTIVATOR,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Suspending an already-suspended permission should fail"
+    );
+}
+
+#[tokio::test]
+async fn test_permission_resume_active_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::SENTINEL,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ResumePermission(PermissionResumeArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(result.is_err(), "Resuming an active permission should fail");
+}
+
+#[tokio::test]
+async fn test_permission_globalstate_admin_flag() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::GLOBALSTATE_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.permissions, permission_flags::GLOBALSTATE_ADMIN);
+    assert_eq!(permission.status, PermissionStatus::Activated);
+}
+
+#[tokio::test]
+async fn test_permission_contributor_admin_flag() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::CONTRIBUTOR_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.permissions, permission_flags::CONTRIBUTOR_ADMIN);
+    assert_eq!(permission.status, PermissionStatus::Activated);
+}
+
+#[tokio::test]
+async fn test_permission_combined_tier1_flags() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    let all_tier1 = permission_flags::PERMISSION_ADMIN
+        | permission_flags::GLOBALSTATE_ADMIN
+        | permission_flags::CONTRIBUTOR_ADMIN;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: all_tier1,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let permission = get_permission(&mut banks_client, program_id, &user_payer).await;
+    assert_eq!(permission.permissions, all_tier1);
+}

--- a/smartcontract/sdk/go/serviceability/client.go
+++ b/smartcontract/sdk/go/serviceability/client.go
@@ -24,6 +24,7 @@ type ProgramData struct {
 	MulticastGroups    []MulticastGroup
 	ProgramConfig      ProgramConfig
 	ResourceExtensions []ResourceExtension
+	Permissions        []Permission
 }
 
 func New(rpc RPCClient, programID solana.PublicKey) *Client {
@@ -57,6 +58,7 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 	multicastGroups := []MulticastGroup{}
 	programConfig := ProgramConfig{}
 	resourceExtensions := []ResourceExtension{}
+	permissions := []Permission{}
 
 	var errs error
 	for _, element := range out {
@@ -118,6 +120,11 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 			DeserializeResourceExtension(reader, &resourceExtension)
 			resourceExtension.PubKey = element.Pubkey
 			resourceExtensions = append(resourceExtensions, resourceExtension)
+		case byte(PermissionType):
+			var permission Permission
+			DeserializePermission(reader, &permission)
+			permission.PubKey = element.Pubkey
+			permissions = append(permissions, permission)
 		}
 	}
 
@@ -133,6 +140,7 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 		MulticastGroups:    multicastGroups,
 		ProgramConfig:      programConfig,
 		ResourceExtensions: resourceExtensions,
+		Permissions:        permissions,
 	}, errs
 }
 

--- a/smartcontract/sdk/go/serviceability/client_test.go
+++ b/smartcontract/sdk/go/serviceability/client_test.go
@@ -198,6 +198,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -229,6 +230,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -291,6 +293,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -323,6 +326,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -358,6 +362,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -398,6 +403,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -430,6 +436,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -467,6 +474,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				MulticastGroups:    []MulticastGroup{},
 				ProgramConfig:      ProgramConfig{},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 		{
@@ -492,6 +500,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 					},
 				},
 				ResourceExtensions: []ResourceExtension{},
+				Permissions:        []Permission{},
 			},
 		},
 	}

--- a/smartcontract/sdk/go/serviceability/deserialize.go
+++ b/smartcontract/sdk/go/serviceability/deserialize.go
@@ -245,6 +245,16 @@ func DeserializeProgramVersion(reader *ByteReader, programversion *ProgramVersio
 // Bitmap starts at offset 88 (aligned to 8 bytes)
 const resourceExtensionBitmapOffset = 88
 
+func DeserializePermission(reader *ByteReader, perm *Permission) {
+	perm.AccountType = AccountType(reader.ReadU8())
+	perm.Owner = reader.ReadPubkey()
+	perm.BumpSeed = reader.ReadU8()
+	perm.Status = PermissionStatus(reader.ReadU8())
+	perm.UserPayer = reader.ReadPubkey()
+	perm.PermissionsLo = reader.ReadU64() // bits 0-63 (low u64 of u128)
+	perm.PermissionsHi = reader.ReadU64() // bits 64-127 (high u64 of u128)
+}
+
 func DeserializeResourceExtension(reader *ByteReader, ext *ResourceExtension) {
 	ext.AccountType = AccountType(reader.ReadU8())
 	ext.Owner = reader.ReadPubkey()

--- a/smartcontract/sdk/go/serviceability/executor.go
+++ b/smartcontract/sdk/go/serviceability/executor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -31,6 +32,9 @@ type Executor struct {
 	signer                *solana.PrivateKey
 	programID             solana.PublicKey
 	waitForVisibleTimeout time.Duration
+
+	permissionOnce sync.Once
+	permissionPDA  *solana.PublicKey // nil if no Permission account exists for this signer
 }
 
 type ExecutorRPCClient interface {
@@ -38,6 +42,7 @@ type ExecutorRPCClient interface {
 	SendTransactionWithOpts(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error)
 	GetSignatureStatuses(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error)
 	GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
+	GetAccountInfo(ctx context.Context, account solana.PublicKey) (*solanarpc.GetAccountInfoResult, error)
 }
 
 type ExecutorOption func(*Executor)
@@ -200,12 +205,43 @@ func (i *genericInstruction) Data() ([]byte, error) {
 	return i.data, nil
 }
 
+// resolvePermissionPDA checks on-chain (once) whether a Permission account exists for this
+// executor's signer and caches the PDA address. Subsequent calls are no-ops.
+func (e *Executor) resolvePermissionPDA(ctx context.Context) {
+	e.permissionOnce.Do(func() {
+		if e.signer == nil {
+			return
+		}
+		pda, _, err := GetPermissionPDA(e.programID, e.signer.PublicKey())
+		if err != nil {
+			e.log.Warn("failed to derive Permission PDA", "error", err)
+			return
+		}
+		info, err := e.rpc.GetAccountInfo(ctx, pda)
+		if err != nil || info == nil || info.Value == nil {
+			return
+		}
+		e.permissionPDA = &pda
+		e.log.Debug("Permission account found, will include in transactions", "pda", pda)
+	})
+}
+
 func (e *Executor) executeTransaction(ctx context.Context, instructions []solana.Instruction) (solana.Signature, *solanarpc.GetTransactionResult, error) {
 	if e.signer == nil {
 		return solana.Signature{}, nil, ErrNoPrivateKey
 	}
 	if e.programID.IsZero() {
 		return solana.Signature{}, nil, ErrNoProgramID
+	}
+
+	// Resolve and inject the Permission PDA into every instruction when the account exists.
+	e.resolvePermissionPDA(ctx)
+	if e.permissionPDA != nil {
+		for _, instr := range instructions {
+			if gi, ok := instr.(*genericInstruction); ok {
+				gi.accounts = append(gi.accounts, solana.Meta(*e.permissionPDA))
+			}
+		}
 	}
 
 	blockhashResult, err := e.rpc.GetLatestBlockhash(ctx, solanarpc.CommitmentFinalized)

--- a/smartcontract/sdk/go/serviceability/executor_test.go
+++ b/smartcontract/sdk/go/serviceability/executor_test.go
@@ -20,6 +20,7 @@ type mockRPCClient struct {
 	sendTransactionFunc      func(ctx context.Context, transaction *solana.Transaction, opts solanarpc.TransactionOpts) (solana.Signature, error)
 	getSignatureStatusesFunc func(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error)
 	getTransactionFunc       func(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
+	getAccountInfoFunc       func(ctx context.Context, account solana.PublicKey) (*solanarpc.GetAccountInfoResult, error)
 	sentTransactions         []*solana.Transaction
 }
 
@@ -60,6 +61,14 @@ func (m *mockRPCClient) GetTransaction(ctx context.Context, txSig solana.Signatu
 	return &solanarpc.GetTransactionResult{
 		Meta: &solanarpc.TransactionMeta{},
 	}, nil
+}
+
+func (m *mockRPCClient) GetAccountInfo(ctx context.Context, account solana.PublicKey) (*solanarpc.GetAccountInfoResult, error) {
+	if m.getAccountInfoFunc != nil {
+		return m.getAccountInfoFunc(ctx, account)
+	}
+	// Default: account does not exist (no Permission account).
+	return &solanarpc.GetAccountInfoResult{Value: nil}, nil
 }
 
 func newTestExecutor(t *testing.T, rpc *mockRPCClient) (*Executor, solana.PrivateKey) {
@@ -620,5 +629,93 @@ func TestParseFailingInstructionIndex(t *testing.T) {
 
 		require.Error(t, parseErr)
 		assert.ErrorIs(t, parseErr, ErrInstructionFailed)
+	})
+}
+
+func TestPermissionPDAInjection(t *testing.T) {
+	t.Parallel()
+
+	globalStatePubkey := solana.NewWallet().PublicKey()
+
+	t.Run("does not append permission PDA when account does not exist", func(t *testing.T) {
+		signer := solana.NewWallet().PrivateKey
+		programID := solana.NewWallet().PublicKey()
+		permissionPDA, _, err := GetPermissionPDA(programID, signer.PublicKey())
+		require.NoError(t, err)
+
+		rpc := &mockRPCClient{} // default: GetAccountInfo returns nil Value
+		executor := NewExecutor(slog.Default(), rpc, &signer, programID)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+		_, err = executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+		require.NoError(t, err)
+
+		require.Len(t, rpc.sentTransactions, 1)
+		tx := rpc.sentTransactions[0]
+		for _, key := range tx.Message.AccountKeys {
+			assert.False(t, key.Equals(permissionPDA), "permission PDA should not be in accounts")
+		}
+	})
+
+	t.Run("appends permission PDA when account exists", func(t *testing.T) {
+		signer := solana.NewWallet().PrivateKey
+		programID := solana.NewWallet().PublicKey()
+		permissionPDA, _, err := GetPermissionPDA(programID, signer.PublicKey())
+		require.NoError(t, err)
+
+		rpc := &mockRPCClient{
+			getAccountInfoFunc: func(ctx context.Context, account solana.PublicKey) (*solanarpc.GetAccountInfoResult, error) {
+				if account.Equals(permissionPDA) {
+					return &solanarpc.GetAccountInfoResult{
+						Value: &solanarpc.Account{},
+					}, nil
+				}
+				return &solanarpc.GetAccountInfoResult{Value: nil}, nil
+			},
+		}
+		executor := NewExecutor(slog.Default(), rpc, &signer, programID)
+
+		updates := []DeviceHealthUpdate{
+			{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+		}
+		_, err = executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+		require.NoError(t, err)
+
+		require.Len(t, rpc.sentTransactions, 1)
+		tx := rpc.sentTransactions[0]
+		found := false
+		for _, key := range tx.Message.AccountKeys {
+			if key.Equals(permissionPDA) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "permission PDA should be present in transaction accounts")
+	})
+
+	t.Run("permission PDA is resolved only once across multiple transactions", func(t *testing.T) {
+		lookupCount := 0
+		signer := solana.NewWallet().PrivateKey
+		programID := solana.NewWallet().PublicKey()
+
+		rpc := &mockRPCClient{
+			getAccountInfoFunc: func(ctx context.Context, account solana.PublicKey) (*solanarpc.GetAccountInfoResult, error) {
+				lookupCount++
+				return &solanarpc.GetAccountInfoResult{Value: nil}, nil
+			},
+		}
+		executor := NewExecutor(slog.Default(), rpc, &signer, programID)
+
+		for range 3 {
+			updates := []DeviceHealthUpdate{
+				{DevicePubkey: solana.NewWallet().PublicKey(), Health: DeviceHealthReadyForUsers},
+			}
+			_, err := executor.SetDeviceHealthBatch(context.Background(), updates, globalStatePubkey)
+			require.NoError(t, err)
+		}
+
+		assert.Equal(t, 1, lookupCount, "permission PDA should be resolved exactly once")
 	})
 }

--- a/smartcontract/sdk/go/serviceability/pda.go
+++ b/smartcontract/sdk/go/serviceability/pda.go
@@ -12,6 +12,7 @@ const (
 	SeedMulticastGroupBlock     = "multicastgroupblock"
 	SeedMulticastPublisherBlock = "multicastpublisherblock"
 	SeedTenant                  = "tenant"
+	SeedPermission              = "permission"
 )
 
 // GetLinkIdsPDA derives the PDA for the global LinkIds resource extension
@@ -74,6 +75,16 @@ func GetTenantPDA(programID solana.PublicKey, code string) (solana.PublicKey, ui
 		[]byte(SeedPrefix),
 		[]byte(SeedTenant),
 		[]byte(code),
+	}
+	return solana.FindProgramAddress(seeds, programID)
+}
+
+// GetPermissionPDA derives the PDA for a Permission account given the user_payer pubkey.
+func GetPermissionPDA(programID solana.PublicKey, userPayer solana.PublicKey) (solana.PublicKey, uint8, error) {
+	seeds := [][]byte{
+		[]byte(SeedPrefix),
+		[]byte(SeedPermission),
+		userPayer[:],
 	}
 	return solana.FindProgramAddress(seeds, programID)
 }

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -24,6 +24,8 @@ const (
 	AccessPassType
 	ResourceExtensionType // 12
 	TenantType            // 13
+	// 14 is reserved
+	PermissionType AccountType = 15
 )
 
 type LocationStatus uint8
@@ -1026,6 +1028,82 @@ func (r *ResourceExtension) RangeString() string {
 		return ""
 	}
 	return fmt.Sprintf("[%d, %d)", r.Allocator.IdAllocator.RangeStart, r.Allocator.IdAllocator.RangeEnd)
+}
+
+type PermissionStatus uint8
+
+const (
+	PermissionStatusNone      PermissionStatus = 0
+	PermissionStatusActivated PermissionStatus = 1
+	PermissionStatusSuspended PermissionStatus = 2
+	PermissionStatusDeleting  PermissionStatus = 3
+)
+
+func (s PermissionStatus) String() string {
+	switch s {
+	case PermissionStatusNone:
+		return "none"
+	case PermissionStatusActivated:
+		return "activated"
+	case PermissionStatusSuspended:
+		return "suspended"
+	case PermissionStatusDeleting:
+		return "deleting"
+	default:
+		return "unknown"
+	}
+}
+
+func (s PermissionStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// Permission flag bit positions (bitmask stored as u128, split into Lo/Hi uint64).
+const (
+	PermissionFlagFoundation       uint64 = 1 << 0
+	PermissionFlagPermissionAdmin  uint64 = 1 << 1
+	PermissionFlagInfraAdmin       uint64 = 1 << 2
+	PermissionFlagNetworkAdmin     uint64 = 1 << 3
+	PermissionFlagTenantAdmin      uint64 = 1 << 4
+	PermissionFlagMulticastAdmin   uint64 = 1 << 5
+	PermissionFlagReservation      uint64 = 1 << 6
+	PermissionFlagActivator        uint64 = 1 << 7
+	PermissionFlagSentinel         uint64 = 1 << 8
+	PermissionFlagUserAdmin        uint64 = 1 << 9
+	PermissionFlagAccessPassAdmin  uint64 = 1 << 10
+	PermissionFlagHealthOracle     uint64 = 1 << 11
+	PermissionFlagQA               uint64 = 1 << 12
+	PermissionFlagGlobalstateAdmin uint64 = 1 << 13
+	PermissionFlagContributorAdmin uint64 = 1 << 14
+)
+
+type Permission struct {
+	AccountType   AccountType
+	Owner         [32]byte
+	BumpSeed      uint8
+	Status        PermissionStatus
+	UserPayer     [32]byte
+	PermissionsLo uint64
+	PermissionsHi uint64
+	PubKey        [32]byte
+}
+
+func (p Permission) MarshalJSON() ([]byte, error) {
+	type PermissionAlias Permission
+
+	return json.Marshal(&struct {
+		PermissionAlias
+		Owner     string `json:"Owner"`
+		UserPayer string `json:"UserPayer"`
+		PubKey    string `json:"PubKey"`
+		Status    string `json:"Status"`
+	}{
+		PermissionAlias: PermissionAlias(p),
+		Owner:           base58.Encode(p.Owner[:]),
+		UserPayer:       base58.Encode(p.UserPayer[:]),
+		PubKey:          base58.Encode(p.PubKey[:]),
+		Status:          p.Status.String(),
+	})
 }
 
 func (r ResourceExtension) MarshalJSON() ([]byte, error) {

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 
 use crate::config::default_program_id;
 use doublezero_serviceability::{
-    error::DoubleZeroError, instructions::*, state::accounttype::AccountType,
+    error::DoubleZeroError, instructions::*, pda::get_permission_pda,
+    state::accounttype::AccountType,
 };
 use eyre::{bail, eyre, OptionExt};
 use log::debug;
@@ -374,6 +375,66 @@ impl DZClient {
 
         Ok(errors)
     }
+
+    fn build_and_send(
+        &self,
+        instruction: DoubleZeroInstruction,
+        accounts: Vec<AccountMeta>,
+        with_permission: bool,
+    ) -> eyre::Result<Signature> {
+        let payer = self
+            .payer
+            .as_ref()
+            .ok_or_eyre("No default signer found, run \"doublezero keygen\" to create a new one")?;
+        let data = instruction.pack();
+
+        let mut trailing = vec![
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new(program::id(), false),
+        ];
+        if with_permission {
+            let (permission_pda, _) = get_permission_pda(&self.program_id, &payer.pubkey());
+            if self.client.get_account(&permission_pda).is_ok() {
+                trailing.push(AccountMeta::new_readonly(permission_pda, false));
+            }
+        }
+
+        let mut transaction = Transaction::new_with_payer(
+            &[Instruction::new_with_bytes(
+                self.program_id,
+                &data,
+                [accounts, trailing].concat(),
+            )],
+            Some(&payer.pubkey()),
+        );
+
+        let blockhash = self.client.get_latest_blockhash().map_err(|e| eyre!(e))?;
+        transaction.sign(&[&payer], blockhash);
+
+        debug!("Simulating transaction: {transaction:?}");
+
+        let result = self.client.simulate_transaction(&transaction)?;
+        if result.value.err.is_some() {
+            eprintln!("Program Logs:");
+            if let Some(logs) = result.value.logs {
+                for log in logs {
+                    eprintln!("{log}");
+                }
+            }
+        }
+
+        if let Some(TransactionError::InstructionError(_index, InstructionError::Custom(number))) =
+            result.value.err
+        {
+            return Err(eyre!(DoubleZeroError::from(number)));
+        } else if let Some(err) = result.value.err {
+            return Err(eyre!(err));
+        }
+
+        self.client
+            .send_and_confirm_transaction(&transaction)
+            .map_err(|e| eyre!(e))
+    }
 }
 
 impl DoubleZeroClient for DZClient {
@@ -450,7 +511,7 @@ impl DoubleZeroClient for DZClient {
         instruction: DoubleZeroInstruction,
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature> {
-        self.execute_transaction_inner(instruction, accounts, false)
+        self.build_and_send(instruction, accounts, false)
     }
 
     fn execute_transaction_quiet(
@@ -459,6 +520,14 @@ impl DoubleZeroClient for DZClient {
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature> {
         self.execute_transaction_inner(instruction, accounts, true)
+    }
+
+    fn execute_authorized_transaction(
+        &self,
+        instruction: DoubleZeroInstruction,
+        accounts: Vec<AccountMeta>,
+    ) -> eyre::Result<Signature> {
+        self.build_and_send(instruction, accounts, true)
     }
 
     fn gets(&self, account_type: AccountType) -> eyre::Result<HashMap<Pubkey, AccountData>> {

--- a/smartcontract/sdk/rs/src/commands/accesspass/close.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/close.rs
@@ -15,7 +15,7 @@ impl CloseAccessPassCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::CloseAccessPass(CloseAccessPassArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -50,7 +50,7 @@ mod tests {
         let (pda_pubkey, _) = get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CloseAccessPass(
                     CloseAccessPassArgs {},

--- a/smartcontract/sdk/rs/src/commands/accesspass/set.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set.rs
@@ -65,7 +65,7 @@ impl SetAccessPassCommand {
             accounts.push(AccountMeta::new(self.tenant, false));
         }
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
                 accesspass_type: self.accesspass_type.clone(),
                 client_ip: self.client_ip,
@@ -127,7 +127,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::AccessPass(accesspass.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
                     accesspass_type: AccessPassType::Prepaid,

--- a/smartcontract/sdk/rs/src/commands/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod link;
 pub mod location;
 pub mod migrate;
 pub mod multicastgroup;
+pub mod permission;
 pub mod programconfig;
 pub mod resource;
 pub mod tenant;

--- a/smartcontract/sdk/rs/src/commands/permission/create.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/create.rs
@@ -1,0 +1,86 @@
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_permission_pda,
+    processors::permission::create::PermissionCreateArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CreatePermissionCommand {
+    pub user_payer: Pubkey,
+    pub permissions: u128,
+}
+
+impl CreatePermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Signature, Pubkey)> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &self.user_payer);
+
+        client
+            .execute_authorized_transaction(
+                DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+                    user_payer: self.user_payer,
+                    permissions: self.permissions,
+                }),
+                vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ],
+            )
+            .map(|sig| (sig, permission_pda))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::permission::create::CreatePermissionCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_permission_pda},
+        processors::permission::create::PermissionCreateArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_permission_create_command() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let permissions: u128 = 0b11;
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &user_payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::CreatePermission(
+                    PermissionCreateArgs {
+                        user_payer,
+                        permissions,
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = CreatePermissionCommand {
+            user_payer,
+            permissions,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let (_, returned_pda) = res.unwrap();
+        assert_eq!(returned_pda, permission_pda);
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/delete.rs
@@ -1,0 +1,66 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::permission::delete::PermissionDeleteArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeletePermissionCommand {
+    pub permission_pda: Pubkey,
+}
+
+impl DeletePermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::DeletePermission(PermissionDeleteArgs {}),
+            vec![
+                AccountMeta::new(self.permission_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::permission::delete::DeletePermissionCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_permission_pda},
+        processors::permission::delete::PermissionDeleteArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_permission_delete_command() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &user_payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::DeletePermission(
+                    PermissionDeleteArgs {},
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = DeletePermissionCommand { permission_pda }.execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/get.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/get.rs
@@ -1,0 +1,153 @@
+use crate::{utils::parse_pubkey, DoubleZeroClient};
+use doublezero_serviceability::state::{
+    accountdata::AccountData, accounttype::AccountType, permission::Permission,
+};
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetPermissionCommand {
+    pub pubkey: String,
+}
+
+impl GetPermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Pubkey, Permission)> {
+        match parse_pubkey(&self.pubkey) {
+            Some(pk) => match client.get(pk)? {
+                AccountData::Permission(permission) => Ok((pk, permission)),
+                _ => Err(eyre::eyre!("Invalid Account Type")),
+            },
+            None => client
+                .gets(AccountType::Permission)?
+                .into_iter()
+                .find(|(_, v)| match v {
+                    AccountData::Permission(permission) => {
+                        permission.user_payer.to_string() == self.pubkey
+                    }
+                    _ => false,
+                })
+                .map(|(pk, v)| match v {
+                    AccountData::Permission(permission) => Ok((pk, permission)),
+                    _ => Err(eyre::eyre!("Invalid Account Type")),
+                })
+                .unwrap_or_else(|| {
+                    Err(eyre::eyre!(
+                        "Permission for user_payer {} not found",
+                        self.pubkey
+                    ))
+                }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        commands::permission::get::GetPermissionCommand, tests::utils::create_test_client,
+    };
+    use doublezero_serviceability::state::{
+        accountdata::AccountData,
+        accounttype::AccountType,
+        permission::{Permission, PermissionStatus},
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_permission_get_command_by_pubkey() {
+        let mut client = create_test_client();
+
+        let permission_pubkey = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: Pubkey::new_unique(),
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer,
+            permissions: 0b11,
+        };
+
+        let permission2 = permission.clone();
+        client
+            .expect_get()
+            .with(predicate::eq(permission_pubkey))
+            .returning(move |_| Ok(AccountData::Permission(permission2.clone())));
+
+        // Search by permission PDA pubkey
+        let res = GetPermissionCommand {
+            pubkey: permission_pubkey.to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.1.user_payer, user_payer);
+        assert_eq!(res.1.permissions, 0b11);
+    }
+
+    #[test]
+    fn test_commands_permission_get_command_by_user_payer_string() {
+        let mut client = create_test_client();
+
+        let permission_pubkey = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let permission = Permission {
+            account_type: AccountType::Permission,
+            owner: Pubkey::new_unique(),
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer,
+            permissions: 0b11,
+        };
+
+        let permission3 = permission.clone();
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Permission))
+            .returning(move |_| {
+                Ok(HashMap::from([(
+                    permission_pubkey,
+                    AccountData::Permission(permission3.clone()),
+                )]))
+            });
+
+        // Search using a non-pubkey string that matches user_payer.to_string() via gets
+        // (In practice, callers pass user_payer.to_string() but since parse_pubkey would
+        // resolve it, this test uses a non-decodable search string to exercise the gets path.)
+        let res = GetPermissionCommand {
+            pubkey: "notfound".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("Permission for user_payer notfound not found"));
+    }
+
+    #[test]
+    fn test_commands_permission_get_command_invalid_account_type() {
+        let mut client = create_test_client();
+
+        let permission_pubkey = Pubkey::new_unique();
+
+        client
+            .expect_get()
+            .with(predicate::eq(permission_pubkey))
+            .returning(move |_| Ok(AccountData::None));
+
+        let res = GetPermissionCommand {
+            pubkey: permission_pubkey.to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid Account Type"));
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/list.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/list.rs
@@ -1,0 +1,100 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::state::{
+    accountdata::AccountData, accounttype::AccountType, permission::Permission,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ListPermissionCommand {}
+
+impl ListPermissionCommand {
+    pub fn execute(
+        &self,
+        client: &dyn DoubleZeroClient,
+    ) -> eyre::Result<HashMap<Pubkey, Permission>> {
+        Ok(client
+            .gets(AccountType::Permission)?
+            .into_iter()
+            .filter_map(|(pk, account_data)| match account_data {
+                AccountData::Permission(permission) => Some((pk, permission)),
+                _ => None,
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        commands::permission::list::ListPermissionCommand, tests::utils::create_test_client,
+    };
+    use doublezero_serviceability::state::{
+        accountdata::AccountData,
+        accounttype::AccountType,
+        permission::{Permission, PermissionStatus},
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_permission_list_command() {
+        let mut client = create_test_client();
+
+        let permission1_pubkey = Pubkey::new_unique();
+        let user_payer1 = Pubkey::new_unique();
+        let permission1 = Permission {
+            account_type: AccountType::Permission,
+            owner: Pubkey::new_unique(),
+            bump_seed: 255,
+            status: PermissionStatus::Activated,
+            user_payer: user_payer1,
+            permissions: 0b01,
+        };
+
+        let permission2_pubkey = Pubkey::new_unique();
+        let user_payer2 = Pubkey::new_unique();
+        let permission2 = Permission {
+            account_type: AccountType::Permission,
+            owner: Pubkey::new_unique(),
+            bump_seed: 254,
+            status: PermissionStatus::Activated,
+            user_payer: user_payer2,
+            permissions: 0b11,
+        };
+
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Permission))
+            .returning(move |_| {
+                let mut permissions = HashMap::new();
+                permissions.insert(
+                    permission1_pubkey,
+                    AccountData::Permission(permission1.clone()),
+                );
+                permissions.insert(
+                    permission2_pubkey,
+                    AccountData::Permission(permission2.clone()),
+                );
+                Ok(permissions)
+            });
+
+        let res = ListPermissionCommand {}.execute(&client);
+
+        assert!(res.is_ok());
+        let list = res.unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.contains_key(&permission1_pubkey));
+        assert!(list.contains_key(&permission2_pubkey));
+        assert_eq!(
+            list.get(&permission1_pubkey).unwrap().user_payer,
+            user_payer1
+        );
+        assert_eq!(
+            list.get(&permission2_pubkey).unwrap().user_payer,
+            user_payer2
+        );
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/mod.rs
@@ -1,0 +1,7 @@
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod resume;
+pub mod suspend;
+pub mod update;

--- a/smartcontract/sdk/rs/src/commands/permission/resume.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/resume.rs
@@ -1,0 +1,66 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::permission::resume::PermissionResumeArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ResumePermissionCommand {
+    pub permission_pda: Pubkey,
+}
+
+impl ResumePermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::ResumePermission(PermissionResumeArgs {}),
+            vec![
+                AccountMeta::new(self.permission_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::permission::resume::ResumePermissionCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_permission_pda},
+        processors::permission::resume::PermissionResumeArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_permission_resume_command() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &user_payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::ResumePermission(
+                    PermissionResumeArgs {},
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = ResumePermissionCommand { permission_pda }.execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/suspend.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/suspend.rs
@@ -1,0 +1,66 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::permission::suspend::PermissionSuspendArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct SuspendPermissionCommand {
+    pub permission_pda: Pubkey,
+}
+
+impl SuspendPermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+            vec![
+                AccountMeta::new(self.permission_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::permission::suspend::SuspendPermissionCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_permission_pda},
+        processors::permission::suspend::PermissionSuspendArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_permission_suspend_command() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &user_payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::SuspendPermission(
+                    PermissionSuspendArgs {},
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = SuspendPermissionCommand { permission_pda }.execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/permission/update.rs
+++ b/smartcontract/sdk/rs/src/commands/permission/update.rs
@@ -1,0 +1,74 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+    processors::permission::update::PermissionUpdateArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UpdatePermissionCommand {
+    pub permission_pda: Pubkey,
+    pub permissions: u128,
+}
+
+impl UpdatePermissionCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::UpdatePermission(PermissionUpdateArgs {
+                permissions: self.permissions,
+            }),
+            vec![
+                AccountMeta::new(self.permission_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::permission::update::UpdatePermissionCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_permission_pda},
+        processors::permission::update::PermissionUpdateArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_permission_update_command() {
+        let mut client = create_test_client();
+
+        let user_payer = Pubkey::new_unique();
+        let permissions: u128 = 0b111;
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (permission_pda, _) = get_permission_pda(&client.get_program_id(), &user_payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdatePermission(
+                    PermissionUpdateArgs { permissions },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(permission_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = UpdatePermissionCommand {
+            permission_pda,
+            permissions,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/tenant/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/tenant/delete.rs
@@ -286,9 +286,9 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(|_| Ok(HashMap::new()));
 
-        // 4. DeleteUserCommand internally: execute_transaction(DeleteUser)
+        // 4. DeleteUserCommand internally: execute_authorized_transaction(DeleteUser)
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteUser(UserDeleteArgs::default())),
                 predicate::always(),
@@ -313,9 +313,9 @@ mod tests {
                 Ok(map)
             });
 
-        // 6. SetAccessPassCommand: execute_transaction(SetAccessPass) to reset tenant
+        // 6. SetAccessPassCommand: execute_authorized_transaction(SetAccessPass) to reset tenant
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
                     accesspass_type: AccessPassType::Prepaid,
@@ -415,9 +415,9 @@ mod tests {
                 Ok(map)
             });
 
-        // 2. SetAccessPassCommand: execute_transaction(SetAccessPass) to reset tenant
+        // 2. SetAccessPassCommand: execute_authorized_transaction(SetAccessPass) to reset tenant
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
                     accesspass_type: AccessPassType::Prepaid,

--- a/smartcontract/sdk/rs/src/commands/user/ban.rs
+++ b/smartcontract/sdk/rs/src/commands/user/ban.rs
@@ -24,16 +24,12 @@ impl BanUserCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        let instruction = DoubleZeroInstruction::BanUser(UserBanArgs {});
-        let accounts = vec![
-            AccountMeta::new(self.pubkey, false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ];
-
-        if quiet {
-            client.execute_transaction_quiet(instruction, accounts)
-        } else {
-            client.execute_transaction(instruction, accounts)
-        }
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::BanUser(UserBanArgs {}),
+            vec![
+                AccountMeta::new(self.pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
+        )
     }
 }

--- a/smartcontract/sdk/rs/src/commands/user/closeaccount.rs
+++ b/smartcontract/sdk/rs/src/commands/user/closeaccount.rs
@@ -113,16 +113,13 @@ impl CloseAccountUserCommand {
             accounts.push(AccountMeta::new(user.tenant_pk, false));
         }
 
-        let instruction = DoubleZeroInstruction::CloseAccountUser(UserCloseAccountArgs {
-            dz_prefix_count,
-            multicast_publisher_count,
-        });
-
-        if quiet {
-            client.execute_transaction_quiet(instruction, accounts)
-        } else {
-            client.execute_transaction(instruction, accounts)
-        }
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::CloseAccountUser(UserCloseAccountArgs {
+                dz_prefix_count,
+                multicast_publisher_count,
+            }),
+            accounts,
+        )
     }
 }
 
@@ -185,7 +182,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::User(user.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CloseAccountUser(
                     UserCloseAccountArgs {
@@ -289,7 +286,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::GlobalConfig(globalconfig.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CloseAccountUser(
                     UserCloseAccountArgs {
@@ -354,7 +351,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::User(user.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CloseAccountUser(
                     UserCloseAccountArgs {
@@ -457,7 +454,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::GlobalConfig(globalconfig.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CloseAccountUser(
                     UserCloseAccountArgs {

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -168,7 +168,7 @@ impl DeleteUserCommand {
             (0u8, 0u8)
         };
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
                 dz_prefix_count,
                 multicast_publisher_count,
@@ -393,7 +393,7 @@ mod tests {
 
         // Execute transaction for DeleteUser
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteUser(UserDeleteArgs::default())),
                 predicate::eq(vec![
@@ -593,7 +593,7 @@ mod tests {
 
         // DeleteUser transaction
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteUser(UserDeleteArgs::default())),
                 predicate::eq(vec![
@@ -726,7 +726,7 @@ mod tests {
             get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pk, 0));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
                     dz_prefix_count: 1,

--- a/smartcontract/sdk/rs/src/commands/user/requestban.rs
+++ b/smartcontract/sdk/rs/src/commands/user/requestban.rs
@@ -15,7 +15,7 @@ impl RequestBanUserCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::RequestBanUser(UserRequestBanArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),

--- a/smartcontract/sdk/rs/src/doublezeroclient.rs
+++ b/smartcontract/sdk/rs/src/doublezeroclient.rs
@@ -50,6 +50,15 @@ pub trait DoubleZeroClient {
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature>;
 
+    /// Like `execute_transaction` but appends the payer's Permission PDA
+    /// (read-only) when it exists on-chain, so `authorize()` can find it.
+    /// Use this for instructions whose processor calls `authorize()`.
+    fn execute_authorized_transaction(
+        &self,
+        instruction: DoubleZeroInstruction,
+        accounts: Vec<AccountMeta>,
+    ) -> eyre::Result<Signature>;
+
     fn get_transactions(&self, pubkey: Pubkey) -> eyre::Result<Vec<DZTransaction>>;
 }
 

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -7,8 +7,8 @@ pub use doublezero_serviceability::{
     addresses::*,
     pda::{
         get_contributor_pda, get_device_pda, get_exchange_pda, get_globalconfig_pda, get_link_pda,
-        get_location_pda, get_multicastgroup_pda, get_resource_extension_pda, get_tenant_pda,
-        get_user_old_pda,
+        get_location_pda, get_multicastgroup_pda, get_permission_pda, get_resource_extension_pda,
+        get_tenant_pda, get_user_old_pda,
     },
     programversion::ProgramVersion,
     resource::{IdOrIp, ResourceType},
@@ -26,6 +26,7 @@ pub use doublezero_serviceability::{
         link::{Link, LinkLinkType, LinkStatus},
         location::{Location, LocationStatus},
         multicastgroup::{MulticastGroup, MulticastGroupStatus},
+        permission::{Permission, PermissionStatus},
         programconfig::ProgramConfig,
         resource_extension::ResourceExtensionOwned,
         tenant::Tenant,

--- a/smartcontract/test/start-test-permissions.sh
+++ b/smartcontract/test/start-test-permissions.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+#
+# start-test-permissions.sh
+#
+# Two-phase validation of the Permission account model:
+#
+# PHASE 1 — Legacy mode (require-permission-accounts OFF)
+#   Runs the full initial network setup (locations, exchanges, contributors,
+#   devices, interfaces, links, access passes, users) using only the
+#   foundation allowlist for authorization, identical to start-test.sh.
+#
+# PHASE 2 — Permission account mode (require-permission-accounts ON)
+#   Disables the legacy path, creates Permission accounts for the payer,
+#   then adds more devices, links, access passes and users — all authorized
+#   exclusively via Permission accounts.
+
+clear
+killall solana-test-validator > /dev/null 2>&1
+killall doublezero-activator > /dev/null 2>&1
+killall solana > /dev/null 2>&1
+
+set -e
+set -x
+
+mkdir -p ./logs ./target
+
+export OPENSSL_NO_VENDOR=1
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+echo "Build the program"
+cargo build-sbf --manifest-path ../programs/doublezero-serviceability/Cargo.toml -- -Znext-lockfile-bump --target-dir ../../target/
+cp ../../target/deploy/doublezero_serviceability.so ./target/doublezero_serviceability.so
+
+echo "Build the activator"
+cargo build --manifest-path ../../activator/Cargo.toml --target-dir ../../target/
+cp ../../target/debug/doublezero-activator ./target/
+
+echo "Build the client"
+cargo build --manifest-path ../../client/doublezero/Cargo.toml --target-dir ../../target/
+cp ../../target/debug/doublezero ./target/
+
+# ── Start validator ───────────────────────────────────────────────────────────
+
+solana config set --url http://127.0.0.1:8899
+./target/doublezero config set --url http://127.0.0.1:8899
+./target/doublezero config set --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX
+
+echo "Start solana local test cluster"
+solana-test-validator --reset --bpf-program ./keypair.json ./target/doublezero_serviceability.so >./logs/validator.log 2>&1 &
+
+echo "Waiting 15 seconds for the validator to start"
+sleep 15
+
+echo "Start instruction logger"
+solana logs >./logs/instruction.log 2>&1 &
+
+# ── Init ─────────────────────────────────────────────────────────────────────
+
+./target/doublezero init
+
+./target/doublezero global-config set \
+    --local-asn 65100 --remote-asn 65001 \
+    --device-tunnel-block 172.16.0.0/16 \
+    --user-tunnel-block 169.254.0.0/16 \
+    --multicastgroup-block 233.84.178.0/24
+
+./target/doublezero global-config authority set \
+    --activator-authority me --sentinel-authority me
+
+# Enable onchain-allocation only — legacy path still active at this point.
+./target/doublezero global-config feature-flags set --enable onchain-allocation
+
+./target/doublezero global-config feature-flags get
+
+echo "Start the activator"
+RUST_LOG=info ./target/doublezero-activator \
+    --program-id 7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX \
+    --rpc http://127.0.0.1:8899 --ws ws://127.0.0.1:8900 \
+    --keypair ~/.config/doublezero/id.json >./logs/activator.log 2>&1 &
+
+PAYER=$(./target/doublezero address)
+echo "Payer pubkey: $PAYER"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# PHASE 1 — Legacy authorization (foundation allowlist)
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "###################################################################"
+echo "# PHASE 1: Legacy mode — foundation allowlist authorization"
+echo "###################################################################"
+
+# ── Locations ─────────────────────────────────────────────────────────────────
+
+echo "Creating locations"
+./target/doublezero location create --code lax --name "Los Angeles" --country US --lat 34.049641274076464 --lng -118.25939642499903
+./target/doublezero location create --code ewr --name "New York"    --country US --lat 40.780297071772125 --lng -74.07203003496925
+./target/doublezero location create --code lhr --name "London"      --country UK --lat 51.513999803939384 --lng -0.12014764843092213
+./target/doublezero location create --code fra --name "Frankfurt"   --country DE --lat 50.1215356432098   --lng 8.642047117175098
+./target/doublezero location create --code ams --name "Amsterdam"   --country NL --lat 52.30085793004002  --lng 4.942241140085309
+./target/doublezero location create --code sin --name "Singapore"   --country SG --lat 1.2807150707390342 --lng 103.85507136144396
+./target/doublezero location create --code tyo --name "Tokyo"       --country JP --lat 35.66875144228767  --lng 139.76565267564501
+
+# ── Exchanges ─────────────────────────────────────────────────────────────────
+
+echo "Creating exchanges"
+./target/doublezero exchange create --code xlax --name "Los Angeles" --lat 34.049641274076464 --lng -118.25939642499903
+./target/doublezero exchange create --code xewr --name "New York"    --lat 40.780297071772125 --lng -74.07203003496925
+./target/doublezero exchange create --code xlhr --name "London"      --lat 51.513999803939384 --lng -0.12014764843092213
+./target/doublezero exchange create --code xfra --name "Frankfurt"   --lat 50.1215356432098   --lng 8.642047117175098
+./target/doublezero exchange create --code xams --name "Amsterdam"   --lat 52.30085793004002  --lng 4.942241140085309
+./target/doublezero exchange create --code xsin --name "Singapore"   --lat 1.2807150707390342 --lng 103.85507136144396
+./target/doublezero exchange create --code xtyo --name "Tokyo"       --lat 35.66875144228767  --lng 139.76565267564501
+
+# ── Contributors ──────────────────────────────────────────────────────────────
+
+echo "Creating contributors"
+./target/doublezero contributor create --code co01 --owner me
+./target/doublezero contributor create --code co02 --owner me
+
+# ── Tenants ───────────────────────────────────────────────────────────────────
+
+echo "Creating tenants"
+./target/doublezero tenant create --code acme --administrator me
+./target/doublezero tenant create --code corp --administrator me
+
+./target/doublezero tenant update --pubkey acme --vrf-id 100
+./target/doublezero tenant update --pubkey corp --vrf-id 200
+
+# ── Phase 1 devices ───────────────────────────────────────────────────────────
+
+echo "Creating devices (phase 1)"
+./target/doublezero device create --code la2-dz01 --contributor co01 --location lax --exchange xlax \
+    --public-ip "207.45.216.134" --dz-prefixes "100.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code ny5-dz01 --contributor co01 --location ewr --exchange xewr \
+    --public-ip "64.86.249.80"  --dz-prefixes "101.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code ld4-dz01 --contributor co01 --location lhr --exchange xlhr \
+    --public-ip "195.219.120.72" --dz-prefixes "102.0.0.0/29,103.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code ams-dz01 --contributor co01 --location ams --exchange xams \
+    --public-ip "195.219.138.50" --dz-prefixes "108.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+
+./target/doublezero device update --pubkey la2-dz01 --max-users 128
+./target/doublezero device update --pubkey ny5-dz01 --max-users 128
+./target/doublezero device update --pubkey ld4-dz01 --max-users 128
+./target/doublezero device update --pubkey ams-dz01 --max-users 128
+
+# ── Phase 1 interfaces ────────────────────────────────────────────────────────
+
+echo "Creating device interfaces (phase 1)"
+./target/doublezero device interface create la2-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create la2-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ny5-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ny5-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ld4-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ld4-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ams-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create ams-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+
+# ── Phase 1 links ─────────────────────────────────────────────────────────────
+
+echo "Creating links (phase 1)"
+./target/doublezero link create wan --code "la2-dz01:ny5-dz01" --contributor co01 \
+    --side-a la2-dz01 --side-a-interface Switch1/1/1 \
+    --side-z ny5-dz01 --side-z-interface Switch1/1/2 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 40 --jitter-ms 3 \
+    --desired-status activated -w
+./target/doublezero link create wan --code "ny5-dz01:ld4-dz01" --contributor co01 \
+    --side-a ny5-dz01 --side-a-interface Switch1/1/1 \
+    --side-z ld4-dz01 --side-z-interface Switch1/1/2 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 30 --jitter-ms 3 \
+    --desired-status activated -w
+./target/doublezero link create wan --code "ld4-dz01:ams-dz01" --contributor co01 \
+    --side-a ld4-dz01 --side-a-interface Switch1/1/1 \
+    --side-z ams-dz01 --side-z-interface Switch1/1/2 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 10 --jitter-ms 2 \
+    --desired-status activated -w
+
+# ── Multicast groups ──────────────────────────────────────────────────────────
+
+echo "Creating multicast groups"
+./target/doublezero multicast group create --code mg01 --max-bandwidth 1Gbps --owner me -w
+./target/doublezero multicast group create --code mg02 --max-bandwidth 1Gbps --owner me -w
+
+# ── Phase 1 access passes (legacy — no Permission account needed) ─────────────
+
+echo "Phase 1 access passes (legacy path via foundation allowlist)"
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 100.0.0.5 --tenant acme
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 100.0.0.6 --tenant acme
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 177.54.159.95 --tenant corp
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 147.28.171.51 --tenant corp
+
+# ── Phase 1 users ─────────────────────────────────────────────────────────────
+
+echo "Phase 1 users (legacy path)"
+./target/doublezero user create --device ld4-dz01 --client-ip 177.54.159.95 --tenant corp -w
+./target/doublezero user create --device ld4-dz01 --client-ip 147.28.171.51 --tenant corp -w
+
+./target/doublezero multicast group allowlist subscriber add --code mg01 --user-payer me --client-ip 100.0.0.5
+./target/doublezero multicast group allowlist publisher  add --code mg01 --user-payer me --client-ip 100.0.0.6
+./target/doublezero user create-subscribe --device la2-dz01 --client-ip 100.0.0.5 --subscriber mg01 -w
+./target/doublezero user create-subscribe --device la2-dz01 --client-ip 100.0.0.6 --publisher mg01 -w
+
+echo "Phase 1 complete — listing accounts"
+./target/doublezero device list
+./target/doublezero link list
+./target/doublezero access-pass list
+./target/doublezero user list
+
+# ════════════════════════════════════════════════════════════════════════════
+# PHASE 2 — Switch to Permission account model
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "###################################################################"
+echo "# PHASE 2: Enabling require-permission-accounts"
+echo "###################################################################"
+
+# Enable the flag.  From this point, the legacy path is blocked for all
+# instructions that use authorize() (access-pass, user delete, permissions).
+# Processors that still check foundation_allowlist directly (device, link,
+# contributor, etc.) continue to work — the flag only enforces the new model
+# for instructions already migrated to authorize().
+./target/doublezero global-config feature-flags set --enable require-permission-accounts
+./target/doublezero global-config feature-flags get
+
+# Bootstrap the payer's Permission account.
+# Foundation members retain access to permission management even in strict
+# mode (PERMISSION_ADMIN bootstrap exception in authorize.rs), so this works
+# without a pre-existing Permission account.
+echo "Creating Permission account for payer"
+./target/doublezero permission set --user-payer "$PAYER" \
+    --add permission-admin \
+    --add access-pass-admin \
+    --add user-admin \
+    --add network-admin \
+    --add infra-admin \
+    --add contributor-admin \
+    --add tenant-admin \
+    --add multicast-admin
+
+./target/doublezero permission get --user-payer "$PAYER"
+./target/doublezero permission list
+
+# ── Phase 2 locations & exchanges ────────────────────────────────────────────
+
+echo "Phase 2: adding more locations and exchanges"
+./target/doublezero location create --code pit --name "Pittsburgh" --country US --lat 40.45119259881935 --lng -80.00498215509094
+
+./target/doublezero exchange create --code xpit --name "Pittsburgh" --lat 40.45119259881935 --lng -80.00498215509094
+
+# ── Phase 2 contributor ───────────────────────────────────────────────────────
+
+echo "Phase 2: creating contributor co03"
+./target/doublezero contributor create --code co03 --owner me
+
+# ── Phase 2 devices ───────────────────────────────────────────────────────────
+
+echo "Phase 2: creating devices (permission-account mode)"
+./target/doublezero device create --code fra-dz01 --contributor co02 --location fra --exchange xfra \
+    --public-ip "195.219.220.88" --dz-prefixes "104.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code sin-dz01 --contributor co02 --location sin --exchange xsin \
+    --public-ip "180.87.102.104" --dz-prefixes "105.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code tyo-dz01 --contributor co02 --location tyo --exchange xtyo \
+    --public-ip "180.87.154.112" --dz-prefixes "106.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+./target/doublezero device create --code pit-dz01 --contributor co03 --location pit --exchange xpit \
+    --public-ip "204.16.241.243" --dz-prefixes "107.0.0.0/16" \
+    --metrics-publisher 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB --mgmt-vrf mgmt \
+    --desired-status activated -w
+
+./target/doublezero device update --pubkey fra-dz01 --max-users 128
+./target/doublezero device update --pubkey sin-dz01 --max-users 128
+./target/doublezero device update --pubkey tyo-dz01 --max-users 128
+./target/doublezero device update --pubkey pit-dz01 --max-users 128
+
+# ── Phase 2 interfaces ────────────────────────────────────────────────────────
+
+echo "Phase 2: creating device interfaces"
+./target/doublezero device interface create fra-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create fra-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create sin-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create sin-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create tyo-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create tyo-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create pit-dz01 "Switch1/1/1" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+./target/doublezero device interface create pit-dz01 "Switch1/1/2" --bandwidth "10 Gbps" --cir "10 Gbps" --mtu 1500 --routing-mode static -w
+
+# ── Phase 2 links ─────────────────────────────────────────────────────────────
+
+echo "Phase 2: creating links"
+./target/doublezero link create wan --code "ams-dz01:fra-dz01" --contributor co01 \
+    --side-a ams-dz01 --side-a-interface Switch1/1/2 \
+    --side-z fra-dz01 --side-z-interface Switch1/1/1 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 8 --jitter-ms 1 \
+    --desired-status activated -w
+./target/doublezero link create wan --code "fra-dz01:sin-dz01" --contributor co02 \
+    --side-a fra-dz01 --side-a-interface Switch1/1/2 \
+    --side-z sin-dz01 --side-z-interface Switch1/1/1 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 150 --jitter-ms 10 \
+    --desired-status activated -w
+./target/doublezero link create wan --code "sin-dz01:tyo-dz01" --contributor co02 \
+    --side-a sin-dz01 --side-a-interface Switch1/1/2 \
+    --side-z tyo-dz01 --side-z-interface Switch1/1/1 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 70 --jitter-ms 5 \
+    --desired-status activated -w
+./target/doublezero link create wan --code "la2-dz01:pit-dz01" --contributor co03 \
+    --side-a la2-dz01 --side-a-interface Switch1/1/2 \
+    --side-z pit-dz01 --side-z-interface Switch1/1/1 \
+    --bandwidth "10 Gbps" --mtu 9000 --delay-ms 50 --jitter-ms 4 \
+    --desired-status activated -w
+
+# ── Phase 2 access passes (new path — Permission account used) ────────────────
+
+echo "Phase 2 access passes (permission-account path)"
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 200.0.0.1
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 200.0.0.2
+./target/doublezero access-pass set --accesspass-type prepaid --user-payer me --client-ip 200.0.0.3 --tenant acme
+
+# ── Phase 2 users ─────────────────────────────────────────────────────────────
+
+echo "Phase 2 users (permission-account path)"
+./target/doublezero user create --device fra-dz01 --client-ip 200.0.0.1 -w
+./target/doublezero user create --device sin-dz01 --client-ip 200.0.0.2 -w
+./target/doublezero user create --device tyo-dz01 --client-ip 200.0.0.3 --tenant acme -w
+
+# ── Permission management validation ─────────────────────────────────────────
+
+echo "Phase 2: permission management"
+SECOND_PUBKEY=testGjWJiksK7wdGmH7ZZsaqRGU695LHgvjRd6jfHYF
+
+./target/doublezero permission set --user-payer "$SECOND_PUBKEY" \
+    --add network-admin \
+    --add infra-admin
+
+./target/doublezero permission set --user-payer "$SECOND_PUBKEY" --add user-admin
+./target/doublezero permission set --user-payer "$SECOND_PUBKEY" --remove infra-admin
+./target/doublezero permission get --user-payer "$SECOND_PUBKEY"
+
+./target/doublezero permission suspend --user-payer "$SECOND_PUBKEY"
+./target/doublezero permission get --user-payer "$SECOND_PUBKEY"
+
+./target/doublezero permission resume --user-payer "$SECOND_PUBKEY"
+./target/doublezero permission get --user-payer "$SECOND_PUBKEY"
+
+# ── Final state ───────────────────────────────────────────────────────────────
+
+echo "Final state"
+./target/doublezero device list
+./target/doublezero link list
+./target/doublezero access-pass list
+./target/doublezero user list
+./target/doublezero permission list
+
+echo "########################################################################"
+echo "Phase 1 (legacy) + Phase 2 (permission accounts) — validation complete"


### PR DESCRIPTION
Solves: https://github.com/malbeclabs/doublezero/issues/1528 & https://github.com/malbeclabs/doublezero/issues/3183

The migration process consists of first creating the Permission accounts, which define the access for each user/payer. Then, permissions are created for the existing allowlists. Finally, once everything has been properly configured under the new model, the legacy allowlists system is disabled.

## Summary of Changes
- Add `Permission` onchain account (type 15) with a 128-bit permission bitmask and full CRUD instructions: `CreatePermission`, `UpdatePermission`, `DeletePermission`, `SuspendPermission`, `ResumePermission`
- Add `authorize()` helper in `authorize.rs` that reads the last account of an instruction as the signer's Permission PDA and validates the required flag; wire it into `accesspass/set`, `accesspass/close`, `user/ban`, `user/closeaccount`, `user/delete`, `user/requestban`, and all Permission processors
- Split Rust SDK's `execute_transaction` into `execute_transaction` (no auth, no PDA injection) and `execute_authorized_transaction` (injects Permission PDA when the account exists); this prevents breaking processors that use `accounts.len()` for optional-account detection
- Add `permission set/get/list/suspend/resume/delete` subcommands to both `doublezero` and `doublezero-admin` CLIs; `permission set` supports incremental `--add` / `--remove` flags over an existing bitmask and creates the account when it does not exist yet
- Add Permission state, deserialization, PDA derivation, and `GetProgramData` support to all three read-only SDKs (Go, Python, TypeScript)
- Add Permission support to the Go transaction executor (`smartcontract/sdk/go/serviceability`): checks once on-chain whether a Permission account exists for the signer and, if so, appends it to every instruction

## Diff Breakdown
| Category       | Files | Lines (+/-)     | Net    |
|----------------|-------|-----------------|--------|
| Core logic     |    37 | +2740 / -115    | +2625  |
| Scaffolding    |    18 | +1181 / -4      | +1177  |
| Tests          |     4 | +917 / 0        | +917   |
| Docs           |     2 | +243 / 0        | +243   |

Heavy on core logic: roughly half the new lines are the onchain program (authorize helper, Permission state, 5 CRUD processors), the rest are SDK plumbing across Rust/Go/Python/TypeScript plus CLI commands.

<details>
<summary>Key files (click to expand)</summary>

- [`smartcontract/programs/doublezero-serviceability/src/authorize.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-9c5dc3e319047894761a18ec2bdd0b82481a00140fac6cdfb9cb7488ab1256df) — `authorize()` helper + exhaustive unit tests for every permission flag and status combination
- [`smartcontract/programs/doublezero-serviceability/tests/permission_test.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-02db3431a833380ea76fee26832ec8b22f32fb4164371e0721e8f6d43d2b7c78) — integration tests covering all five Permission instructions and error paths
- [`smartcontract/cli/src/permission/set.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-23cfdb288180ab4efe3c6f2bd036cd5f13fe3c4461d807e205c6441bc88130cb) — `permission set` CLI: incremental `--add`/`--remove` flags, creates account if absent, validates bitmask never goes to zero
- [`smartcontract/programs/doublezero-serviceability/src/state/permission.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-9881683e315a684b8b037335221a6058d2280bf3b861418d0b71ed7e277e89ba) — `Permission` struct, `PermissionStatus` enum, and all 15 permission flag constants
- [`smartcontract/sdk/rs/src/client.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-b0decf3341561973c730de1be7d3c81a98ae032c15eb2ca322b39adc624dc7a5) — refactored into `execute_transaction` / `execute_authorized_transaction` via a shared `build_and_send(with_permission: bool)` private helper
- [`smartcontract/programs/doublezero-serviceability/src/processors/permission/create.rs`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-02eb27910d305ba847bd40f33f77c795e95ea50ec8c1e8630b1938f38f24c405) — `CreatePermission` processor: requires `PERMISSION_ADMIN` or `FOUNDATION` flag, validates non-zero bitmask, allocates PDA
- [`smartcontract/sdk/go/serviceability/executor.go`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-7be6c1e59c995ffb57df9bcf3926738f52220f83f5b4e4747fc0dd2d993d1bc8) — Go executor: `resolvePermissionPDA` (lazy, `sync.Once`) appends the Permission PDA to every instruction when the account exists
- [`smartcontract/test/start-test-permissions.sh`](https://github.com/malbeclabs/doublezero/pull/3186/files#diff-f87f253ca043903562072b50971d2e6511e8b90e136e908c1c79103c8fa583c7) — end-to-end devnet test script exercising the full permission lifecycle

</details>

## Testing Verification
- E2E tests run unchanged under the legacy permissions model.
- Rust integration tests in `tests/permission_test.rs` cover all five Permission instructions, authorization enforcement for each flag, suspend/resume state transitions, and rejection of invalid inputs
- `authorize.rs` contains exhaustive unit tests for every permission flag and every `PermissionStatus` variant
- Go executor tests verify permission PDA injection when the account exists, no injection when absent, and that the on-chain lookup happens exactly once (`sync.Once`)
- `start-test-permissions.sh` exercises the full lifecycle (create, update, get, list, suspend, resume, delete) against a local devnet with multiple permission holders