### PR TITLE
release: add goreleaser config and workflows for geoprobe-agent

### DIFF
--- a/.github/workflows/release.geoprobe-agent.yml
+++ b/.github/workflows/release.geoprobe-agent.yml
@@ -1,0 +1,37 @@
+name: releaser.geoprobe-agent
+
+on:
+  push:
+    tags:
+      - "geoprobe-agent/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.testnet.geoprobe-agent.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/.github/workflows/release.testnet.push.tags.components.yml
+++ b/.github/workflows/release.testnet.push.tags.components.yml
@@ -22,6 +22,7 @@ jobs:
           - internet-latency-collector
           - agent
           - device-telemetry-agent
+          - geoprobe-agent
           - funder
           - monitor
           - client

--- a/release/.goreleaser.base.geoprobe-agent.yaml
+++ b/release/.goreleaser.base.geoprobe-agent.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: doublezero-geoprobe-agent
+
+monorepo:
+  tag_prefix: geoprobe-agent/
+  dir: controlplane/telemetry
+
+builds:
+  - id: doublezero-geoprobe-agent
+    main: cmd/geoprobe-agent/main.go
+    binary: doublezero-geoprobe-agent
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - id: geoprobe_agent_archive
+    formats: ['tar.gz']
+    ids: [doublezero-geoprobe-agent]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+nfpms:
+  - id: doublezero-geoprobe-agent
+    package_name: doublezero-geoprobe-agent
+    ids: [doublezero-geoprobe-agent]
+    vendor: doublezero
+    homepage: doublezero.xyz
+    maintainer: nik <nik@malbeclabs.com>
+    description: |-
+      DoubleZero geoprobe agent for network geolocation measurements
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    release: "1"
+    section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-geoprobe-agent.service
+        dst: /lib/systemd/system/doublezero-geoprobe-agent.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-geoprobe-agent.service
+            dst: /usr/lib/systemd/system/doublezero-geoprobe-agent.service
+            type: config
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: malbeclabs
+    name: doublezero
+  draft: false
+  replace_existing_artifacts: true
+
+announce:
+  slack:
+    enabled: true
+    message_template: "DoubleZero Geoprobe Agent {{.Tag}} has been released! Check it out at {{ .ReleaseURL }}"
+    channel: "#bots"
+
+git:
+  ignore_tags:
+    - geoprobe-agent/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
+  tag_name: 'geoprobe-agent/daily'

--- a/release/.goreleaser.devnet.geoprobe-agent.yaml
+++ b/release/.goreleaser.devnet.geoprobe-agent.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geoprobe-agent.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.geoprobe-agent.yaml
+++ b/release/.goreleaser.testnet.geoprobe-agent.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geoprobe-agent.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-geoprobe-agent.service
+++ b/release/packaging/systemd/doublezero-geoprobe-agent.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the geoprobe agent with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-geoprobe-agent.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Geoprobe Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-geoprobe-agent
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary of Changes
* Add goreleaser base, devnet, and testnet configs for geoprobe-agent binary packaging (deb + rpm)
* Add systemd placeholder service file for nfpm packaging
* Add tag-triggered GitHub Actions release workflow for testnet releases
* Add geoprobe-agent to the testnet tag push component matrix
* Devnet daily workflows intentionally deferred pending Ansible playbook in malbeclabs/infra
* Fixes #3207

## Testing Verification
* Tested package build and deployment by hand
