### PR TITLE
liveness: fix flaky soft-loss fault test after interval increase

### DIFF
--- a/client/doublezerod/internal/liveness/faults_test.go
+++ b/client/doublezerod/internal/liveness/faults_test.go
@@ -21,9 +21,9 @@ var (
 	txMinFlag      = flag.Duration("tx-min", 1*time.Second, "tx min")
 	rxMinFlag      = flag.Duration("rx-min", 1*time.Second, "rx min")
 	detectMultFlag = flag.Uint("detect-mult", 3, "detect mult")
-	backoffMaxFlag = flag.Duration("backoff-max", 1*time.Second, "backoff max")
+	backoffMaxFlag = flag.Duration("backoff-max", 3*time.Second, "backoff max")
 
-	stableDurationFlag  = flag.Duration("stable-duration", 2*time.Second, "stable duration")
+	stableDurationFlag  = flag.Duration("stable-duration", 7*time.Second, "stable duration")
 	bgpFlapCyclesFlag   = flag.Uint("bgp-flap-cycles", 3, "number of BGP flap cycles")
 	softLossPctFlag     = flag.Float64("soft-loss-pct", 0.01, "soft loss percentage")
 	softLossCyclesFlag  = flag.Int("soft-loss-cycles", 3, "number of soft-loss windows to run")


### PR DESCRIPTION
## Summary of Changes
- PR #3174 increased liveness tx/rx intervals from 300ms to 1s (detectTime: 900ms → 3s) but left `backoffMaxFlag` at 1s and `stableDurationFlag` at 2s, causing `TestClient_Liveness_Faults_SoftLoss_TimeoutAtHighLoss` to fail intermittently under CI load
- Bump `backoffMaxFlag` from 1s → 3s and `stableDurationFlag` from 2s → 7s to restore proportional headroom relative to the new detect time

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Tests    |     1 | +2 / -2     |   0 |

Two constant changes in test configuration flags.

<details>
<summary>Key files (click to expand)</summary>

- `client/doublezerod/internal/liveness/faults_test.go` — adjust backoffMax and stableDuration test flags to match the 1s interval introduced in #3174

</details>

## Testing Verification
- `TestClient_Liveness_Faults_SoftLoss_TimeoutAtHighLoss` passes 3/3 runs with `-race -count=3`
- All 5 `TestClient_Liveness_Faults_*` tests pass
