### PR TITLE
telemetry/geoprobe: use per-probe TWAMP port and change geoprobe default from 862 to 8925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - Suppress noisy program log output from race conditions caused by dual event processing (websocket + snapshot poll). The SDK's new `execute_transaction_quiet` returns a `SimulationError` with program logs; the activator verifies suspected races by re-fetching user state before deciding whether to print logs ([#3197](https://github.com/malbeclabs/doublezero/pull/3197))
 - Telemetry
   - Fix race condition in internet-latency-collector where export and management goroutines independently loaded/saved the same state file, causing newly created RIPE Atlas measurement metadata to be overwritten and measurements to be stuck in a create-destroy-create loop ([#3195](https://github.com/malbeclabs/doublezero/pull/3195))
+  - Change geoprobe-agent and geoprobe-target default TWAMP reflector port from 862 to 8925 to avoid DZD ACL blocks, use per-probe TWAMP port instead of hardcoded constant, and update `--additional-child-probes`/`--additional-targets` format to `host` or `host:offset_port:twamp_port` (two-field `host:port` rejected as ambiguous)
 - CLI
   - Add `doublezero-geolocation` CLI for managing geolocation program entities: GeoProbe CRUD (create, get, list, update, delete), parent device management (add/remove), program config initialization, and geolocation-specific config get/set
 - SDK

--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultTWAMPListenPort       = 862
+	defaultTWAMPListenPort       = 8925
 	defaultSignedTWAMPListenPort = 8924
 	defaultUDPListenPort         = 8923
 	defaultProbeInterval         = 5 * time.Minute
@@ -42,7 +42,7 @@ var (
 	keypairPath           = flag.String("keypair", "", "The path to the probe's Ed25519 keypair file for signing messages.")
 	geoProbePubkeyStr     = flag.String("geoprobe-pubkey", "", "The geoprobe device's public key (base58). Identifies this specific probe in offsets. Should Match DZ Ledger")
 	additionalParent      = flag.String("additional-parent", "", "Trusted parent DZD in the format devicekey,metricskey (base58 pubkeys).")
-	additionalTargets     = flag.String("additional-targets", "", "Comma-separated list of target addresses (host:port) to measure and send composite offsets.")
+	additionalTargets     = flag.String("additional-targets", "", "Comma-separated list of target addresses (host or host:offset_port:twamp_port) to measure and send composite offsets.")
 	twampListenPort       = flag.Uint("twamp-listen-port", defaultTWAMPListenPort, "Port for TWAMP reflector.")
 	signedTWAMPListenPort = flag.Uint("signed-twamp-port", defaultSignedTWAMPListenPort, "Port for Signed TWAMP reflector for inbound probing.")
 	allowedPubkeysFlag    = flag.String("allowed-pubkeys", "", "Comma-separated base58 Ed25519 pubkeys always authorized for signed TWAMP probes in inbound probing.")

--- a/controlplane/telemetry/cmd/geoprobe-target/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultTWAMPPort         = 862
+	defaultTWAMPPort         = 8925
 	defaultUDPPort           = 8923
 	defaultTWAMPTimeout      = 1 * time.Second
 	defaultRateLimit         = 10

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -85,7 +85,7 @@ var (
 	gnmiTunnelServerAddr = flag.String("gnmi-tunnel-server-addr", "", "Address of the gNMI tunnel server (defaults to env config, e.g., gnmic-devnet.doublezero.xyz:443).")
 
 	// geoprobe flags
-	additionalChildProbes = flag.String("additional-child-probes", "", "Comma-separated list of child geoProbe addresses (host:port) to measure RTT and send location offsets.")
+	additionalChildProbes = flag.String("additional-child-probes", "", "Comma-separated list of child geoProbe addresses (host or host:offset_port:twamp_port) to measure RTT and send location offsets.")
 
 	// Set by LDFLAGS
 	version = "dev"

--- a/controlplane/telemetry/internal/geoprobe/address.go
+++ b/controlplane/telemetry/internal/geoprobe/address.go
@@ -5,16 +5,19 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 )
 
 // ProbeAddress represents a child geoProbe's network address.
 type ProbeAddress struct {
-	Host string
-	Port uint16
+	Host      string
+	Port      uint16 // UDP offset port (used by Publisher)
+	TWAMPPort uint16 // TWAMP reflector port (used by Pinger)
 }
 
 func (p ProbeAddress) String() string {
-	return fmt.Sprintf("%s:%d", p.Host, p.Port)
+	return fmt.Sprintf("%s:%d:%d", p.Host, p.Port, p.TWAMPPort)
 }
 
 // Validate checks if the ProbeAddress has valid Host and Port values.
@@ -28,10 +31,15 @@ func (p ProbeAddress) Validate() error {
 	if p.Port == 0 {
 		return fmt.Errorf("port cannot be zero")
 	}
+	if p.TWAMPPort == 0 {
+		return fmt.Errorf("twamp port cannot be zero")
+	}
 	return nil
 }
 
-// ParseProbeAddresses parses a comma-separated list of host:port values.
+// ParseProbeAddresses parses a comma-separated list of probe addresses.
+// Each entry is either host (default ports) or host:offset_port:twamp_port
+// (both explicit). Two-field format (host:port) is rejected as ambiguous.
 func ParseProbeAddresses(s string) ([]ProbeAddress, error) {
 	if s == "" {
 		return nil, nil
@@ -47,20 +55,45 @@ func ParseProbeAddresses(s string) ([]ProbeAddress, error) {
 			continue
 		}
 
-		host, portStr, err := net.SplitHostPort(part)
-		if err != nil {
-			return nil, fmt.Errorf("invalid probe address %q: %w", part, err)
-		}
+		fields := strings.Split(part, ":")
+		var addr ProbeAddress
 
-		port, err := strconv.ParseUint(portStr, 10, 16)
-		if err != nil {
-			return nil, fmt.Errorf("invalid port in %q: %w", part, err)
-		}
-		if port == 0 {
-			return nil, fmt.Errorf("invalid port 0 in %q", part)
-		}
+		switch len(fields) {
+		case 1:
+			host := fields[0]
+			if net.ParseIP(host) == nil {
+				return nil, fmt.Errorf("invalid probe address %q: invalid IP address", part)
+			}
+			addr = ProbeAddress{
+				Host:      host,
+				Port:      telemetryconfig.DefaultGeoprobeUDPPort,
+				TWAMPPort: telemetryconfig.DefaultGeoprobeTWAMPPort,
+			}
 
-		addr := ProbeAddress{Host: host, Port: uint16(port)}
+		case 3:
+			host := fields[0]
+			if net.ParseIP(host) == nil {
+				return nil, fmt.Errorf("invalid probe address %q: invalid IP address", part)
+			}
+			port, err := strconv.ParseUint(fields[1], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid port in %q: %w", part, err)
+			}
+			if port == 0 {
+				return nil, fmt.Errorf("invalid port 0 in %q", part)
+			}
+			twampPort, err := strconv.ParseUint(fields[2], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid twamp port in %q: %w", part, err)
+			}
+			if twampPort == 0 {
+				return nil, fmt.Errorf("invalid twamp port 0 in %q", part)
+			}
+			addr = ProbeAddress{Host: host, Port: uint16(port), TWAMPPort: uint16(twampPort)}
+
+		default:
+			return nil, fmt.Errorf("invalid probe address %q: expected host or host:offset_port:twamp_port", part)
+		}
 
 		// Deduplicate
 		key := addr.String()

--- a/controlplane/telemetry/internal/geoprobe/address_test.go
+++ b/controlplane/telemetry/internal/geoprobe/address_test.go
@@ -15,42 +15,56 @@ func TestProbeAddress_Validate(t *testing.T) {
 		{
 			name: "Valid IP address",
 			addr: ProbeAddress{
-				Host: "192.0.2.1",
-				Port: 10000,
+				Host:      "192.0.2.1",
+				Port:      10000,
+				TWAMPPort: 8925,
 			},
 			wantErr: "",
 		},
 		{
 			name: "Empty host",
 			addr: ProbeAddress{
-				Host: "",
-				Port: 10000,
+				Host:      "",
+				Port:      10000,
+				TWAMPPort: 8925,
 			},
 			wantErr: "host cannot be empty",
 		},
 		{
 			name: "Zero port",
 			addr: ProbeAddress{
-				Host: "192.0.2.1",
-				Port: 0,
+				Host:      "192.0.2.1",
+				Port:      0,
+				TWAMPPort: 8925,
 			},
 			wantErr: "port cannot be zero",
 		},
 		{
 			name: "Another valid IP",
 			addr: ProbeAddress{
-				Host: "8.8.8.8",
-				Port: 12345,
+				Host:      "8.8.8.8",
+				Port:      12345,
+				TWAMPPort: 8925,
 			},
 			wantErr: "",
 		},
 		{
 			name: "Hostname rejected",
 			addr: ProbeAddress{
-				Host: "probe1.example.com",
-				Port: 10000,
+				Host:      "probe1.example.com",
+				Port:      10000,
+				TWAMPPort: 8925,
 			},
 			wantErr: "host must be a valid IP address",
+		},
+		{
+			name: "Zero twamp port",
+			addr: ProbeAddress{
+				Host:      "192.0.2.1",
+				Port:      10000,
+				TWAMPPort: 0,
+			},
+			wantErr: "twamp port cannot be zero",
 		},
 	}
 
@@ -79,34 +93,54 @@ func TestParseProbeAddresses(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name:      "Single public IP",
-			input:     "8.8.8.8:53",
+			name:      "Single host only",
+			input:     "8.8.8.8",
 			wantCount: 1,
 		},
 		{
-			name:      "Multiple public IPs",
-			input:     "8.8.8.8:53,1.1.1.1:53",
+			name:      "Multiple hosts only",
+			input:     "8.8.8.8,1.1.1.1",
 			wantCount: 2,
 		},
 		{
-			name:       "Invalid format",
+			name:       "Invalid host",
 			input:      "invalid",
 			wantErrMsg: "invalid probe address",
 		},
 		{
-			name:       "Invalid port",
-			input:      "8.8.8.8:invalid",
-			wantErrMsg: "invalid port",
+			name:       "Two-field format rejected",
+			input:      "8.8.8.8:53",
+			wantErrMsg: "invalid probe address",
 		},
 		{
 			name:      "Deduplication",
-			input:     "8.8.8.8:53,8.8.8.8:53",
+			input:     "8.8.8.8,8.8.8.8",
 			wantCount: 1,
 		},
 		{
 			name:      "Whitespace handling",
-			input:     " 8.8.8.8:53 , 1.1.1.1:53 ",
+			input:     " 8.8.8.8 , 1.1.1.1 ",
 			wantCount: 2,
+		},
+		{
+			name:      "Three-field format",
+			input:     "8.8.8.8:53:8925",
+			wantCount: 1,
+		},
+		{
+			name:      "Mixed one and three field formats",
+			input:     "8.8.8.8,1.1.1.1:53:9000",
+			wantCount: 2,
+		},
+		{
+			name:       "Invalid twamp port",
+			input:      "8.8.8.8:53:invalid",
+			wantErrMsg: "invalid twamp port",
+		},
+		{
+			name:       "Too many fields",
+			input:      "8.8.8.8:53:8925:extra",
+			wantErrMsg: "invalid probe address",
 		},
 	}
 
@@ -122,4 +156,24 @@ func TestParseProbeAddresses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseProbeAddresses_Values(t *testing.T) {
+	t.Run("host-only format uses default ports", func(t *testing.T) {
+		addrs, err := ParseProbeAddresses("10.0.0.1")
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+		require.Equal(t, "10.0.0.1", addrs[0].Host)
+		require.Equal(t, uint16(8923), addrs[0].Port)
+		require.Equal(t, uint16(8925), addrs[0].TWAMPPort)
+	})
+
+	t.Run("three-field format uses explicit ports", func(t *testing.T) {
+		addrs, err := ParseProbeAddresses("10.0.0.1:8923:9000")
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+		require.Equal(t, "10.0.0.1", addrs[0].Host)
+		require.Equal(t, uint16(8923), addrs[0].Port)
+		require.Equal(t, uint16(9000), addrs[0].TWAMPPort)
+	})
 }

--- a/controlplane/telemetry/internal/geoprobe/coordinator_test.go
+++ b/controlplane/telemetry/internal/geoprobe/coordinator_test.go
@@ -56,8 +56,8 @@ func TestNewCoordinator_WithInitialProbes(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 
 	coordinator, err := NewCoordinator(cfg)
@@ -112,15 +112,15 @@ func TestCoordinator_HandleProbeUpdate_Add(t *testing.T) {
 
 	ctx := context.Background()
 	newProbes := []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 
 	coordinator.handleProbeUpdate(ctx, newProbes)
 
 	assert.Len(t, coordinator.probes, 2)
-	assert.Contains(t, coordinator.probes, "127.0.0.1:12345")
-	assert.Contains(t, coordinator.probes, "192.0.2.1:12346")
+	assert.Contains(t, coordinator.probes, "127.0.0.1:12345:8925")
+	assert.Contains(t, coordinator.probes, "192.0.2.1:12346:8925")
 }
 
 func TestCoordinator_HandleProbeUpdate_Remove(t *testing.T) {
@@ -128,8 +128,8 @@ func TestCoordinator_HandleProbeUpdate_Remove(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -138,14 +138,14 @@ func TestCoordinator_HandleProbeUpdate_Remove(t *testing.T) {
 
 	ctx := context.Background()
 	newProbes := []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
 	}
 
 	coordinator.handleProbeUpdate(ctx, newProbes)
 
 	assert.Len(t, coordinator.probes, 1)
-	assert.Contains(t, coordinator.probes, "127.0.0.1:12345")
-	assert.NotContains(t, coordinator.probes, "192.0.2.1:12346")
+	assert.Contains(t, coordinator.probes, "127.0.0.1:12345:8925")
+	assert.NotContains(t, coordinator.probes, "192.0.2.1:12346:8925")
 }
 
 func TestCoordinator_HandleProbeUpdate_Mixed(t *testing.T) {
@@ -153,8 +153,8 @@ func TestCoordinator_HandleProbeUpdate_Mixed(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -163,16 +163,16 @@ func TestCoordinator_HandleProbeUpdate_Mixed(t *testing.T) {
 
 	ctx := context.Background()
 	newProbes := []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "198.51.100.1", Port: 12347},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "198.51.100.1", Port: 12347, TWAMPPort: 8925},
 	}
 
 	coordinator.handleProbeUpdate(ctx, newProbes)
 
 	assert.Len(t, coordinator.probes, 2)
-	assert.Contains(t, coordinator.probes, "127.0.0.1:12345")
-	assert.Contains(t, coordinator.probes, "198.51.100.1:12347")
-	assert.NotContains(t, coordinator.probes, "192.0.2.1:12346")
+	assert.Contains(t, coordinator.probes, "127.0.0.1:12345:8925")
+	assert.Contains(t, coordinator.probes, "198.51.100.1:12347:8925")
+	assert.NotContains(t, coordinator.probes, "192.0.2.1:12346:8925")
 }
 
 func TestCoordinator_HandleProbeUpdate_Empty(t *testing.T) {
@@ -180,8 +180,8 @@ func TestCoordinator_HandleProbeUpdate_Empty(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestCoordinator_RunMeasurementCycle_WithProbes(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestCoordinator_Run_ProbeUpdates(t *testing.T) {
 	defer cancel()
 
 	newProbes := []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
 	}
 	cfg.ProbeUpdateCh <- newProbes
 
@@ -266,7 +266,7 @@ func TestCoordinator_Run_ProbeUpdates(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, coordinator.probes, 1)
-	assert.Contains(t, coordinator.probes, "127.0.0.1:12345")
+	assert.Contains(t, coordinator.probes, "127.0.0.1:12345:8925")
 }
 
 func TestCoordinator_Run_ProbeUpdateChannelClosed(t *testing.T) {
@@ -293,7 +293,7 @@ func TestCoordinator_Run_MeasurementCycles(t *testing.T) {
 	cfg := newTestCoordinatorConfig()
 	cfg.Interval = 20 * time.Millisecond
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -311,8 +311,8 @@ func TestCoordinator_Close(t *testing.T) {
 
 	cfg := newTestCoordinatorConfig()
 	cfg.InitialProbes = []ProbeAddress{
-		{Host: "127.0.0.1", Port: 12345},
-		{Host: "192.0.2.1", Port: 12346},
+		{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+		{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 	}
 	coordinator, err := NewCoordinator(cfg)
 	require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestCoordinator_Concurrent_HandleProbeUpdate(t *testing.T) {
 	go func() {
 		for i := 0; i < 10; i++ {
 			newProbes := []ProbeAddress{
-				{Host: "127.0.0.1", Port: uint16(12345 + i)},
+				{Host: "127.0.0.1", Port: uint16(12345 + i), TWAMPPort: 8925},
 			}
 			coordinator.handleProbeUpdate(ctx, newProbes)
 			time.Sleep(5 * time.Millisecond)
@@ -386,18 +386,18 @@ func TestCoordinator_Run_MultipleProbeUpdates(t *testing.T) {
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		cfg.ProbeUpdateCh <- []ProbeAddress{
-			{Host: "127.0.0.1", Port: 12345},
+			{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
 		}
 
 		time.Sleep(20 * time.Millisecond)
 		cfg.ProbeUpdateCh <- []ProbeAddress{
-			{Host: "127.0.0.1", Port: 12345},
-			{Host: "192.0.2.1", Port: 12346},
+			{Host: "127.0.0.1", Port: 12345, TWAMPPort: 8925},
+			{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 		}
 
 		time.Sleep(20 * time.Millisecond)
 		cfg.ProbeUpdateCh <- []ProbeAddress{
-			{Host: "192.0.2.1", Port: 12346},
+			{Host: "192.0.2.1", Port: 12346, TWAMPPort: 8925},
 		}
 	}()
 
@@ -405,5 +405,5 @@ func TestCoordinator_Run_MultipleProbeUpdates(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, coordinator.probes, 1)
-	assert.Contains(t, coordinator.probes, "192.0.2.1:12346")
+	assert.Contains(t, coordinator.probes, "192.0.2.1:12346:8925")
 }

--- a/controlplane/telemetry/internal/geoprobe/pinger.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 	twamplight "github.com/malbeclabs/doublezero/tools/twamp/pkg/light"
 )
 
@@ -61,7 +60,7 @@ func (p *Pinger) AddProbe(ctx context.Context, addr ProbeAddress) error {
 		return fmt.Errorf("invalid probe address %s: %w", key, err)
 	}
 
-	resolvedAddr := &net.UDPAddr{IP: net.ParseIP(addr.Host), Port: telemetryconfig.TWAMPListenPort}
+	resolvedAddr := &net.UDPAddr{IP: net.ParseIP(addr.Host), Port: int(addr.TWAMPPort)}
 
 	sourceAddr := &net.UDPAddr{
 		IP:   net.IPv4zero,

--- a/controlplane/telemetry/internal/geoprobe/pinger_test.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger_test.go
@@ -47,8 +47,9 @@ func TestPinger_AddProbe(t *testing.T) {
 	ctx := context.Background()
 
 	addr := ProbeAddress{
-		Host: "127.0.0.1",
-		Port: 12345,
+		Host:      "127.0.0.1",
+		Port:      12345,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.AddProbe(ctx, addr)
@@ -76,8 +77,9 @@ func TestPinger_AddProbe_Duplicate(t *testing.T) {
 	ctx := context.Background()
 
 	addr := ProbeAddress{
-		Host: "127.0.0.1",
-		Port: 12346,
+		Host:      "127.0.0.1",
+		Port:      12346,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.AddProbe(ctx, addr)
@@ -114,8 +116,9 @@ func TestPinger_AddProbe_InvalidHost(t *testing.T) {
 	ctx := context.Background()
 
 	addr := ProbeAddress{
-		Host: "not-an-ip",
-		Port: 12347,
+		Host:      "not-an-ip",
+		Port:      12347,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.AddProbe(ctx, addr)
@@ -143,8 +146,9 @@ func TestPinger_RemoveProbe(t *testing.T) {
 	ctx := context.Background()
 
 	addr := ProbeAddress{
-		Host: "127.0.0.1",
-		Port: 12348,
+		Host:      "127.0.0.1",
+		Port:      12348,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.AddProbe(ctx, addr)
@@ -174,8 +178,9 @@ func TestPinger_RemoveProbe_NotFound(t *testing.T) {
 	pinger := NewPinger(cfg)
 
 	addr := ProbeAddress{
-		Host: "192.0.2.1",
-		Port: 12345,
+		Host:      "192.0.2.1",
+		Port:      12345,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.RemoveProbe(addr)
@@ -215,8 +220,9 @@ func TestPinger_MeasureAll_WithContext(t *testing.T) {
 	pinger := NewPinger(cfg)
 
 	addr := ProbeAddress{
-		Host: "127.0.0.1",
-		Port: 12349,
+		Host:      "127.0.0.1",
+		Port:      12349,
+		TWAMPPort: 8925,
 	}
 	err := pinger.AddProbe(context.Background(), addr)
 	require.NoError(t, err)
@@ -243,8 +249,8 @@ func TestPinger_Close(t *testing.T) {
 	pinger := NewPinger(cfg)
 	ctx := context.Background()
 
-	addr1 := ProbeAddress{Host: "127.0.0.1", Port: 12352}
-	addr2 := ProbeAddress{Host: "127.0.0.1", Port: 12353}
+	addr1 := ProbeAddress{Host: "127.0.0.1", Port: 12352, TWAMPPort: 8925}
+	addr2 := ProbeAddress{Host: "127.0.0.1", Port: 12353, TWAMPPort: 8925}
 
 	err := pinger.AddProbe(ctx, addr1)
 	require.NoError(t, err)
@@ -284,8 +290,9 @@ func TestPinger_Concurrent(t *testing.T) {
 			defer wg.Done()
 
 			addr := ProbeAddress{
-				Host: "127.0.0.1",
-				Port: uint16(13000 + id),
+				Host:      "127.0.0.1",
+				Port:      uint16(13000 + id),
+				TWAMPPort: 8925,
 			}
 
 			err := pinger.AddProbe(ctx, addr)
@@ -323,8 +330,9 @@ func TestPinger_AddRemoveSequential(t *testing.T) {
 	ctx := context.Background()
 
 	addr := ProbeAddress{
-		Host: "127.0.0.1",
-		Port: 12354,
+		Host:      "127.0.0.1",
+		Port:      12354,
+		TWAMPPort: 8925,
 	}
 
 	err := pinger.AddProbe(ctx, addr)
@@ -371,8 +379,9 @@ func TestPinger_MeasureAll_ConcurrencyLimit(t *testing.T) {
 	numProbes := 2000
 	for i := 0; i < numProbes; i++ {
 		addr := ProbeAddress{
-			Host: "127.0.0.1",
-			Port: uint16(15000 + i),
+			Host:      "127.0.0.1",
+			Port:      uint16(15000 + i),
+			TWAMPPort: 8925,
 		}
 		err := pinger.AddProbe(ctx, addr)
 		require.NoError(t, err)
@@ -403,9 +412,9 @@ func TestPinger_MeasureAll_AllFailed(t *testing.T) {
 	pinger := NewPinger(cfg)
 	ctx := context.Background()
 
-	addr1 := ProbeAddress{Host: "192.0.2.254", Port: 12345}
-	addr2 := ProbeAddress{Host: "192.0.2.253", Port: 12346}
-	addr3 := ProbeAddress{Host: "192.0.2.252", Port: 12347}
+	addr1 := ProbeAddress{Host: "192.0.2.254", Port: 12345, TWAMPPort: 8925}
+	addr2 := ProbeAddress{Host: "192.0.2.253", Port: 12346, TWAMPPort: 8925}
+	addr3 := ProbeAddress{Host: "192.0.2.252", Port: 12347, TWAMPPort: 8925}
 
 	err := pinger.AddProbe(ctx, addr1)
 	require.NoError(t, err)
@@ -440,8 +449,9 @@ func TestPinger_MeasureAll_LargeScale(t *testing.T) {
 
 	for i := 0; i < numProbes; i++ {
 		addr := ProbeAddress{
-			Host: "127.0.0.1",
-			Port: uint16(20000 + i),
+			Host:      "127.0.0.1",
+			Port:      uint16(20000 + i),
+			TWAMPPort: 8925,
 		}
 		err := pinger.AddProbe(ctx, addr)
 		require.NoError(t, err)
@@ -475,8 +485,9 @@ func TestPinger_MeasureAll_Staggering(t *testing.T) {
 	numProbes := 10
 	for i := 0; i < numProbes; i++ {
 		addr := ProbeAddress{
-			Host: "127.0.0.1",
-			Port: uint16(25000 + i),
+			Host:      "127.0.0.1",
+			Port:      uint16(25000 + i),
+			TWAMPPort: 8925,
 		}
 		err := pinger.AddProbe(ctx, addr)
 		require.NoError(t, err)
@@ -513,8 +524,9 @@ func TestPinger_MeasureAll_ContextCancellation(t *testing.T) {
 	numProbes := 100
 	for i := 0; i < numProbes; i++ {
 		addr := ProbeAddress{
-			Host: "127.0.0.1",
-			Port: uint16(30000 + i),
+			Host:      "127.0.0.1",
+			Port:      uint16(30000 + i),
+			TWAMPPort: 8925,
 		}
 		err := pinger.AddProbe(ctx, addr)
 		require.NoError(t, err)

--- a/controlplane/telemetry/internal/geoprobe/publisher_test.go
+++ b/controlplane/telemetry/internal/geoprobe/publisher_test.go
@@ -425,7 +425,7 @@ func TestPublisher_AddProbe(t *testing.T) {
 	pub, err := NewPublisher(cfg)
 	require.NoError(t, err)
 
-	addr := ProbeAddress{Host: "127.0.0.1", Port: 9999}
+	addr := ProbeAddress{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}
 
 	t.Run("adds probe successfully", func(t *testing.T) {
 		err := pub.AddProbe(context.Background(), addr)
@@ -464,7 +464,7 @@ func TestPublisher_RemoveProbe(t *testing.T) {
 	pub, err := NewPublisher(cfg)
 	require.NoError(t, err)
 
-	addr := ProbeAddress{Host: "127.0.0.1", Port: 9999}
+	addr := ProbeAddress{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}
 
 	t.Run("removes existing probe", func(t *testing.T) {
 		err := pub.AddProbe(context.Background(), addr)
@@ -506,8 +506,8 @@ func TestPublisher_Close(t *testing.T) {
 	pub, err := NewPublisher(cfg)
 	require.NoError(t, err)
 
-	addr1 := ProbeAddress{Host: "127.0.0.1", Port: 9999}
-	addr2 := ProbeAddress{Host: "127.0.0.1", Port: 10000}
+	addr1 := ProbeAddress{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}
+	addr2 := ProbeAddress{Host: "127.0.0.1", Port: 10000, TWAMPPort: 8925}
 
 	err = pub.AddProbe(context.Background(), addr1)
 	require.NoError(t, err)
@@ -551,7 +551,7 @@ func TestPublisher_Publish(t *testing.T) {
 	defer listener.Close()
 
 	localAddr := listener.LocalAddr().(*net.UDPAddr)
-	probeAddr := ProbeAddress{Host: "127.0.0.1", Port: uint16(localAddr.Port)}
+	probeAddr := ProbeAddress{Host: "127.0.0.1", Port: uint16(localAddr.Port), TWAMPPort: 8925}
 
 	err = pub.AddProbe(context.Background(), probeAddr)
 	require.NoError(t, err)
@@ -644,7 +644,7 @@ func TestPublisher_Publish_LatLngError(t *testing.T) {
 	ctx := context.Background()
 
 	rttData := map[ProbeAddress]uint64{
-		{Host: "127.0.0.1", Port: 9999}: 800000,
+		{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}: 800000,
 	}
 
 	err = pub.Publish(ctx, rttData)
@@ -681,7 +681,7 @@ func TestPublisher_Publish_SlotError(t *testing.T) {
 	ctx := context.Background()
 
 	rttData := map[ProbeAddress]uint64{
-		{Host: "127.0.0.1", Port: 9999}: 800000,
+		{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}: 800000,
 	}
 
 	err = pub.Publish(ctx, rttData)
@@ -716,7 +716,7 @@ func TestPublisher_Publish_ProbeNotInPool(t *testing.T) {
 	ctx := context.Background()
 
 	rttData := map[ProbeAddress]uint64{
-		{Host: "127.0.0.1", Port: 9999}: 800000,
+		{Host: "127.0.0.1", Port: 9999, TWAMPPort: 8925}: 800000,
 	}
 
 	err = pub.Publish(ctx, rttData)

--- a/controlplane/telemetry/internal/telemetry/config_test.go
+++ b/controlplane/telemetry/internal/telemetry/config_test.go
@@ -87,7 +87,7 @@ func TestConfig_Validate_GeoprobeFields(t *testing.T) {
 		{
 			name: "valid config with geoprobe",
 			modify: func(c *Config) {
-				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080}}
+				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080, TWAMPPort: 8925}}
 				c.ServiceabilityProgramClient = serviceabilityClient
 				c.RPCClient = rpcClient
 			},
@@ -96,7 +96,7 @@ func TestConfig_Validate_GeoprobeFields(t *testing.T) {
 		{
 			name: "geoprobe enabled but missing serviceability client",
 			modify: func(c *Config) {
-				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080}}
+				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080, TWAMPPort: 8925}}
 				c.RPCClient = rpcClient
 			},
 			expectError: "serviceability client is required when geoprobe is enabled",
@@ -104,7 +104,7 @@ func TestConfig_Validate_GeoprobeFields(t *testing.T) {
 		{
 			name: "geoprobe enabled but missing rpc client",
 			modify: func(c *Config) {
-				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080}}
+				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080, TWAMPPort: 8925}}
 				c.ServiceabilityProgramClient = serviceabilityClient
 			},
 			expectError: "rpc client is required when geoprobe is enabled",
@@ -112,7 +112,7 @@ func TestConfig_Validate_GeoprobeFields(t *testing.T) {
 		{
 			name: "geoprobe enabled but missing keypair",
 			modify: func(c *Config) {
-				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080}}
+				c.InitialChildGeoProbes = []geoprobe.ProbeAddress{{Host: "192.0.2.1", Port: 8080, TWAMPPort: 8925}}
 				c.ServiceabilityProgramClient = serviceabilityClient
 				c.RPCClient = rpcClient
 				c.Keypair = nil

--- a/controlplane/telemetry/pkg/config/constants.go
+++ b/controlplane/telemetry/pkg/config/constants.go
@@ -4,6 +4,12 @@ const (
 	// TWAMPListenPort is the port on which devices listen for TWAMP probes.
 	TWAMPListenPort = 862
 
+	// DefaultGeoprobeUDPPort is the default UDP offset port for geoprobe-agents.
+	DefaultGeoprobeUDPPort = 8923
+
+	// DefaultGeoprobeTWAMPPort is the default TWAMP reflector port for geoprobe-agents.
+	DefaultGeoprobeTWAMPPort = 8925
+
 	// InternetTelemetryDataProviderNameRIPEAtlas is the name of the RIPE Atlas data provider.
 	InternetTelemetryDataProviderNameRIPEAtlas = "ripeatlas"
 


### PR DESCRIPTION
## Summary of Changes
- DZD ACL policies block TWAMP replies on port 862 from geoprobe-agents. Change the geoprobe-agent and geoprobe-target default TWAMP reflector port from 862 to 8925, and make the pinger use a per-probe TWAMP port instead of a hardcoded constant.
- Add `TWAMPPort` field to `ProbeAddress` so each probe carries both its UDP offset port and TWAMP reflector port.
- Update `ParseProbeAddresses` to accept `host` (defaults both ports to 8923/8925) or `host:offset_port:twamp_port` (both explicit). The old two-field `host:port` format is rejected as ambiguous.
- Device-to-device TWAMP (port 862) and controller ACL templates are unaffected.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +56 / -20   | +36  |
| CLI/config   |     3 | +4 / -4     |   0  |
| Tests        |     4 | +159 / -91  | +68  |

Most of the diff is mechanical test updates adding `TWAMPPort: 8925` to `ProbeAddress` literals.

<details>
<summary>Key files (click to expand)</summary>
