### PR TITLE
controller: downgrade transient clickhouse errors to WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Controller
+  - Downgrade transient ClickHouse write errors from ERROR to WARN, escalating to ERROR only after 3 consecutive flush failures to reduce alert noise ([#3220](https://github.com/malbeclabs/doublezero/issues/3220))
 - Telemetry
   - Detect and replace unresponsive RIPE Atlas source probes that stop returning ping results, with a 24-hour TTL on the unresponsive probe blacklist so probes are retried after expiry
   - Compare source probe IDs (not just location codes) during measurement reconciliation so that probe replacements trigger measurement recreation

--- a/controlplane/controller/internal/controller/clickhouse.go
+++ b/controlplane/controller/internal/controller/clickhouse.go
@@ -18,12 +18,17 @@ type getConfigEvent struct {
 }
 
 type ClickhouseWriter struct {
-	conn   clickhouse.Conn
-	log    *slog.Logger
-	db     string
-	mu     sync.Mutex
-	events []getConfigEvent
+	conn              clickhouse.Conn
+	log               *slog.Logger
+	db                string
+	mu                sync.Mutex
+	events            []getConfigEvent
+	consecutiveErrors int
 }
+
+// consecutiveErrorThreshold is the number of consecutive flush failures
+// before escalating from WARN to ERROR level logging.
+const consecutiveErrorThreshold = 3
 
 // buildClickhouseOptions constructs clickhouse.Options for the HTTP protocol.
 // When disableTLS is false (default), TLS is enabled (HTTPS).
@@ -113,24 +118,41 @@ func (cw *ClickhouseWriter) flush(ctx context.Context) {
 		`INSERT INTO "%s".controller_grpc_getconfig_success (timestamp, device_pubkey)`, cw.db,
 	))
 	if err != nil {
-		cw.log.Error("error preparing clickhouse batch", "error", err)
+		cw.recordFlushError("error preparing clickhouse batch", err)
 		return
 	}
 	for _, e := range events {
 		if err := batch.Append(e.Timestamp, e.DevicePubkey); err != nil {
-			cw.log.Error("error appending to clickhouse batch", "error", err)
+			cw.logFlushError("error appending to clickhouse batch", err)
 		}
 	}
 	if err := batch.Send(); err != nil {
 		_ = batch.Close()
-		cw.log.Error("error sending clickhouse batch", "error", err)
+		cw.recordFlushError("error sending clickhouse batch", err)
 		return
 	}
 	if err := batch.Close(); err != nil {
-		cw.log.Error("error closing clickhouse batch", "error", err)
+		cw.recordFlushError("error closing clickhouse batch", err)
 		return
 	}
+	cw.consecutiveErrors = 0
 	cw.log.Debug("flushed getconfig events to clickhouse", "count", len(events))
+}
+
+// recordFlushError increments the consecutive error counter and logs at the
+// appropriate level. Transient errors are logged as WARN; persistent errors
+// (exceeding consecutiveErrorThreshold) are logged as ERROR.
+func (cw *ClickhouseWriter) recordFlushError(msg string, err error) {
+	cw.consecutiveErrors++
+	cw.logFlushError(msg, err)
+}
+
+func (cw *ClickhouseWriter) logFlushError(msg string, err error) {
+	if cw.consecutiveErrors >= consecutiveErrorThreshold {
+		cw.log.Error(msg, "error", err, "consecutive_errors", cw.consecutiveErrors)
+	} else {
+		cw.log.Warn(msg, "error", err)
+	}
 }
 
 func (cw *ClickhouseWriter) Close() {

--- a/controlplane/controller/internal/controller/clickhouse_test.go
+++ b/controlplane/controller/internal/controller/clickhouse_test.go
@@ -1,10 +1,71 @@
 package controller
 
 import (
+	"context"
+	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
+
+// logEntry captures a single log call for test assertions.
+type logEntry struct {
+	Level   slog.Level
+	Message string
+}
+
+// capturingHandler is a slog.Handler that records log entries.
+type capturingHandler struct {
+	entries []logEntry
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.entries = append(h.entries, logEntry{Level: r.Level, Message: r.Message})
+	return nil
+}
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func TestClickhouseWriterLogEscalation(t *testing.T) {
+	h := &capturingHandler{}
+	logger := slog.New(h)
+	cw := &ClickhouseWriter{log: logger}
+
+	testErr := errors.New("connection reset")
+
+	// First few errors should be WARN
+	for range consecutiveErrorThreshold {
+		cw.recordFlushError("error sending clickhouse batch", testErr)
+	}
+
+	// Verify first errors are WARN, last one crosses threshold and is ERROR
+	for i, entry := range h.entries {
+		if i < consecutiveErrorThreshold-1 {
+			if entry.Level != slog.LevelWarn {
+				t.Errorf("entry[%d]: got level %v, want WARN", i, entry.Level)
+			}
+		} else {
+			if entry.Level != slog.LevelError {
+				t.Errorf("entry[%d]: got level %v, want ERROR", i, entry.Level)
+			}
+		}
+	}
+
+	// Reset counter (simulating a successful flush)
+	cw.consecutiveErrors = 0
+	h.entries = nil
+
+	// Next error after reset should be WARN again
+	cw.recordFlushError("error sending clickhouse batch", testErr)
+	if len(h.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(h.entries))
+	}
+	if h.entries[0].Level != slog.LevelWarn {
+		t.Errorf("after reset: got level %v, want WARN", h.entries[0].Level)
+	}
+}
 
 func TestBuildClickhouseOptions(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Downgrade transient ClickHouse batch write errors from ERROR to WARN to reduce alert noise
- Escalate to ERROR only after 3 consecutive flush failures, with `consecutive_errors` count in log attributes
- Reset consecutive error counter on successful flush

Closes #3220

## Testing Verification

- Unit test validates WARN→ERROR escalation after threshold and reset back to WARN after successful flush