### PR TITLE
onchain allocation: DeviceInterfaceUpdate add support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
   - Serviceability: fix `validate_account_code` forcing lowercase on all entity types — restrict lowercase normalization to device and link codes only, preserving original case for locations, exchanges, contributors, and other entities
   - feat(smartcontract): atomic onchain allocation for CreateDevice ([#3216](https://github.com/malbeclabs/doublezero/pull/3216))
   - Serviceability: RequestBanUser instruction supports atomic deallocate when OnchainAllocation feature is enabled
+  - Serviceability: DeviceInterfaceUpdate instruction supports onchain allocation of node_segment_idx
 - CLI
   - Add `access-pass user-balances` command to show per-payer SOL balance, required amount (rent + gas reserve), and missing amount, with filters (`--user-payer`, `--min-balance`, `--max-balance`, `--min-missing`, `--max-missing`), sorting, and `--top N`
   - Add `access-pass fund` command to top up underfunded user payers, with `--dry-run`, `--force` (skip confirmation), `--min-balance`, and a pre-transfer sender balance check; required balance floor includes a gas-fee reserve (50 × 5,000 lamports) and the wallet rent-exempt minimum to prevent on-chain transfer failures

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/update.rs
@@ -2,11 +2,18 @@ use crate::{
     error::{DoubleZeroError, Validate},
     format_option,
     helper::format_option_displayable,
+    pda::get_resource_extension_pda,
+    processors::{
+        resource::{allocate_specific_id, deallocate_id},
+        validation::validate_program_account,
+    },
+    resource::ResourceType,
     serializer::try_acc_write,
     state::{
         accounttype::AccountType,
         contributor::Contributor,
         device::*,
+        feature_flags::{is_feature_enabled, FeatureFlag},
         globalstate::GlobalState,
         interface::{
             InterfaceCYOA, InterfaceDIA, InterfaceStatus, InterfaceType, LoopbackType, RoutingMode,
@@ -76,6 +83,19 @@ pub fn process_update_device_interface(
     let device_account = next_account_info(accounts_iter)?;
     let contributor_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
+
+    // Optional: SegmentRoutingIds resource extension account (when node_segment_idx
+    // is being updated with onchain allocation enabled).
+    // Account layout WITH onchain allocation (node_segment_idx is Some):
+    //   [device, contributor, globalstate, segment_routing_ids_ext, payer, system]
+    // Account layout WITHOUT (legacy):
+    //   [device, contributor, globalstate, payer, system]
+    let segment_routing_ids_ext = if accounts.len() > 5 {
+        Some(next_account_info(accounts_iter)?)
+    } else {
+        None
+    };
+
     let payer_account = next_account_info(accounts_iter)?;
     let _system_program = next_account_info(accounts_iter)?;
 
@@ -178,6 +198,31 @@ pub fn process_update_device_interface(
         if !globalstate.foundation_allowlist.contains(payer_account.key) {
             return Err(DoubleZeroError::NotAllowed.into());
         }
+
+        if is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation) {
+            let seg_ext = segment_routing_ids_ext.ok_or(DoubleZeroError::InvalidArgument)?;
+
+            let (expected_seg_pda, _, _) =
+                get_resource_extension_pda(program_id, ResourceType::SegmentRoutingIds);
+            validate_program_account!(
+                seg_ext,
+                program_id,
+                writable = true,
+                pda = Some(&expected_seg_pda),
+                "SegmentRoutingIds"
+            );
+
+            // Deallocate old value if non-zero
+            if iface.node_segment_idx != 0 {
+                deallocate_id(seg_ext, iface.node_segment_idx);
+            }
+
+            // Allocate new value if non-zero
+            if node_segment_idx != 0 {
+                allocate_specific_id(seg_ext, node_segment_idx)?;
+            }
+        }
+
         iface.node_segment_idx = node_segment_idx;
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::DoubleZeroError,
     pda::{get_globalconfig_pda, get_resource_extension_pda},
-    resource::ResourceType,
+    resource::{IdOrIp, ResourceType},
     seeds::SEED_PREFIX,
     state::{
         device::Device,
@@ -192,6 +192,22 @@ pub fn allocate_id(account: &AccountInfo) -> Result<u16, ProgramError> {
         .allocate(1)?
         .as_id()
         .ok_or(DoubleZeroError::InvalidArgument.into())
+}
+
+/// Borrow a ResourceExtension account, deserialize it, and allocate a specific ID.
+pub fn allocate_specific_id(account: &AccountInfo, id: u16) -> Result<(), ProgramError> {
+    let mut buffer = account.data.borrow_mut();
+    let mut resource = ResourceExtensionBorrowed::inplace_from(&mut buffer[..])?;
+    resource.allocate_specific(&IdOrIp::Id(id))?;
+    Ok(())
+}
+
+/// Borrow a ResourceExtension account, deserialize it, and deallocate a single ID.
+pub fn deallocate_id(account: &AccountInfo, id: u16) {
+    let mut buffer = account.data.borrow_mut();
+    if let Ok(mut resource) = ResourceExtensionBorrowed::inplace_from(&mut buffer[..]) {
+        resource.deallocate(&IdOrIp::Id(id));
+    }
 }
 
 /// Try each account in order and return the first successful single-IP allocation.

--- a/smartcontract/programs/doublezero-serviceability/tests/interface_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/interface_onchain_allocation_test.rs
@@ -1,0 +1,664 @@
+//! Integration tests for onchain allocation of node_segment_idx during UpdateDeviceInterface.
+
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    instructions::*,
+    pda::*,
+    processors::{
+        contributor::create::ContributorCreateArgs,
+        device::{
+            activate::DeviceActivateArgs,
+            create::DeviceCreateArgs,
+            interface::{create::DeviceInterfaceCreateArgs, update::DeviceInterfaceUpdateArgs},
+        },
+        exchange::create::ExchangeCreateArgs,
+        globalstate::setfeatureflags::SetFeatureFlagsArgs,
+        location::create::LocationCreateArgs,
+    },
+    resource::{IdOrIp, ResourceType},
+    state::{
+        device::*,
+        feature_flags::FeatureFlag,
+        interface::{InterfaceCYOA, InterfaceDIA, LoopbackType, RoutingMode},
+    },
+};
+use solana_program::instruction::InstructionError;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::AccountMeta, pubkey::Pubkey, signer::Signer, transaction::TransactionError,
+};
+
+mod test_helpers;
+use test_helpers::*;
+
+/// Helper: set up a full environment with a device that has a loopback interface.
+/// Returns (device_pubkey, contributor_pubkey, segment_routing_ids_pda).
+async fn setup_device_with_interface(
+    banks_client: &mut BanksClient,
+    recent_blockhash: solana_program::hash::Hash,
+    program_id: Pubkey,
+    globalstate_pubkey: Pubkey,
+    globalconfig_pubkey: Pubkey,
+    payer: &solana_sdk::signature::Keypair,
+) -> (Pubkey, Pubkey, Pubkey) {
+    // Create Location
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create Exchange
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create Contributor
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) =
+        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create Device
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+    let (tunnel_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "dz1".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [8, 8, 8, 8].into(),
+            dz_prefixes: "110.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+            resource_count: 0,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Activate Device
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(DeviceActivateArgs { resource_count: 2 }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(tunnel_ids_pda, false),
+            AccountMeta::new(dz_prefix_pda, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create a loopback interface
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(DeviceInterfaceCreateArgs {
+            name: "loopback0".to_string(),
+            interface_dia: InterfaceDIA::None,
+            loopback_type: LoopbackType::Vpnv4,
+            interface_cyoa: InterfaceCYOA::None,
+            bandwidth: 0,
+            cir: 0,
+            ip_net: None,
+            mtu: 1500,
+            routing_mode: RoutingMode::Static,
+            vlan_id: 0,
+            user_tunnel_endpoint: false,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+
+    (device_pubkey, contributor_pubkey, segment_routing_ids_pda)
+}
+
+/// Test: update node_segment_idx with onchain allocation enabled (0 → N)
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_onchain_alloc() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Enable OnChainAllocation
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey, segment_routing_ids_pda) = setup_device_with_interface(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    // Update node_segment_idx from 0 → 42 with resource account
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify device interface has node_segment_idx = 42
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    let iface = device.interfaces[0].into_current_version();
+    assert_eq!(iface.node_segment_idx, 42);
+
+    // Verify ID 42 is allocated in the resource extension
+    let resource = get_resource_extension_data(&mut banks_client, segment_routing_ids_pda)
+        .await
+        .expect("SegmentRoutingIds resource not found");
+    let allocated = resource.iter_allocated();
+    assert!(
+        allocated.contains(&IdOrIp::Id(42)),
+        "ID 42 should be allocated"
+    );
+}
+
+/// Test: update node_segment_idx N → M (deallocate old, allocate new)
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_change_value() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Enable OnChainAllocation
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey, segment_routing_ids_pda) = setup_device_with_interface(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    // Set node_segment_idx to 100
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(100),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Change node_segment_idx from 100 → 200
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(200),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify device interface has node_segment_idx = 200
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    let iface = device.interfaces[0].into_current_version();
+    assert_eq!(iface.node_segment_idx, 200);
+
+    // Verify old ID 100 is deallocated and new ID 200 is allocated
+    let resource = get_resource_extension_data(&mut banks_client, segment_routing_ids_pda)
+        .await
+        .expect("SegmentRoutingIds resource not found");
+    let allocated = resource.iter_allocated();
+    assert!(
+        !allocated.contains(&IdOrIp::Id(100)),
+        "ID 100 should be deallocated"
+    );
+    assert!(
+        allocated.contains(&IdOrIp::Id(200)),
+        "ID 200 should be allocated"
+    );
+}
+
+/// Test: update node_segment_idx N → 0 (deallocate only)
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_clear() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Enable OnChainAllocation
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey, segment_routing_ids_pda) = setup_device_with_interface(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    // Set node_segment_idx to 50
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(50),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Clear node_segment_idx (50 → 0)
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(0),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify device interface has node_segment_idx = 0
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    let iface = device.interfaces[0].into_current_version();
+    assert_eq!(iface.node_segment_idx, 0);
+
+    // Verify ID 50 is deallocated
+    let resource = get_resource_extension_data(&mut banks_client, segment_routing_ids_pda)
+        .await
+        .expect("SegmentRoutingIds resource not found");
+    let allocated = resource.iter_allocated();
+    assert!(
+        !allocated.contains(&IdOrIp::Id(50)),
+        "ID 50 should be deallocated"
+    );
+}
+
+/// Test: update node_segment_idx with feature flag OFF (legacy behavior, no resource account)
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_legacy() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Do NOT enable OnChainAllocation feature flag
+
+    let (device_pubkey, contributor_pubkey, _segment_routing_ids_pda) =
+        setup_device_with_interface(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            globalstate_pubkey,
+            globalconfig_pubkey,
+            &payer,
+        )
+        .await;
+
+    // Update node_segment_idx without resource account (legacy)
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify device interface has node_segment_idx = 42
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    let iface = device.interfaces[0].into_current_version();
+    assert_eq!(iface.node_segment_idx, 42);
+}
+
+/// Test: update node_segment_idx with feature flag ON but missing resource account fails
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_missing_resource_account() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Enable OnChainAllocation
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey, _segment_routing_ids_pda) =
+        setup_device_with_interface(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            globalstate_pubkey,
+            globalconfig_pubkey,
+            &payer,
+        )
+        .await;
+
+    // Try to update node_segment_idx WITHOUT resource account — should fail
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let err = result.expect_err("Expected error with missing resource account");
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(code),
+        )) => {
+            assert_eq!(DoubleZeroError::InvalidArgument, code.into());
+        }
+        _ => panic!("Unexpected error type: {:?}", err),
+    }
+}
+
+/// Test: allocating an already-taken ID fails
+#[tokio::test]
+async fn test_update_interface_node_segment_idx_duplicate_allocation() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Enable OnChainAllocation
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey, segment_routing_ids_pda) = setup_device_with_interface(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    // Create a second interface
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(DeviceInterfaceCreateArgs {
+            name: "loopback1".to_string(),
+            interface_dia: InterfaceDIA::None,
+            loopback_type: LoopbackType::Vpnv4,
+            interface_cyoa: InterfaceCYOA::None,
+            bandwidth: 0,
+            cir: 0,
+            ip_net: None,
+            mtu: 1500,
+            routing_mode: RoutingMode::Static,
+            vlan_id: 0,
+            user_tunnel_endpoint: false,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Allocate ID 42 on loopback0
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Try to allocate ID 42 on loopback1 — should fail (already taken)
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
+            name: "loopback1".to_string(),
+            node_segment_idx: Some(42),
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let err = result.expect_err("Expected error for duplicate allocation");
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(code),
+        )) => {
+            assert_eq!(DoubleZeroError::AllocationFailed, code.into());
+        }
+        _ => panic!("Unexpected error type: {:?}", err),
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/device/interface/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/update.rs
@@ -5,8 +5,13 @@ use crate::{
 use doublezero_program_common::types::NetworkV4;
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
+    pda::get_resource_extension_pda,
     processors::device::interface::DeviceInterfaceUpdateArgs,
-    state::interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus, LoopbackType, RoutingMode},
+    resource::ResourceType,
+    state::{
+        feature_flags::{is_feature_enabled, FeatureFlag},
+        interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus, LoopbackType, RoutingMode},
+    },
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
@@ -30,7 +35,7 @@ pub struct UpdateDeviceInterfaceCommand {
 
 impl UpdateDeviceInterfaceCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
-        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+        let (globalstate_pubkey, globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
@@ -38,6 +43,24 @@ impl UpdateDeviceInterfaceCommand {
             pubkey_or_code: self.pubkey.to_string(),
         }
         .execute(client)?;
+
+        let mut accounts = vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(device.contributor_pk, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ];
+
+        // Include SegmentRoutingIds resource account when updating node_segment_idx
+        // with onchain allocation enabled
+        if self.node_segment_idx.is_some()
+            && is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation)
+        {
+            let (seg_routing_pda, _, _) = get_resource_extension_pda(
+                &client.get_program_id(),
+                ResourceType::SegmentRoutingIds,
+            );
+            accounts.push(AccountMeta::new(seg_routing_pda, false));
+        }
 
         client.execute_transaction(
             DoubleZeroInstruction::UpdateDeviceInterface(DeviceInterfaceUpdateArgs {
@@ -55,11 +78,7 @@ impl UpdateDeviceInterfaceCommand {
                 ip_net: self.ip_net,
                 node_segment_idx: self.node_segment_idx,
             }),
-            vec![
-                AccountMeta::new(device_pubkey, false),
-                AccountMeta::new(device.contributor_pk, false),
-                AccountMeta::new(globalstate_pubkey, false),
-            ],
+            accounts,
         )
     }
 }
@@ -67,26 +86,21 @@ impl UpdateDeviceInterfaceCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::utils::create_test_client;
+    use crate::{tests::utils::create_test_client, MockDoubleZeroClient};
     use doublezero_serviceability::{
         pda::get_globalstate_pda,
         state::{
             accountdata::AccountData,
             accounttype::AccountType,
             device::{Device, DeviceDesiredStatus, DeviceHealth, DeviceStatus, DeviceType},
+            feature_flags::FeatureFlag,
+            globalstate::GlobalState,
         },
     };
     use mockall::predicate;
 
-    #[test]
-    fn test_commands_device_interface_update_command() {
-        let mut client = create_test_client();
-
-        let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
-
-        let device_pubkey = Pubkey::new_unique();
-
-        let device = Device {
+    fn make_test_device() -> Device {
+        Device {
             account_type: AccountType::Device,
             owner: Pubkey::new_unique(),
             index: 0,
@@ -112,8 +126,17 @@ mod tests {
             max_unicast_users: 0,
             max_multicast_users: 0,
             reserved_seats: 0,
-        };
+        }
+    }
 
+    #[test]
+    fn test_commands_device_interface_update_command() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_test_device();
         let contributor_pk = device.contributor_pk;
 
         client
@@ -164,6 +187,145 @@ mod tests {
             ip_net: None,
             interface_dia: None,
             node_segment_idx: None,
+        };
+
+        let res = update_command.execute(&client);
+        assert!(res.is_ok());
+    }
+
+    /// Test that node_segment_idx update with OnChainAllocation includes the resource account
+    #[test]
+    fn test_commands_device_interface_update_node_segment_idx_onchain() {
+        let mut client = MockDoubleZeroClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+        let payer = Pubkey::new_unique();
+        client.expect_get_payer().returning(move || payer);
+
+        let (globalstate_pubkey, bump_seed) = get_globalstate_pda(&program_id);
+        let globalstate = GlobalState {
+            account_type: AccountType::GlobalState,
+            bump_seed,
+            account_index: 0,
+            foundation_allowlist: vec![],
+            _device_allowlist: vec![],
+            _user_allowlist: vec![],
+            activator_authority_pk: Pubkey::new_unique(),
+            sentinel_authority_pk: Pubkey::new_unique(),
+            contributor_airdrop_lamports: 1_000_000_000,
+            user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![],
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+            reservation_authority_pk: Pubkey::default(),
+        };
+        client
+            .expect_get()
+            .with(predicate::eq(globalstate_pubkey))
+            .returning(move |_| Ok(AccountData::GlobalState(globalstate.clone())));
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_test_device();
+        let contributor_pk = device.contributor_pk;
+
+        client
+            .expect_get()
+            .with(predicate::eq(device_pubkey))
+            .returning(move |_| Ok(AccountData::Device(device.clone())));
+
+        let (seg_routing_pda, _, _) =
+            get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdateDeviceInterface(
+                    DeviceInterfaceUpdateArgs {
+                        name: "loopback0".to_string(),
+                        node_segment_idx: Some(42),
+                        ..Default::default()
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(device_pubkey, false),
+                    AccountMeta::new(contributor_pk, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                    AccountMeta::new(seg_routing_pda, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let update_command = UpdateDeviceInterfaceCommand {
+            pubkey: device_pubkey,
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            loopback_type: None,
+            interface_cyoa: None,
+            interface_dia: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
+        };
+
+        let res = update_command.execute(&client);
+        assert!(res.is_ok());
+    }
+
+    /// Test that node_segment_idx update without OnChainAllocation does NOT include resource account
+    #[test]
+    fn test_commands_device_interface_update_node_segment_idx_legacy() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_test_device();
+        let contributor_pk = device.contributor_pk;
+
+        client
+            .expect_get()
+            .with(predicate::eq(device_pubkey))
+            .returning(move |_| Ok(AccountData::Device(device.clone())));
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdateDeviceInterface(
+                    DeviceInterfaceUpdateArgs {
+                        name: "loopback0".to_string(),
+                        node_segment_idx: Some(42),
+                        ..Default::default()
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(device_pubkey, false),
+                    AccountMeta::new(contributor_pk, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let update_command = UpdateDeviceInterfaceCommand {
+            pubkey: device_pubkey,
+            name: "loopback0".to_string(),
+            node_segment_idx: Some(42),
+            loopback_type: None,
+            interface_cyoa: None,
+            interface_dia: None,
+            bandwidth: None,
+            cir: None,
+            mtu: None,
+            routing_mode: None,
+            vlan_id: None,
+            user_tunnel_endpoint: None,
+            status: None,
+            ip_net: None,
         };
 
         let res = update_command.execute(&client);


### PR DESCRIPTION
Closes #3217

## Summary of Changes
* DeviceInterfaceUpdate instruction modified such that if the onchain allocation feature is enabled, and the node_segment_idx is being updated, use the resource extension account for allocating this resource.
* Updates relevent SDKs

## Testing Verification
* New tests added
* Existing tests pass
