### PR TITLE
telemetry: retry flow-ingest e2e on connection reset

### DIFF
--- a/telemetry/flow-ingest/internal/e2e/server_test.go
+++ b/telemetry/flow-ingest/internal/e2e/server_test.go
@@ -279,6 +279,7 @@ func isRetryableContainerStartErr(err error) bool {
 		strings.Contains(s, "context deadline exceeded") ||
 		strings.Contains(s, "TLS handshake") ||
 		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connection reset") ||
 		strings.Contains(s, "container exited") ||
 		strings.Contains(s, "/containers/") && strings.Contains(s, "json") ||
 		strings.Contains(s, "Get \"http")


### PR DESCRIPTION
## Summary

- Add `connection reset` to the retryable error patterns in `isRetryableContainerStartErr`, fixing a test flake where the Redpanda container image pull fails with `connection reset by peer` from the registry

## Testing Verification

- Verified the new pattern matches the exact error string from the [flaky CI run](https://github.com/malbeclabs/doublezero/actions/runs/22920208655/job/66516530504)