### PR TITLE
geolocation-cli: add goreleaser config and release workflow

### DIFF
--- a/.github/workflows/release.geolocation-cli.yml
+++ b/.github/workflows/release.geolocation-cli.yml
@@ -1,0 +1,39 @@
+name: releaser.geolocation-cli
+
+on:
+  push:
+    tags:
+      - "geolocation-cli/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-24.04-16c-64gb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: |
+            target
+            target/x86_64-unknown-linux-gnu/release
+      - name: Install rust for cli
+        uses: dtolnay/rust-toolchain@1.90.0
+      - name: Install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install squashfs-tools rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.testnet.geolocation-cli.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/release/.goreleaser.base.geolocation-cli.yaml
+++ b/release/.goreleaser.base.geolocation-cli.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: doublezero-geolocation
+
+monorepo:
+  tag_prefix: geolocation-cli/
+
+builds:
+  - id: doublezero-geolocation
+    binary: doublezero-geolocation
+    builder: rust
+    tool: cargo
+    command: build
+    flags:
+      - --package=doublezero-geolocation-cli
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+    env:
+      - RUSTFLAGS=-C linker=x86_64-linux-gnu-gcc
+      - BUILD_VERSION={{.Version}}
+      - BUILD_COMMIT={{.ShortCommit}}
+      - BUILD_DATE={{.Date}}
+
+archives:
+  - id: geolocation_cli_archive
+    formats: ['tar.gz']
+    ids: [doublezero-geolocation]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+nfpms:
+  - id: doublezero-geolocation
+    package_name: doublezero-geolocation
+    ids: [doublezero-geolocation]
+    vendor: doublezero
+    homepage: doublezero.xyz
+    maintainer: steve <steve@malbeclabs.com>
+    description: |-
+      DoubleZero geolocation CLI
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    release: 1
+    section: default
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: malbeclabs
+    name: doublezero
+  draft: false
+  replace_existing_artifacts: true
+
+announce:
+  slack:
+    enabled: true
+    message_template: "DoubleZero Geolocation CLI {{.Tag}} has been released! Check it out at {{ .ReleaseURL }}"
+    channel: "#bots"
+
+git:
+  ignore_tags:
+    - geolocation-cli/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
+  tag_name: 'geolocation-cli/daily'

--- a/release/.goreleaser.devnet.geolocation-cli.yaml
+++ b/release/.goreleaser.devnet.geolocation-cli.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geolocation-cli.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.geolocation-cli.yaml
+++ b/release/.goreleaser.testnet.geolocation-cli.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geolocation-cli.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-geoprobe-agent.service
+++ b/release/packaging/systemd/doublezero-geoprobe-agent.service
@@ -11,7 +11,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/doublezero-geoprobe-agent
+ExecStart=/usr/bin/doublezero-geoprobe-agent
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary of Changes
* Add goreleaser base/devnet/testnet configuration files for the `doublezero-geolocation` CLI binary
* Add GitHub Actions release workflow triggered on `geolocation-cli/v*.*.*` tags
* Fixes #3236

## Testing Verification
* Build tested by hand
