### PR TITLE
geolocation: add goreleaser config and workflows for geoprobe-target

### DIFF
--- a/.github/workflows/release.geoprobe-target.yml
+++ b/.github/workflows/release.geoprobe-target.yml
@@ -1,0 +1,37 @@
+name: releaser.geoprobe-target
+
+on:
+  push:
+    tags:
+      - "geoprobe-target/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt-get install rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.testnet.geoprobe-target.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/.github/workflows/release.testnet.push.tags.components.yml
+++ b/.github/workflows/release.testnet.push.tags.components.yml
@@ -23,6 +23,7 @@ jobs:
           - agent
           - device-telemetry-agent
           - geoprobe-agent
+          - geoprobe-target
           - funder
           - monitor
           - client

--- a/release/.goreleaser.base.geoprobe-target.yaml
+++ b/release/.goreleaser.base.geoprobe-target.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: doublezero-geoprobe-target
+
+monorepo:
+  tag_prefix: geoprobe-target/
+  dir: controlplane/telemetry
+
+builds:
+  - id: doublezero-geoprobe-target
+    main: cmd/geoprobe-target/main.go
+    binary: doublezero-geoprobe-target
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - id: geoprobe_target_archive
+    formats: ['tar.gz']
+    ids: [doublezero-geoprobe-target]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+nfpms:
+  - id: doublezero-geoprobe-target
+    package_name: doublezero-geoprobe-target
+    ids: [doublezero-geoprobe-target]
+    vendor: doublezero
+    homepage: doublezero.xyz
+    maintainer: nik <nik@malbeclabs.com>
+    description: |-
+      DoubleZero geoprobe target for network geolocation measurements
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/local/bin
+    release: "1"
+    section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-geoprobe-target.service
+        dst: /lib/systemd/system/doublezero-geoprobe-target.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-geoprobe-target.service
+            dst: /usr/lib/systemd/system/doublezero-geoprobe-target.service
+            type: config
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: malbeclabs
+    name: doublezero
+  draft: false
+  replace_existing_artifacts: true
+
+announce:
+  slack:
+    enabled: true
+    message_template: "DoubleZero Geoprobe Target {{.Tag}} has been released! Check it out at {{ .ReleaseURL }}"
+    channel: "#bots"
+
+git:
+  ignore_tags:
+    - geoprobe-target/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: '{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}'
+  tag_name: 'geoprobe-target/daily'

--- a/release/.goreleaser.devnet.geoprobe-target.yaml
+++ b/release/.goreleaser.devnet.geoprobe-target.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geoprobe-target.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.testnet.geoprobe-target.yaml
+++ b/release/.goreleaser.testnet.geoprobe-target.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+includes:
+  - from_file:
+      path: release/.goreleaser.base.geoprobe-target.yaml
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-geoprobe-target.service
+++ b/release/packaging/systemd/doublezero-geoprobe-target.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the geoprobe target with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-geoprobe-target.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Geoprobe Target
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-geoprobe-target
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary of Changes
* Add goreleaser base, testnet, and devnet configs for the `geoprobe-target` binary (`controlplane/telemetry/cmd/geoprobe-target/main.go`)
* Add GitHub Actions workflow (`release.geoprobe-target.yml`) triggered on `geoprobe-target/v*.*.*` tags to build and publish `.deb`/`.rpm` packages to Cloudsmith testnet
* Add systemd service placeholder for package installation (Ansible manages runtime flags via override)
* Add `geoprobe-target` to the `release.testnet.push.tags.components.yml` matrix for bulk version tagging

Fixes #3235

## Testing Verification
* Tested package build/install by hand