### PR TITLE
onchain allocation: UpdateUser atomic allocate/deallocate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
   - Serviceability: DeleteMulticastGroup instruction supports atomic deallocate+closeaccount when OnchainAllocation feature is enabled
   - Serviceability: CreateSubscribeUser instruction supports atomic create+allocate+activate when OnchainAllocation feature is enabled
   - Serviceability: MulitcastGroupUpdate instruction supports atomic ip allocation when OnchainAllocation feature is enabled
+  - Serviceability: UpdateUser instruction supports atomic allocate+deallocate when OnchainAllocation feature is enabled
 
 ## [v0.10.0](https://github.com/malbeclabs/doublezero/compare/client/v0.9.0...client/v0.10.0) - 2026-03-04
 

--- a/smartcontract/programs/common/src/types/network_v4.rs
+++ b/smartcontract/programs/common/src/types/network_v4.rs
@@ -71,6 +71,12 @@ impl From<Ipv4Network> for NetworkV4 {
     }
 }
 
+impl From<Ipv4Addr> for NetworkV4 {
+    fn from(ip: Ipv4Addr) -> Self {
+        NetworkV4::new(ip, 32).unwrap() // Ipv4Addr is valid, so we can safely unwrap this
+    }
+}
+
 impl FromStr for NetworkV4 {
     type Err = String;
 

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -839,6 +839,8 @@ mod tests {
                 tunnel_net: Some("1.2.3.4/1".parse().unwrap()),
                 validator_pubkey: Some(Pubkey::new_unique()),
                 tenant_pk: Some(Pubkey::new_unique()),
+                dz_prefix_count: 0,
+                multicast_publisher_count: 0,
             }),
             "UpdateUser",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
@@ -129,7 +129,10 @@ pub fn process_update_multicastgroup(
 
             // Deallocate the old IP (if it was allocated)
             if multicastgroup.multicast_ip != std::net::Ipv4Addr::UNSPECIFIED {
-                deallocate_ip(multicast_group_block_ext, multicastgroup.multicast_ip);
+                deallocate_ip(
+                    multicast_group_block_ext,
+                    multicastgroup.multicast_ip.into(),
+                );
             }
 
             // Allocate the new specific IP

--- a/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
@@ -211,21 +211,21 @@ pub fn allocate_specific_ip(account: &AccountInfo, ip: NetworkV4) -> Result<(), 
 }
 
 /// Borrow a ResourceExtension account, deserialize it, and deallocate an IP.
-pub fn deallocate_ip(account: &AccountInfo, ip: Ipv4Addr) {
+pub fn deallocate_ip(account: &AccountInfo, ip: NetworkV4) -> bool {
     let mut buffer = account.data.borrow_mut();
     if let Ok(mut resource) = ResourceExtensionBorrowed::inplace_from(&mut buffer[..]) {
-        if let Ok(net) = NetworkV4::new(ip, 32) {
-            let _ = resource.deallocate(&IdOrIp::Ip(net));
-        }
+        return resource.deallocate(&IdOrIp::Ip(ip));
     }
+    false
 }
 
 /// Borrow a ResourceExtension account, deserialize it, and deallocate a single ID.
-pub fn deallocate_id(account: &AccountInfo, id: u16) {
+pub fn deallocate_id(account: &AccountInfo, id: u16) -> bool {
     let mut buffer = account.data.borrow_mut();
     if let Ok(mut resource) = ResourceExtensionBorrowed::inplace_from(&mut buffer[..]) {
-        resource.deallocate(&IdOrIp::Id(id));
+        return resource.deallocate(&IdOrIp::Id(id));
     }
+    false
 }
 
 /// Try each account in order and return the first successful single-IP allocation.

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/update.rs
@@ -2,8 +2,19 @@ use crate::{
     error::DoubleZeroError,
     format_option,
     helper::format_option_displayable,
+    pda::get_resource_extension_pda,
+    processors::{
+        resource::{allocate_specific_id, allocate_specific_ip, deallocate_id, deallocate_ip},
+        validation::validate_program_account,
+    },
+    resource::ResourceType,
     serializer::try_acc_write,
-    state::{globalstate::GlobalState, tenant::Tenant, user::*},
+    state::{
+        feature_flags::{is_feature_enabled, FeatureFlag},
+        globalstate::GlobalState,
+        tenant::Tenant,
+        user::*,
+    },
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -15,7 +26,7 @@ use solana_program::{
     entrypoint::ProgramResult,
     pubkey::Pubkey,
 };
-use std::fmt;
+use std::{fmt, net::Ipv4Addr};
 
 #[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
 pub struct UserUpdateArgs {
@@ -26,13 +37,17 @@ pub struct UserUpdateArgs {
     pub tunnel_net: Option<NetworkV4>,
     pub validator_pubkey: Option<Pubkey>,
     pub tenant_pk: Option<Pubkey>,
+    #[incremental(default = 0)]
+    pub dz_prefix_count: u8,
+    #[incremental(default = 0)]
+    pub multicast_publisher_count: u8,
 }
 
 impl fmt::Debug for UserUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "user_type: {}, cyoa_type: {}, dz_ip: {}, tunnel_id: {}, tunnel_net: {}, validator_pubkey: {}, tenant_pk: {}",
+            "user_type: {}, cyoa_type: {}, dz_ip: {}, tunnel_id: {}, tunnel_net: {}, validator_pubkey: {}, tenant_pk: {}, dz_prefix_count: {}, multicast_publisher_count: {}",
             format_option!(self.user_type),
             format_option!(self.cyoa_type),
             format_option!(self.dz_ip),
@@ -40,6 +55,8 @@ impl fmt::Debug for UserUpdateArgs {
             format_option!(self.tunnel_net),
             format_option!(self.validator_pubkey),
             format_option!(self.tenant_pk),
+            self.dz_prefix_count,
+            self.multicast_publisher_count,
         )
     }
 }
@@ -53,23 +70,54 @@ pub fn process_update_user(
 
     let user_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
-    let payer_account = next_account_info(accounts_iter)?;
-    let system_program = next_account_info(accounts_iter)?;
 
-    // Check if tenant accounts are provided (new format with tenant reference counting)
-    // Old format: 4 accounts (user, globalstate, payer, system_program)
-    // New format: 6 accounts (user, globalstate, payer, system_program, old_tenant, new_tenant)
-    let has_tenant_accounts = accounts.len() >= 6;
-    let old_tenant_account = if has_tenant_accounts {
-        Some(next_account_info(accounts_iter)?)
+    // Account layout WITH resource accounts (dz_prefix_count > 0):
+    //   [user, globalstate, user_tunnel_block, multicast_publisher_block?, device_tunnel_ids, dz_prefix_0..N, old_tenant?, new_tenant?, payer, system]
+    // Account layout WITHOUT (legacy, dz_prefix_count == 0):
+    //   [user, globalstate, old_tenant?, new_tenant?, payer, system]
+    let resource_accounts = if value.dz_prefix_count > 0 {
+        let user_tunnel_block_ext = next_account_info(accounts_iter)?;
+
+        let multicast_publisher_block_ext = if value.multicast_publisher_count > 0 {
+            Some(next_account_info(accounts_iter)?)
+        } else {
+            None
+        };
+
+        let device_tunnel_ids_ext = next_account_info(accounts_iter)?;
+
+        let mut dz_prefix_accounts = Vec::with_capacity(value.dz_prefix_count as usize);
+        for _ in 0..value.dz_prefix_count {
+            dz_prefix_accounts.push(next_account_info(accounts_iter)?);
+        }
+
+        Some((
+            user_tunnel_block_ext,
+            multicast_publisher_block_ext,
+            device_tunnel_ids_ext,
+            dz_prefix_accounts,
+        ))
     } else {
         None
     };
-    let new_tenant_account = if has_tenant_accounts {
-        Some(next_account_info(accounts_iter)?)
-    } else {
-        None
-    };
+
+    // Tenant accounts are optional — present when tenant_pk is being updated.
+    // We compute the expected count of remaining accounts to detect their presence.
+    // Remaining accounts: [old_tenant?, new_tenant?, payer, system]
+    // With tenants: 4 remaining. Without tenants: 2 remaining.
+    let remaining: Vec<_> = accounts_iter.collect();
+    let has_tenant_accounts = remaining.len() >= 4;
+    let (old_tenant_account, new_tenant_account, payer_account, _system_program) =
+        if has_tenant_accounts {
+            (
+                Some(remaining[0]),
+                Some(remaining[1]),
+                remaining[2],
+                remaining[3],
+            )
+        } else {
+            (None, None, remaining[0], remaining[1])
+        };
 
     #[cfg(test)]
     msg!("process_update_user({:?})", value);
@@ -83,11 +131,6 @@ pub fn process_update_user(
         globalstate_account.owner, program_id,
         "Invalid GlobalState Account Owner"
     );
-    assert_eq!(
-        *system_program.unsigned_key(),
-        solana_system_interface::program::ID,
-        "Invalid System Program Account Owner"
-    );
     // Check if the account is writable
     assert!(user_account.is_writable, "PDA Account is not writable");
 
@@ -98,15 +141,184 @@ pub fn process_update_user(
 
     let mut user: User = User::try_from(user_account)?;
 
-    if let Some(value) = value.dz_ip {
-        user.dz_ip = value;
+    // Handle resource allocation/deallocation for tunnel_id, tunnel_net, dz_ip
+    if let Some((
+        user_tunnel_block_ext,
+        multicast_publisher_block_ext,
+        device_tunnel_ids_ext,
+        ref dz_prefix_accounts,
+    )) = resource_accounts
+    {
+        // Resource accounts provided — require feature flag
+        if !is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation) {
+            return Err(DoubleZeroError::FeatureNotEnabled.into());
+        }
+
+        // Validate UserTunnelBlock PDA
+        let (expected_user_tunnel_pda, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+        validate_program_account!(
+            user_tunnel_block_ext,
+            program_id,
+            writable = true,
+            pda = Some(&expected_user_tunnel_pda),
+            "UserTunnelBlock"
+        );
+
+        // Validate MulticastPublisherBlock PDA if provided
+        if let Some(multicast_publisher_ext) = multicast_publisher_block_ext {
+            let (expected_multicast_publisher_pda, _, _) =
+                get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+            validate_program_account!(
+                multicast_publisher_ext,
+                program_id,
+                writable = true,
+                pda = Some(&expected_multicast_publisher_pda),
+                "MulticastPublisherBlock"
+            );
+        }
+
+        // Validate TunnelIds PDA
+        let (expected_tunnel_ids_pda, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::TunnelIds(user.device_pk, 0));
+        validate_program_account!(
+            device_tunnel_ids_ext,
+            program_id,
+            writable = true,
+            pda = Some(&expected_tunnel_ids_pda),
+            "TunnelIds"
+        );
+
+        // Validate all DzPrefixBlock accounts
+        for (idx, dz_prefix_account) in dz_prefix_accounts.iter().enumerate() {
+            let (expected_dz_prefix_pda, _, _) = get_resource_extension_pda(
+                program_id,
+                ResourceType::DzPrefixBlock(user.device_pk, idx),
+            );
+            validate_program_account!(
+                dz_prefix_account,
+                program_id,
+                writable = true,
+                pda = Some(&expected_dz_prefix_pda),
+                &format!("DzPrefixBlock[{idx}]")
+            );
+        }
+
+        // Deallocate/allocate tunnel_id
+        if let Some(new_tunnel_id) = value.tunnel_id {
+            if user.tunnel_id != 0 {
+                deallocate_id(device_tunnel_ids_ext, user.tunnel_id);
+                #[cfg(test)]
+                msg!("Deallocated old tunnel_id {}", user.tunnel_id);
+            }
+            if new_tunnel_id != 0 {
+                allocate_specific_id(device_tunnel_ids_ext, new_tunnel_id)?;
+                #[cfg(test)]
+                msg!("Allocated new tunnel_id {}", new_tunnel_id);
+            }
+            user.tunnel_id = new_tunnel_id;
+        }
+
+        // Deallocate/allocate tunnel_net
+        if let Some(new_tunnel_net) = value.tunnel_net {
+            if user.tunnel_net != NetworkV4::default() {
+                deallocate_ip(user_tunnel_block_ext, user.tunnel_net);
+                #[cfg(test)]
+                msg!("Deallocated old tunnel_net {}", user.tunnel_net);
+            }
+            if new_tunnel_net != NetworkV4::default() {
+                allocate_specific_ip(user_tunnel_block_ext, new_tunnel_net)?;
+                #[cfg(test)]
+                msg!("Allocated new tunnel_net {}", new_tunnel_net);
+            }
+            user.tunnel_net = new_tunnel_net;
+        }
+
+        // Deallocate/allocate dz_ip
+        if let Some(new_dz_ip) = value.dz_ip {
+            // Deallocate old dz_ip if it was allocated (not client_ip and not UNSPECIFIED)
+            if user.dz_ip != user.client_ip && user.dz_ip != Ipv4Addr::UNSPECIFIED {
+                if let Ok(old_dz_ip_net) = NetworkV4::new(user.dz_ip, 32) {
+                    let mut deallocated = false;
+
+                    // Try MulticastPublisherBlock first
+                    if let Some(multicast_publisher_ext) = multicast_publisher_block_ext {
+                        deallocated = deallocate_ip(multicast_publisher_ext, old_dz_ip_net);
+                        #[cfg(test)]
+                        msg!(
+                            "Deallocated old dz_ip {} from MulticastPublisherBlock: {}",
+                            old_dz_ip_net,
+                            deallocated
+                        );
+                    }
+
+                    // Fall back to DzPrefixBlock
+                    if !deallocated {
+                        for dz_prefix_account in dz_prefix_accounts.iter() {
+                            deallocated = deallocate_ip(dz_prefix_account, old_dz_ip_net);
+                            #[cfg(test)]
+                            msg!(
+                                "Deallocated old dz_ip {} from DzPrefixBlock: {}",
+                                old_dz_ip_net,
+                                deallocated
+                            );
+                            if deallocated {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Allocate new dz_ip if it's not UNSPECIFIED and not client_ip
+            if new_dz_ip != Ipv4Addr::UNSPECIFIED && new_dz_ip != user.client_ip {
+                if let Ok(new_dz_ip_net) = NetworkV4::new(new_dz_ip, 32) {
+                    // Try MulticastPublisherBlock first
+                    let mut allocated = false;
+                    if let Some(multicast_publisher_ext) = multicast_publisher_block_ext {
+                        if allocate_specific_ip(multicast_publisher_ext, new_dz_ip_net).is_ok() {
+                            allocated = true;
+                            #[cfg(test)]
+                            msg!(
+                                "Allocated new dz_ip {} in MulticastPublisherBlock",
+                                new_dz_ip_net
+                            );
+                        }
+                    }
+
+                    // Fall back to DzPrefixBlock
+                    if !allocated {
+                        let mut found = false;
+                        for dz_prefix_account in dz_prefix_accounts.iter() {
+                            if allocate_specific_ip(dz_prefix_account, new_dz_ip_net).is_ok() {
+                                found = true;
+                                #[cfg(test)]
+                                msg!("Allocated new dz_ip {} in DzPrefixBlock", new_dz_ip_net);
+                                break;
+                            }
+                        }
+                        if !found {
+                            return Err(DoubleZeroError::AllocationFailed.into());
+                        }
+                    }
+                }
+            }
+
+            user.dz_ip = new_dz_ip;
+        }
+    } else {
+        // Legacy path: no resource accounts, just overwrite fields
+        if let Some(value) = value.dz_ip {
+            user.dz_ip = value;
+        }
+        if let Some(value) = value.tunnel_id {
+            user.tunnel_id = value;
+        }
+        if let Some(value) = value.tunnel_net {
+            user.tunnel_net = value;
+        }
     }
-    if let Some(value) = value.tunnel_id {
-        user.tunnel_id = value;
-    }
-    if let Some(value) = value.tunnel_net {
-        user.tunnel_net = value;
-    }
+
     if let Some(value) = value.user_type {
         user.user_type = value;
     }

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_allow_multiple_ip.rs
@@ -415,6 +415,7 @@ async fn test_accesspass_allow_multiple_ip() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -449,6 +450,7 @@ async fn test_accesspass_allow_multiple_ip() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/user_old_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_old_test.rs
@@ -410,6 +410,7 @@ async fn test_old_user() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -444,6 +445,7 @@ async fn test_old_user() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
@@ -34,7 +34,7 @@ use doublezero_serviceability::{
         },
         user::{
             activate::UserActivateArgs, closeaccount::UserCloseAccountArgs, create::UserCreateArgs,
-            delete::UserDeleteArgs, requestban::UserRequestBanArgs,
+            delete::UserDeleteArgs, requestban::UserRequestBanArgs, update::UserUpdateArgs,
         },
     },
     resource::ResourceType,
@@ -3162,4 +3162,416 @@ async fn test_request_ban_user_onchain_feature_flag_disabled() {
     );
 
     println!("[PASS] test_request_ban_user_onchain_feature_flag_disabled");
+}
+
+// ============================================================================
+// UpdateUser Onchain Allocation Tests
+// ============================================================================
+
+/// Helper: set up an activated user with onchain allocation and feature flag enabled.
+/// Returns all the usual pubkeys plus the user's allocated values.
+async fn setup_activated_user_for_update(
+    client_ip: [u8; 4],
+) -> (
+    BanksClient,
+    solana_sdk::signature::Keypair,
+    Pubkey,                           // program_id
+    Pubkey,                           // globalstate_pubkey
+    Pubkey,                           // device_pubkey
+    Pubkey,                           // user_pubkey
+    Pubkey,                           // accesspass_pubkey
+    (Pubkey, Pubkey, Pubkey, Pubkey), // resource pubkeys
+) {
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        device_pubkey,
+        user_pubkey,
+        accesspass_pubkey,
+        resource_pubkeys,
+    ) = setup_user_onchain_allocation_test(UserType::IBRLWithAllocatedIP, client_ip).await;
+
+    let (user_tunnel_block, multicast_publisher_block, tunnel_ids, dz_prefix_block) =
+        resource_pubkeys;
+
+    // Enable feature flag
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // Activate user with onchain allocation
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateUser(UserActivateArgs {
+            tunnel_id: 0,
+            tunnel_net: "0.0.0.0/0".parse().unwrap(),
+            dz_ip: [0, 0, 0, 0].into(),
+            dz_prefix_count: 1,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    (
+        banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        device_pubkey,
+        user_pubkey,
+        accesspass_pubkey,
+        resource_pubkeys,
+    )
+}
+
+#[tokio::test]
+async fn test_update_user_tunnel_id_with_onchain_allocation() {
+    println!("[TEST] test_update_user_tunnel_id_with_onchain_allocation");
+
+    let client_ip = [100, 0, 0, 50];
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        _device_pubkey,
+        user_pubkey,
+        _accesspass_pubkey,
+        (user_tunnel_block, multicast_publisher_block, tunnel_ids, dz_prefix_block),
+    ) = setup_activated_user_for_update(client_ip).await;
+
+    // Read the user to get current allocated tunnel_id
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Activated);
+    let old_tunnel_id = user.tunnel_id;
+    assert!((500..=4596).contains(&old_tunnel_id));
+
+    // Pick a new tunnel_id
+    let new_tunnel_id: u16 = if old_tunnel_id == 501 { 502 } else { 501 };
+
+    // Verify old tunnel_id is allocated in bitmap
+    let tunnel_ids_resource = get_resource_extension_data(&mut banks_client, tunnel_ids)
+        .await
+        .expect("TunnelIds should exist");
+    let allocated_before = tunnel_ids_resource.iter_allocated();
+    assert!(
+        allocated_before
+            .iter()
+            .any(|a| a.as_id() == Some(old_tunnel_id)),
+        "Old tunnel_id should be allocated before update"
+    );
+
+    // Update tunnel_id with onchain allocation
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+            tunnel_id: Some(new_tunnel_id),
+            dz_prefix_count: 1,
+            multicast_publisher_count: 1,
+            ..UserUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify user has new tunnel_id
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.tunnel_id, new_tunnel_id);
+
+    // Verify bitmap: old deallocated, new allocated
+    let tunnel_ids_resource = get_resource_extension_data(&mut banks_client, tunnel_ids)
+        .await
+        .expect("TunnelIds should exist");
+    let allocated_after = tunnel_ids_resource.iter_allocated();
+    assert!(
+        !allocated_after
+            .iter()
+            .any(|a| a.as_id() == Some(old_tunnel_id)),
+        "Old tunnel_id should be deallocated after update"
+    );
+    assert!(
+        allocated_after
+            .iter()
+            .any(|a| a.as_id() == Some(new_tunnel_id)),
+        "New tunnel_id should be allocated after update"
+    );
+
+    println!("[PASS] test_update_user_tunnel_id_with_onchain_allocation");
+}
+
+#[tokio::test]
+async fn test_update_user_tunnel_net_with_onchain_allocation() {
+    println!("[TEST] test_update_user_tunnel_net_with_onchain_allocation");
+
+    let client_ip = [100, 0, 0, 51];
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        _device_pubkey,
+        user_pubkey,
+        _accesspass_pubkey,
+        (user_tunnel_block, multicast_publisher_block, tunnel_ids, dz_prefix_block),
+    ) = setup_activated_user_for_update(client_ip).await;
+
+    // Read user to get current tunnel_net
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    let old_tunnel_net = user.tunnel_net;
+    assert!(old_tunnel_net.ip().is_link_local());
+
+    // Count allocations in UserTunnelBlock before update
+    let utb_resource = get_resource_extension_data(&mut banks_client, user_tunnel_block)
+        .await
+        .expect("UserTunnelBlock should exist");
+    let alloc_count_before = utb_resource.iter_allocated().len();
+
+    // Pick a new tunnel_net in the link-local range with the same prefix (/31)
+    let new_tunnel_net: doublezero_program_common::types::NetworkV4 =
+        "169.254.0.2/31".parse().unwrap();
+
+    // Update tunnel_net with onchain allocation
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+            tunnel_net: Some(new_tunnel_net),
+            dz_prefix_count: 1,
+            multicast_publisher_count: 1,
+            ..UserUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify user has new tunnel_net
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.tunnel_net, new_tunnel_net);
+
+    // Verify allocation count is the same (one deallocated, one allocated)
+    let utb_resource = get_resource_extension_data(&mut banks_client, user_tunnel_block)
+        .await
+        .expect("UserTunnelBlock should exist");
+    let alloc_count_after = utb_resource.iter_allocated().len();
+    assert_eq!(
+        alloc_count_before, alloc_count_after,
+        "Allocation count should remain the same after tunnel_net swap"
+    );
+
+    println!("[PASS] test_update_user_tunnel_net_with_onchain_allocation");
+}
+
+#[tokio::test]
+async fn test_update_user_dz_ip_with_onchain_allocation() {
+    println!("[TEST] test_update_user_dz_ip_with_onchain_allocation");
+
+    let client_ip = [100, 0, 0, 52];
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        _device_pubkey,
+        user_pubkey,
+        _accesspass_pubkey,
+        (user_tunnel_block, multicast_publisher_block, tunnel_ids, dz_prefix_block),
+    ) = setup_activated_user_for_update(client_ip).await;
+
+    // Read user to get current dz_ip
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    let old_dz_ip = user.dz_ip;
+    // IBRLWithAllocatedIP should have dz_ip from DzPrefixBlock (110.1.0.0/24)
+    assert_eq!(old_dz_ip.octets()[0], 110);
+    assert_eq!(old_dz_ip.octets()[1], 1);
+
+    // Count allocations in DzPrefixBlock before (should be 2: reserved index 0 + user's dz_ip)
+    let dpb_resource = get_resource_extension_data(&mut banks_client, dz_prefix_block)
+        .await
+        .expect("DzPrefixBlock should exist");
+    let alloc_count_before = dpb_resource.iter_allocated().len();
+
+    // Pick a new dz_ip in the 110.1.0.0/24 range
+    let new_dz_ip = Ipv4Addr::new(110, 1, 0, 5);
+
+    // Update dz_ip with onchain allocation
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+            dz_ip: Some(new_dz_ip),
+            dz_prefix_count: 1,
+            multicast_publisher_count: 1,
+            ..UserUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify user has new dz_ip
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.dz_ip, new_dz_ip);
+
+    // Verify allocation count is the same (one deallocated, one allocated)
+    let dpb_resource = get_resource_extension_data(&mut banks_client, dz_prefix_block)
+        .await
+        .expect("DzPrefixBlock should exist");
+    let alloc_count_after = dpb_resource.iter_allocated().len();
+    assert_eq!(
+        alloc_count_before, alloc_count_after,
+        "Allocation count should remain the same after dz_ip swap"
+    );
+
+    println!("[PASS] test_update_user_dz_ip_with_onchain_allocation");
+}
+
+#[tokio::test]
+async fn test_update_user_backward_compat() {
+    println!("[TEST] test_update_user_backward_compat");
+
+    let client_ip = [100, 0, 0, 53];
+    let (
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        _device_pubkey,
+        user_pubkey,
+        _accesspass_pubkey,
+        (_user_tunnel_block, _multicast_publisher_block, tunnel_ids, _dz_prefix_block),
+    ) = setup_activated_user_for_update(client_ip).await;
+
+    // Read user to get current values
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    let old_tunnel_id = user.tunnel_id;
+
+    // Record bitmap state before
+    let tunnel_ids_resource = get_resource_extension_data(&mut banks_client, tunnel_ids)
+        .await
+        .expect("TunnelIds should exist");
+    let alloc_before = tunnel_ids_resource.iter_allocated();
+
+    // Update with dz_prefix_count=0 (legacy path) — should NOT touch bitmaps
+    let new_tunnel_id: u16 = if old_tunnel_id == 600 { 601 } else { 600 };
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+            tunnel_id: Some(new_tunnel_id),
+            dz_prefix_count: 0,
+            multicast_publisher_count: 0,
+            ..UserUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify user has new tunnel_id
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.tunnel_id, new_tunnel_id);
+
+    // Verify bitmap is UNCHANGED (legacy path doesn't touch bitmaps)
+    let tunnel_ids_resource = get_resource_extension_data(&mut banks_client, tunnel_ids)
+        .await
+        .expect("TunnelIds should exist");
+    let alloc_after = tunnel_ids_resource.iter_allocated();
+    assert_eq!(
+        alloc_before.len(),
+        alloc_after.len(),
+        "Bitmap should be unchanged in legacy path"
+    );
+
+    println!("[PASS] test_update_user_backward_compat");
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -413,6 +413,7 @@ async fn test_user() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -447,6 +448,7 @@ async fn test_user() {
             tunnel_net: Some("169.254.0.2/25".parse().unwrap()),
             validator_pubkey: None,
             tenant_pk: None,
+            ..UserUpdateArgs::default()
         }),
         vec![
             AccountMeta::new(user_pubkey, false),

--- a/smartcontract/sdk/rs/src/commands/user/update.rs
+++ b/smartcontract/sdk/rs/src/commands/user/update.rs
@@ -1,12 +1,20 @@
 use crate::{
-    commands::{globalstate::get::GetGlobalStateCommand, user::get::GetUserCommand},
+    commands::{
+        device::get::GetDeviceCommand, globalstate::get::GetGlobalStateCommand,
+        user::get::GetUserCommand,
+    },
     DoubleZeroClient,
 };
 use doublezero_program_common::types::NetworkV4;
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
+    pda::get_resource_extension_pda,
     processors::user::update::UserUpdateArgs,
-    state::user::{UserCYOA, UserType},
+    resource::ResourceType,
+    state::{
+        feature_flags::{is_feature_enabled, FeatureFlag},
+        user::{UserCYOA, UserType},
+    },
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 use std::net::Ipv4Addr;
@@ -25,18 +33,75 @@ pub struct UpdateUserCommand {
 
 impl UpdateUserCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
-        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+        let (globalstate_pubkey, globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let use_onchain_allocation =
+            is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation);
+
+        let updating_resources =
+            self.dz_ip.is_some() || self.tunnel_id.is_some() || self.tunnel_net.is_some();
 
         let mut accounts = vec![
             AccountMeta::new(self.pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
         ];
 
+        let (dz_prefix_count, multicast_publisher_count) = if use_onchain_allocation
+            && updating_resources
+        {
+            // Fetch user to get device_pk
+            let (_user_pubkey, user) = GetUserCommand {
+                pubkey: self.pubkey,
+            }
+            .execute(client)?;
+
+            // Fetch device to get dz_prefixes count
+            let (_, device) = GetDeviceCommand {
+                pubkey_or_code: user.device_pk.to_string(),
+            }
+            .execute(client)
+            .map_err(|_| eyre::eyre!("Device not found"))?;
+
+            let count = device.dz_prefixes.len();
+
+            // UserTunnelBlock (global)
+            let (user_tunnel_block_ext, _, _) =
+                get_resource_extension_pda(&client.get_program_id(), ResourceType::UserTunnelBlock);
+            accounts.push(AccountMeta::new(user_tunnel_block_ext, false));
+
+            // MulticastPublisherBlock (global) — always include for deallocation
+            let (multicast_publisher_block_ext, _, _) = get_resource_extension_pda(
+                &client.get_program_id(),
+                ResourceType::MulticastPublisherBlock,
+            );
+            accounts.push(AccountMeta::new(multicast_publisher_block_ext, false));
+
+            // TunnelIds (per-device)
+            let (device_tunnel_ids_ext, _, _) = get_resource_extension_pda(
+                &client.get_program_id(),
+                ResourceType::TunnelIds(user.device_pk, 0),
+            );
+            accounts.push(AccountMeta::new(device_tunnel_ids_ext, false));
+
+            // DzPrefixBlock accounts (per-device)
+            for idx in 0..count {
+                let (dz_prefix_ext, _, _) = get_resource_extension_pda(
+                    &client.get_program_id(),
+                    ResourceType::DzPrefixBlock(user.device_pk, idx),
+                );
+                accounts.push(AccountMeta::new(dz_prefix_ext, false));
+            }
+
+            (count as u8, 1u8)
+        } else {
+            (0u8, 0u8)
+        };
+
         // If updating tenant_pk, add old and new tenant accounts for reference counting
         if let Some(new_tenant_pk) = self.tenant_pk {
-            // Get current user to find old tenant
+            // Get current user to find old tenant (may already have been fetched above)
             let (_user_pubkey, user) = GetUserCommand {
                 pubkey: self.pubkey,
             }
@@ -58,8 +123,272 @@ impl UpdateUserCommand {
                 tunnel_net: self.tunnel_net,
                 validator_pubkey: self.validator_pubkey,
                 tenant_pk: self.tenant_pk,
+                dz_prefix_count,
+                multicast_publisher_count,
             }),
             accounts,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::user::update::UpdateUserCommand, tests::utils::create_test_client,
+        DoubleZeroClient, MockDoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_resource_extension_pda},
+        processors::user::update::UserUpdateArgs,
+        resource::ResourceType,
+        state::{
+            accountdata::AccountData,
+            accounttype::AccountType,
+            device::Device,
+            feature_flags::FeatureFlag,
+            globalstate::GlobalState,
+            user::{User, UserCYOA, UserStatus, UserType},
+        },
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_commands_user_update_legacy() {
+        // Feature flag disabled — no resource accounts should be included
+        let client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let user_pubkey = Pubkey::new_unique();
+
+        let mut client = client;
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+                    user_type: Some(UserType::IBRL),
+                    cyoa_type: None,
+                    dz_ip: Some(Ipv4Addr::new(10, 0, 0, 1)),
+                    tunnel_id: Some(500),
+                    tunnel_net: Some("169.254.0.0/31".parse().unwrap()),
+                    validator_pubkey: None,
+                    tenant_pk: None,
+                    dz_prefix_count: 0,
+                    multicast_publisher_count: 0,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pubkey, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = UpdateUserCommand {
+            pubkey: user_pubkey,
+            user_type: Some(UserType::IBRL),
+            cyoa_type: None,
+            dz_ip: Some(Ipv4Addr::new(10, 0, 0, 1)),
+            tunnel_id: Some(500),
+            tunnel_net: Some("169.254.0.0/31".parse().unwrap()),
+            validator_pubkey: None,
+            tenant_pk: None,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_commands_user_update_with_onchain_allocation() {
+        // Feature flag enabled + resource fields being updated — resource accounts should be included
+        let mut client = MockDoubleZeroClient::new();
+
+        let payer = Pubkey::new_unique();
+        client.expect_get_payer().returning(move || payer);
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let (globalstate_pubkey, bump_seed) = get_globalstate_pda(&program_id);
+        let globalstate = GlobalState {
+            account_type: AccountType::GlobalState,
+            bump_seed,
+            account_index: 0,
+            foundation_allowlist: vec![],
+            _device_allowlist: vec![],
+            _user_allowlist: vec![],
+            activator_authority_pk: Pubkey::new_unique(),
+            sentinel_authority_pk: Pubkey::new_unique(),
+            contributor_airdrop_lamports: 1_000_000_000,
+            user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![],
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+            reservation_authority_pk: Pubkey::default(),
+        };
+        client
+            .expect_get()
+            .with(predicate::eq(globalstate_pubkey))
+            .returning(move |_| Ok(AccountData::GlobalState(globalstate.clone())));
+
+        let user_pubkey = Pubkey::new_unique();
+        let device_pk = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(192, 168, 1, 10);
+
+        let user = User {
+            account_type: AccountType::User,
+            owner: payer,
+            bump_seed: 0,
+            index: 1,
+            tenant_pk: Pubkey::default(),
+            user_type: UserType::IBRLWithAllocatedIP,
+            device_pk,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip,
+            dz_ip: Ipv4Addr::new(10, 0, 0, 1),
+            tunnel_id: 500,
+            tunnel_net: "169.254.0.0/31".parse().unwrap(),
+            status: UserStatus::Activated,
+            publishers: vec![],
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+        };
+
+        client
+            .expect_get()
+            .with(predicate::eq(user_pubkey))
+            .returning(move |_| Ok(AccountData::User(user.clone())));
+
+        // Mock Device fetch (1 dz_prefix)
+        let device = Device {
+            account_type: AccountType::Device,
+            dz_prefixes: "10.0.0.0/24".parse().unwrap(),
+            ..Default::default()
+        };
+        client
+            .expect_get()
+            .with(predicate::eq(device_pk))
+            .returning(move |_| Ok(AccountData::Device(device.clone())));
+
+        // Compute ResourceExtension PDAs
+        let (user_tunnel_block_ext, _, _) =
+            get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+        let (multicast_publisher_block_ext, _, _) =
+            get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+        let (device_tunnel_ids_ext, _, _) =
+            get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pk, 0));
+        let (dz_prefix_ext, _, _) =
+            get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pk, 0));
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+                    user_type: None,
+                    cyoa_type: None,
+                    dz_ip: None,
+                    tunnel_id: Some(501),
+                    tunnel_net: None,
+                    validator_pubkey: None,
+                    tenant_pk: None,
+                    dz_prefix_count: 1,
+                    multicast_publisher_count: 1,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pubkey, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                    AccountMeta::new(user_tunnel_block_ext, false),
+                    AccountMeta::new(multicast_publisher_block_ext, false),
+                    AccountMeta::new(device_tunnel_ids_ext, false),
+                    AccountMeta::new(dz_prefix_ext, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = UpdateUserCommand {
+            pubkey: user_pubkey,
+            user_type: None,
+            cyoa_type: None,
+            dz_ip: None,
+            tunnel_id: Some(501),
+            tunnel_net: None,
+            validator_pubkey: None,
+            tenant_pk: None,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_commands_user_update_no_resource_fields_skips_accounts() {
+        // Feature flag enabled but NOT updating resource fields — no resource accounts
+        let user_pubkey = Pubkey::new_unique();
+
+        let mut client = MockDoubleZeroClient::new();
+        let payer = Pubkey::new_unique();
+        client.expect_get_payer().returning(move || payer);
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let (globalstate_pubkey, bump_seed) = get_globalstate_pda(&program_id);
+        let globalstate = GlobalState {
+            account_type: AccountType::GlobalState,
+            bump_seed,
+            account_index: 0,
+            foundation_allowlist: vec![],
+            _device_allowlist: vec![],
+            _user_allowlist: vec![],
+            activator_authority_pk: Pubkey::new_unique(),
+            sentinel_authority_pk: Pubkey::new_unique(),
+            contributor_airdrop_lamports: 1_000_000_000,
+            user_airdrop_lamports: 40_000,
+            health_oracle_pk: Pubkey::new_unique(),
+            qa_allowlist: vec![],
+            feature_flags: FeatureFlag::OnChainAllocation.to_mask(),
+            reservation_authority_pk: Pubkey::default(),
+        };
+        client
+            .expect_get()
+            .with(predicate::eq(globalstate_pubkey))
+            .returning(move |_| Ok(AccountData::GlobalState(globalstate.clone())));
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::UpdateUser(UserUpdateArgs {
+                    user_type: Some(UserType::IBRL),
+                    cyoa_type: None,
+                    dz_ip: None,
+                    tunnel_id: None,
+                    tunnel_net: None,
+                    validator_pubkey: None,
+                    tenant_pk: None,
+                    dz_prefix_count: 0,
+                    multicast_publisher_count: 0,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pubkey, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = UpdateUserCommand {
+            pubkey: user_pubkey,
+            user_type: Some(UserType::IBRL),
+            cyoa_type: None,
+            dz_ip: None,
+            tunnel_id: None,
+            tunnel_net: None,
+            validator_pubkey: None,
+            tenant_pk: None,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
Closes #3170

## Summary of Changes
* Modified process_update_user to handle resource allocation onchain if feature flag is enabled and the users cli is new enough (passing the extra accounts).
* Changes the SDK UpdateUser to appropriately call the smartcontract based on feature flag

## Testing Verification
* New tests added
* Existing tests pass
