### PR TITLE
ci: fix goreleaser v2 mainnet-beta build by removing CARGO_TARGET_DIR

### DIFF
--- a/release/.goreleaser.base.client.yaml
+++ b/release/.goreleaser.base.client.yaml
@@ -47,10 +47,6 @@ builds:
     env:
       - RUSTFLAGS=-C linker=x86_64-linux-gnu-gcc
       - BUILD_VERSION={{.Version}}
-      - CARGO_TARGET_DIR=target/mainnet-beta
-    hooks:
-      post:
-        - mkdir -p target/x86_64-unknown-linux-gnu/release && cp target/mainnet-beta/x86_64-unknown-linux-gnu/release/doublezero target/x86_64-unknown-linux-gnu/release/doublezero
 
 archives:
   - id: doublezero_archive


### PR DESCRIPTION
## Summary
- Fixes GoReleaser v2 build failure for mainnet-beta client by removing the `CARGO_TARGET_DIR` environment variable

## Context
PR #3243 added `CARGO_TARGET_DIR=target/mainnet-beta` to prevent the mainnet-beta build from overwriting the testnet build. However, this causes failures with GoReleaser v2 because:

1. GoReleaser v2's Rust builder is hardcoded to look for binaries at `target/x86_64-unknown-linux-gnu/release/`
2. With `CARGO_TARGET_DIR=target/mainnet-beta`, the binary is built at `target/mainnet-beta/x86_64-unknown-linux-gnu/release/`
3. GoReleaser fails with "no such file or directory" when trying to copy the binary to dist

## Solution
Remove `CARGO_TARGET_DIR` entirely. GoReleaser v2 handles multiple Rust builds correctly by:
1. Building each binary sequentially
2. Immediately copying each binary to its own dist folder after building
3. This happens before the next build overwrites the target directory

## Testing Verification
- Built locally with `goreleaser release --snapshot` - both binaries build successfully
- Verified the testnet and mainnet-beta packages contain different binaries (different SHA256 checksums)
- Testnet package: contains testnet binary (SHA: `84b09ea4...`, size: 15358696)
- Mainnet-beta package: contains mainnet-beta binary (SHA: `8d9482de...`, size: 15358472)
- CI validation workflow passes