### PR TITLE
telemetry/geoprobe: add version and target IP to LocationOffset wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 ### Changes
 - Client
   - Demote passive-mode liveness session-down log messages from Info to Debug to reduce log noise when no dataplane action is taken
+- Telemetry
+  - Add `Version` (uint8) and `TargetIP` ([4]byte) fields to LocationOffset wire format (v1, 174 bytes), with version validation on unmarshal to enable safe future format evolution
+- Tools
+  - Update TWAMP signed packet parser byte offsets and `OffsetInfo` struct for LocationOffset v1 layout
 - E2E Tests
   - Add geoprobe E2E test (`TestE2E_GeoprobeDiscovery`) that exercises the full geolocation flow: deploy geolocation program, create probe onchain, start geoprobe-agent container, and verify the telemetry-agent discovers and measures the probe via TWAMP
   - Add geoprobe Docker image, geolocation program build/deploy support, and manager geolocation CLI configuration to the E2E devnet infrastructure

--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -749,11 +749,13 @@ func runMeasurementCycle(
 	sentCount := 0
 	for addr, measuredRttNs := range rttData {
 		compositeOffset := geoprobe.LocationOffset{
+			Version:         geoprobe.LocationOffsetVersion,
 			MeasurementSlot: slot,
 			MeasuredRttNs:   measuredRttNs,
 			Lat:             dzdOffset.Lat,
 			Lng:             dzdOffset.Lng,
 			RttNs:           dzdOffset.RttNs + measuredRttNs,
+			TargetIP:        geoprobe.IPToTargetIP(addr.Host),
 			NumReferences:   1,
 			References:      []geoprobe.LocationOffset{*dzdOffset},
 		}

--- a/controlplane/telemetry/cmd/geoprobe-target/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target/main.go
@@ -323,6 +323,7 @@ type OffsetOutput struct {
 	SourceAddr        string            `json:"source_addr"`
 	AuthorityPubkey   string            `json:"authority_pubkey"`
 	SenderPubkey      string            `json:"sender_pubkey"`
+	TargetIP          string            `json:"target_ip"`
 	ReferencePoint    CoordinateOutput  `json:"reference_point"`
 	RttMs             float64           `json:"rtt_ms"`
 	MeasuredRttMs     float64           `json:"measured_rtt_ms"`
@@ -343,6 +344,7 @@ type CoordinateOutput struct {
 type ReferenceOutput struct {
 	AuthorityPubkey string           `json:"authority_pubkey"`
 	SenderPubkey    string           `json:"sender_pubkey"`
+	TargetIP        string           `json:"target_ip"`
 	Location        CoordinateOutput `json:"location"`
 	RttMs           float64          `json:"rtt_ms"`
 	MeasuredRttMs   float64          `json:"measured_rtt_ms"`
@@ -359,6 +361,7 @@ func formatLocationOffset(offset *geoprobe.LocationOffset, addr *net.UDPAddr, si
 		SourceAddr:       addr.String(),
 		AuthorityPubkey:  formatPubkey(offset.AuthorityPubkey[:]),
 		SenderPubkey:     formatPubkey(offset.SenderPubkey[:]),
+		TargetIP:         geoprobe.FormatTargetIP(offset.TargetIP),
 		ReferencePoint:   formatCoordinate(offset.Lat, offset.Lng),
 		RttMs:            rttMs,
 		MeasuredRttMs:    measuredRttMs,
@@ -378,6 +381,7 @@ func formatLocationOffset(offset *geoprobe.LocationOffset, addr *net.UDPAddr, si
 		output.DZDReferenceChain = append(output.DZDReferenceChain, ReferenceOutput{
 			AuthorityPubkey: formatPubkey(ref.AuthorityPubkey[:]),
 			SenderPubkey:    formatPubkey(ref.SenderPubkey[:]),
+			TargetIP:        geoprobe.FormatTargetIP(ref.TargetIP),
 			Location:        formatCoordinate(ref.Lat, ref.Lng),
 			RttMs:           refRttMs,
 			MeasuredRttMs:   refMeasuredRttMs,
@@ -394,6 +398,7 @@ func formatTextOutput(output OffsetOutput) string {
 	sb.WriteString(fmt.Sprintf("[%s] Received LocationOffset from Probe\n", output.Timestamp))
 	sb.WriteString(fmt.Sprintf("  Authority: %s\n", output.AuthorityPubkey))
 	sb.WriteString(fmt.Sprintf("  Sender:    %s\n", output.SenderPubkey))
+	sb.WriteString(fmt.Sprintf("  Target IP: %s\n", output.TargetIP))
 	sb.WriteString(fmt.Sprintf("  Reference Point: %s\n", output.ReferencePoint.Formatted))
 	sb.WriteString(fmt.Sprintf("  RTT to Target: %.2fms\n", output.RttMs))
 	sb.WriteString(fmt.Sprintf("  Measured RTT:  %.2fms\n", output.MeasuredRttMs))

--- a/controlplane/telemetry/internal/geoprobe/offset.go
+++ b/controlplane/telemetry/internal/geoprobe/offset.go
@@ -3,11 +3,14 @@ package geoprobe
 import (
 	"fmt"
 	"io"
+	"net"
 
 	bin "github.com/gagliardetto/binary"
 )
 
 const (
+	LocationOffsetVersion = 1
+
 	MaxReferenceDepth  = 2
 	MaxTotalReferences = 5
 )
@@ -22,6 +25,7 @@ const (
 // Based on RFC16: Geolocation Verification
 type LocationOffset struct {
 	Signature       [64]byte         // Ed25519 signature over the serialized bytes (excluding this field)
+	Version         uint8            // Wire format version (currently 1)
 	AuthorityPubkey [32]byte         // Signer's public key (metrics publisher key or probe signing key)
 	SenderPubkey    [32]byte         // Device public key (DZD or Probe)
 	MeasurementSlot uint64           // Current DoubleZero Slot when measurement was taken
@@ -29,8 +33,27 @@ type LocationOffset struct {
 	Lat             float64          // Reference point latitude in WGS84 (decimal degrees)
 	Lng             float64          // Reference point longitude in WGS84 (decimal degrees)
 	RttNs           uint64           // Accumulated RTT to target in nanoseconds from lat/lng
+	TargetIP        [4]byte          // IPv4 address of the TWAMP measurement target
 	NumReferences   uint8            // Number of reference offsets in the chain
 	References      []LocationOffset // Reference offsets (recursive chain for verification)
+}
+
+// IPToTargetIP converts an IP address string to a [4]byte for use in TargetIP.
+func IPToTargetIP(host string) [4]byte {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return [4]byte{}
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return [4]byte{}
+	}
+	return [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]}
+}
+
+// FormatTargetIP formats a [4]byte TargetIP as a dotted-decimal string.
+func FormatTargetIP(ip [4]byte) string {
+	return fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
 }
 
 // Marshal serializes the LocationOffset to bytes using Borsh encoding.
@@ -41,6 +64,9 @@ func (o *LocationOffset) Marshal() ([]byte, error) {
 
 	if err := enc.Encode(o.Signature); err != nil {
 		return nil, fmt.Errorf("failed to encode signature: %w", err)
+	}
+	if err := enc.Encode(o.Version); err != nil {
+		return nil, fmt.Errorf("failed to encode version: %w", err)
 	}
 	if err := enc.Encode(o.AuthorityPubkey); err != nil {
 		return nil, fmt.Errorf("failed to encode authority pubkey: %w", err)
@@ -62,6 +88,9 @@ func (o *LocationOffset) Marshal() ([]byte, error) {
 	}
 	if err := enc.Encode(o.RttNs); err != nil {
 		return nil, fmt.Errorf("failed to encode rtt: %w", err)
+	}
+	if err := enc.Encode(o.TargetIP); err != nil {
+		return nil, fmt.Errorf("failed to encode target ip: %w", err)
 	}
 	if err := enc.Encode(o.NumReferences); err != nil {
 		return nil, fmt.Errorf("failed to encode num references: %w", err)
@@ -108,6 +137,12 @@ func (o *LocationOffset) unmarshalHelper(data []byte, dec *bin.Decoder, depth in
 	if err := dec.Decode(&o.Signature); err != nil {
 		return fmt.Errorf("failed to decode signature: %w", err)
 	}
+	if err := dec.Decode(&o.Version); err != nil {
+		return fmt.Errorf("failed to decode version: %w", err)
+	}
+	if o.Version != LocationOffsetVersion {
+		return fmt.Errorf("unsupported location offset version %d (expected %d)", o.Version, LocationOffsetVersion)
+	}
 	if err := dec.Decode(&o.AuthorityPubkey); err != nil {
 		return fmt.Errorf("failed to decode authority pubkey: %w", err)
 	}
@@ -129,6 +164,9 @@ func (o *LocationOffset) unmarshalHelper(data []byte, dec *bin.Decoder, depth in
 	if err := dec.Decode(&o.RttNs); err != nil {
 		return fmt.Errorf("failed to decode rtt: %w", err)
 	}
+	if err := dec.Decode(&o.TargetIP); err != nil {
+		return fmt.Errorf("failed to decode target ip: %w", err)
+	}
 	if err := dec.Decode(&o.NumReferences); err != nil {
 		return fmt.Errorf("failed to decode num references: %w", err)
 	}
@@ -149,6 +187,9 @@ func (o *LocationOffset) GetSigningBytes() ([]byte, error) {
 	w := &bytesWriter{buf: buf}
 	enc := bin.NewBorshEncoder(w)
 
+	if err := enc.Encode(o.Version); err != nil {
+		return nil, fmt.Errorf("failed to encode version: %w", err)
+	}
 	if err := enc.Encode(o.AuthorityPubkey); err != nil {
 		return nil, fmt.Errorf("failed to encode authority pubkey: %w", err)
 	}
@@ -169,6 +210,9 @@ func (o *LocationOffset) GetSigningBytes() ([]byte, error) {
 	}
 	if err := enc.Encode(o.RttNs); err != nil {
 		return nil, fmt.Errorf("failed to encode rtt: %w", err)
+	}
+	if err := enc.Encode(o.TargetIP); err != nil {
+		return nil, fmt.Errorf("failed to encode target ip: %w", err)
 	}
 	if err := enc.Encode(o.NumReferences); err != nil {
 		return nil, fmt.Errorf("failed to encode num references: %w", err)

--- a/controlplane/telemetry/internal/geoprobe/offset_test.go
+++ b/controlplane/telemetry/internal/geoprobe/offset_test.go
@@ -12,6 +12,7 @@ func TestLocationOffset_MarshalUnmarshal(t *testing.T) {
 	// Create a test offset with Amsterdam coordinates (from RFC16)
 	offset := &LocationOffset{
 		Signature:       [64]byte{1, 2, 3, 4, 5},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{10, 11, 12, 13, 14},
 		SenderPubkey:    [32]byte{20, 21, 22, 23, 24},
 		MeasurementSlot: 123456789,
@@ -19,6 +20,7 @@ func TestLocationOffset_MarshalUnmarshal(t *testing.T) {
 		Lat:             52.3676, // Amsterdam
 		Lng:             4.9041,
 		RttNs:           12500000, // 12.5ms
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -35,6 +37,7 @@ func TestLocationOffset_MarshalUnmarshal(t *testing.T) {
 
 	// Verify all fields match
 	require.Equal(t, offset.Signature, decoded.Signature)
+	require.Equal(t, offset.Version, decoded.Version)
 	require.Equal(t, offset.AuthorityPubkey, decoded.AuthorityPubkey)
 	require.Equal(t, offset.SenderPubkey, decoded.SenderPubkey)
 	require.Equal(t, offset.MeasurementSlot, decoded.MeasurementSlot)
@@ -42,6 +45,7 @@ func TestLocationOffset_MarshalUnmarshal(t *testing.T) {
 	require.Equal(t, offset.Lng, decoded.Lng)
 	require.Equal(t, offset.MeasuredRttNs, decoded.MeasuredRttNs)
 	require.Equal(t, offset.RttNs, decoded.RttNs)
+	require.Equal(t, offset.TargetIP, decoded.TargetIP)
 	require.Equal(t, offset.NumReferences, decoded.NumReferences)
 	require.Len(t, decoded.References, 0)
 }
@@ -52,12 +56,14 @@ func TestLocationOffset_WithReferences(t *testing.T) {
 	// Create a DZD offset (no references)
 	dzdOffset := &LocationOffset{
 		Signature:       [64]byte{1, 2, 3},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{10, 11, 12},
 		MeasurementSlot: 100,
 		MeasuredRttNs:   800000,
 		Lat:             50.1109, // Frankfurt
 		Lng:             8.6821,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -65,12 +71,14 @@ func TestLocationOffset_WithReferences(t *testing.T) {
 	// Create a Probe offset that references the DZD offset
 	probeOffset := &LocationOffset{
 		Signature:       [64]byte{4, 5, 6},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{20, 21, 22},
 		MeasurementSlot: 101,
 		MeasuredRttNs:   12500000, // 12.5ms probe-to-target
 		Lat:             50.1109,  // Copied from DZD
 		Lng:             8.6821,
 		RttNs:           13300000, // 800000 + 12500000
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   1,
 		References:      []LocationOffset{*dzdOffset},
 	}
@@ -87,6 +95,7 @@ func TestLocationOffset_WithReferences(t *testing.T) {
 
 	// Verify top-level fields
 	require.Equal(t, probeOffset.Signature, decoded.Signature)
+	require.Equal(t, probeOffset.Version, decoded.Version)
 	require.Equal(t, probeOffset.AuthorityPubkey, decoded.AuthorityPubkey)
 	require.Equal(t, probeOffset.SenderPubkey, decoded.SenderPubkey)
 	require.Equal(t, probeOffset.MeasurementSlot, decoded.MeasurementSlot)
@@ -94,16 +103,19 @@ func TestLocationOffset_WithReferences(t *testing.T) {
 	require.Equal(t, probeOffset.Lng, decoded.Lng)
 	require.Equal(t, probeOffset.MeasuredRttNs, decoded.MeasuredRttNs)
 	require.Equal(t, probeOffset.RttNs, decoded.RttNs)
+	require.Equal(t, probeOffset.TargetIP, decoded.TargetIP)
 	require.Equal(t, probeOffset.NumReferences, decoded.NumReferences)
 
 	// Verify reference chain
 	require.Len(t, decoded.References, 1)
 	require.Equal(t, dzdOffset.Signature, decoded.References[0].Signature)
+	require.Equal(t, dzdOffset.Version, decoded.References[0].Version)
 	require.Equal(t, dzdOffset.AuthorityPubkey, decoded.References[0].AuthorityPubkey)
 	require.Equal(t, dzdOffset.SenderPubkey, decoded.References[0].SenderPubkey)
 	require.Equal(t, dzdOffset.MeasurementSlot, decoded.References[0].MeasurementSlot)
 	require.Equal(t, dzdOffset.Lat, decoded.References[0].Lat)
 	require.Equal(t, dzdOffset.Lng, decoded.References[0].Lng)
+	require.Equal(t, dzdOffset.TargetIP, decoded.References[0].TargetIP)
 	require.Equal(t, dzdOffset.NumReferences, decoded.References[0].NumReferences)
 }
 
@@ -113,6 +125,7 @@ func TestLocationOffset_EmptyReferences(t *testing.T) {
 	// DZD-generated offset with no references
 	offset := &LocationOffset{
 		Signature:       [64]byte{},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{},
 		MeasurementSlot: 1,
 		MeasuredRttNs:   1000,
@@ -141,12 +154,14 @@ func TestLocationOffset_GetSigningBytes(t *testing.T) {
 
 	offset := &LocationOffset{
 		Signature:       [64]byte{99, 99, 99}, // Should be excluded from signing bytes
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{1, 2, 3},
 		MeasurementSlot: 42,
 		MeasuredRttNs:   1000,
 		Lat:             10.5,
 		Lng:             20.5,
 		RttNs:           2000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -170,24 +185,28 @@ func TestLocationOffset_GetSigningBytes_WithReferences(t *testing.T) {
 
 	dzdOffset := &LocationOffset{
 		Signature:       [64]byte{1},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{1},
 		MeasurementSlot: 100,
 		MeasuredRttNs:   1000,
 		Lat:             1.0,
 		Lng:             2.0,
 		RttNs:           1000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
 
 	probeOffset := &LocationOffset{
 		Signature:       [64]byte{2},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{2},
 		MeasurementSlot: 101,
 		MeasuredRttNs:   2000,
 		Lat:             1.0,
 		Lng:             2.0,
 		RttNs:           3000,
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   1,
 		References:      []LocationOffset{*dzdOffset},
 	}
@@ -210,6 +229,7 @@ func TestLocationOffset_UnmarshalError_TruncatedData(t *testing.T) {
 
 	offset := &LocationOffset{
 		Signature:       [64]byte{1, 2, 3},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{4, 5, 6},
 		MeasurementSlot: 123,
 		MeasuredRttNs:   1000,
@@ -230,12 +250,41 @@ func TestLocationOffset_UnmarshalError_TruncatedData(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLocationOffset_UnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	offset := &LocationOffset{
+		Signature:       [64]byte{1, 2, 3},
+		Version:         LocationOffsetVersion,
+		AuthorityPubkey: [32]byte{4, 5, 6},
+		MeasurementSlot: 123,
+		MeasuredRttNs:   1000,
+		Lat:             1.0,
+		Lng:             2.0,
+		RttNs:           2000,
+		NumReferences:   0,
+		References:      nil,
+	}
+
+	data, err := offset.Marshal()
+	require.NoError(t, err)
+
+	// Corrupt the version byte (byte index 64, right after the 64-byte signature)
+	data[64] = 99
+
+	decoded := &LocationOffset{}
+	err = decoded.Unmarshal(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported location offset version")
+}
+
 func TestLocationOffset_Size(t *testing.T) {
 	t.Parallel()
 
 	// Minimal offset
 	offset := &LocationOffset{
 		Signature:       [64]byte{},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{},
 		MeasurementSlot: 0,
 		MeasuredRttNs:   0,
@@ -250,8 +299,8 @@ func TestLocationOffset_Size(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, size, 0)
 
-	// Size should be: 64 (sig) + 32 (authority) + 32 (sender) + 8 (slot) + 8 (lat) + 8 (lng) + 8 (measured) + 8 (rtt) + 1 (numref) = 169 bytes
-	require.Equal(t, 169, size)
+	// Size should be: 64 (sig) + 1 (version) + 32 (authority) + 32 (sender) + 8 (slot) + 8 (lat) + 8 (lng) + 8 (measured) + 8 (rtt) + 4 (targetip) + 1 (numref) = 174 bytes
+	require.Equal(t, 174, size)
 }
 
 func TestLocationOffset_ReferenceDepthLimit(t *testing.T) {
@@ -260,6 +309,7 @@ func TestLocationOffset_ReferenceDepthLimit(t *testing.T) {
 	// Create a chain that exceeds MaxReferenceDepth (2)
 	current := &LocationOffset{
 		Signature:       [64]byte{0},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{0},
 		MeasurementSlot: 0,
 		MeasuredRttNs:   100,
@@ -274,6 +324,7 @@ func TestLocationOffset_ReferenceDepthLimit(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		parent := &LocationOffset{
 			Signature:       [64]byte{byte(i)},
+			Version:         LocationOffsetVersion,
 			AuthorityPubkey: [32]byte{byte(i)},
 			MeasurementSlot: uint64(i),
 			MeasuredRttNs:   uint64((i + 1) * 100),
@@ -309,6 +360,7 @@ func TestLocationOffset_TotalReferencesLimit(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		leafOffsets[i] = LocationOffset{
 			Signature:       [64]byte{byte(i)},
+			Version:         LocationOffsetVersion,
 			AuthorityPubkey: [32]byte{byte(i)},
 			MeasurementSlot: uint64(i),
 			MeasuredRttNs:   100,
@@ -325,6 +377,7 @@ func TestLocationOffset_TotalReferencesLimit(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		midOffsets[i] = LocationOffset{
 			Signature:       [64]byte{byte(100 + i)},
+			Version:         LocationOffsetVersion,
 			AuthorityPubkey: [32]byte{byte(100 + i)},
 			MeasurementSlot: uint64(100 + i),
 			MeasuredRttNs:   200,
@@ -339,6 +392,7 @@ func TestLocationOffset_TotalReferencesLimit(t *testing.T) {
 	// Root node referencing all 3 middle nodes (total refs = 3 + 3 = 6, exceeds limit of 5)
 	rootOffset := &LocationOffset{
 		Signature:       [64]byte{200},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{200},
 		MeasurementSlot: 200,
 		MeasuredRttNs:   300,
@@ -367,6 +421,7 @@ func TestLocationOffset_ValidReferenceLimits(t *testing.T) {
 	// Create a chain at exactly the depth limit (2)
 	current := &LocationOffset{
 		Signature:       [64]byte{0},
+		Version:         LocationOffsetVersion,
 		AuthorityPubkey: [32]byte{0},
 		MeasurementSlot: 0,
 		MeasuredRttNs:   100,
@@ -381,6 +436,7 @@ func TestLocationOffset_ValidReferenceLimits(t *testing.T) {
 	for i := 1; i <= 2; i++ {
 		parent := &LocationOffset{
 			Signature:       [64]byte{byte(i)},
+			Version:         LocationOffsetVersion,
 			AuthorityPubkey: [32]byte{byte(i)},
 			MeasurementSlot: uint64(i),
 			MeasuredRttNs:   uint64((i + 1) * 100),

--- a/controlplane/telemetry/internal/geoprobe/publisher.go
+++ b/controlplane/telemetry/internal/geoprobe/publisher.go
@@ -184,11 +184,13 @@ func (p *Publisher) Publish(ctx context.Context, rttData map[ProbeAddress]uint64
 			}
 
 			offset := LocationOffset{
+				Version:         LocationOffsetVersion,
 				MeasurementSlot: slot,
 				Lat:             lat,
 				Lng:             lng,
 				MeasuredRttNs:   rttNs,
 				RttNs:           rttNs,
+				TargetIP:        IPToTargetIP(addr.Host),
 				NumReferences:   0,
 				References:      []LocationOffset{},
 			}

--- a/controlplane/telemetry/internal/geoprobe/signer_test.go
+++ b/controlplane/telemetry/internal/geoprobe/signer_test.go
@@ -18,11 +18,13 @@ func TestSignOffset_Success(t *testing.T) {
 
 	// Create an offset
 	offset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 12345,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   800000,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -56,11 +58,13 @@ func TestVerifyOffset_InvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	offset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 99999,
 		Lat:             50.1109,
 		Lng:             8.6821,
 		MeasuredRttNs:   1000000,
 		RttNs:           1000000,
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -87,11 +91,13 @@ func TestVerifyOffset_WrongPublicKey(t *testing.T) {
 	require.NoError(t, err)
 
 	offset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 55555,
 		Lat:             1.0,
 		Lng:             2.0,
 		MeasuredRttNs:   500000,
 		RttNs:           500000,
+		TargetIP:        [4]byte{10, 0, 0, 3},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -119,11 +125,13 @@ func TestSignOffset_WithReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	dzdOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 100,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   800000,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -138,11 +146,13 @@ func TestSignOffset_WithReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	probeOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 101,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   12500000,
 		RttNs:           13300000,
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   1,
 		References:      []LocationOffset{*dzdOffset},
 	}
@@ -169,11 +179,13 @@ func TestVerifyOffsetChain_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	dzdOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 100,
 		Lat:             50.1109,
 		Lng:             8.6821,
 		MeasuredRttNs:   800000,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -187,11 +199,13 @@ func TestVerifyOffsetChain_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	probeOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 101,
 		Lat:             50.1109,
 		Lng:             8.6821,
 		MeasuredRttNs:   10000000,
 		RttNs:           10800000,
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   1,
 		References:      []LocationOffset{*dzdOffset},
 	}
@@ -214,11 +228,13 @@ func TestVerifyOffsetChain_InvalidReference(t *testing.T) {
 	require.NoError(t, err)
 
 	dzdOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 100,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   800000,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -236,11 +252,13 @@ func TestVerifyOffsetChain_InvalidReference(t *testing.T) {
 	require.NoError(t, err)
 
 	probeOffset := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 101,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   12500000,
 		RttNs:           13300000,
+		TargetIP:        [4]byte{10, 0, 0, 2},
 		NumReferences:   1,
 		References:      []LocationOffset{*dzdOffset},
 	}
@@ -275,21 +293,25 @@ func TestOffsetSignaturesEqual(t *testing.T) {
 	require.NoError(t, err)
 
 	offset1 := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 12345,
 		Lat:             1.0,
 		Lng:             2.0,
 		MeasuredRttNs:   1000,
 		RttNs:           1000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
 
 	offset2 := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 12345,
 		Lat:             1.0,
 		Lng:             2.0,
 		MeasuredRttNs:   1000,
 		RttNs:           1000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}
@@ -323,11 +345,13 @@ func TestSignOffset_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	original := &LocationOffset{
+		Version:         LocationOffsetVersion,
 		MeasurementSlot: 99999,
 		Lat:             52.3676,
 		Lng:             4.9041,
 		MeasuredRttNs:   800000,
 		RttNs:           800000,
+		TargetIP:        [4]byte{10, 0, 0, 1},
 		NumReferences:   0,
 		References:      nil,
 	}

--- a/rfcs/rfc16-geolocation-verification.md
+++ b/rfcs/rfc16-geolocation-verification.md
@@ -43,6 +43,7 @@ A signed data structure containing a DZD's geographic location (latitude and lon
 ```go
 type LocationOffset struct {
     Signature       [64]byte  // Ed25519 signature
+    Version         uint8     // Wire format version (currently 1)
     AuthorityPubkey [32]byte  // Signer's public key (metrics publisher key or probe signing key)
     SenderPubkey    [32]byte  // Device public key (DZD or Probe)
     MeasurementSlot uint64    // Current DoubleZero Slot
@@ -50,7 +51,7 @@ type LocationOffset struct {
     Lng             float64   // Reference point longitude (WGS84)
     MeasuredRttNs   uint64    // Measured RTT in nanoseconds, minimum
     RttNs           uint64    // RTT to target in ns, from lat/lng
-    TargetIP        uint32    // IPv4 Address from TWAMP measurement **NEW**
+    TargetIP        [4]byte   // IPv4 address of the TWAMP measurement target
     NumReferences   uint8     // Number of reference offsets in chain
     References      []Offset  // Reference offsets (empty for DZD→Probe)
 }

--- a/tools/twamp/pkg/signed/packet.go
+++ b/tools/twamp/pkg/signed/packet.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	ProbePacketSize    = 108
-	LocationOffsetSize = 169 // size of a 0-reference LocationOffset, Borsh-encoded
+	LocationOffsetSize = 174 // size of a 0-reference LocationOffset, Borsh-encoded
 	MaxOffsets         = 5
 
 	// Probe(108) + AuthorityPubkey(32) + GeoprobePubkey(32) +
@@ -304,18 +304,25 @@ type OffsetInfo struct {
 	Lat             float64
 	Lng             float64
 	RttNs           uint64
+	TargetIP        [4]byte
 }
 
 // ParseOffsetInfo extracts location and timing fields from a Borsh-encoded
 // LocationOffset blob at known byte positions (little-endian).
+//
+// Byte layout (v1): Signature(64) + Version(1) + AuthorityPubkey(32) +
+// SenderPubkey(32) + MeasurementSlot(8) + Lat(8) + Lng(8) + MeasuredRttNs(8) +
+// RttNs(8) + TargetIP(4) + NumReferences(1) = 174 bytes
 func ParseOffsetInfo(blob []byte) (OffsetInfo, bool) {
 	if len(blob) < LocationOffsetSize {
 		return OffsetInfo{}, false
 	}
+	targetIP := [4]byte(blob[169:173])
 	return OffsetInfo{
-		MeasurementSlot: binary.LittleEndian.Uint64(blob[128:136]),
-		Lat:             math.Float64frombits(binary.LittleEndian.Uint64(blob[136:144])),
-		Lng:             math.Float64frombits(binary.LittleEndian.Uint64(blob[144:152])),
-		RttNs:           binary.LittleEndian.Uint64(blob[160:168]),
+		MeasurementSlot: binary.LittleEndian.Uint64(blob[129:137]),
+		Lat:             math.Float64frombits(binary.LittleEndian.Uint64(blob[137:145])),
+		Lng:             math.Float64frombits(binary.LittleEndian.Uint64(blob[145:153])),
+		RttNs:           binary.LittleEndian.Uint64(blob[161:169]),
+		TargetIP:        targetIP,
 	}, true
 }

--- a/tools/twamp/pkg/signed/packet_test.go
+++ b/tools/twamp/pkg/signed/packet_test.go
@@ -564,11 +564,12 @@ func TestParseOffsetInfo(t *testing.T) {
 
 	t.Run("valid blob", func(t *testing.T) {
 		blob := make([]byte, signed.LocationOffsetSize)
-		binary.LittleEndian.PutUint64(blob[128:136], 42_000_000)                  // MeasurementSlot
-		binary.LittleEndian.PutUint64(blob[136:144], math.Float64bits(37.7749))   // Lat
-		binary.LittleEndian.PutUint64(blob[144:152], math.Float64bits(-122.4194)) // Lng
-		binary.LittleEndian.PutUint64(blob[152:160], 99_999_999)                  // MeasuredRttNs (skipped by ParseOffsetInfo)
-		binary.LittleEndian.PutUint64(blob[160:168], 5_000_000)                   // RttNs
+		binary.LittleEndian.PutUint64(blob[129:137], 42_000_000)                  // MeasurementSlot
+		binary.LittleEndian.PutUint64(blob[137:145], math.Float64bits(37.7749))   // Lat
+		binary.LittleEndian.PutUint64(blob[145:153], math.Float64bits(-122.4194)) // Lng
+		binary.LittleEndian.PutUint64(blob[153:161], 99_999_999)                  // MeasuredRttNs (skipped by ParseOffsetInfo)
+		binary.LittleEndian.PutUint64(blob[161:169], 5_000_000)                   // RttNs
+		copy(blob[169:173], []byte{10, 20, 30, 40})                               // TargetIP
 
 		info, ok := signed.ParseOffsetInfo(blob)
 		require.True(t, ok)
@@ -576,6 +577,7 @@ func TestParseOffsetInfo(t *testing.T) {
 		assert.Equal(t, 37.7749, info.Lat)
 		assert.Equal(t, -122.4194, info.Lng)
 		assert.Equal(t, uint64(5_000_000), info.RttNs, "should read RttNs, not MeasuredRttNs")
+		assert.Equal(t, [4]byte{10, 20, 30, 40}, info.TargetIP)
 	})
 
 	t.Run("blob too small", func(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes
- Adds `Version` (uint8) and `TargetIP` ([4]byte) fields to the `LocationOffset` struct, bumping the wire format to v1 (174 bytes, up from 169)
- Version is validated on unmarshal — unknown versions are rejected with a clear error
- Target IP captures the IPv4 address of the TWAMP measurement target, propagated through the reference chain
- Updates all serialization paths (Marshal, Unmarshal, GetSigningBytes) and the raw-byte `ParseOffsetInfo` parser
- Updates RFC16 to match the implementation

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     5 | +65 / -5    | +60  |
| Tests      |     3 | +89 / -7    | +82  |
| Docs       |     1 | +2 / -1     | +1   |

~58% of new lines are tests.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/internal/geoprobe/offset.go` — new `Version`/`TargetIP` fields, `IPToTargetIP`/`FormatTargetIP` helpers, updated Marshal/Unmarshal/GetSigningBytes with version check
- `controlplane/telemetry/internal/geoprobe/offset_test.go` — updated all fixtures for new fields, added `TestLocationOffset_UnsupportedVersion`
- `controlplane/telemetry/internal/geoprobe/signer_test.go` — updated all signing/verification test fixtures
- `tools/twamp/pkg/signed/packet.go` — adjusted `LocationOffsetSize` (169→174), shifted byte offsets in `ParseOffsetInfo`, added `TargetIP` to `OffsetInfo`
- `tools/twamp/pkg/signed/packet_test.go` — updated byte offsets in test blob construction, added `TargetIP` assertion
- `controlplane/telemetry/cmd/geoprobe-target/main.go` — surface `TargetIP` in JSON and text output
- `controlplane/telemetry/cmd/geoprobe-agent/main.go` — populate `Version` and `TargetIP` when constructing offsets
- `controlplane/telemetry/internal/geoprobe/publisher.go` — populate `Version` and `TargetIP` in DZD publisher path

</details>

## Testing Verification
- All existing offset Marshal/Unmarshal, signing, and chain verification tests updated and passing with new fields
- New `TestLocationOffset_UnsupportedVersion` test validates that corrupted version byte is rejected
- `TestLocationOffset_Size` updated to assert the new 174-byte size
- `TestParseOffsetInfo` validates correct extraction of `TargetIP` from raw bytes at the new offsets
