### PR TITLE
smartcontract/cli: fix stale multicast device field names in tests

### DIFF
--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -417,9 +417,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
 
@@ -486,9 +488,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
 

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -505,9 +505,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
 

--- a/smartcontract/cli/src/link/dzx_create.rs
+++ b/smartcontract/cli/src/link/dzx_create.rs
@@ -607,9 +607,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
         let device2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");

--- a/smartcontract/cli/src/link/wan_create.rs
+++ b/smartcontract/cli/src/link/wan_create.rs
@@ -691,9 +691,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
         let device2_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcf");
@@ -732,9 +734,11 @@ mod tests {
             desired_status:
                 doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
             unicast_users_count: 0,
-            multicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
             max_unicast_users: 0,
-            max_multicast_users: 0,
+            max_multicast_subscribers: 0,
+            max_multicast_publishers: 0,
             reserved_seats: 0,
         };
 


### PR DESCRIPTION
## Summary of Changes
- Replace removed `multicast_users_count` and `max_multicast_users` fields with `multicast_subscribers_count`/`multicast_publishers_count` and `max_multicast_subscribers`/`max_multicast_publishers` in CLI test `Device` struct literals, fixing the compilation break introduced by #3234

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Tests    |     4 | +24 / -12   | +12 |

Pure test fix — all changes are in test code updating struct field names.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/device/interface/create.rs` — update 2 test `Device` literals (2 occurrences)
- `smartcontract/cli/src/link/wan_create.rs` — update 2 test `Device` literals (2 occurrences)
- `smartcontract/cli/src/device/interface/update.rs` — update 1 test `Device` literal
- `smartcontract/cli/src/link/dzx_create.rs` — update 1 test `Device` literal

</details>

## Testing Verification
- `make rust-lint` passes cleanly
- All 263 CLI tests and 147 SDK tests pass
