### PR TITLE
telemetry: add doublezero-geoprobe-target release workflow

### DIFF
--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -36,6 +36,8 @@ jobs:
             playbook: playbooks/qa_agents.yml
           - component: geoprobe-agent
             playbook: playbooks/geoprobe_agents.yml
+          - component: geoprobe-target
+            playbook: playbooks/geoprobe_targets.yml
     with:
       component: ${{ matrix.component }}
       playbook: ${{ matrix.playbook }}

--- a/.github/workflows/release.devnet.geoprobe-target.daily.yml
+++ b/.github/workflows/release.devnet.geoprobe-target.daily.yml
@@ -1,0 +1,15 @@
+name: release.devnet.geoprobe-target.daily
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.daily.yml
+    with:
+      component: geoprobe-target
+      playbook: playbooks/geoprobe_targets.yml
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write

--- a/release/.goreleaser.base.geoprobe-target.yaml
+++ b/release/.goreleaser.base.geoprobe-target.yaml
@@ -21,11 +21,22 @@ builds:
       - linux
     goarch:
       - amd64
+  - id: doublezero-geoprobe-target-sender
+    main: cmd/geoprobe-target-sender/main.go
+    binary: doublezero-geoprobe-target-sender
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
 
 archives:
   - id: geoprobe_target_archive
     formats: ['tar.gz']
-    ids: [doublezero-geoprobe-target]
+    ids: [doublezero-geoprobe-target, doublezero-geoprobe-target-sender]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -38,7 +49,7 @@ archives:
 nfpms:
   - id: doublezero-geoprobe-target
     package_name: doublezero-geoprobe-target
-    ids: [doublezero-geoprobe-target]
+    ids: [doublezero-geoprobe-target, doublezero-geoprobe-target-sender]
     vendor: doublezero
     homepage: doublezero.xyz
     maintainer: nik <nik@malbeclabs.com>


### PR DESCRIPTION
## Summary
- Add daily devnet release for geoprobe-target
- Include geoprobe-target in the daily devnet deployment matrix to ensure automated deployments
- Add geoprobe-target-sender binary to the geoprobe-target release configuration (rfc16 "inbound probing flow")
- Infra repo companion: https://github.com/malbeclabs/infra/pull/766

## Testing Verification
- Tested updated package build by hand
