### PR TITLE
geolocation: add GeolocationUser CRUD instruction processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 - Onchain Programs
   - Add `GeolocationUser` account state to the geolocation program with owner, billing config (flat-per-epoch), payment/user status, and a target list supporting outbound (IP + port) and inbound (pubkey) geolocation targets
+  - Add GeolocationUser CRUD instruction processors (create, update, delete) with owner authorization and target-empty guard on delete
 - Client
   - Demote passive-mode liveness session-down log messages from Info to Debug to reduce log noise when no dataplane action is taken
 - Telemetry

--- a/smartcontract/programs/doublezero-geolocation/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/entrypoint.rs
@@ -6,6 +6,10 @@ use crate::{
             delete::process_delete_geo_probe, remove_parent_device::process_remove_parent_device,
             update::process_update_geo_probe,
         },
+        geolocation_user::{
+            create::process_create_geolocation_user, delete::process_delete_geolocation_user,
+            update::process_update_geolocation_user,
+        },
         program_config::{
             init::process_init_program_config, update::process_update_program_config,
         },
@@ -47,6 +51,15 @@ pub fn process_instruction(
         GeolocationInstruction::AddParentDevice => process_add_parent_device(program_id, accounts)?,
         GeolocationInstruction::RemoveParentDevice(args) => {
             process_remove_parent_device(program_id, accounts, &args)?
+        }
+        GeolocationInstruction::CreateGeolocationUser(args) => {
+            process_create_geolocation_user(program_id, accounts, &args)?
+        }
+        GeolocationInstruction::UpdateGeolocationUser(args) => {
+            process_update_geolocation_user(program_id, accounts, &args)?
+        }
+        GeolocationInstruction::DeleteGeolocationUser => {
+            process_delete_geolocation_user(program_id, accounts)?
         }
     };
 

--- a/smartcontract/programs/doublezero-geolocation/src/error.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/error.rs
@@ -28,6 +28,18 @@ pub enum GeolocationError {
     UnauthorizedInitializer = 17,
     #[error("min_compatible_version cannot exceed version")]
     InvalidMinCompatibleVersion = 18,
+    #[error("Unauthorized: signer is not the account owner")]
+    Unauthorized = 19,
+    #[error("Targets must be empty before deleting user")]
+    TargetsNotEmpty = 20,
+    #[error("Maximum targets reached")]
+    MaxTargetsReached = 21,
+    #[error("Target not found")]
+    TargetNotFound = 22,
+    #[error("Target already exists")]
+    TargetAlreadyExists = 23,
+    #[error("Invalid payment status")]
+    InvalidPaymentStatus = 24,
 }
 
 impl From<GeolocationError> for ProgramError {
@@ -54,6 +66,12 @@ mod tests {
             (GeolocationError::ReferenceCountNotZero, 15),
             (GeolocationError::UnauthorizedInitializer, 17),
             (GeolocationError::InvalidMinCompatibleVersion, 18),
+            (GeolocationError::Unauthorized, 19),
+            (GeolocationError::TargetsNotEmpty, 20),
+            (GeolocationError::MaxTargetsReached, 21),
+            (GeolocationError::TargetNotFound, 22),
+            (GeolocationError::TargetAlreadyExists, 23),
+            (GeolocationError::InvalidPaymentStatus, 24),
         ]
     }
 

--- a/smartcontract/programs/doublezero-geolocation/src/instructions.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/instructions.rs
@@ -5,6 +5,7 @@ pub use crate::processors::{
         create::CreateGeoProbeArgs, remove_parent_device::RemoveParentDeviceArgs,
         update::UpdateGeoProbeArgs,
     },
+    geolocation_user::{create::CreateGeolocationUserArgs, update::UpdateGeolocationUserArgs},
     program_config::{init::InitProgramConfigArgs, update::UpdateProgramConfigArgs},
 };
 
@@ -17,6 +18,9 @@ pub enum GeolocationInstruction {
     DeleteGeoProbe,
     AddParentDevice,
     RemoveParentDevice(RemoveParentDeviceArgs),
+    CreateGeolocationUser(CreateGeolocationUserArgs),
+    UpdateGeolocationUser(UpdateGeolocationUserArgs),
+    DeleteGeolocationUser,
 }
 
 #[cfg(test)]
@@ -66,6 +70,23 @@ mod tests {
                 device_pk: Pubkey::new_unique(),
             },
         ));
+        test_instruction(GeolocationInstruction::CreateGeolocationUser(
+            CreateGeolocationUserArgs {
+                code: "geo-user-01".to_string(),
+                token_account: Pubkey::new_unique(),
+            },
+        ));
+        test_instruction(GeolocationInstruction::UpdateGeolocationUser(
+            UpdateGeolocationUserArgs {
+                token_account: Some(Pubkey::new_unique()),
+            },
+        ));
+        test_instruction(GeolocationInstruction::UpdateGeolocationUser(
+            UpdateGeolocationUserArgs {
+                token_account: None,
+            },
+        ));
+        test_instruction(GeolocationInstruction::DeleteGeolocationUser);
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
@@ -1,0 +1,86 @@
+use crate::{
+    pda::get_geolocation_user_pda,
+    seeds::{SEED_GEOUSER, SEED_PREFIX},
+    serializer::try_acc_create,
+    state::{
+        accounttype::AccountType,
+        geolocation_user::{
+            GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUser,
+            GeolocationUserStatus,
+        },
+    },
+    validation::validate_code_length,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use doublezero_program_common::validate_account_code;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
+pub struct CreateGeolocationUserArgs {
+    pub code: String,
+    pub token_account: Pubkey,
+}
+
+pub fn process_create_geolocation_user(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    args: &CreateGeolocationUserArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let user_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    if !payer_account.is_signer {
+        msg!("Payer must be a signer");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    validate_code_length(&args.code)?;
+    let code = validate_account_code(&args.code)
+        .map_err(|_| crate::error::GeolocationError::InvalidAccountCode)?;
+
+    let (expected_pda, bump_seed) = get_geolocation_user_pda(program_id, &code);
+    if user_account.key != &expected_pda {
+        msg!("Invalid GeolocationUser PubKey");
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    if !user_account.data_is_empty() {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    }
+
+    let user = GeolocationUser {
+        account_type: AccountType::GeolocationUser,
+        owner: *payer_account.key,
+        code,
+        token_account: args.token_account,
+        payment_status: GeolocationPaymentStatus::Delinquent,
+        billing: GeolocationBillingConfig::default(),
+        status: GeolocationUserStatus::Activated,
+        targets: vec![],
+    };
+
+    try_acc_create(
+        &user,
+        user_account,
+        payer_account,
+        system_program,
+        program_id,
+        &[
+            SEED_PREFIX,
+            SEED_GEOUSER,
+            user.code.as_bytes(),
+            &[bump_seed],
+        ],
+    )?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/delete.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/delete.rs
@@ -1,0 +1,60 @@
+use crate::{
+    error::GeolocationError, processors::check_foundation_allowlist, serializer::try_acc_close,
+    state::geolocation_user::GeolocationUser,
+};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+pub fn process_delete_geolocation_user(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let user_account = next_account_info(accounts_iter)?;
+    let program_config_account = next_account_info(accounts_iter)?;
+    let serviceability_globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+
+    if !payer_account.is_signer {
+        msg!("Payer must be a signer");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if user_account.owner != program_id {
+        msg!("Invalid GeolocationUser Account Owner");
+        return Err(ProgramError::IllegalOwner);
+    }
+    if !user_account.is_writable {
+        msg!("GeolocationUser account must be writable");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let user = GeolocationUser::try_from(user_account)?;
+
+    if user.owner != *payer_account.key {
+        check_foundation_allowlist(
+            program_config_account,
+            serviceability_globalstate_account,
+            payer_account,
+            program_id,
+        )?;
+    }
+
+    if !user.targets.is_empty() {
+        msg!(
+            "Cannot delete GeolocationUser with {} remaining targets",
+            user.targets.len()
+        );
+        return Err(GeolocationError::TargetsNotEmpty.into());
+    }
+
+    try_acc_close(user_account, payer_account)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/mod.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/mod.rs
@@ -1,0 +1,3 @@
+pub mod create;
+pub mod delete;
+pub mod update;

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
@@ -1,0 +1,61 @@
+use crate::{
+    error::GeolocationError, serializer::try_acc_write, state::geolocation_user::GeolocationUser,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Default, PartialEq, Clone)]
+pub struct UpdateGeolocationUserArgs {
+    pub token_account: Option<Pubkey>,
+}
+
+pub fn process_update_geolocation_user(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    args: &UpdateGeolocationUserArgs,
+) -> ProgramResult {
+    if *args == UpdateGeolocationUserArgs::default() {
+        msg!("No-op Update, Skipping");
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let accounts_iter = &mut accounts.iter();
+
+    let user_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+
+    if !payer_account.is_signer {
+        msg!("Payer must be a signer");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if user_account.owner != program_id {
+        msg!("Invalid GeolocationUser Account Owner");
+        return Err(ProgramError::IllegalOwner);
+    }
+    if !user_account.is_writable {
+        msg!("GeolocationUser account must be writable");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let mut user = GeolocationUser::try_from(user_account)?;
+
+    if user.owner != *payer_account.key {
+        msg!("Signer is not the account owner");
+        return Err(GeolocationError::Unauthorized.into());
+    }
+
+    if let Some(token_account) = args.token_account {
+        user.token_account = token_account;
+    }
+
+    try_acc_write(&user, user_account, payer_account, accounts)?;
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-geolocation/src/processors/mod.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/mod.rs
@@ -1,4 +1,5 @@
 pub mod geo_probe;
+pub mod geolocation_user;
 pub mod program_config;
 
 use crate::{error::GeolocationError, state::program_config::GeolocationProgramConfig};

--- a/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
@@ -1,0 +1,455 @@
+#![allow(unused_mut)]
+
+mod test_helpers;
+
+use doublezero_geolocation::{
+    entrypoint::process_instruction,
+    error::GeolocationError,
+    instructions::GeolocationInstruction,
+    pda::get_geolocation_user_pda,
+    processors::geolocation_user::{
+        create::CreateGeolocationUserArgs, update::UpdateGeolocationUserArgs,
+    },
+    serviceability_program_id,
+    state::{
+        accounttype::AccountType,
+        geolocation_user::{
+            GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUser,
+            GeolocationUserStatus,
+        },
+    },
+};
+use doublezero_serviceability::state::exchange::ExchangeStatus;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction, InstructionError},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
+use test_helpers::setup_test_with_exchange;
+
+/// Minimal test setup for self-service instructions (no foundation allowlist needed).
+async fn setup_test() -> (
+    BanksClient,
+    Pubkey,
+    tokio::sync::RwLock<solana_sdk::hash::Hash>,
+    Keypair,
+) {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new(
+        "doublezero_geolocation",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let context = program_test.start_with_context().await;
+    let recent_blockhash = tokio::sync::RwLock::new(context.last_blockhash);
+
+    (
+        context.banks_client,
+        program_id,
+        recent_blockhash,
+        context.payer,
+    )
+}
+
+fn build_create_user_ix(
+    program_id: &Pubkey,
+    code: &str,
+    token_account: &Pubkey,
+    payer: &Pubkey,
+) -> Instruction {
+    let (user_pda, _) = get_geolocation_user_pda(program_id, code);
+    Instruction::new_with_borsh(
+        *program_id,
+        &GeolocationInstruction::CreateGeolocationUser(CreateGeolocationUserArgs {
+            code: code.to_string(),
+            token_account: *token_account,
+        }),
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new(*payer, true),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ],
+    )
+}
+
+#[tokio::test]
+async fn test_create_geolocation_user_success() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let code = "geo-user-01";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Verify account
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+
+    let expected = GeolocationUser {
+        account_type: AccountType::GeolocationUser,
+        owner: payer.pubkey(),
+        code: code.to_string(),
+        token_account,
+        payment_status: GeolocationPaymentStatus::Delinquent,
+        billing: GeolocationBillingConfig::default(),
+        status: GeolocationUserStatus::Activated,
+        targets: vec![],
+    };
+    assert_eq!(user, expected);
+}
+
+#[tokio::test]
+async fn test_create_geolocation_user_invalid_code() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let code = "a".repeat(33);
+    let token_account = Pubkey::new_unique();
+    // Use truncated code for PDA derivation to avoid mismatch panic
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, &code[..32]);
+    let ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::CreateGeolocationUser(CreateGeolocationUserArgs {
+            code,
+            token_account,
+        }),
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::InvalidCodeLength as u32);
+        }
+        _ => panic!("Expected InvalidCodeLength error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_create_geolocation_user_duplicate() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let code = "geo-user-dup";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    // First create succeeds
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Second create with same code but different token_account (different tx bytes)
+    let different_token = Pubkey::new_unique();
+    let ix2 = build_create_user_ix(&program_id, code, &different_token, &payer.pubkey());
+    let tx = Transaction::new_signed_with_payer(
+        &[ix2],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::AccountAlreadyInitialized) => {}
+        _ => panic!("Expected AccountAlreadyInitialized error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_update_geolocation_user_success() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let code = "geo-user-upd";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Update token_account
+    let new_token_account = Pubkey::new_unique();
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let update_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::UpdateGeolocationUser(UpdateGeolocationUserArgs {
+            token_account: Some(new_token_account),
+        }),
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new(payer.pubkey(), true),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[update_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.token_account, new_token_account);
+    assert_eq!(user.code, code);
+}
+
+#[tokio::test]
+async fn test_update_geolocation_user_not_owner() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let code = "geo-user-auth";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Try to update with a different signer
+    let other_signer = Keypair::new();
+    // Fund the other signer
+    let transfer_ix = solana_sdk::system_instruction::transfer(
+        &payer.pubkey(),
+        &other_signer.pubkey(),
+        1_000_000_000,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let update_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::UpdateGeolocationUser(UpdateGeolocationUserArgs {
+            token_account: Some(Pubkey::new_unique()),
+        }),
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new(other_signer.pubkey(), true),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[update_ix],
+        Some(&other_signer.pubkey()),
+        &[&other_signer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::Unauthorized as u32);
+        }
+        _ => panic!("Expected Unauthorized error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_delete_geolocation_user_not_owner_not_foundation() {
+    let (mut banks_client, program_id, recent_blockhash, payer, _) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let code = "geo-user-delauth";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let other_signer = Keypair::new();
+    let transfer_ix = solana_sdk::system_instruction::transfer(
+        &payer.pubkey(),
+        &other_signer.pubkey(),
+        1_000_000_000,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let program_config_pda = doublezero_geolocation::pda::get_program_config_pda(&program_id).0;
+    let serviceability_globalstate_pda =
+        doublezero_serviceability::pda::get_globalstate_pda(&serviceability_program_id()).0;
+
+    let delete_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::DeleteGeolocationUser,
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new_readonly(program_config_pda, false),
+            AccountMeta::new_readonly(serviceability_globalstate_pda, false),
+            AccountMeta::new(other_signer.pubkey(), true),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[delete_ix],
+        Some(&other_signer.pubkey()),
+        &[&other_signer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::NotAllowed as u32);
+        }
+        _ => panic!("Expected NotAllowed error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_delete_geolocation_user_success() {
+    let (mut banks_client, program_id, recent_blockhash, payer, _) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let code = "geo-user-del";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &payer.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let program_config_pda = doublezero_geolocation::pda::get_program_config_pda(&program_id).0;
+    let serviceability_globalstate_pda =
+        doublezero_serviceability::pda::get_globalstate_pda(&serviceability_program_id()).0;
+
+    let delete_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::DeleteGeolocationUser,
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new_readonly(program_config_pda, false),
+            AccountMeta::new_readonly(serviceability_globalstate_pda, false),
+            AccountMeta::new(payer.pubkey(), true),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[delete_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap();
+    assert!(account.is_none());
+}
+
+#[tokio::test]
+async fn test_delete_geolocation_user_by_foundation() {
+    let (mut banks_client, program_id, recent_blockhash, payer, _) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    // Create a user owned by a different keypair.
+    let user_owner = Keypair::new();
+    let transfer_ix = solana_sdk::system_instruction::transfer(
+        &payer.pubkey(),
+        &user_owner.pubkey(),
+        2_000_000_000,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let code = "geo-user-fnd";
+    let token_account = Pubkey::new_unique();
+    let ix = build_create_user_ix(&program_id, code, &token_account, &user_owner.pubkey());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&user_owner.pubkey()),
+        &[&user_owner],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Foundation member (payer) deletes the user they don't own.
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, code);
+    let program_config_pda = doublezero_geolocation::pda::get_program_config_pda(&program_id).0;
+    let serviceability_globalstate_pda =
+        doublezero_serviceability::pda::get_globalstate_pda(&serviceability_program_id()).0;
+
+    let delete_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::DeleteGeolocationUser,
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new_readonly(program_config_pda, false),
+            AccountMeta::new_readonly(serviceability_globalstate_pda, false),
+            AccountMeta::new(payer.pubkey(), true),
+        ],
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[delete_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap();
+    assert!(account.is_none());
+}


### PR DESCRIPTION
## Summary of Changes
- Add Create, Update, and Delete instruction processors for GeolocationUser accounts
- Create is self-service (any signer becomes owner); Update is owner-only (token_account field)
- Delete supports owner OR foundation authority, with a target-empty guard preventing deletion while targets remain
- 6 new error variants for user-specific validation

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     6 | +244 / -0   | +244 |
| Scaffolding  |     3 | +17 / -0    |  +17 |
| Tests        |     1 | +455 / -0   | +455 |
| Docs         |     1 | +1 / -0     |   +1 |

~63% tests; core logic is the three CRUD processors plus error/instruction registration.

<details>
<summary>Key files (click to expand)</summary>

- [`geolocation_user_test.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-26d1729d85e05d9142aead2b0cfdd1a0bd86a2d3f082f3287adb01081728b34f) — integration tests: create (success/duplicate/invalid-code), update (success/unauthorized), delete (owner success, foundation success, not-owner-not-foundation rejection)
- [`create.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-6ac7c251e2cf0310beba75f653127ba07b88e97c56e5cc2674a2f66ea1153261) — validates code, derives PDA, initializes account with default billing and empty targets
- [`update.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-07a80e32cf6f8fa6be7c63887e2a2032e047874656d18551ea6d5b83f5290c11) — owner-gated, updates token_account, skips write on no-op
- [`delete.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-be54fe23d5ea3e0e85bc6e67ac3b2e6910b1fcaec9f7d99a40d1355d2d789b73) — owner-or-foundation gated via `check_foundation_allowlist`, requires targets empty
- [`instructions.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-5a39eac93e61480c1a3a9f2bb6ef4a750547d401d933fd5d359a8041606dc95a) — register three new instruction variants with serialization roundtrip tests
- [`error.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-7079b25a2132d6732a0609657990f8050e98fa10516a649a6b5e9c978cb5e293) — add 6 error codes (19–24) for user validation
- [`entrypoint.rs`](https://github.com/malbeclabs/doublezero/pull/3279/files#diff-0005272e5dc254f3aa2be1715ef91f33177c076365a82e445f4092060a688540) — wire new instructions to processors

</details>

## Testing Verification
- Integration tests cover: create success with full struct equality assertion, duplicate rejection, invalid code length, update token_account, unauthorized update by non-owner, owner delete success, foundation delete of another user's account, and rejection of non-owner non-foundation delete
- Instruction serialization roundtrip tests for all three new variants
- Full `cargo test -p doublezero-geolocation` passes (all 54 tests)
