### PR TITLE
release: bump version to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Breaking
 
 ### Changes
+
+## [v0.12.0](https://github.com/malbeclabs/doublezero/compare/client/v0.11.0...client/v0.12.0) - 2026-03-16
+
+### Breaking
+
+### Changes
 - Onchain Programs
   - Add `GeolocationUser` account state to the geolocation program with owner, billing config (flat-per-epoch), payment/user status, and a target list supporting outbound (IP + port) and inbound (pubkey) geolocation targets
 - Client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-activator"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "backon",
  "base64 0.22.1",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "eyre",
  "serde",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "doublezero-config",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -2124,7 +2124,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.11.0 to 0.12.0
- Add v0.12.0 release header to CHANGELOG.md, moving all current Unreleased entries under the new version

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Config/build |     2 | +14 / -14   |   0  |
| Docs         |     1 | +6 / -0    |  +6  |

Version bump and changelog header only.

## Testing Verification
- No logic changes; version metadata only