### PR TITLE
e2e: add diagnostic dump on route liveness test failure

### DIFF
--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -578,18 +578,18 @@ func (c *Client) WaitForTunnelStatus(ctx context.Context, wantStatus ClientSessi
 		return false, nil
 	}, timeout, 1*time.Second)
 	if err != nil {
-		c.dumpDiagnostics()
+		c.DumpDiagnostics()
 		return fmt.Errorf("failed to wait for client tunnel status %s: %w", wantStatus, err)
 	}
 
 	return nil
 }
 
-// dumpDiagnostics prints client-side and device-side diagnostic information to help debug
+// DumpDiagnostics prints client-side and device-side diagnostic information to help debug
 // tunnel status failures. It uses a fresh context since the test context may have expired.
 // Output is buffered and written in a single fmt.Fprint call so that parallel tests don't
 // interleave each other's diagnostics.
-func (c *Client) dumpDiagnostics() {
+func (c *Client) DumpDiagnostics() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/e2e/multi_client_ibrl_liveness_test.go
+++ b/e2e/multi_client_ibrl_liveness_test.go
@@ -3,6 +3,7 @@
 package e2e_test
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -184,6 +185,65 @@ func TestE2E_MultiClientIBRL_RouteLiveness(t *testing.T) {
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + client4.CYOANetworkIP + " --user-payer " + client4.Pubkey})
 	require.NoError(t, err)
 	log.Debug("--> Clients added to user Access Pass")
+
+	// Dump diagnostics on failure.
+	clients := []*devnet.Client{client1, client2, client3, client4}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		var buf strings.Builder
+		fmt.Fprintf(&buf, "\n=== ROUTE LIVENESS DIAGNOSTIC DUMP (deploy=%s) ===\n", deployID)
+
+		// Client-side diagnostics.
+		for i, c := range clients {
+			fmt.Fprintf(&buf, "\n--- Client%d (%s) diagnostics ---\n", i+1, c.Pubkey)
+			for _, cmd := range []struct {
+				label   string
+				command []string
+			}{
+				{"doublezero status", []string{"curl", "-s", "--unix-socket", "/var/run/doublezerod/doublezerod.sock", "http://doublezero/status"}},
+				{"ip addr show", []string{"ip", "addr", "show"}},
+				{"ip route show", []string{"ip", "route", "show"}},
+				{"iptables -L INPUT", []string{"iptables", "-L", "INPUT", "-n", "-v"}},
+			} {
+				output, err := c.Exec(ctx, cmd.command)
+				if err != nil {
+					fmt.Fprintf(&buf, "\n  %s: ERROR: %v\n", cmd.label, err)
+				} else {
+					fmt.Fprintf(&buf, "\n  %s:\n%s", cmd.label, string(output))
+				}
+			}
+			// Dump container logs.
+			c.DumpDiagnostics()
+		}
+
+		// Device-side diagnostics.
+		for code, device := range dn.Devices {
+			for _, cmd := range []struct {
+				label   string
+				command []string
+			}{
+				{"show running-config section Tunnel", []string{"Cli", "-p", "15", "-c", "show running-config section Tunnel"}},
+				{"show ip bgp summary", []string{"Cli", "-c", "show ip bgp summary"}},
+				{"show ip bgp summary vrf vrf1", []string{"Cli", "-c", "show ip bgp summary vrf vrf1"}},
+				{"doublezero-agent log (last 100 lines)", []string{"tail", "-100", "/var/log/agents-latest/doublezero-agent"}},
+			} {
+				output, err := device.Exec(ctx, cmd.command)
+				if err != nil {
+					fmt.Fprintf(&buf, "\n--- Device %s: %s (ERROR: %v)\n", code, cmd.label, err)
+				} else {
+					fmt.Fprintf(&buf, "\n--- Device %s: %s\n%s", code, cmd.label, string(output))
+				}
+			}
+		}
+
+		fmt.Fprintf(&buf, "\n=== ROUTE LIVENESS DIAGNOSTIC DUMP END ===\n")
+		fmt.Fprint(os.Stderr, buf.String())
+	})
 
 	// Run route liveness workflow test.
 	runMultiClientIBRLRouteLivenessTest(t, log, dn, client1, client2, client3, client4, deviceCode1, deviceCode2)

--- a/e2e/multi_client_ibrl_test.go
+++ b/e2e/multi_client_ibrl_test.go
@@ -500,16 +500,25 @@ func unblockUDPLiveness(t *testing.T, c *devnet.Client) {
 	require.NoError(t, err)
 }
 
-func hasRoute(t *testing.T, from *devnet.Client, ip string) bool {
+func hasRoute(t *testing.T, from *devnet.Client, ip string) (bool, error) {
 	t.Helper()
 	out, err := from.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-	require.NoError(t, err)
-	return strings.Contains(string(out), ip)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(string(out), ip), nil
 }
 
 func requireEventuallyRoute(t *testing.T, from *devnet.Client, ip string, want bool, wait, tick time.Duration, msg string) {
 	t.Helper()
-	require.Eventually(t, func() bool { return hasRoute(t, from, ip) == want }, wait, tick, msg)
+	require.Eventually(t, func() bool {
+		has, err := hasRoute(t, from, ip)
+		if err != nil {
+			t.Logf("hasRoute error (will retry): %v", err)
+			return false
+		}
+		return has == want
+	}, wait, tick, msg)
 }
 
 func requireUDPLivenessOnDZ0(t *testing.T, c *devnet.Client, host string, msg string) {


### PR DESCRIPTION
## Summary

- Fix `hasRoute` to return errors instead of calling `require.NoError` inside `require.Eventually`, which caused misleading "context canceled" errors masking the real failure when the test timed out
- Export `DumpDiagnostics` on `devnet.Client` so tests can call it from cleanup handlers
- Add `t.Cleanup` to `TestE2E_MultiClientIBRL_RouteLiveness` that dumps client status, routes, iptables state, container logs, and device state on failure

## Testing Verification

- `go vet -tags e2e ./e2e/...` passes
- Diagnostic dump only runs on test failure (guarded by `t.Failed()`)
- Uses `context.Background()` with 30s timeout so diagnostics work even when the test context is expired