### PR TITLE
geoprobe: add target_ip and verbose drop logging

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -408,6 +408,9 @@ func main() {
 		log.Error("Failed to create Signed TWAMP reflector", "error", err)
 		os.Exit(1)
 	}
+	if *verbose {
+		signedReflector.SetLogger(log)
+	}
 
 	// Set up UDP listener for receiving DZD offsets.
 	offsetListener, err := geoprobe.NewUDPListener(int(*udpListenPort))
@@ -664,6 +667,7 @@ func runOffsetListener(
 			"authority_pubkey", authorityPK,
 			"sender_pubkey", senderPK,
 			"addr", addr,
+			"target_ip", geoprobe.FormatTargetIP(offset.TargetIP),
 			"rtt_ns", offset.RttNs,
 			"measured_rtt_ns", offset.MeasuredRttNs,
 			"lat", offset.Lat,

--- a/controlplane/telemetry/cmd/geoprobe-target/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target/main.go
@@ -312,6 +312,7 @@ func handleOffset(log *slog.Logger, offset *geoprobe.LocationOffset, addr *net.U
 		"from", addr,
 		"authority_pubkey", output.AuthorityPubkey,
 		"sender_pubkey", output.SenderPubkey,
+		"target_ip", output.TargetIP,
 		"rtt_ms", output.RttMs,
 		"max_distance_miles", output.MaxDistanceMiles,
 		"signature_valid", signatureValid,

--- a/tools/twamp/pkg/signed/reflector.go
+++ b/tools/twamp/pkg/signed/reflector.go
@@ -2,6 +2,7 @@ package signed
 
 import (
 	"context"
+	"log/slog"
 	"time"
 )
 
@@ -12,6 +13,7 @@ type Reflector interface {
 	Port() uint16
 	SetAuthorizedKeys(keys [][32]byte)
 	SetOffsets(offsets [][]byte)
+	SetLogger(logger *slog.Logger)
 }
 
 // NewReflector creates a signed TWAMP reflector. Only the port in addr is used; any IP is ignored.

--- a/tools/twamp/pkg/signed/reflector_linux.go
+++ b/tools/twamp/pkg/signed/reflector_linux.go
@@ -3,6 +3,7 @@ package signed
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"runtime"
 	"sync"
@@ -41,6 +42,7 @@ type LinuxReflector struct {
 	offsets        [][]byte
 	shutdown       chan struct{}
 	closed         chan struct{}
+	logger         *slog.Logger
 }
 
 // NewLinuxReflector creates a signed TWAMP reflector. Only the port in addr is used; any IP is ignored.
@@ -140,6 +142,10 @@ func (r *LinuxReflector) SetOffsets(offsets [][]byte) {
 	r.offsetsMu.Unlock()
 }
 
+func (r *LinuxReflector) SetLogger(logger *slog.Logger) {
+	r.logger = logger
+}
+
 func (r *LinuxReflector) Port() uint16 {
 	return r.port
 }
@@ -199,6 +205,9 @@ func (r *LinuxReflector) Run(ctx context.Context) error {
 			}
 
 			if _, ok := r.authorizedKeys.Load(probe.SenderPubkey); !ok {
+				if r.logger != nil {
+					r.logger.Debug("dropping probe from unauthorized pubkey", "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey))
+				}
 				continue
 			}
 
@@ -212,6 +221,9 @@ func (r *LinuxReflector) Run(ctx context.Context) error {
 			if interval := r.verifyInterval; interval > 0 {
 				if state.pairCount >= 2 {
 					if now.Sub(state.pairStart) < interval {
+						if r.logger != nil {
+							r.logger.Debug("dropping rate-limited probe", "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey))
+						}
 						continue
 					}
 					state.pairCount = 0
@@ -233,6 +245,12 @@ func (r *LinuxReflector) Run(ctx context.Context) error {
 			if state.pairCount == 0 {
 				state.pairSourceIP = fromAddr.Addr
 			} else if fromAddr.Addr != state.pairSourceIP {
+				if r.logger != nil {
+					r.logger.Debug("dropping probe with mismatched source IP",
+						"sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey),
+						"expected", net.IP(state.pairSourceIP[:]).String(),
+						"actual", net.IP(fromAddr.Addr[:]).String())
+				}
 				continue
 			}
 


### PR DESCRIPTION
## Summary of Changes
- Log the TWAMP reflector target IP (`target_ip`) in geoprobe-agent and geoprobe-target offset messages for easier debugging
- Add opt-in verbose logging to the signed TWAMP reflector for three probe drop paths: unauthorized pubkey, rate-limited, and source IP mismatch (gated behind `--verbose` / nil logger check to avoid hot-path overhead)

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +25 / -0    |  +25 |

All changes are core logic — observability additions to existing probe and offset handling paths.

<details>
<summary>Key files (click to expand)</summary>

- `tools/twamp/pkg/signed/reflector_linux.go` — Add `logger` field, `SetLogger` method, and debug logging on three drop paths (unauthorized, rate-limited, IP mismatch)
- `controlplane/telemetry/cmd/geoprobe-agent/main.go` — Log `target_ip` in cached offset message; wire `SetLogger` when `--verbose` is set
- `tools/twamp/pkg/signed/reflector.go` — Add `SetLogger` to `Reflector` interface
- `controlplane/telemetry/cmd/geoprobe-target/main.go` — Log `target_ip` in received offset message

</details>

## Testing Verification
- Verified `go build` succeeds for both `./tools/twamp/pkg/signed/` and `./controlplane/telemetry/cmd/geoprobe-agent/`
- Logger is nil by default so no overhead in normal operation; only activated when `--verbose` is passed
