### PR TITLE
geolocation: add Rust SDK instruction builders for GeolocationUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to this project will be documented in this file.
 - SDK
   - Add read-only Go SDK for `doublezero-geolocation` program with state deserialization, PDA derivation, and RPC client for querying geoprobe configuration
   - Add `GetGeoProbeKeys` to geolocation SDK for lightweight account key fetching using DataSlice to minimize RPC bandwidth
+  - Add Rust SDK instruction builders for GeolocationUser management: CRUD (create, update, delete), target management (add, remove), payment status updates, and read queries (get by code/pubkey, list all)
 - Telemetry
   - Add onchain GeoProbe discovery to the telemetry agent: periodically queries the Geolocation program for child probes parented to the local device, replacing the need for `--additional-child-probes` CLI flag
   - Embed LocationOffsets from parent DZDs in signed TWAMP replies so inbound probes carry geolocation context, and make signed TWAMP replies more like LocationOffsets to couple with a new double-probe system for inbound probing.

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/add_target.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/add_target.rs
@@ -1,0 +1,148 @@
+use doublezero_geolocation::{
+    instructions::{AddTargetArgs, GeolocationInstruction},
+    pda,
+    state::geolocation_user::GeoLocationTargetType,
+    validation::{validate_code_length, validate_public_ip},
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+use std::net::Ipv4Addr;
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct AddTargetCommand {
+    pub code: String,
+    pub probe_pk: Pubkey,
+    pub target_type: GeoLocationTargetType,
+    pub ip_address: Ipv4Addr,
+    pub location_offset_port: u16,
+    pub target_pk: Pubkey,
+}
+
+impl AddTargetCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<Signature> {
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        match self.target_type {
+            GeoLocationTargetType::Outbound => {
+                validate_public_ip(&self.ip_address)?;
+            }
+            GeoLocationTargetType::Inbound => {
+                if self.target_pk == Pubkey::default() {
+                    return Err(eyre::eyre!(
+                        "inbound target requires a non-default target_pk"
+                    ));
+                }
+            }
+        }
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+
+        client.execute_transaction(
+            GeolocationInstruction::AddTarget(AddTargetArgs {
+                target_type: self.target_type,
+                ip_address: self.ip_address,
+                location_offset_port: self.location_offset_port,
+                target_pk: self.target_pk,
+            }),
+            vec![
+                AccountMeta::new(user_pda, false),
+                AccountMeta::new(self.probe_pk, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_add_target_outbound() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let code = "geo-user-01";
+        let probe_pk = Pubkey::new_unique();
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::AddTarget(AddTargetArgs {
+                    target_type: GeoLocationTargetType::Outbound,
+                    ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                    location_offset_port: 8923,
+                    target_pk: Pubkey::default(),
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new(probe_pk, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = AddTargetCommand {
+            code: code.to_string(),
+            probe_pk,
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_add_target_inbound() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let code = "geo-user-01";
+        let probe_pk = Pubkey::new_unique();
+        let target_pk = Pubkey::new_unique();
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::AddTarget(AddTargetArgs {
+                    target_type: GeoLocationTargetType::Inbound,
+                    ip_address: Ipv4Addr::UNSPECIFIED,
+                    location_offset_port: 0,
+                    target_pk,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new(probe_pk, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = AddTargetCommand {
+            code: code.to_string(),
+            probe_pk,
+            target_type: GeoLocationTargetType::Inbound,
+            ip_address: Ipv4Addr::UNSPECIFIED,
+            location_offset_port: 0,
+            target_pk,
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/create.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/create.rs
@@ -1,0 +1,87 @@
+use doublezero_geolocation::{
+    instructions::{CreateGeolocationUserArgs, GeolocationInstruction},
+    pda,
+    validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CreateGeolocationUserCommand {
+    pub code: String,
+    pub token_account: Pubkey,
+}
+
+impl CreateGeolocationUserCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<(Signature, Pubkey)> {
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+
+        client
+            .execute_transaction(
+                GeolocationInstruction::CreateGeolocationUser(CreateGeolocationUserArgs {
+                    code,
+                    token_account: self.token_account,
+                }),
+                vec![AccountMeta::new(user_pda, false)],
+            )
+            .map(|sig| (sig, user_pda))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_create_geolocation_user_command() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let token_account = Pubkey::new_unique();
+        let code = "geo-user-01";
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::CreateGeolocationUser(
+                    CreateGeolocationUserArgs {
+                        code: code.to_string(),
+                        token_account,
+                    },
+                )),
+                predicate::eq(vec![AccountMeta::new(user_pda, false)]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = CreateGeolocationUserCommand {
+            code: code.to_string(),
+            token_account,
+        };
+
+        let invalid_command = CreateGeolocationUserCommand {
+            code: "geo/user".to_string(),
+            ..command.clone()
+        };
+
+        let res = invalid_command.execute(&client);
+        assert!(res.is_err());
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+        let (_, returned_pda) = result.unwrap();
+        assert_eq!(returned_pda, user_pda);
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/delete.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/delete.rs
@@ -1,0 +1,75 @@
+use doublezero_geolocation::{
+    instructions::GeolocationInstruction, pda, validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeleteGeolocationUserCommand {
+    pub code: String,
+    pub serviceability_globalstate_pk: Pubkey,
+}
+
+impl DeleteGeolocationUserCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<Signature> {
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
+
+        client.execute_transaction(
+            GeolocationInstruction::DeleteGeolocationUser,
+            vec![
+                AccountMeta::new(user_pda, false),
+                AccountMeta::new_readonly(config_pda, false),
+                AccountMeta::new_readonly(self.serviceability_globalstate_pk, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_delete_geolocation_user_command() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let svc_gs = Pubkey::new_unique();
+        let code = "geo-user-01";
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::DeleteGeolocationUser),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new_readonly(config_pda, false),
+                    AccountMeta::new_readonly(svc_gs, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = DeleteGeolocationUserCommand {
+            code: code.to_string(),
+            serviceability_globalstate_pk: svc_gs,
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
@@ -1,0 +1,126 @@
+use doublezero_geolocation::{
+    pda, state::geolocation_user::GeolocationUser, validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetGeolocationUserCommand {
+    pub pubkey_or_code: String,
+}
+
+impl GetGeolocationUserCommand {
+    pub fn execute(
+        &self,
+        client: &dyn GeolocationClient,
+    ) -> eyre::Result<(Pubkey, GeolocationUser)> {
+        let program_id = client.get_program_id();
+
+        let pubkey = match Pubkey::from_str(&self.pubkey_or_code) {
+            Ok(pk) => pk,
+            Err(_) => {
+                validate_code_length(&self.pubkey_or_code)?;
+                let code = validate_account_code(&self.pubkey_or_code)
+                    .map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+                let (pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+                pda
+            }
+        };
+
+        let account = client.get_account(pubkey)?;
+        let user = GeolocationUser::try_from(&account.data[..])
+            .map_err(|_| eyre::eyre!("Failed to deserialize GeolocationUser account"))?;
+
+        Ok((pubkey, user))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use doublezero_geolocation::state::{
+        accounttype::AccountType,
+        geolocation_user::{
+            GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUserStatus,
+        },
+    };
+    use solana_sdk::account::Account;
+
+    fn make_geolocation_user(code: &str) -> GeolocationUser {
+        GeolocationUser {
+            account_type: AccountType::GeolocationUser,
+            owner: Pubkey::new_unique(),
+            code: code.to_string(),
+            token_account: Pubkey::new_unique(),
+            payment_status: GeolocationPaymentStatus::Delinquent,
+            billing: GeolocationBillingConfig::default(),
+            status: GeolocationUserStatus::Activated,
+            targets: vec![],
+        }
+    }
+
+    #[test]
+    fn test_get_geolocation_user_by_code() {
+        let mut client = MockGeolocationClient::new();
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let code = "geo-user-01";
+        let user = make_geolocation_user(code);
+        let (expected_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_get_account()
+            .withf(move |pk| *pk == expected_pda)
+            .returning(move |_| {
+                Ok(Account {
+                    data: borsh::to_vec(&user.clone()).unwrap(),
+                    owner: program_id,
+                    ..Account::default()
+                })
+            });
+
+        let cmd = GetGeolocationUserCommand {
+            pubkey_or_code: code.to_string(),
+        };
+        let result = cmd.execute(&client);
+        assert!(result.is_ok());
+        let (pk, returned_user) = result.unwrap();
+        assert_eq!(pk, expected_pda);
+        assert_eq!(returned_user.code, code);
+    }
+
+    #[test]
+    fn test_get_geolocation_user_by_pubkey() {
+        let mut client = MockGeolocationClient::new();
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let user_pk = Pubkey::new_unique();
+        let user = make_geolocation_user("geo-user-02");
+
+        client
+            .expect_get_account()
+            .withf(move |pk| *pk == user_pk)
+            .returning(move |_| {
+                Ok(Account {
+                    data: borsh::to_vec(&user.clone()).unwrap(),
+                    owner: program_id,
+                    ..Account::default()
+                })
+            });
+
+        let cmd = GetGeolocationUserCommand {
+            pubkey_or_code: user_pk.to_string(),
+        };
+        let result = cmd.execute(&client);
+        assert!(result.is_ok());
+        let (pk, returned_user) = result.unwrap();
+        assert_eq!(pk, user_pk);
+        assert_eq!(returned_user.code, "geo-user-02");
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+
+use doublezero_geolocation::state::{accounttype::AccountType, geolocation_user::GeolocationUser};
+use solana_account_decoder::UiAccountEncoding;
+use solana_rpc_client_api::{
+    config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
+};
+use solana_sdk::pubkey::Pubkey;
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ListGeolocationUserCommand;
+
+impl ListGeolocationUserCommand {
+    pub fn execute(
+        &self,
+        client: &dyn GeolocationClient,
+    ) -> eyre::Result<HashMap<Pubkey, GeolocationUser>> {
+        let program_id = client.get_program_id();
+        let filters = vec![RpcFilterType::Memcmp(Memcmp::new(
+            0,
+            MemcmpEncodedBytes::Bytes(vec![AccountType::GeolocationUser as u8]),
+        ))];
+
+        let accounts = client.get_program_accounts(
+            &program_id,
+            RpcProgramAccountsConfig {
+                filters: Some(filters),
+                account_config: RpcAccountInfoConfig {
+                    encoding: Some(UiAccountEncoding::Base64),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )?;
+
+        accounts
+            .into_iter()
+            .map(|(pubkey, account)| {
+                let user = GeolocationUser::try_from(&account.data[..]).map_err(|_| {
+                    eyre::eyre!("Failed to deserialize GeolocationUser account {pubkey}")
+                })?;
+                Ok((pubkey, user))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use doublezero_geolocation::state::geolocation_user::{
+        GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUserStatus,
+    };
+    use solana_sdk::account::Account;
+
+    fn make_geolocation_user(code: &str) -> GeolocationUser {
+        GeolocationUser {
+            account_type: AccountType::GeolocationUser,
+            owner: Pubkey::new_unique(),
+            code: code.to_string(),
+            token_account: Pubkey::new_unique(),
+            payment_status: GeolocationPaymentStatus::Delinquent,
+            billing: GeolocationBillingConfig::default(),
+            status: GeolocationUserStatus::Activated,
+            targets: vec![],
+        }
+    }
+
+    #[test]
+    fn test_list_geolocation_users() {
+        let mut client = MockGeolocationClient::new();
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let user1 = make_geolocation_user("geo-user-01");
+        let user2 = make_geolocation_user("geo-user-02");
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+
+        let accounts = vec![
+            (
+                pk1,
+                Account {
+                    data: borsh::to_vec(&user1).unwrap(),
+                    owner: program_id,
+                    ..Account::default()
+                },
+            ),
+            (
+                pk2,
+                Account {
+                    data: borsh::to_vec(&user2).unwrap(),
+                    owner: program_id,
+                    ..Account::default()
+                },
+            ),
+        ];
+
+        client
+            .expect_get_program_accounts()
+            .returning(move |_, _| Ok(accounts.clone()));
+
+        let cmd = ListGeolocationUserCommand;
+        let result = cmd.execute(&client);
+        assert!(result.is_ok());
+        let users = result.unwrap();
+        assert_eq!(users.len(), 2);
+        assert_eq!(users[&pk1].code, "geo-user-01");
+        assert_eq!(users[&pk2].code, "geo-user-02");
+    }
+
+    #[test]
+    fn test_list_geolocation_users_empty() {
+        let mut client = MockGeolocationClient::new();
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        client
+            .expect_get_program_accounts()
+            .returning(|_, _| Ok(vec![]));
+
+        let cmd = ListGeolocationUserCommand;
+        let result = cmd.execute(&client);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/mod.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/mod.rs
@@ -1,0 +1,8 @@
+pub mod add_target;
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod remove_target;
+pub mod update;
+pub mod update_payment_status;

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs
@@ -1,0 +1,89 @@
+use doublezero_geolocation::{
+    instructions::{GeolocationInstruction, RemoveTargetArgs},
+    pda,
+    state::geolocation_user::GeoLocationTargetType,
+    validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+use std::net::Ipv4Addr;
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct RemoveTargetCommand {
+    pub code: String,
+    pub probe_pk: Pubkey,
+    pub target_type: GeoLocationTargetType,
+    pub ip_address: Ipv4Addr,
+    pub target_pk: Pubkey,
+}
+
+impl RemoveTargetCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<Signature> {
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+
+        client.execute_transaction(
+            GeolocationInstruction::RemoveTarget(RemoveTargetArgs {
+                target_type: self.target_type,
+                ip_address: self.ip_address,
+                target_pk: self.target_pk,
+            }),
+            vec![
+                AccountMeta::new(user_pda, false),
+                AccountMeta::new(self.probe_pk, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_remove_target_command() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let code = "geo-user-01";
+        let probe_pk = Pubkey::new_unique();
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::RemoveTarget(RemoveTargetArgs {
+                    target_type: GeoLocationTargetType::Outbound,
+                    ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                    target_pk: Pubkey::default(),
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new(probe_pk, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = RemoveTargetCommand {
+            code: code.to_string(),
+            probe_pk,
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            target_pk: Pubkey::default(),
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/update.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/update.rs
@@ -1,0 +1,90 @@
+use doublezero_geolocation::{
+    instructions::{GeolocationInstruction, UpdateGeolocationUserArgs},
+    pda,
+    validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UpdateGeolocationUserCommand {
+    pub code: String,
+    pub token_account: Option<Pubkey>,
+}
+
+impl UpdateGeolocationUserCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<Signature> {
+        if self.token_account.is_none() {
+            return Err(eyre::eyre!("at least one field must be set"));
+        }
+
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+
+        client.execute_transaction(
+            GeolocationInstruction::UpdateGeolocationUser(UpdateGeolocationUserArgs {
+                token_account: self.token_account,
+            }),
+            vec![AccountMeta::new(user_pda, false)],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_update_geolocation_user_command() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let code = "geo-user-01";
+        let new_token = Pubkey::new_unique();
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::UpdateGeolocationUser(
+                    UpdateGeolocationUserArgs {
+                        token_account: Some(new_token),
+                    },
+                )),
+                predicate::eq(vec![AccountMeta::new(user_pda, false)]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = UpdateGeolocationUserCommand {
+            code: code.to_string(),
+            token_account: Some(new_token),
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_geolocation_user_all_none_is_error() {
+        let client = MockGeolocationClient::new();
+
+        let command = UpdateGeolocationUserCommand {
+            code: "geo-user-01".to_string(),
+            token_account: None,
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_err());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/update_payment_status.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/update_payment_status.rs
@@ -1,0 +1,131 @@
+use doublezero_geolocation::{
+    instructions::{GeolocationInstruction, UpdatePaymentStatusArgs},
+    pda,
+    state::geolocation_user::GeolocationPaymentStatus,
+    validation::validate_code_length,
+};
+use doublezero_program_common::validate_account_code;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::geolocation::client::GeolocationClient;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UpdatePaymentStatusCommand {
+    pub code: String,
+    pub serviceability_globalstate_pk: Pubkey,
+    pub payment_status: GeolocationPaymentStatus,
+    pub last_deduction_dz_epoch: Option<u64>,
+}
+
+impl UpdatePaymentStatusCommand {
+    pub fn execute(&self, client: &dyn GeolocationClient) -> eyre::Result<Signature> {
+        validate_code_length(&self.code)?;
+        let code =
+            validate_account_code(&self.code).map_err(|err| eyre::eyre!("invalid code: {err}"))?;
+
+        let program_id = client.get_program_id();
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
+
+        client.execute_transaction(
+            GeolocationInstruction::UpdatePaymentStatus(UpdatePaymentStatusArgs {
+                payment_status: self.payment_status,
+                last_deduction_dz_epoch: self.last_deduction_dz_epoch,
+            }),
+            vec![
+                AccountMeta::new(user_pda, false),
+                AccountMeta::new_readonly(config_pda, false),
+                AccountMeta::new_readonly(self.serviceability_globalstate_pk, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geolocation::client::MockGeolocationClient;
+    use mockall::predicate;
+
+    #[test]
+    fn test_update_payment_status_paid() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let svc_gs = Pubkey::new_unique();
+        let code = "geo-user-01";
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::UpdatePaymentStatus(
+                    UpdatePaymentStatusArgs {
+                        payment_status: GeolocationPaymentStatus::Paid,
+                        last_deduction_dz_epoch: Some(42),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new_readonly(config_pda, false),
+                    AccountMeta::new_readonly(svc_gs, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = UpdatePaymentStatusCommand {
+            code: code.to_string(),
+            serviceability_globalstate_pk: svc_gs,
+            payment_status: GeolocationPaymentStatus::Paid,
+            last_deduction_dz_epoch: Some(42),
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_payment_status_delinquent() {
+        let mut client = MockGeolocationClient::new();
+
+        let program_id = Pubkey::new_unique();
+        client.expect_get_program_id().returning(move || program_id);
+
+        let svc_gs = Pubkey::new_unique();
+        let code = "geo-user-01";
+
+        let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(GeolocationInstruction::UpdatePaymentStatus(
+                    UpdatePaymentStatusArgs {
+                        payment_status: GeolocationPaymentStatus::Delinquent,
+                        last_deduction_dz_epoch: None,
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(user_pda, false),
+                    AccountMeta::new_readonly(config_pda, false),
+                    AccountMeta::new_readonly(svc_gs, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let command = UpdatePaymentStatusCommand {
+            code: code.to_string(),
+            serviceability_globalstate_pk: svc_gs,
+            payment_status: GeolocationPaymentStatus::Delinquent,
+            last_deduction_dz_epoch: None,
+        };
+
+        let result = command.execute(&client);
+        assert!(result.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/geolocation/mod.rs
+++ b/smartcontract/sdk/rs/src/geolocation/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 pub mod geo_probe;
+pub mod geolocation_user;
 pub mod programconfig;


### PR DESCRIPTION
Relates to: #3014

## Summary of Changes
- Add `geolocation_user` module to the Rust SDK with command structs for all 6 GeolocationUser onchain instructions: create, update, delete, add target, remove target, and update payment status
- Add get (by pubkey or code) and list query commands for reading GeolocationUser accounts
- Each command validates inputs, derives PDAs, and builds the correct instruction + account metas for `execute_transaction`

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     8 | +328 / -0   | +328 |
| Scaffolding  |     2 | +9 / -0     |   +9 |
| Tests        |     — | +532 / -0   | +532 |
| Docs         |     1 | +1 / -0     |   +1 |

~38% core logic, ~61% tests — well-tested SDK addition with no scaffolding overhead.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/sdk/rs/src/geolocation/geolocation_user/add_target.rs` — AddTargetCommand: builds AddTarget instruction with user PDA + probe account metas
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs` — ListGeolocationUserCommand: queries all GeolocationUser accounts via Memcmp filter on AccountType discriminator
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/update_payment_status.rs` — UpdatePaymentStatusCommand: builds foundation-only payment status update with config + globalstate accounts
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs` — GetGeolocationUserCommand: fetches by pubkey or derives PDA from code, then deserializes
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/update.rs` — UpdateGeolocationUserCommand: updates token account with no-op guard
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs` — RemoveTargetCommand: builds RemoveTarget instruction with user PDA + probe account metas
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/create.rs` — CreateGeolocationUserCommand: creates user PDA, returns (Signature, Pubkey)
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/delete.rs` — DeleteGeolocationUserCommand: builds delete with config + globalstate for foundation allowlist check

</details>

## Testing Verification
- All 160 SDK unit tests pass (`cargo test -p doublezero_sdk`), including 11 new tests covering every command with MockGeolocationClient
- Tests verify exact instruction args and account metas via `mockall::predicate::eq`
- Invalid code tests verify validation rejects forbidden characters
- `cargo clippy -p doublezero_sdk -- -Dclippy::all -Dwarnings` clean
- `cargo +nightly fmt --check -p doublezero_sdk` clean
