### PR TITLE
telemetry: add verbose logging to geoprobe programs

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -639,6 +639,8 @@ func runOffsetListener(
 		senderPK := solana.PublicKeyFromBytes(offset.SenderPubkey[:])
 		authorityPK := solana.PublicKeyFromBytes(offset.AuthorityPubkey[:])
 
+		log.Debug("received UDP offset packet", "from", addr, "sender_pubkey", senderPK, "authority_pubkey", authorityPK)
+
 		// Verify the sender is a known parent and the authority matches.
 		expectedAuthority, knownParent := parents.getAuthority(offset.SenderPubkey)
 		if !knownParent {
@@ -659,6 +661,8 @@ func runOffsetListener(
 			log.Warn("Offset signature verification failed", "authority_pubkey", authorityPK, "addr", addr, "error", err)
 			continue
 		}
+
+		log.Debug("signature verification successful", "authority_pubkey", authorityPK)
 
 		cache.Put(offset)
 		signedReflector.SetOffsets(marshalBestOffset(cache))
@@ -738,6 +742,11 @@ func runMeasurementCycle(
 		return
 	}
 
+	// Log individual target measurement results
+	for addr, rttNs := range rttData {
+		log.Debug("target measurement result", "target", addr.Host, "rtt_ms", float64(rttNs)/1000000.0)
+	}
+
 	dzdOffset := cache.GetBest()
 	if dzdOffset == nil {
 		log.Warn("No valid DZD offsets in cache, skipping composite generation")
@@ -749,6 +758,8 @@ func runMeasurementCycle(
 		log.Error("Failed to get current slot", "error", err)
 		return
 	}
+
+	log.Debug("fetched current slot", "slot", slot)
 
 	sentCount := 0
 	for addr, measuredRttNs := range rttData {

--- a/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
@@ -122,6 +122,7 @@ func main() {
 		}
 
 		seq++
+		log.Debug("starting probe pair iteration", "seq", seq, "target", remoteAddr.String())
 		probePair(ctx, log, sender, seq)
 
 		if *count > 0 && seq >= uint32(*count) {
@@ -146,6 +147,8 @@ func probePair(ctx context.Context, log *slog.Logger, sender signed.Sender, seq 
 	probeCtx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
 
+	log.Debug("sending probe pair", "seq", seq)
+
 	result, err := sender.ProbePair(probeCtx)
 	if err != nil {
 		logProbeError(log, seq, err)
@@ -164,6 +167,16 @@ func probePair(ctx context.Context, log *slog.Logger, sender signed.Sender, seq 
 
 	// Target Measured RTT: lower of the two sender-measured RTTs.
 	targetMeasuredRtt := min(result.RTT0, result.RTT1)
+
+	log.Debug("probe pair replies received",
+		"seq", seq,
+		"rtt0_ms", float64(result.RTT0.Microseconds())/1000.0,
+		"rtt1_ms", float64(result.RTT1.Microseconds())/1000.0,
+		"probe_measured_rtt_ms", float64(probeMeasuredRttNs)/1e6,
+		"reply0_probe_sig", reply0ProbeSigValid,
+		"reply0_sig", reply0SigValid,
+		"reply1_probe_sig", reply1ProbeSigValid,
+		"reply1_sig", reply1SigValid)
 
 	logPairedResult(log, seq, probeMeasuredRttNs, targetMeasuredRtt,
 		reply0ProbeSigValid, reply0SigValid, reply1ProbeSigValid, reply1SigValid, result.Reply1)
@@ -325,13 +338,6 @@ func formatNsAsMs(ns uint64) string {
 	return fmt.Sprintf("%.3fms", float64(ns)/1e6)
 }
 
-func abbreviatePubkey(pk string) string {
-	if len(pk) <= 10 {
-		return pk
-	}
-	return pk[:4] + "..." + pk[len(pk)-4:]
-}
-
 func formatTextResult(seq uint32, probeMeasuredRttNs uint64, targetMeasuredRtt time.Duration, reply0ProbeSigValid, reply0SigValid, reply1ProbeSigValid, reply1SigValid bool, authorityPK, geoprobePK solana.PublicKey, reply *signed.ReplyPacket, offsets []offsetOutput) string {
 	var sb strings.Builder
 
@@ -342,16 +348,16 @@ func formatTextResult(seq uint32, probeMeasuredRttNs uint64, targetMeasuredRtt t
 	fmt.Fprintf(&sb, "  Reference Point: %s\n", formatCoordinate(reply.Lat, reply.Lng))
 	fmt.Fprintf(&sb, "  Accumulated RTT: %s\n", formatNsAsMs(reply.RttNs))
 	fmt.Fprintf(&sb, "  Measurement Slot: %d\n", reply.MeasurementSlot)
-	fmt.Fprintf(&sb, "  Authority: %s\n", abbreviatePubkey(authorityPK.String()))
-	fmt.Fprintf(&sb, "  GeoProbe:  %s\n", abbreviatePubkey(geoprobePK.String()))
+	fmt.Fprintf(&sb, "  Authority: %s\n", authorityPK.String())
+	fmt.Fprintf(&sb, "  GeoProbe:  %s\n", geoprobePK.String())
 	fmt.Fprintf(&sb, "  Reply 0: sender_sig=%s geoprobe_sig=%s\n", sigMark(reply0ProbeSigValid), sigMark(reply0SigValid))
 	fmt.Fprintf(&sb, "  Reply 1: sender_sig=%s geoprobe_sig=%s\n", sigMark(reply1ProbeSigValid), sigMark(reply1SigValid))
 
 	if len(offsets) > 0 {
 		sb.WriteString("\n  DZD Reference Chain:\n")
 		for i, o := range offsets {
-			fmt.Fprintf(&sb, "    [%d] Authority: %s\n", i+1, abbreviatePubkey(o.AuthorityPubkey))
-			fmt.Fprintf(&sb, "        Sender:    %s\n", abbreviatePubkey(o.SenderPubkey))
+			fmt.Fprintf(&sb, "    [%d] Authority: %s\n", i+1, o.AuthorityPubkey)
+			fmt.Fprintf(&sb, "        Sender:    %s\n", o.SenderPubkey)
 			fmt.Fprintf(&sb, "        Location:  %s\n", formatCoordinate(o.Lat, o.Lng))
 			fmt.Fprintf(&sb, "        RTT: %s  Measured RTT: %s\n", formatNsAsMs(o.RttNs), formatNsAsMs(o.MeasuredRttNs))
 			fmt.Fprintf(&sb, "        Signature: %s\n", sigMark(o.SigValid))

--- a/controlplane/telemetry/cmd/geoprobe-target-sender/main_test.go
+++ b/controlplane/telemetry/cmd/geoprobe-target-sender/main_test.go
@@ -86,27 +86,6 @@ func TestFormatNsAsMs(t *testing.T) {
 	}
 }
 
-func TestAbbreviatePubkey(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"short key", "abc", "abc"},
-		{"exactly 10", "1234567890", "1234567890"},
-		{"long key", "FSM7abc123456zmQ", "FSM7...6zmQ"},
-		{"full base58", "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM", "9WzD...AWWM"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := abbreviatePubkey(tt.input)
-			if got != tt.expected {
-				t.Errorf("expected %q, got %q", tt.expected, got)
-			}
-		})
-	}
-}
-
 func TestProbeOutput_JSON(t *testing.T) {
 	output := probeOutput{
 		Timestamp:           "2025-01-15T14:23:45Z",

--- a/controlplane/telemetry/cmd/geoprobe-target/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/geoprobe"
 	twamplight "github.com/malbeclabs/doublezero/tools/twamp/pkg/light"
 )
@@ -37,6 +38,7 @@ var (
 	logFormat       = flag.String("log-format", "text", "Log format: text or json")
 	verifySignature = flag.Bool("verify-signatures", true, "Verify Ed25519 signatures on received offsets")
 	rateLimit       = flag.Uint("rate-limit", defaultRateLimit, "Maximum packets per second per source IP (0 disables rate limiting)")
+	verbose         = flag.Bool("verbose", false, "Enable verbose logging")
 	showVersion     = flag.Bool("version", false, "Print version and exit")
 
 	version = "dev"
@@ -61,7 +63,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log := setupLogger(*logFormat)
+	log := setupLogger(*logFormat, *verbose)
 	log.Info("starting geoprobe-target",
 		"version", version,
 		"commit", commit,
@@ -95,10 +97,14 @@ func main() {
 	}
 }
 
-func setupLogger(format string) *slog.Logger {
+func setupLogger(format string, debug bool) *slog.Logger {
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
 	var handler slog.Handler
 	opts := &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: level,
 	}
 
 	switch format {
@@ -244,6 +250,8 @@ func runUDPListener(ctx context.Context, log *slog.Logger, port uint, verifySign
 			continue
 		}
 
+		log.Debug("received UDP packet", "from", addr, "sender_pubkey", solana.PublicKeyFromBytes(offset.SenderPubkey[:]).String(), "authority_pubkey", solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String())
+
 		if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
 			errCh <- fmt.Errorf("failed to set read deadline: %w", err)
 			return
@@ -293,6 +301,7 @@ func handleOffset(log *slog.Logger, offset *geoprobe.LocationOffset, addr *net.U
 	if verifySignatures {
 		verifyError = geoprobe.VerifyOffsetChain(offset)
 		signatureValid = verifyError == nil
+		log.Debug("signature verification complete", "authority_pubkey", solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String(), "valid", signatureValid)
 	}
 
 	output := formatLocationOffset(offset, addr, signatureValid, verifyError)
@@ -317,6 +326,7 @@ func handleOffset(log *slog.Logger, offset *geoprobe.LocationOffset, addr *net.U
 		"max_distance_miles", output.MaxDistanceMiles,
 		"signature_valid", signatureValid,
 	)
+	log.Debug("offset processed successfully", "from", addr, "authority_pubkey", solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String(), "rtt_ms", float64(offset.RttNs)/1000000.0)
 }
 
 type OffsetOutput struct {
@@ -360,8 +370,8 @@ func formatLocationOffset(offset *geoprobe.LocationOffset, addr *net.UDPAddr, si
 	output := OffsetOutput{
 		Timestamp:        time.Now().UTC().Format("2006-01-02 15:04:05 MST"),
 		SourceAddr:       addr.String(),
-		AuthorityPubkey:  formatPubkey(offset.AuthorityPubkey[:]),
-		SenderPubkey:     formatPubkey(offset.SenderPubkey[:]),
+		AuthorityPubkey:  solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String(),
+		SenderPubkey:     solana.PublicKeyFromBytes(offset.SenderPubkey[:]).String(),
 		TargetIP:         geoprobe.FormatTargetIP(offset.TargetIP),
 		ReferencePoint:   formatCoordinate(offset.Lat, offset.Lng),
 		RttMs:            rttMs,
@@ -380,8 +390,8 @@ func formatLocationOffset(offset *geoprobe.LocationOffset, addr *net.UDPAddr, si
 		refRttMs := float64(ref.RttNs) / nanosecondsPerMs
 		refMeasuredRttMs := float64(ref.MeasuredRttNs) / nanosecondsPerMs
 		output.DZDReferenceChain = append(output.DZDReferenceChain, ReferenceOutput{
-			AuthorityPubkey: formatPubkey(ref.AuthorityPubkey[:]),
-			SenderPubkey:    formatPubkey(ref.SenderPubkey[:]),
+			AuthorityPubkey: solana.PublicKeyFromBytes(ref.AuthorityPubkey[:]).String(),
+			SenderPubkey:    solana.PublicKeyFromBytes(ref.SenderPubkey[:]).String(),
 			TargetIP:        geoprobe.FormatTargetIP(ref.TargetIP),
 			Location:        formatCoordinate(ref.Lat, ref.Lng),
 			RttMs:           refRttMs,
@@ -466,13 +476,4 @@ func formatCoordinate(lat, lng float64) CoordinateOutput {
 		Longitude: lng,
 		Formatted: formatted,
 	}
-}
-
-func formatPubkey(pubkey []byte) string {
-	if len(pubkey) < 8 {
-		return fmt.Sprintf("%x", pubkey)
-	}
-	prefix := fmt.Sprintf("%x", pubkey[:4])
-	suffix := fmt.Sprintf("%x", pubkey[len(pubkey)-4:])
-	return fmt.Sprintf("%s...%s", prefix, suffix)
 }


### PR DESCRIPTION
## Summary of Changes
* Add comprehensive debug logging to geoprobe programs (agent, target, target-sender) when -verbose flag is enabled
* Add -verbose flag to geoprobe-target for controlling debug output
* Update geoprobe-target to display pubkeys in base58 format instead of hex for consistency with other geoprobe programs
* Fixes #3301

## Testing Verification
* Built all Go components successfully with `make go-build`
* Passed all linter checks with `make go-lint`
* Verified -verbose flag appears in geoprobe-target help output
* Manually tested that debug logs only appear when -verbose flag is provided