### PR TITLE
telemetry: mark TWAMP probe traffic as DSCP CS5 (TC5)

### DIFF
--- a/tools/twamp/pkg/light/reflector_linux.go
+++ b/tools/twamp/pkg/light/reflector_linux.go
@@ -31,6 +31,12 @@ func NewLinuxReflector(addr string, timeout time.Duration) (*LinuxReflector, err
 		return nil, fmt.Errorf("socket: %w", err)
 	}
 
+	// Mark reflected probes as TC5 (DSCP CS5 = 40, TOS byte = 0xA0).
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_TOS, tosDSCPCS5); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("IP_TOS: %w", err)
+	}
+
 	sockaddr := &unix.SockaddrInet4{Port: udpAddr.Port}
 	copy(sockaddr.Addr[:], udpAddr.IP.To4())
 	if err := unix.Bind(fd, sockaddr); err != nil {

--- a/tools/twamp/pkg/light/sender_linux.go
+++ b/tools/twamp/pkg/light/sender_linux.go
@@ -13,6 +13,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// tosDSCPCS5 is the IP TOS byte value for DSCP CS5 (Traffic Class 5).
+// DSCP CS5 = 40 (0b101000), shifted left 2 bits into the TOS byte = 0xA0.
+const tosDSCPCS5 = 0xA0
+
 type LinuxSender struct {
 	fd         int
 	epfd       int
@@ -30,6 +34,12 @@ func NewLinuxSender(ctx context.Context, iface string, local *net.UDPAddr, remot
 	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_NONBLOCK, unix.IPPROTO_UDP)
 	if err != nil {
 		return nil, fmt.Errorf("socket: %w", err)
+	}
+
+	// Mark probes as TC5 (DSCP CS5 = 40, TOS byte = 0xA0).
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_TOS, tosDSCPCS5); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("IP_TOS: %w", err)
 	}
 
 	if iface != "" {

--- a/tools/twamp/pkg/signed/reflector_linux.go
+++ b/tools/twamp/pkg/signed/reflector_linux.go
@@ -57,6 +57,12 @@ func NewLinuxReflector(addr string, timeout time.Duration, signer Signer, geopro
 		return nil, fmt.Errorf("socket: %w", err)
 	}
 
+	// Mark reflected probes as TC5 (DSCP CS5 = 40, TOS byte = 0xA0).
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_TOS, tosDSCPCS5); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("IP_TOS: %w", err)
+	}
+
 	sockaddr := &unix.SockaddrInet4{Port: udpAddr.Port}
 	if err := unix.Bind(fd, sockaddr); err != nil {
 		unix.Close(fd)

--- a/tools/twamp/pkg/signed/sender_linux.go
+++ b/tools/twamp/pkg/signed/sender_linux.go
@@ -16,6 +16,10 @@ import (
 
 const defaultProbeTimeout = 1 * time.Second
 
+// tosDSCPCS5 is the IP TOS byte value for DSCP CS5 (Traffic Class 5).
+// DSCP CS5 = 40 (0b101000), shifted left 2 bits into the TOS byte = 0xA0.
+const tosDSCPCS5 = 0xA0
+
 // busyPollWindow keeps the thread warm via EpollWait(timeout=0) so that
 // scheduler wakeup latency doesn't dominate short-RTT measurements.
 const busyPollWindow = 15 * time.Millisecond
@@ -38,6 +42,12 @@ func NewLinuxSender(ctx context.Context, iface string, local *net.UDPAddr, remot
 	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_NONBLOCK, unix.IPPROTO_UDP)
 	if err != nil {
 		return nil, fmt.Errorf("socket: %w", err)
+	}
+
+	// Mark probes as TC5 (DSCP CS5 = 40, TOS byte = 0xA0).
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_TOS, tosDSCPCS5); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("IP_TOS: %w", err)
 	}
 
 	if iface != "" {


### PR DESCRIPTION
Closes https://github.com/malbeclabs/doublezero/issues/3293

## Summary of Changes
- Set `IP_TOS` socket option on all TWAMP sender and reflector sockets to mark probe packets as DSCP CS5 (TC5 priority)
- Applies to both light and signed TWAMP variants, ensuring probe traffic gets priority treatment in both directions of the round trip

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +32 / -0    |  +32 |

All changes are core logic — 4 socket setup call sites gain a `setsockopt` for `IP_TOS`.

<details>
<summary>Key files (click to expand)</summary>

- [`tools/twamp/pkg/light/sender_linux.go`](#diff-78f7a8a612f8a14ce75edd1e06918d77a65e8edd7221bfafbb45188464af6bb3) — add `tosDSCPCS5` const and `IP_TOS` setsockopt on light sender socket
- [`tools/twamp/pkg/signed/sender_linux.go`](#diff-9a45a12b9f581e1377e1119f473aa5a8028b9648cc7af12b418df4d661a95050) — add `tosDSCPCS5` const and `IP_TOS` setsockopt on signed sender socket
- [`tools/twamp/pkg/light/reflector_linux.go`](#diff-e5da526e5d837f2194629f75490e4d1b1aed8ce339a905d3f3ff99049e8eb520) — add `IP_TOS` setsockopt on light reflector socket
- [`tools/twamp/pkg/signed/reflector_linux.go`](#diff-4a412449845c51f90365163b49587cf84a488e8306ba4ea5a40ec9a909d09a6e) — add `IP_TOS` setsockopt on signed reflector socket

</details>

## Testing Verification
- Verified `GOOS=linux GOARCH=amd64 go build` succeeds for both `tools/twamp/pkg/light/` and `tools/twamp/pkg/signed/`