### PR TITLE
cli/geolocation: improve probe CLI help text and accept codes for --device & --exchange

### DIFF
--- a/smartcontract/cli/src/geoclicommand.rs
+++ b/smartcontract/cli/src/geoclicommand.rs
@@ -1,6 +1,6 @@
 use doublezero_geolocation::state::{geo_probe::GeoProbe, geolocation_user::GeolocationUser};
 use doublezero_sdk::{
-    commands::exchange::get::GetExchangeCommand,
+    commands::{device::get::GetDeviceCommand, exchange::get::GetExchangeCommand},
     geolocation::{
         geo_probe::{
             add_parent_device::AddParentDeviceCommand, create::CreateGeoProbeCommand,
@@ -56,6 +56,7 @@ pub trait GeoCliCommand {
     fn update_payment_status(&self, cmd: UpdatePaymentStatusCommand) -> eyre::Result<Signature>;
 
     fn resolve_exchange_pk(&self, pubkey_or_code: String) -> eyre::Result<Pubkey>;
+    fn resolve_device_pk(&self, pubkey_or_code: String) -> eyre::Result<Pubkey>;
 }
 
 pub struct GeoCliCommandImpl<'a> {
@@ -160,6 +161,11 @@ impl GeoCliCommand for GeoCliCommandImpl<'_> {
 
     fn resolve_exchange_pk(&self, pubkey_or_code: String) -> eyre::Result<Pubkey> {
         let (pk, _) = GetExchangeCommand { pubkey_or_code }.execute(self.svc_client)?;
+        Ok(pk)
+    }
+
+    fn resolve_device_pk(&self, pubkey_or_code: String) -> eyre::Result<Pubkey> {
+        let (pk, _) = GetDeviceCommand { pubkey_or_code }.execute(self.svc_client)?;
         Ok(pk)
     }
 }

--- a/smartcontract/cli/src/geolocation/probe/add_parent.rs
+++ b/smartcontract/cli/src/geolocation/probe/add_parent.rs
@@ -1,25 +1,24 @@
 use crate::{
     geoclicommand::GeoCliCommand,
-    validators::{validate_code, validate_pubkey},
+    validators::{validate_code, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::geolocation::geo_probe::add_parent_device::AddParentDeviceCommand;
-use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
 
 #[derive(Args, Debug)]
 pub struct AddParentGeoProbeCliCommand {
     /// Probe code
-    #[arg(long, value_parser = validate_code)]
+    #[arg(long, value_name = "PROBE_CODE", value_parser = validate_code)]
     pub code: String,
-    /// Device account pubkey to add as parent
-    #[arg(long, value_parser = validate_pubkey)]
+    /// Device pubkey or code to add as parent
+    #[arg(long, value_name = "PARENT_DEVICE", value_parser = validate_pubkey_or_code)]
     pub device: String,
 }
 
 impl AddParentGeoProbeCliCommand {
     pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
-        let device_pk: Pubkey = self.device.parse().expect("validated by clap");
+        let device_pk = client.resolve_device_pk(self.device)?;
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.add_parent_device(AddParentDeviceCommand {
@@ -53,6 +52,11 @@ mod tests {
             139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
             100, 221, 20, 137, 4, 5,
         ]);
+
+        client
+            .expect_resolve_device_pk()
+            .with(predicate::eq(device_pk.to_string()))
+            .returning(move |_| Ok(device_pk));
 
         client
             .expect_get_serviceability_globalstate_pk()

--- a/smartcontract/cli/src/geolocation/probe/create.rs
+++ b/smartcontract/cli/src/geolocation/probe/create.rs
@@ -1,6 +1,6 @@
 use crate::{
     geoclicommand::GeoCliCommand,
-    validators::{validate_code, validate_pubkey},
+    validators::{validate_code, validate_pubkey, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::geolocation::geo_probe::create::CreateGeoProbeCommand;
@@ -10,10 +10,10 @@ use std::{io::Write, net::Ipv4Addr};
 #[derive(Args, Debug)]
 pub struct CreateGeoProbeCliCommand {
     /// Unique probe code (e.g., "ams-probe-01")
-    #[arg(long, value_parser = validate_code)]
+    #[arg(long, value_name = "PROBE_CODE", value_parser = validate_code)]
     pub code: String,
-    /// Exchange account pubkey
-    #[arg(long, value_parser = validate_pubkey)]
+    /// Exchange pubkey or code
+    #[arg(long, value_name = "PROBE_EXCHANGE", value_parser = validate_pubkey_or_code)]
     pub exchange: String,
     /// Public IPv4 address where probe listens
     #[arg(long)]
@@ -28,7 +28,7 @@ pub struct CreateGeoProbeCliCommand {
 
 impl CreateGeoProbeCliCommand {
     pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
-        let exchange_pk: Pubkey = self.exchange.parse().expect("validated by clap");
+        let exchange_pk = client.resolve_exchange_pk(self.exchange)?;
         let metrics_publisher_pk: Pubkey = self.signing_keypair.parse().expect("validated by clap");
 
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
@@ -69,6 +69,11 @@ mod tests {
             139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
             100, 221, 20, 137, 4, 5,
         ]);
+
+        client
+            .expect_resolve_exchange_pk()
+            .with(predicate::eq(exchange_pk.to_string()))
+            .returning(move |_| Ok(exchange_pk));
 
         client
             .expect_get_serviceability_globalstate_pk()

--- a/smartcontract/cli/src/geolocation/probe/delete.rs
+++ b/smartcontract/cli/src/geolocation/probe/delete.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 #[derive(Args, Debug)]
 pub struct DeleteGeoProbeCliCommand {
     /// Probe code to delete
-    #[arg(long, value_parser = validate_code)]
+    #[arg(long, value_name = "PROBE_CODE", value_parser = validate_code)]
     pub code: String,
     /// Skip confirmation prompt
     #[arg(long, default_value_t = false)]

--- a/smartcontract/cli/src/geolocation/probe/remove_parent.rs
+++ b/smartcontract/cli/src/geolocation/probe/remove_parent.rs
@@ -1,25 +1,24 @@
 use crate::{
     geoclicommand::GeoCliCommand,
-    validators::{validate_code, validate_pubkey},
+    validators::{validate_code, validate_pubkey_or_code},
 };
 use clap::Args;
 use doublezero_sdk::geolocation::geo_probe::remove_parent_device::RemoveParentDeviceCommand;
-use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
 
 #[derive(Args, Debug)]
 pub struct RemoveParentGeoProbeCliCommand {
     /// Probe code
-    #[arg(long, value_parser = validate_code)]
+    #[arg(long, value_name = "PROBE_CODE", value_parser = validate_code)]
     pub code: String,
-    /// Device account pubkey to remove as parent
-    #[arg(long, value_parser = validate_pubkey)]
+    /// Device pubkey or code to remove as parent
+    #[arg(long, value_name = "PARENT_DEVICE", value_parser = validate_pubkey_or_code)]
     pub device: String,
 }
 
 impl RemoveParentGeoProbeCliCommand {
     pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
-        let device_pk: Pubkey = self.device.parse().expect("validated by clap");
+        let device_pk = client.resolve_device_pk(self.device)?;
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.remove_parent_device(RemoveParentDeviceCommand {
@@ -53,6 +52,11 @@ mod tests {
             139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
             100, 221, 20, 137, 4, 5,
         ]);
+
+        client
+            .expect_resolve_device_pk()
+            .with(predicate::eq(device_pk.to_string()))
+            .returning(move |_| Ok(device_pk));
 
         client
             .expect_get_serviceability_globalstate_pk()

--- a/smartcontract/cli/src/geolocation/probe/update.rs
+++ b/smartcontract/cli/src/geolocation/probe/update.rs
@@ -10,7 +10,7 @@ use std::{io::Write, net::Ipv4Addr};
 #[derive(Args, Debug)]
 pub struct UpdateGeoProbeCliCommand {
     /// Probe code to update
-    #[arg(long, value_parser = validate_code)]
+    #[arg(long, value_name = "PROBE_CODE", value_parser = validate_code)]
     pub code: String,
     /// Updated public IPv4 address
     #[arg(long)]


### PR DESCRIPTION
## Summary of Changes
- Add descriptive `value_name` attributes to geoprobe CLI flags so help output shows `<PROBE_CODE>`, `<PROBE_EXCHANGE>`, and `<PARENT_DEVICE>` instead of generic `<CODE>`, `<EXCHANGE>`, `<DEVICE>`
- Allow `--exchange` (probe create) and `--device` (add-parent, remove-parent) to accept entity codes in addition to pubkeys, using existing onchain code-to-pubkey resolution

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +28 / -17   | +11  |
| Scaffolding  |     2 | +2 / -2     |   0  |
| Tests        |     3 | +15 / -0    | +15  |

Most new lines are test mock setup for the added resolution calls.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/geolocation/probe/add_parent.rs` — accept device code via `resolve_device_pk`, add `value_name` for `--code` and `--device`
- `smartcontract/cli/src/geolocation/probe/create.rs` — accept exchange code via `resolve_exchange_pk`, add `value_name` for `--code` and `--exchange`
- `smartcontract/cli/src/geolocation/probe/remove_parent.rs` — accept device code via `resolve_device_pk`, add `value_name` for `--code` and `--device`
- `smartcontract/cli/src/geoclicommand.rs` — add `resolve_device_pk` to `GeoCliCommand` trait and impl
- `smartcontract/cli/src/geolocation/probe/delete.rs` — add `value_name` for `--code`
- `smartcontract/cli/src/geolocation/probe/update.rs` — add `value_name` for `--code`

</details>

## Testing Verification
- All 10 geoprobe unit tests pass (`cargo test -p doublezero_cli --lib geolocation::probe`)
- Clippy clean with `-Dclippy::all -Dwarnings`
- Formatting verified with `cargo +nightly fmt --check`
- E2E tests unaffected (pass pubkeys which remain valid input)
