### PR TITLE
geolocation: allow foundation to remove targets from users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Breaking
 
 ### Changes
+- Onchain Programs
+  - Allow foundation to remove targets from GeolocationUser accounts via the `RemoveTarget` instruction, unblocking foundation-initiated user deletion when targets still exist
 - Client
   - Set tunnel interface administratively down before deleting during teardown, so external applications with sockets bound to the tunnel's overlay IP receive errors before the interface is removed
 - CLI

--- a/smartcontract/cli/src/geolocation/user/remove_target.rs
+++ b/smartcontract/cli/src/geolocation/user/remove_target.rs
@@ -52,6 +52,7 @@ impl RemoveTargetCliCommand {
         };
 
         let probe_pk = super::add_target::resolve_probe(client, self.probe, self.exchange)?;
+        let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.remove_target(RemoveTargetCommand {
             code: self.code,
@@ -59,6 +60,7 @@ impl RemoveTargetCliCommand {
             target_type,
             ip_address,
             target_pk,
+            serviceability_globalstate_pk,
         })?;
 
         writeln!(out, "Signature: {sig}")?;
@@ -95,6 +97,7 @@ mod tests {
         let mut client = MockGeoCliCommand::new();
 
         let probe_pk = Pubkey::from_str_const("BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB");
+        let svc_gs_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange_pk = Pubkey::new_unique();
         let probe = make_probe(exchange_pk);
         let signature = Signature::new_unique();
@@ -107,6 +110,10 @@ mod tests {
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
         client
+            .expect_get_serviceability_globalstate_pk()
+            .returning(move || svc_gs_pk);
+
+        client
             .expect_remove_target()
             .with(predicate::eq(RemoveTargetCommand {
                 code: "geo-user-01".to_string(),
@@ -114,6 +121,7 @@ mod tests {
                 target_type: GeoLocationTargetType::Outbound,
                 ip_address: Ipv4Addr::new(8, 8, 8, 8),
                 target_pk: Pubkey::default(),
+                serviceability_globalstate_pk: svc_gs_pk,
             }))
             .returning(move |_| Ok(signature));
 
@@ -137,6 +145,7 @@ mod tests {
         let mut client = MockGeoCliCommand::new();
 
         let probe_pk = Pubkey::from_str_const("BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB");
+        let svc_gs_pk = Pubkey::from_str_const("HQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
         let exchange_pk = Pubkey::new_unique();
         let probe = make_probe(exchange_pk);
         let target_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
@@ -150,6 +159,10 @@ mod tests {
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
         client
+            .expect_get_serviceability_globalstate_pk()
+            .returning(move || svc_gs_pk);
+
+        client
             .expect_remove_target()
             .with(predicate::eq(RemoveTargetCommand {
                 code: "geo-user-01".to_string(),
@@ -157,6 +170,7 @@ mod tests {
                 target_type: GeoLocationTargetType::Inbound,
                 ip_address: Ipv4Addr::UNSPECIFIED,
                 target_pk,
+                serviceability_globalstate_pk: svc_gs_pk,
             }))
             .returning(move |_| Ok(signature));
 

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::GeolocationError,
+    processors::check_foundation_allowlist,
     serializer::try_acc_write,
     state::{
         geo_probe::GeoProbe,
@@ -32,6 +33,8 @@ pub fn process_remove_target(
 
     let user_account = next_account_info(accounts_iter)?;
     let probe_account = next_account_info(accounts_iter)?;
+    let program_config_account = next_account_info(accounts_iter)?;
+    let serviceability_globalstate_account = next_account_info(accounts_iter)?;
     let payer_account = next_account_info(accounts_iter)?;
     let _system_program = next_account_info(accounts_iter)?;
 
@@ -61,8 +64,12 @@ pub fn process_remove_target(
     let mut user = GeolocationUser::try_from(user_account)?;
 
     if user.owner != *payer_account.key {
-        msg!("Signer is not the account owner");
-        return Err(GeolocationError::Unauthorized.into());
+        check_foundation_allowlist(
+            program_config_account,
+            serviceability_globalstate_account,
+            payer_account,
+            program_id,
+        )?;
     }
 
     let mut probe = GeoProbe::try_from(probe_account)?;

--- a/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
@@ -531,12 +531,18 @@ fn build_remove_target_ix(
     payer: &Pubkey,
     args: RemoveTargetArgs,
 ) -> Instruction {
+    let program_config_pda = doublezero_geolocation::pda::get_program_config_pda(program_id).0;
+    let serviceability_globalstate_pda =
+        doublezero_serviceability::pda::get_globalstate_pda(&serviceability_program_id()).0;
+
     Instruction::new_with_borsh(
         *program_id,
         &GeolocationInstruction::RemoveTarget(args),
         vec![
             AccountMeta::new(*user_pda, false),
             AccountMeta::new(*probe_pda, false),
+            AccountMeta::new_readonly(program_config_pda, false),
+            AccountMeta::new_readonly(serviceability_globalstate_pda, false),
             AccountMeta::new(*payer, true),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
         ],
@@ -924,6 +930,190 @@ async fn test_remove_target_not_found() {
             assert_eq!(code, GeolocationError::TargetNotFound as u32);
         }
         _ => panic!("Expected TargetNotFound error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_remove_target_foundation_can_remove() {
+    let (mut banks_client, program_id, recent_blockhash, payer, exchange_pubkey) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let probe_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-rm-f",
+    )
+    .await;
+
+    // Create a user owned by a different keypair.
+    let user_owner = Keypair::new();
+    let transfer_ix = solana_sdk::system_instruction::transfer(
+        &payer.pubkey(),
+        &user_owner.pubkey(),
+        2_000_000_000,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let user_code = "user-rm-f";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &user_owner.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&user_owner.pubkey()),
+        &[&user_owner],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Owner adds a target
+    let add_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe_pda,
+        &user_owner.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add_ix],
+        Some(&user_owner.pubkey()),
+        &[&user_owner],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Foundation (payer) removes the target
+    let rm_ix = build_remove_target_ix(
+        &program_id,
+        &user_pda,
+        &probe_pda,
+        &payer.pubkey(),
+        RemoveTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[rm_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert!(user.targets.is_empty());
+}
+
+#[tokio::test]
+async fn test_remove_target_unauthorized_non_owner() {
+    let (mut banks_client, program_id, recent_blockhash, payer, exchange_pubkey) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let probe_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-rm-u",
+    )
+    .await;
+
+    let user_code = "user-rm-u";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Owner (payer) adds a target
+    let add_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe_pda,
+        &payer.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Random non-owner, non-foundation signer tries to remove
+    let random_signer = Keypair::new();
+    let program_config_pda = doublezero_geolocation::pda::get_program_config_pda(&program_id).0;
+    let serviceability_globalstate_pda =
+        doublezero_serviceability::pda::get_globalstate_pda(&serviceability_program_id()).0;
+
+    let rm_ix = Instruction::new_with_borsh(
+        program_id,
+        &GeolocationInstruction::RemoveTarget(RemoveTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            target_pk: Pubkey::default(),
+        }),
+        vec![
+            AccountMeta::new(user_pda, false),
+            AccountMeta::new(probe_pda, false),
+            AccountMeta::new_readonly(program_config_pda, false),
+            AccountMeta::new_readonly(serviceability_globalstate_pda, false),
+            AccountMeta::new(random_signer.pubkey(), true),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ],
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[rm_ix],
+        Some(&payer.pubkey()),
+        &[&payer, &random_signer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::NotAllowed as u32);
+        }
+        _ => panic!("Expected NotAllowed error, got: {:?}", err),
     }
 }
 

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs
@@ -17,6 +17,7 @@ pub struct RemoveTargetCommand {
     pub target_type: GeoLocationTargetType,
     pub ip_address: Ipv4Addr,
     pub target_pk: Pubkey,
+    pub serviceability_globalstate_pk: Pubkey,
 }
 
 impl RemoveTargetCommand {
@@ -27,6 +28,7 @@ impl RemoveTargetCommand {
 
         let program_id = client.get_program_id();
         let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, &code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
 
         client.execute_transaction(
             GeolocationInstruction::RemoveTarget(RemoveTargetArgs {
@@ -37,6 +39,8 @@ impl RemoveTargetCommand {
             vec![
                 AccountMeta::new(user_pda, false),
                 AccountMeta::new(self.probe_pk, false),
+                AccountMeta::new_readonly(config_pda, false),
+                AccountMeta::new_readonly(self.serviceability_globalstate_pk, false),
             ],
         )
     }
@@ -57,8 +61,10 @@ mod tests {
 
         let code = "geo-user-01";
         let probe_pk = Pubkey::new_unique();
+        let svc_gs = Pubkey::new_unique();
 
         let (user_pda, _) = pda::get_geolocation_user_pda(&program_id, code);
+        let (config_pda, _) = pda::get_program_config_pda(&program_id);
 
         client
             .expect_execute_transaction()
@@ -71,6 +77,8 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(user_pda, false),
                     AccountMeta::new(probe_pk, false),
+                    AccountMeta::new_readonly(config_pda, false),
+                    AccountMeta::new_readonly(svc_gs, false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));
@@ -81,6 +89,7 @@ mod tests {
             target_type: GeoLocationTargetType::Outbound,
             ip_address: Ipv4Addr::new(8, 8, 8, 8),
             target_pk: Pubkey::default(),
+            serviceability_globalstate_pk: svc_gs,
         };
 
         let result = command.execute(&client);


### PR DESCRIPTION
## Summary of Changes
- The `RemoveTarget` instruction previously only allowed the user owner to remove targets. This blocked the foundation from fully deleting a geolocation user who still had targets, since `DeleteGeolocationUser` requires targets to be empty first.
- Foundation members (via the serviceability GlobalState allowlist) can now remove targets on behalf of any user, matching the authorization pattern already used by `DeleteGeolocationUser`.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Core logic   |     2 | +20 / -2    |  +18  |
| Scaffolding  |     1 | +14 / -0    |  +14  |
| Tests        |     1 | +190 / -0   | +190  |

~85% tests, ~15% implementation — narrow authorization change with thorough coverage.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs` — added foundation-can-remove and unauthorized-non-owner tests; updated `build_remove_target_ix` helper with new account layout
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs` — replaced owner-only check with `check_foundation_allowlist` fallback; added `program_config` and `serviceability_globalstate` accounts
- `smartcontract/cli/src/geolocation/user/remove_target.rs` — passes `serviceability_globalstate_pk` through to SDK command
- `smartcontract/sdk/rs/src/geolocation/geolocation_user/remove_target.rs` — added `serviceability_globalstate_pk` field and `config_pda`/`globalstate` readonly accounts to transaction

</details>

## Testing Verification
- `test_remove_target_foundation_can_remove`: foundation member successfully removes a target from a user they don't own
- `test_remove_target_unauthorized_non_owner`: random signer (not owner, not foundation) gets `NotAllowed` error
- Existing `test_remove_target_success` and `test_remove_target_not_found` still pass (owner path unaffected)
- SDK and CLI unit tests updated and passing
- `make rust-lint` and `make rust-fmt` clean
