### PR TITLE
geolocation: rename `--code` to `--user` on geolocation user subcommands

### DIFF
--- a/e2e/geoprobe_test.go
+++ b/e2e/geoprobe_test.go
@@ -855,7 +855,7 @@ func updateGeolocationUserPayment(t *testing.T, dn *devnet.Devnet, code, status 
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
 		"doublezero-geolocation", "user", "update-payment",
-		"--code", code,
+		"--user", code,
 		"--status", status,
 	})
 	require.NoError(t, err, "user update-payment failed: %s", string(output))
@@ -866,7 +866,7 @@ func addGeolocationOutboundTarget(t *testing.T, dn *devnet.Devnet, userCode, tar
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
 		"doublezero-geolocation", "user", "add-target",
-		"--code", userCode,
+		"--user", userCode,
 		"--type", "outbound",
 		"--target-ip", targetIP,
 		"--target-port", fmt.Sprintf("%d", targetPort),
@@ -880,7 +880,7 @@ func addGeolocationInboundTarget(t *testing.T, dn *devnet.Devnet, userCode, targ
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
 		"doublezero-geolocation", "user", "add-target",
-		"--code", userCode,
+		"--user", userCode,
 		"--type", "inbound",
 		"--target-pk", targetPK,
 		"--probe", probeCode,

--- a/smartcontract/cli/src/geolocation/user/add_target.rs
+++ b/smartcontract/cli/src/geolocation/user/add_target.rs
@@ -22,7 +22,7 @@ pub enum TargetType {
 pub struct AddTargetCliCommand {
     /// User code
     #[arg(long, value_parser = validate_code)]
-    pub code: String,
+    pub user: String,
     /// Target type
     #[arg(long = "type", value_enum)]
     pub target_type: TargetType,
@@ -69,7 +69,7 @@ impl AddTargetCliCommand {
         let probe_pk = resolve_probe(client, self.probe, self.exchange)?;
 
         let sig = client.add_target(AddTargetCommand {
-            code: self.code,
+            code: self.user,
             probe_pk,
             target_type,
             ip_address,
@@ -171,7 +171,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
             target_port: 8923,
@@ -216,7 +216,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Inbound,
             target_ip: None,
             target_port: 8923,
@@ -265,7 +265,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
             target_port: 8923,
@@ -314,7 +314,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
             target_port: 8923,
@@ -342,7 +342,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: None,
             target_port: 8923,
@@ -361,7 +361,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Inbound,
             target_ip: None,
             target_port: 8923,
@@ -397,7 +397,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = AddTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
             target_port: 8923,

--- a/smartcontract/cli/src/geolocation/user/delete.rs
+++ b/smartcontract/cli/src/geolocation/user/delete.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 pub struct DeleteGeolocationUserCliCommand {
     /// User code to delete
     #[arg(long, value_parser = validate_code)]
-    pub code: String,
+    pub user: String,
     /// Skip confirmation prompt
     #[arg(long, default_value_t = false)]
     pub yes: bool,
@@ -16,7 +16,7 @@ pub struct DeleteGeolocationUserCliCommand {
 impl DeleteGeolocationUserCliCommand {
     pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
         if !self.yes {
-            eprint!("Delete user '{}'? [y/N]: ", self.code);
+            eprint!("Delete user '{}'? [y/N]: ", self.user);
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
             if !input.trim().eq_ignore_ascii_case("y") {
@@ -28,7 +28,7 @@ impl DeleteGeolocationUserCliCommand {
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.delete_geolocation_user(DeleteGeolocationUserCommand {
-            code: self.code,
+            code: self.user,
             serviceability_globalstate_pk,
         })?;
 
@@ -71,7 +71,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = DeleteGeolocationUserCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             yes: true,
         }
         .execute(&client, &mut output);

--- a/smartcontract/cli/src/geolocation/user/remove_target.rs
+++ b/smartcontract/cli/src/geolocation/user/remove_target.rs
@@ -15,7 +15,7 @@ use super::add_target::TargetType;
 pub struct RemoveTargetCliCommand {
     /// User code
     #[arg(long, value_parser = validate_code)]
-    pub code: String,
+    pub user: String,
     /// Target type
     #[arg(long = "type", value_enum)]
     pub target_type: TargetType,
@@ -55,7 +55,7 @@ impl RemoveTargetCliCommand {
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.remove_target(RemoveTargetCommand {
-            code: self.code,
+            code: self.user,
             probe_pk,
             target_type,
             ip_address,
@@ -127,7 +127,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = RemoveTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Outbound,
             target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
             target_pk: None,
@@ -176,7 +176,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = RemoveTargetCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             target_type: TargetType::Inbound,
             target_ip: None,
             target_pk: Some(target_pk.to_string()),

--- a/smartcontract/cli/src/geolocation/user/update_payment_status.rs
+++ b/smartcontract/cli/src/geolocation/user/update_payment_status.rs
@@ -14,7 +14,7 @@ pub enum PaymentStatus {
 pub struct UpdatePaymentStatusCliCommand {
     /// User code
     #[arg(long, value_parser = validate_code)]
-    pub code: String,
+    pub user: String,
     /// New payment status
     #[arg(long, value_enum)]
     pub status: PaymentStatus,
@@ -33,7 +33,7 @@ impl UpdatePaymentStatusCliCommand {
         let serviceability_globalstate_pk = client.get_serviceability_globalstate_pk();
 
         let sig = client.update_payment_status(UpdatePaymentStatusCommand {
-            code: self.code,
+            code: self.user,
             serviceability_globalstate_pk,
             payment_status,
             last_deduction_dz_epoch: self.last_deduction_epoch,
@@ -75,7 +75,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = UpdatePaymentStatusCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             status: PaymentStatus::Paid,
             last_deduction_epoch: Some(42),
         }
@@ -108,7 +108,7 @@ mod tests {
 
         let mut output = Vec::new();
         let res = UpdatePaymentStatusCliCommand {
-            code: "geo-user-01".to_string(),
+            user: "geo-user-01".to_string(),
             status: PaymentStatus::Delinquent,
             last_deduction_epoch: None,
         }


### PR DESCRIPTION
## Summary of Changes
- Rename `--code` to `--user` on `add-target`, `remove-target`, `delete`, and `update-payment` subcommands to reduce confusion — `--code` was ambiguous since probes, targets, and users all have codes
- `user create --code` is unchanged since it defines the user's code
- Update E2E tests to use the new flag

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net |
|--------------|-------|-------------|-----|
| CLI UX       |     4 | +21 / -21   |   0 |
| Tests        |     1 | +3 / -3     |   0 |

Pure rename, no logic changes.

<details>
<summary>Key files (click to expand)</summary>

- [`smartcontract/cli/src/geolocation/user/add_target.rs`](https://github.com/malbeclabs/doublezero/pull/3325/files#diff-cb51e3b1467dd33024170423ca88510dba43472c8208cfcece26f8aa2cdbeffb) — rename `--code` → `--user` on AddTargetCliCommand, update all tests
- [`smartcontract/cli/src/geolocation/user/delete.rs`](https://github.com/malbeclabs/doublezero/pull/3325/files#diff-4a54c7e1eac18e1e5812e8b26a5dc8e1ba2abd03ebab9b2daf2e20e0d397a3b9) — rename `--code` → `--user` on DeleteGeolocationUserCliCommand
- [`smartcontract/cli/src/geolocation/user/remove_target.rs`](https://github.com/malbeclabs/doublezero/pull/3325/files#diff-9eed6e7b1ed1bfe91b6b3caae1b959aeab2f339ebc6b5e5b9e2ded1b62b8b4e7) — rename `--code` → `--user` on RemoveTargetCliCommand
- [`smartcontract/cli/src/geolocation/user/update_payment_status.rs`](https://github.com/malbeclabs/doublezero/pull/3325/files#diff-50a3b7f5f3b91f03fc1aaed3f6c4ac18f0e18e8f81c0c1e5d13b3c5a7e9b2d4f) — rename `--code` → `--user` on UpdatePaymentStatusCliCommand
- [`e2e/geoprobe_test.go`](https://github.com/malbeclabs/doublezero/pull/3325/files#diff-647525bdb87de0a74a963fb66421df693056d82a9d061da8e85cebd63ba4fbac) — update E2E helpers to pass `--user` instead of `--code`

</details>

## Testing Verification
- All 19 CLI unit tests in the affected files pass after rename
- E2E test helpers updated to use `--user` flag
