### PR TITLE
telemetry: add verbose logging to TWAMP reflectors and senders

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
@@ -108,6 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer sender.Close()
+	sender.SetLogger(log)
 
 	log.Info("sending paired probes", "target", remoteAddr.String())
 

--- a/tools/twamp/pkg/signed/reflector_linux.go
+++ b/tools/twamp/pkg/signed/reflector_linux.go
@@ -204,9 +204,13 @@ func (r *LinuxReflector) Run(ctx context.Context) error {
 				continue
 			}
 
+			if r.logger != nil {
+				r.logger.Debug("received signed TWAMP probe", "from", from, "seq", probe.Seq, "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey[:8]))
+			}
+
 			if _, ok := r.authorizedKeys.Load(probe.SenderPubkey); !ok {
 				if r.logger != nil {
-					r.logger.Debug("dropping probe from unauthorized pubkey", "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey))
+					r.logger.Warn("dropping probe from unauthorized pubkey", "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey), "from", from)
 				}
 				continue
 			}
@@ -290,7 +294,10 @@ func (r *LinuxReflector) Run(ctx context.Context) error {
 			replyLen, _ := reply.Marshal(replyBuf[:])
 
 			state.lastTxTime = time.Now()
-			_ = unix.Sendto(r.fd, replyBuf[:replyLen], 0, from)
+			err = unix.Sendto(r.fd, replyBuf[:replyLen], 0, from)
+			if err == nil && r.logger != nil {
+				r.logger.Debug("sent signed TWAMP reply", "to", from, "seq", probe.Seq, "sender_pubkey", fmt.Sprintf("%x", probe.SenderPubkey[:8]), "reply_size", replyLen)
+			}
 		}
 	}
 }

--- a/tools/twamp/pkg/signed/sender.go
+++ b/tools/twamp/pkg/signed/sender.go
@@ -2,6 +2,7 @@ package signed
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"time"
 )
@@ -18,6 +19,7 @@ type ProbePairResult struct {
 type Sender interface {
 	Probe(ctx context.Context) (time.Duration, *ReplyPacket, error)
 	ProbePair(ctx context.Context) (ProbePairResult, error)
+	SetLogger(logger *slog.Logger)
 	Close() error
 }
 

--- a/tools/twamp/pkg/signed/sender_linux.go
+++ b/tools/twamp/pkg/signed/sender_linux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"net"
 	"runtime"
 	"sync"
@@ -31,6 +32,11 @@ type LinuxSender struct {
 	buf          []byte
 	oob          []byte
 	mu           sync.Mutex
+	logger       *slog.Logger
+}
+
+func (s *LinuxSender) SetLogger(logger *slog.Logger) {
+	s.logger = logger
 }
 
 // NewLinuxSender creates a signed TWAMP sender. Only local.Port is used; any IP is ignored.
@@ -377,12 +383,24 @@ func (s *LinuxSender) tryRecv(sendTime time.Time, probe *ProbePacket, verify boo
 	}
 	if verify {
 		if !reply.Probe.Verify() {
+			if s.logger != nil {
+				s.logger.Debug("dropping reply: probe signature verification failed", "seq", reply.Probe.Seq)
+			}
 			return 0, nil, nil, false
 		}
 		if reply.AuthorityPubkey != s.remotePubkey {
+			if s.logger != nil {
+				s.logger.Debug("dropping reply: authority pubkey mismatch",
+					"seq", reply.Probe.Seq,
+					"got", fmt.Sprintf("%x", reply.AuthorityPubkey),
+					"expected", fmt.Sprintf("%x", s.remotePubkey))
+			}
 			return 0, nil, nil, false
 		}
 		if !reply.Verify() {
+			if s.logger != nil {
+				s.logger.Debug("dropping reply: reply signature verification failed", "seq", reply.Probe.Seq)
+			}
 			return 0, nil, nil, false
 		}
 	}


### PR DESCRIPTION
## Summary
Add comprehensive debug logging to TWAMP reflectors and senders to help diagnose connectivity issues between geoprobe programs.

## Changes

### TWAMP Reflectors (receive probes, send replies)
- **BasicReflector**: Log received probes and sent replies with sequence numbers
- **LinuxReflector**: Log signed probes received/sent with sender info
- **Warning on auth failures**: Changed unauthorized pubkey drops from debug to warn level

### TWAMP Senders (send probes, receive replies)  
- **LinuxSender**: Added SetLogger method and debug logging for reply verification failures
- **geoprobe-target-sender**: Now sets logger when verbose mode enabled

## Testing Verification
- All TWAMP packet flows are now logged when `-verbose` flag is used
- Misconfigurations (wrong pubkeys) generate warnings visible without verbose mode
- Helps identify issues like:
  - Probes received but not replied to
  - Reply signature verification failures
  - Authority pubkey mismatches
  - Unauthorized sender attempts

Fixes #3301