### PR TITLE
geolocation: add update_count field for lightweight geoprobe change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain Programs
+  - Add `update_count` field to `GeolocationUser` account, incremented on target add/remove and payment status changes, enabling lightweight change-detection polling by geoprobes
+- SDK
+  - Add `GetGeolocationUserUpdateCounts` to the Go geolocation SDK, using Solana `DataSlice` to fetch only the 4-byte counter per account
+- Telemetry
+  - Optimize geoProbe target discovery to use lightweight update-count polling, falling back to full account fetches only when changes are detected or a configurable full-refresh interval (default 5m) elapses
+
 ## [v0.13.0](https://github.com/malbeclabs/doublezero/compare/client/v0.12.0...client/v0.13.0) - 2026-03-20
 
 ### Breaking

--- a/controlplane/telemetry/internal/geoprobe/target_discovery.go
+++ b/controlplane/telemetry/internal/geoprobe/target_discovery.go
@@ -12,9 +12,11 @@ import (
 	geolocation "github.com/malbeclabs/doublezero/sdk/geolocation/go"
 )
 
-// GeolocationUserClient fetches all GeolocationUser accounts from the onchain program.
+// GeolocationUserClient fetches GeolocationUser accounts and lightweight
+// update-count snapshots used for change-detection polling.
 type GeolocationUserClient interface {
 	GetGeolocationUsers(ctx context.Context) ([]geolocation.KeyedGeolocationUser, error)
+	GetGeolocationUserUpdateCounts(ctx context.Context) (map[solana.PublicKey]uint32, error)
 }
 
 // TargetUpdate contains outbound probe targets discovered from onchain data.
@@ -29,12 +31,13 @@ type InboundKeyUpdate struct {
 
 // TargetDiscoveryConfig holds configuration for target discovery.
 type TargetDiscoveryConfig struct {
-	GeoProbePubkey solana.PublicKey
-	Client         GeolocationUserClient
-	CLITargets     []ProbeAddress
-	CLIAllowedKeys [][32]byte
-	Interval       time.Duration
-	Logger         *slog.Logger
+	GeoProbePubkey      solana.PublicKey
+	Client              GeolocationUserClient
+	CLITargets          []ProbeAddress
+	CLIAllowedKeys      [][32]byte
+	Interval            time.Duration
+	FullRefreshInterval time.Duration
+	Logger              *slog.Logger
 }
 
 // TargetDiscovery polls GeolocationUser accounts and sends target/key updates
@@ -48,9 +51,12 @@ type TargetDiscovery struct {
 	cliAllowedKeys [][32]byte
 	interval       time.Duration
 
-	cachedTargets     []ProbeAddress
-	cachedInboundKeys [][32]byte
-	tickCount         uint64
+	cachedTargets       []ProbeAddress
+	cachedInboundKeys   [][32]byte
+	tickCount           uint64
+	fullRefreshInterval time.Duration
+	lastFullRefresh     time.Time
+	cachedUpdateCounts  map[solana.PublicKey]uint32
 }
 
 // NewTargetDiscovery creates a new TargetDiscovery instance.
@@ -68,13 +74,20 @@ func NewTargetDiscovery(cfg *TargetDiscoveryConfig) (*TargetDiscovery, error) {
 		return nil, fmt.Errorf("interval must be greater than 0")
 	}
 
+	fullRefreshInterval := cfg.FullRefreshInterval
+	if fullRefreshInterval == 0 {
+		fullRefreshInterval = 5 * time.Minute
+	}
+
 	return &TargetDiscovery{
-		log:            cfg.Logger,
-		geoProbePubkey: cfg.GeoProbePubkey,
-		client:         cfg.Client,
-		cliTargets:     cfg.CLITargets,
-		cliAllowedKeys: cfg.CLIAllowedKeys,
-		interval:       cfg.Interval,
+		log:                 cfg.Logger,
+		geoProbePubkey:      cfg.GeoProbePubkey,
+		client:              cfg.Client,
+		cliTargets:          cfg.CLITargets,
+		cliAllowedKeys:      cfg.CLIAllowedKeys,
+		interval:            cfg.Interval,
+		fullRefreshInterval: fullRefreshInterval,
+		cachedUpdateCounts:  make(map[solana.PublicKey]uint32),
 	}, nil
 }
 
@@ -111,6 +124,11 @@ func (d *TargetDiscovery) discoverAndSend(ctx context.Context, targetCh chan<- T
 		return
 	}
 
+	// nil targets and keys means no changes detected (lightweight poll found no differences)
+	if targets == nil && inboundKeys == nil {
+		return
+	}
+
 	if !probeAddressSlicesEqual(targets, d.cachedTargets) {
 		d.cachedTargets = targets
 		select {
@@ -134,6 +152,19 @@ func (d *TargetDiscovery) discoverAndSend(ctx context.Context, targetCh chan<- T
 // merge with CLI values.
 func (d *TargetDiscovery) discover(ctx context.Context) ([]ProbeAddress, [][32]byte, error) {
 	d.tickCount++
+
+	forceFullRefresh := d.fullRefreshInterval > 0 && time.Since(d.lastFullRefresh) >= d.fullRefreshInterval
+
+	// Try lightweight change detection unless forced refresh
+	if !forceFullRefresh {
+		counts, err := d.client.GetGeolocationUserUpdateCounts(ctx)
+		if err != nil {
+			d.log.Warn("Failed to fetch update counts, falling back to full fetch", "error", err)
+		} else if !d.updateCountsChanged(counts) {
+			d.log.Debug("No update count changes detected, skipping full fetch")
+			return nil, nil, nil
+		}
+	}
 
 	users, err := d.client.GetGeolocationUsers(ctx)
 	if err != nil {
@@ -205,7 +236,35 @@ func (d *TargetDiscovery) discover(ctx context.Context) ([]ProbeAddress, [][32]b
 		"mergedKeys", len(mergedKeys),
 	)
 
+	d.lastFullRefresh = time.Now()
+	// Rebuild cached update counts from the full fetch we already have,
+	// regardless of how we got here (lightweight change detection, forced
+	// refresh, or error fallback). This avoids a redundant RPC call.
+	d.cachedUpdateCounts = extractUpdateCounts(users)
+
 	return mergedTargets, mergedKeys, nil
+}
+
+// updateCountsChanged checks whether the given update counts differ from the cached counts.
+func (d *TargetDiscovery) updateCountsChanged(counts map[solana.PublicKey]uint32) bool {
+	if len(d.cachedUpdateCounts) != len(counts) {
+		return true
+	}
+	for pk, count := range counts {
+		if cached, ok := d.cachedUpdateCounts[pk]; !ok || cached != count {
+			return true
+		}
+	}
+	return false
+}
+
+// extractUpdateCounts builds an update-count map from fully-fetched users.
+func extractUpdateCounts(users []geolocation.KeyedGeolocationUser) map[solana.PublicKey]uint32 {
+	counts := make(map[solana.PublicKey]uint32, len(users))
+	for i := range users {
+		counts[users[i].Pubkey] = users[i].UpdateCount
+	}
+	return counts
 }
 
 // targetToProbeAddress converts a GeolocationTarget to a ProbeAddress.

--- a/controlplane/telemetry/internal/geoprobe/target_discovery_test.go
+++ b/controlplane/telemetry/internal/geoprobe/target_discovery_test.go
@@ -13,12 +13,21 @@ import (
 
 // mockGeolocationUserClient implements GeolocationUserClient for testing.
 type mockGeolocationUserClient struct {
-	users []geolocation.KeyedGeolocationUser
-	err   error
+	users        []geolocation.KeyedGeolocationUser
+	err          error
+	updateCounts map[solana.PublicKey]uint32
+	updateErr    error
 }
 
 func (m *mockGeolocationUserClient) GetGeolocationUsers(_ context.Context) ([]geolocation.KeyedGeolocationUser, error) {
 	return m.users, m.err
+}
+
+func (m *mockGeolocationUserClient) GetGeolocationUserUpdateCounts(_ context.Context) (map[solana.PublicKey]uint32, error) {
+	if m.updateCounts == nil && m.updateErr == nil {
+		return nil, fmt.Errorf("not configured")
+	}
+	return m.updateCounts, m.updateErr
 }
 
 func testProbePubkey() solana.PublicKey {
@@ -441,5 +450,124 @@ func TestTargetDiscovery_RejectsNonPublicOutboundTargets(t *testing.T) {
 				t.Errorf("expected non-public target %v to be rejected, got %v", tt.ip, targets)
 			}
 		})
+	}
+}
+
+func TestTargetDiscovery_UpdateCountsSkipsFetch(t *testing.T) {
+	probePK := testProbePubkey()
+	userPK := solana.NewWallet().PublicKey()
+
+	user := makeUser(geolocation.GeolocationUserStatusActivated, geolocation.GeolocationPaymentStatusPaid, "user1", []geolocation.GeolocationTarget{
+		outboundTarget([4]uint8{44, 0, 0, 1}, 9000, probePK),
+	})
+	user.Pubkey = userPK
+	user.UpdateCount = 5
+
+	client := &mockGeolocationUserClient{
+		users:        []geolocation.KeyedGeolocationUser{user},
+		updateCounts: map[solana.PublicKey]uint32{userPK: 5},
+	}
+
+	td := newTestTargetDiscovery(client, nil, nil)
+	ctx := context.Background()
+
+	// First discover: counts changed (cache is empty vs counts has entry) -> full fetch
+	targets, _, err := td.discover(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target on first discover, got %d", len(targets))
+	}
+
+	// Second discover: same counts -> no change, returns nil
+	targets, keys, err := td.discover(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if targets != nil || keys != nil {
+		t.Errorf("expected nil targets/keys when no update count changes, got targets=%v keys=%v", targets, keys)
+	}
+}
+
+func TestTargetDiscovery_UpdateCountsDetectsChange(t *testing.T) {
+	probePK := testProbePubkey()
+	userPK := solana.NewWallet().PublicKey()
+
+	user := makeUser(geolocation.GeolocationUserStatusActivated, geolocation.GeolocationPaymentStatusPaid, "user1", []geolocation.GeolocationTarget{
+		outboundTarget([4]uint8{44, 0, 0, 1}, 9000, probePK),
+	})
+	user.Pubkey = userPK
+	user.UpdateCount = 5
+
+	client := &mockGeolocationUserClient{
+		users:        []geolocation.KeyedGeolocationUser{user},
+		updateCounts: map[solana.PublicKey]uint32{userPK: 5},
+	}
+
+	td := newTestTargetDiscovery(client, nil, nil)
+	ctx := context.Background()
+
+	// First discover to populate cache
+	_, _, _ = td.discover(ctx)
+
+	// Change update count
+	client.updateCounts = map[solana.PublicKey]uint32{userPK: 6}
+
+	// Second discover should detect change and do full fetch
+	targets, _, err := td.discover(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target after count change, got %d", len(targets))
+	}
+}
+
+func TestTargetDiscovery_ForceFullRefresh(t *testing.T) {
+	probePK := testProbePubkey()
+	userPK := solana.NewWallet().PublicKey()
+
+	counts := map[solana.PublicKey]uint32{userPK: 5}
+	client := &mockGeolocationUserClient{
+		users: []geolocation.KeyedGeolocationUser{
+			makeUser(geolocation.GeolocationUserStatusActivated, geolocation.GeolocationPaymentStatusPaid, "user1", []geolocation.GeolocationTarget{
+				outboundTarget([4]uint8{44, 0, 0, 1}, 9000, probePK),
+			}),
+		},
+		updateCounts: counts,
+	}
+
+	td, _ := NewTargetDiscovery(&TargetDiscoveryConfig{
+		GeoProbePubkey:      testProbePubkey(),
+		Client:              client,
+		Interval:            time.Minute,
+		FullRefreshInterval: time.Nanosecond, // Very short interval to force refresh
+		Logger:              slog.Default(),
+	})
+	ctx := context.Background()
+
+	// First discover populates cache
+	targets, _, err := td.discover(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+
+	// Wait a tiny bit to ensure interval elapsed
+	time.Sleep(time.Millisecond)
+
+	// Same update counts, but forced refresh should still do full fetch
+	targets, _, err = td.discover(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if targets == nil {
+		t.Fatal("expected non-nil targets on forced refresh")
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target on forced refresh, got %d", len(targets))
 	}
 }

--- a/sdk/geolocation/go/client.go
+++ b/sdk/geolocation/go/client.go
@@ -2,6 +2,7 @@ package geolocation
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -208,4 +209,46 @@ func (c *Client) GetGeolocationUsers(ctx context.Context) ([]KeyedGeolocationUse
 		users = append(users, KeyedGeolocationUser{Pubkey: acct.Pubkey, GeolocationUser: *user})
 	}
 	return users, nil
+}
+
+// GetGeolocationUserUpdateCounts returns a map of GeolocationUser pubkeys to their
+// update_count values. Uses DataSlice to return only 4 bytes per account, making it
+// suitable for lightweight polling-based change detection.
+func (c *Client) GetGeolocationUserUpdateCounts(ctx context.Context) (map[solana.PublicKey]uint32, error) {
+	offset := uint64(GeolocationUserUpdateCountOffset)
+	length := uint64(GeolocationUserUpdateCountLength)
+	opts := &solanarpc.GetProgramAccountsOpts{
+		Filters: []solanarpc.RPCFilter{
+			{
+				Memcmp: &solanarpc.RPCFilterMemcmp{
+					Offset: 0,
+					Bytes:  solana.Base58([]byte{byte(AccountTypeGeolocationUser)}),
+				},
+			},
+		},
+		DataSlice: &solanarpc.DataSlice{
+			Offset: &offset,
+			Length: &length,
+		},
+	}
+
+	accounts, err := c.rpc.GetProgramAccountsWithOpts(ctx, c.programID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get program accounts: %w", err)
+	}
+
+	result := make(map[solana.PublicKey]uint32, len(accounts))
+	for _, acct := range accounts {
+		if acct.Account.Owner != c.programID {
+			c.log.Warn("skipping account with wrong owner", "pubkey", acct.Pubkey, "owner", acct.Account.Owner)
+			continue
+		}
+		data := acct.Account.Data.GetBinary()
+		if len(data) < 4 {
+			c.log.Warn("skipping account with insufficient data for update_count", "pubkey", acct.Pubkey)
+			continue
+		}
+		result[acct.Pubkey] = binary.LittleEndian.Uint32(data[:4])
+	}
+	return result, nil
 }

--- a/sdk/geolocation/go/client_test.go
+++ b/sdk/geolocation/go/client_test.go
@@ -3,6 +3,7 @@ package geolocation_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"log/slog"
 	"testing"
 
@@ -206,6 +207,7 @@ func TestSDK_Geolocation_Client_GetGeolocationUserByCode_HappyPath(t *testing.T)
 	expected := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "geo-user-01",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,
@@ -268,6 +270,7 @@ func TestSDK_Geolocation_Client_GetGeolocationUsers_HappyPath(t *testing.T) {
 	user1 := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "geo-user-01",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,
@@ -284,6 +287,7 @@ func TestSDK_Geolocation_Client_GetGeolocationUsers_HappyPath(t *testing.T) {
 	user2 := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "geo-user-02",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusDelinquent,
@@ -345,6 +349,7 @@ func TestSDK_Geolocation_Client_GetGeolocationUserByCode_OwnerMismatch(t *testin
 	user := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "geo-user-01",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,
@@ -388,6 +393,7 @@ func TestSDK_Geolocation_Client_GetGeolocationUsers_SkipsWrongOwner(t *testing.T
 	user1 := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "geo-user-01",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,
@@ -438,4 +444,45 @@ func TestSDK_Geolocation_Client_GetGeolocationUsers_Empty(t *testing.T) {
 	users, err := client.GetGeolocationUsers(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, users)
+}
+
+func TestSDK_Geolocation_Client_GetGeolocationUserUpdateCounts_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	programID := solana.NewWallet().PublicKey()
+	acctKey1 := solana.NewWallet().PublicKey()
+	acctKey2 := solana.NewWallet().PublicKey()
+
+	mockRPC := &mockRPCClient{
+		GetProgramAccountsWithOptsFunc: func(_ context.Context, _ solana.PublicKey, opts *solanarpc.GetProgramAccountsOpts) (solanarpc.GetProgramAccountsResult, error) {
+			// Verify DataSlice is set correctly
+			require.NotNil(t, opts.DataSlice)
+			require.Equal(t, uint64(33), *opts.DataSlice.Offset)
+			require.Equal(t, uint64(4), *opts.DataSlice.Length)
+
+			// Return raw 4-byte update_count values
+			data1 := make([]byte, 4)
+			binary.LittleEndian.PutUint32(data1, 42)
+			data2 := make([]byte, 4)
+			binary.LittleEndian.PutUint32(data2, 0)
+
+			return solanarpc.GetProgramAccountsResult{
+				{
+					Pubkey:  acctKey1,
+					Account: &solanarpc.Account{Owner: programID, Data: solanarpc.DataBytesOrJSONFromBytes(data1)},
+				},
+				{
+					Pubkey:  acctKey2,
+					Account: &solanarpc.Account{Owner: programID, Data: solanarpc.DataBytesOrJSONFromBytes(data2)},
+				},
+			}, nil
+		},
+	}
+
+	client := geolocation.New(slog.Default(), mockRPC, programID)
+	counts, err := client.GetGeolocationUserUpdateCounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, counts, 2)
+	require.Equal(t, uint32(42), counts[acctKey1])
+	require.Equal(t, uint32(0), counts[acctKey2])
 }

--- a/sdk/geolocation/go/deserialize_test.go
+++ b/sdk/geolocation/go/deserialize_test.go
@@ -207,11 +207,11 @@ func TestSDK_Geolocation_DeserializeGeolocationUser_OversizedCodeLength(t *testi
 	t.Parallel()
 
 	// Craft raw bytes with a valid discriminator but a code length prefix
-	// that exceeds MaxCodeLength. Layout: account_type(1) + owner(32) + code_len(4).
-	data := make([]byte, 37)
+	// that exceeds MaxCodeLength. Layout: account_type(1) + owner(32) + update_count(4) + code_len(4).
+	data := make([]byte, 41)
 	data[0] = byte(geolocation.AccountTypeGeolocationUser)
-	// Set code length to 255 (> MaxCodeLength=32) at offset 33.
-	data[33] = 255
+	// Set code length to 255 (> MaxCodeLength=32) at offset 37.
+	data[37] = 255
 
 	_, err := geolocation.DeserializeGeolocationUser(data)
 	require.Error(t, err)
@@ -242,8 +242,8 @@ func TestSDK_Geolocation_DeserializeGeolocationUser_OversizedTargetCount(t *test
 	data := buf.Bytes()
 
 	// Target count is the last 4 bytes (code "test" = 4 bytes).
-	// Offset: 1 + 32 + 4 + 4 + 32 + 1 + 17 + 1 = 92.
-	targetCountOffset := 1 + 32 + 4 + len("test") + 32 + 1 + 17 + 1
+	// Offset: 1 + 32 + 4 + 4 + 4 + 32 + 1 + 17 + 1 = 96.
+	targetCountOffset := 1 + 32 + 4 + 4 + len("test") + 32 + 1 + 17 + 1
 	data[targetCountOffset] = 0xFF
 	data[targetCountOffset+1] = 0xFF
 	data[targetCountOffset+2] = 0x00
@@ -276,8 +276,8 @@ func TestSDK_Geolocation_DeserializeGeolocationUser_InvalidPaymentStatus(t *test
 	require.NoError(t, user.Serialize(&buf))
 	data := buf.Bytes()
 
-	// PaymentStatus is at offset: 1 + 32 + 4 + len("test") + 32 = 73.
-	paymentOffset := 1 + 32 + 4 + len("test") + 32
+	// PaymentStatus is at offset: 1 + 32 + 4 + 4 + len("test") + 32 = 77.
+	paymentOffset := 1 + 32 + 4 + 4 + len("test") + 32
 	data[paymentOffset] = 99 // invalid
 
 	_, err := geolocation.DeserializeGeolocationUser(data)
@@ -306,8 +306,8 @@ func TestSDK_Geolocation_DeserializeGeolocationUser_InvalidUserStatus(t *testing
 	require.NoError(t, user.Serialize(&buf))
 	data := buf.Bytes()
 
-	// Status is at offset: 1 + 32 + 4 + len("test") + 32 + 1 + 17 = 91.
-	statusOffset := 1 + 32 + 4 + len("test") + 32 + 1 + 17
+	// Status is at offset: 1 + 32 + 4 + 4 + len("test") + 32 + 1 + 17 = 95.
+	statusOffset := 1 + 32 + 4 + 4 + len("test") + 32 + 1 + 17
 	data[statusOffset] = 99 // invalid
 
 	_, err := geolocation.DeserializeGeolocationUser(data)
@@ -344,9 +344,9 @@ func TestSDK_Geolocation_DeserializeGeolocationUser_InvalidTargetType(t *testing
 	require.NoError(t, user.Serialize(&buf))
 	data := buf.Bytes()
 
-	// First target starts at offset: 1 + 32 + 4 + len("test") + 32 + 1 + 17 + 1 + 4 = 96.
+	// First target starts at offset: 1 + 32 + 4 + 4 + len("test") + 32 + 1 + 17 + 1 + 4 = 100.
 	// The first byte of the target is TargetType.
-	targetOffset := 1 + 32 + 4 + len("test") + 32 + 1 + 17 + 1 + 4
+	targetOffset := 1 + 32 + 4 + 4 + len("test") + 32 + 1 + 17 + 1 + 4
 	data[targetOffset] = 99 // invalid target type
 
 	_, err := geolocation.DeserializeGeolocationUser(data)

--- a/sdk/geolocation/go/state.go
+++ b/sdk/geolocation/go/state.go
@@ -318,6 +318,7 @@ type KeyedGeolocationUser struct {
 type GeolocationUser struct {
 	AccountType   AccountType              // 1 byte
 	Owner         solana.PublicKey         // 32 bytes
+	UpdateCount   uint32                   // 4 bytes LE
 	Code          string                   // 4-byte length prefix + UTF-8 bytes
 	TokenAccount  solana.PublicKey         // 32 bytes
 	PaymentStatus GeolocationPaymentStatus // 1 byte
@@ -332,6 +333,9 @@ func (g *GeolocationUser) Serialize(w io.Writer) error {
 		return err
 	}
 	if err := enc.Encode(g.Owner); err != nil {
+		return err
+	}
+	if err := enc.Encode(g.UpdateCount); err != nil {
 		return err
 	}
 	if err := enc.Encode(g.Code); err != nil {
@@ -361,6 +365,13 @@ func (g *GeolocationUser) Serialize(w io.Writer) error {
 	return nil
 }
 
+// GeolocationUserUpdateCountOffset is the byte offset of the update_count field
+// in the Borsh-serialized GeolocationUser account: account_type(1) + owner(32).
+const GeolocationUserUpdateCountOffset = 33
+
+// GeolocationUserUpdateCountLength is the wire size of the update_count field (u32).
+const GeolocationUserUpdateCountLength = 4
+
 // geolocationBillingConfigSize is the wire size of a GeolocationBillingConfig (1+8+8).
 const geolocationBillingConfigSize = 17
 
@@ -370,8 +381,8 @@ const geolocationUserTargetSize = 71
 func (g *GeolocationUser) Deserialize(data []byte) error {
 	// Pre-validate the code string length prefix from raw bytes before the
 	// decoder allocates memory for it. The prefix sits at a fixed offset:
-	// account_type(1) + owner(32) = 33 bytes.
-	const codeOffset = 1 + 32
+	// account_type(1) + owner(32) + update_count(4) = 37 bytes.
+	const codeOffset = 1 + 32 + 4
 	if len(data) < codeOffset+4 {
 		return fmt.Errorf("data too short for code length prefix: %d bytes", len(data))
 	}
@@ -381,8 +392,8 @@ func (g *GeolocationUser) Deserialize(data []byte) error {
 	}
 
 	// Pre-validate the target count from raw bytes. The count sits after:
-	// code_offset(33) + code_len_prefix(4) + code(codeLen) + token_account(32) +
-	// payment_status(1) + billing + status(1) = 88 + codeLen.
+	// code_offset(37) + code_len_prefix(4) + code(codeLen) + token_account(32) +
+	// payment_status(1) + billing + status(1) = 92 + codeLen.
 	targetCountOffset := codeOffset + 4 + int(codeLen) + 32 + 1 + geolocationBillingConfigSize + 1
 	if len(data) < targetCountOffset+4 {
 		return fmt.Errorf("data too short for target count: %d bytes", len(data))
@@ -401,6 +412,9 @@ func (g *GeolocationUser) Deserialize(data []byte) error {
 		return err
 	}
 	if err := dec.Decode(&g.Owner); err != nil {
+		return err
+	}
+	if err := dec.Decode(&g.UpdateCount); err != nil {
 		return err
 	}
 	if err := dec.Decode(&g.Code); err != nil {

--- a/sdk/geolocation/go/state_test.go
+++ b/sdk/geolocation/go/state_test.go
@@ -129,6 +129,7 @@ func TestSDK_Geolocation_State_GeolocationUser_RoundTrip(t *testing.T) {
 	original := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   5,
 		Code:          "geo-user-01",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,
@@ -166,6 +167,7 @@ func TestSDK_Geolocation_State_GeolocationUser_RoundTrip(t *testing.T) {
 
 	require.Equal(t, original.AccountType, decoded.AccountType)
 	require.Equal(t, original.Owner, decoded.Owner)
+	require.Equal(t, original.UpdateCount, decoded.UpdateCount)
 	require.Equal(t, original.Code, decoded.Code)
 	require.Equal(t, original.TokenAccount, decoded.TokenAccount)
 	require.Equal(t, original.PaymentStatus, decoded.PaymentStatus)
@@ -182,6 +184,7 @@ func TestSDK_Geolocation_State_GeolocationUser_EmptyTargets(t *testing.T) {
 	original := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "empty-targets",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusDelinquent,
@@ -226,6 +229,7 @@ func TestSDK_Geolocation_State_GeolocationTarget_RoundTrip(t *testing.T) {
 	user := &geolocation.GeolocationUser{
 		AccountType:   geolocation.AccountTypeGeolocationUser,
 		Owner:         solana.NewWallet().PublicKey(),
+		UpdateCount:   0,
 		Code:          "target-test",
 		TokenAccount:  solana.NewWallet().PublicKey(),
 		PaymentStatus: geolocation.GeolocationPaymentStatusPaid,

--- a/smartcontract/cli/src/geolocation/user/get.rs
+++ b/smartcontract/cli/src/geolocation/user/get.rs
@@ -149,6 +149,7 @@ mod tests {
         GeolocationUser {
             account_type: AccountType::GeolocationUser,
             owner: Pubkey::from_str_const("DDddB7bhR9azxLAUEH7ZVtW168wRdreiDKhi4McDfKZt"),
+            update_count: 0,
             code: code.to_string(),
             token_account: Pubkey::from_str_const("GQ2UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcc"),
             payment_status: GeolocationPaymentStatus::Paid,

--- a/smartcontract/cli/src/geolocation/user/list.rs
+++ b/smartcontract/cli/src/geolocation/user/list.rs
@@ -81,6 +81,7 @@ mod tests {
         GeolocationUser {
             account_type: AccountType::GeolocationUser,
             owner: Pubkey::new_unique(),
+            update_count: 0,
             code: code.to_string(),
             token_account: Pubkey::new_unique(),
             payment_status: GeolocationPaymentStatus::Delinquent,

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/add_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/add_target.rs
@@ -101,6 +101,7 @@ pub fn process_add_target(
         return Err(GeolocationError::TargetAlreadyExists.into());
     }
 
+    user.update_count = user.update_count.wrapping_add(1);
     user.targets.push(GeolocationTarget {
         target_type: args.target_type,
         ip_address: args.ip_address,

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
@@ -60,6 +60,7 @@ pub fn process_create_geolocation_user(
     let user = GeolocationUser {
         account_type: AccountType::GeolocationUser,
         owner: *payer_account.key,
+        update_count: 0,
         code,
         token_account: args.token_account,
         payment_status: GeolocationPaymentStatus::Delinquent,

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
@@ -89,6 +89,7 @@ pub fn process_remove_target(
         })
         .ok_or(GeolocationError::TargetNotFound)?;
 
+    user.update_count = user.update_count.wrapping_add(1);
     user.targets.swap_remove(index);
 
     probe.reference_count = probe.reference_count.saturating_sub(1);

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
@@ -51,6 +51,9 @@ pub fn process_update_geolocation_user(
         return Err(GeolocationError::Unauthorized.into());
     }
 
+    // update_count is intentionally not incremented here. It tracks changes to
+    // probe-relevant state (targets, payment_status). token_account is billing
+    // plumbing and does not affect geoProbe polling.
     if let Some(token_account) = args.token_account {
         user.token_account = token_account;
     }

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update_payment_status.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update_payment_status.rs
@@ -54,6 +54,7 @@ pub fn process_update_payment_status(
     let mut user = GeolocationUser::try_from(user_account)?;
 
     user.payment_status = args.payment_status;
+    user.update_count = user.update_count.wrapping_add(1);
 
     if let Some(epoch) = args.last_deduction_dz_epoch {
         match &mut user.billing {

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs
@@ -171,6 +171,7 @@ pub struct GeolocationUser {
         )
     )]
     pub owner: Pubkey, // 32
+    pub update_count: u32,         // 4
     pub code: String,              // 4 + len
     #[cfg_attr(
         feature = "serde",
@@ -190,10 +191,11 @@ impl fmt::Display for GeolocationUser {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "account_type: {}, owner: {}, code: {}, token_account: {}, \
+            "account_type: {}, owner: {}, update_count: {}, code: {}, token_account: {}, \
             payment_status: {}, billing: {}, status: {}, targets: {:?}",
             self.account_type,
             self.owner,
+            self.update_count,
             self.code,
             self.token_account,
             self.payment_status,
@@ -243,6 +245,7 @@ mod tests {
         let val = GeolocationUser {
             account_type: AccountType::GeolocationUser,
             owner: Pubkey::new_unique(),
+            update_count: 0,
             code: "geo-user-01".to_string(),
             token_account: Pubkey::new_unique(),
             payment_status: GeolocationPaymentStatus::Paid,

--- a/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
@@ -106,6 +106,7 @@ async fn test_create_geolocation_user_success() {
     let expected = GeolocationUser {
         account_type: AccountType::GeolocationUser,
         owner: payer.pubkey(),
+        update_count: 0,
         code: code.to_string(),
         token_account,
         payment_status: GeolocationPaymentStatus::Delinquent,
@@ -610,6 +611,7 @@ async fn test_add_target_outbound_success() {
     assert_eq!(user.targets[0].target_type, GeoLocationTargetType::Outbound);
     assert_eq!(user.targets[0].ip_address, Ipv4Addr::new(8, 8, 8, 8));
     assert_eq!(user.targets[0].geoprobe_pk, probe_pda);
+    assert_eq!(user.update_count, 1);
 
     // Verify probe reference_count incremented
     let probe_account = banks_client.get_account(probe_pda).await.unwrap().unwrap();
@@ -643,6 +645,7 @@ async fn test_add_target_outbound_success() {
     assert_eq!(user.targets.len(), 2);
     assert_eq!(user.targets[1].target_type, GeoLocationTargetType::Inbound);
     assert_eq!(user.targets[1].target_pk, inbound_target_pk);
+    assert_eq!(user.update_count, 2);
 
     let probe_account = banks_client.get_account(probe_pda).await.unwrap().unwrap();
     let probe = GeoProbe::try_from(&probe_account.data[..]).unwrap();
@@ -868,6 +871,7 @@ async fn test_remove_target_success() {
     let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
     let user = GeolocationUser::try_from(&account.data[..]).unwrap();
     assert!(user.targets.is_empty());
+    assert_eq!(user.update_count, 2); // 1 from add + 1 from remove
 
     // Verify reference_count decremented
     let probe_account = banks_client.get_account(probe_pda).await.unwrap().unwrap();
@@ -1169,6 +1173,7 @@ async fn test_update_payment_status_success() {
     let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
     let user = GeolocationUser::try_from(&account.data[..]).unwrap();
     assert_eq!(user.payment_status, GeolocationPaymentStatus::Paid);
+    assert_eq!(user.update_count, 1);
     match user.billing {
         GeolocationBillingConfig::FlatPerEpoch(config) => {
             assert_eq!(config.last_deduction_dz_epoch, 42);

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
@@ -54,6 +54,7 @@ mod tests {
         GeolocationUser {
             account_type: AccountType::GeolocationUser,
             owner: Pubkey::new_unique(),
+            update_count: 0,
             code: code.to_string(),
             token_account: Pubkey::new_unique(),
             payment_status: GeolocationPaymentStatus::Delinquent,

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
@@ -61,6 +61,7 @@ mod tests {
         GeolocationUser {
             account_type: AccountType::GeolocationUser,
             owner: Pubkey::new_unique(),
+            update_count: 0,
             code: code.to_string(),
             token_account: Pubkey::new_unique(),
             payment_status: GeolocationPaymentStatus::Delinquent,


### PR DESCRIPTION
Resolves: #3304

## Summary of Changes
- Add `update_count` (u32) field to the onchain `GeolocationUser` account, incremented on target add/remove and payment status changes — but not on token_account updates (billing plumbing, irrelevant to geoprobes)
- Add `GetGeolocationUserUpdateCounts` SDK method that uses Solana `DataSlice` to fetch only the 4-byte counter per account, enabling cheap polling
- Rework geoprobe `TargetDiscovery` to use lightweight update-count polling by default, falling back to full fetches only when a change is detected or a configurable `FullRefreshInterval` (default 5m) elapses

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Core logic   |     5 | +148 / -21  | +127  |
| Scaffolding  |     8 | +16 / -0    | +16   |
| Tests        |     5 | +185 / -14  | +171  |

Most new lines are tests; core logic is compact change-detection plumbing.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/internal/geoprobe/target_discovery_test.go` — tests for update-count skip, change detection, and forced full refresh
- `controlplane/telemetry/internal/geoprobe/target_discovery.go` — lightweight polling loop with `updateCountsChanged`, `extractUpdateCounts`, `FullRefreshInterval`
- `sdk/geolocation/go/client_test.go` — test for `GetGeolocationUserUpdateCounts` with DataSlice verification
- `sdk/geolocation/go/client.go` — `GetGeolocationUserUpdateCounts` using DataSlice to fetch only the counter bytes
- `sdk/geolocation/go/state.go` — `UpdateCount` field + offset/length constants + serialization
- `smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs` — `update_count: u32` field on `GeolocationUser`
- `smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs` — assertions that update_count increments on add/remove/payment changes
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs` — comment explaining why update is intentionally not incrementing the counter

</details>

## Testing Verification
- Unit tests verify update-count change detection skips full fetch when counts match
- Unit tests verify full fetch is triggered when counts differ or a new account appears
- Unit tests verify forced full refresh after `FullRefreshInterval` elapses
- SDK test verifies `GetGeolocationUserUpdateCounts` sends correct `DataSlice` params and deserializes response
- Onchain integration tests assert `update_count` increments on add_target, remove_target, and update_payment_status
- Go SDK round-trip and deserialization tests updated for the new field offset
