### PR TITLE
ci: add shreds e2e cross-repo workflow

### DIFF
--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -67,7 +67,7 @@ jobs:
   e2e:
     needs: setup
     runs-on: doublezero-k8s-ci
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       packages: read
       contents: read


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that runs doublezero-shreds e2e tests against the current doublezero commit on every PR and push to main
- Checks out the doublezero-shreds repo, overrides the pinned doublezero SHA in `e2e/.dep-shas.json`, builds shreds e2e container images, and runs the test suite
- Uses a separate GHCR namespace (`dz-shreds-e2e`) to avoid tag collisions with the shreds repo's own CI
- Pins the shreds checkout SHA between setup and e2e jobs to prevent race conditions

## Testing

- Passes in CI