### PR TITLE
qa: add client override flag to multicast settlement test

### DIFF
--- a/e2e/internal/qa/test.go
+++ b/e2e/internal/qa/test.go
@@ -69,6 +69,15 @@ func (t *Test) RandomClient() *Client {
 	return clients[t.rand.Intn(len(clients))]
 }
 
+func (t *Test) ClientByHost(host string) (*Client, bool) {
+	for _, client := range t.clients {
+		if client.Host == host {
+			return client, true
+		}
+	}
+	return nil, false
+}
+
 func (t *Test) RandomMulticastGroupCode() string {
 	suffix := t.rand.Intn(1000000)
 	return fmt.Sprintf("qa-test-group-%06d", suffix)

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -16,6 +16,7 @@ import (
 var (
 	enableSettlementTests = flag.Bool("enable-multicast-settlement-tests", false, "enable multicast settlement tests")
 	keypairFlag           = flag.String("keypair", "$HOME/.config/doublezero/id.json", "path to keypair file for settlement commands")
+	settlementClientFlag  = flag.String("multicast-settlement-client", "", "host of the client to use for settlement tests (overrides random selection)")
 )
 
 func TestQA_MulticastSettlement(t *testing.T) {
@@ -28,7 +29,14 @@ func TestQA_MulticastSettlement(t *testing.T) {
 	test, err := qa.NewTest(ctx, log, hostsArg, portArg, networkConfig, nil)
 	require.NoError(t, err, "failed to create test")
 
-	client := test.RandomClient()
+	var client *qa.Client
+	if *settlementClientFlag != "" {
+		var ok bool
+		client, ok = test.ClientByHost(*settlementClientFlag)
+		require.True(t, ok, "client %q not found in hosts", *settlementClientFlag)
+	} else {
+		client = test.RandomClient()
+	}
 	if *keypairFlag != "" {
 		client.Keypair = *keypairFlag
 	}


### PR DESCRIPTION
## Summary
- Add `-multicast-settlement-client` flag to specify which client host to use for the multicast settlement QA test, overriding the default random selection from baseline hosts
- Add `ClientByHost` helper to the QA test framework for host-based client lookup
- Rename `qa_settlement_test.go` → `qa_multicast_settlement_test.go` to match the `TestQA_MulticastSettlement` test name

## Testing Verification
- Verified the `e2e` package builds with `go build -tags qa ./e2e/...`
- Flag is optional; omitting it preserves existing random client selection behavior