### PR TITLE
geoprobe: create sockets on-demand instead of holding them open per target

### DIFF
--- a/controlplane/telemetry/internal/geoprobe/pinger.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger.go
@@ -20,6 +20,8 @@ const (
 	senderRetryMin      = 50 * time.Millisecond
 )
 
+type senderFactory func(ctx context.Context, log *slog.Logger, iface string, local, remote *net.UDPAddr) (twamplight.Sender, error)
+
 type PingerConfig struct {
 	Logger              *slog.Logger
 	ProbeTimeout        time.Duration
@@ -31,21 +33,21 @@ type PingerConfig struct {
 type Pinger struct {
 	log       *slog.Logger
 	cfg       *PingerConfig
-	senders   map[string]*senderEntry
-	sendersMu sync.Mutex
+	targets   map[string]ProbeAddress
+	targetsMu sync.Mutex
+	newSender senderFactory
 }
 
-type senderEntry struct {
-	addr         ProbeAddress
-	sender       twamplight.Sender
-	warmupSender twamplight.Sender
+func defaultSenderFactory(ctx context.Context, log *slog.Logger, iface string, local, remote *net.UDPAddr) (twamplight.Sender, error) {
+	return newSenderWithRetry(ctx, log, iface, local, remote)
 }
 
 func NewPinger(cfg *PingerConfig) *Pinger {
 	return &Pinger{
-		log:     cfg.Logger,
-		cfg:     cfg,
-		senders: make(map[string]*senderEntry),
+		log:       cfg.Logger,
+		cfg:       cfg,
+		targets:   make(map[string]ProbeAddress),
+		newSender: defaultSenderFactory,
 	}
 }
 
@@ -55,13 +57,12 @@ func newSenderWithRetry(ctx context.Context, log *slog.Logger, iface string, loc
 	})
 }
 
-func (p *Pinger) AddProbe(ctx context.Context, addr ProbeAddress) error {
-	p.sendersMu.Lock()
-	defer p.sendersMu.Unlock()
+func (p *Pinger) AddProbe(_ context.Context, addr ProbeAddress) error {
+	p.targetsMu.Lock()
+	defer p.targetsMu.Unlock()
 
 	key := addr.String()
-
-	if _, exists := p.senders[key]; exists {
+	if _, exists := p.targets[key]; exists {
 		p.log.Debug("Probe already exists", "probe", key)
 		return nil
 	}
@@ -70,67 +71,87 @@ func (p *Pinger) AddProbe(ctx context.Context, addr ProbeAddress) error {
 		return fmt.Errorf("invalid probe address %s: %w", key, err)
 	}
 
-	resolvedAddr := &net.UDPAddr{IP: net.ParseIP(addr.Host), Port: int(addr.TWAMPPort)}
-
-	sourceAddr := &net.UDPAddr{
-		IP:   net.IPv4zero,
-		Port: 0,
-	}
-
-	iface := ""
-	if p.cfg.ManagementNamespace != "" {
-		iface = p.cfg.ManagementNamespace
-	}
-
-	sender, err := newSenderWithRetry(ctx, p.log, iface, sourceAddr, resolvedAddr)
-	if err != nil {
-		return fmt.Errorf("failed to create TWAMP sender for %s: %w", addr.String(), err)
-	}
-
-	warmupSourceAddr := &net.UDPAddr{IP: net.IPv4zero, Port: 0}
-	warmupSender, err := newSenderWithRetry(ctx, p.log, iface, warmupSourceAddr, resolvedAddr)
-	if err != nil {
-		sender.Close()
-		return fmt.Errorf("failed to create warmup TWAMP sender for %s: %w", addr.String(), err)
-	}
-
-	p.senders[key] = &senderEntry{
-		addr:         addr,
-		sender:       sender,
-		warmupSender: warmupSender,
-	}
-
-	p.log.Info("Added probe", "probe", key, "resolved", resolvedAddr.String())
+	p.targets[key] = addr
+	p.log.Info("Added probe", "probe", key)
 	return nil
 }
 
 func (p *Pinger) RemoveProbe(addr ProbeAddress) error {
-	p.sendersMu.Lock()
-	defer p.sendersMu.Unlock()
+	p.targetsMu.Lock()
+	defer p.targetsMu.Unlock()
 
 	key := addr.String()
-
-	entry, exists := p.senders[key]
-	if !exists {
+	if _, exists := p.targets[key]; !exists {
 		p.log.Warn("Probe not found for removal", "probe", key)
 		return nil
 	}
 
-	if err := entry.sender.Close(); err != nil {
-		p.log.Warn("Failed to close sender", "probe", key, "error", err)
-	}
-	if err := entry.warmupSender.Close(); err != nil {
-		p.log.Warn("Failed to close warmup sender", "probe", key, "error", err)
-	}
-
-	delete(p.senders, key)
+	delete(p.targets, key)
 	p.log.Info("Removed probe", "probe", key)
 	return nil
 }
 
+func (p *Pinger) createSenderPair(ctx context.Context, addr ProbeAddress) (sender, warmup twamplight.Sender, err error) {
+	resolvedAddr := &net.UDPAddr{IP: net.ParseIP(addr.Host), Port: int(addr.TWAMPPort)}
+	iface := p.cfg.ManagementNamespace
+
+	sender, err = p.newSender(ctx, p.log, iface, &net.UDPAddr{IP: net.IPv4zero, Port: 0}, resolvedAddr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create sender for %s: %w", addr.String(), err)
+	}
+
+	warmup, err = p.newSender(ctx, p.log, iface, &net.UDPAddr{IP: net.IPv4zero, Port: 0}, resolvedAddr)
+	if err != nil {
+		sender.Close()
+		return nil, nil, fmt.Errorf("create warmup sender for %s: %w", addr.String(), err)
+	}
+
+	return sender, warmup, nil
+}
+
+func (p *Pinger) probeTarget(ctx context.Context, addr ProbeAddress) (time.Duration, bool) {
+	sender, warmup, err := p.createSenderPair(ctx, addr)
+	if err != nil {
+		p.log.Warn("Failed to create senders", "probe", addr.String(), "error", err)
+		return 0, false
+	}
+	defer sender.Close()
+	defer warmup.Close()
+
+	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.ProbeTimeout)
+	defer cancel()
+
+	type probeResult struct {
+		rtt time.Duration
+		err error
+	}
+	ch := make(chan probeResult, 2)
+	go func() {
+		rtt, err := warmup.Probe(probeCtx)
+		ch <- probeResult{rtt, err}
+	}()
+	go func() {
+		time.Sleep(DefaultWarmupDelay)
+		rtt, err := sender.Probe(probeCtx)
+		ch <- probeResult{rtt, err}
+	}()
+
+	var bestRTT time.Duration
+	ok := false
+	for range 2 {
+		r := <-ch
+		if r.err == nil && (!ok || r.rtt < bestRTT) {
+			bestRTT = r.rtt
+			ok = true
+		}
+	}
+
+	return bestRTT, ok
+}
+
 func (p *Pinger) probeWorker(
 	ctx context.Context,
-	batch []*senderEntry,
+	batch []ProbeAddress,
 	staggerDelay time.Duration,
 	results map[ProbeAddress]uint64,
 	resultsMu *sync.Mutex,
@@ -138,52 +159,22 @@ func (p *Pinger) probeWorker(
 ) {
 	defer wg.Done()
 
-	for i, entry := range batch {
+	for i, addr := range batch {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 		}
 
-		probeCtx, cancel := context.WithTimeout(ctx, p.cfg.ProbeTimeout)
-
-		// Send a warmup probe first to wake the reflector's thread, then
-		// send the measurement probe after a short delay. Both run on
-		// separate sockets so neither blocks the other. We take the min RTT.
-		type probeResult struct {
-			rtt time.Duration
-			err error
-		}
-		ch := make(chan probeResult, 2)
-		go func() {
-			rtt, err := entry.warmupSender.Probe(probeCtx)
-			ch <- probeResult{rtt, err}
-		}()
-		go func() {
-			time.Sleep(DefaultWarmupDelay)
-			rtt, err := entry.sender.Probe(probeCtx)
-			ch <- probeResult{rtt, err}
-		}()
-
-		var bestRTT time.Duration
-		ok := false
-		for range 2 {
-			r := <-ch
-			if r.err == nil && (!ok || r.rtt < bestRTT) {
-				bestRTT = r.rtt
-				ok = true
-			}
-		}
-		cancel()
+		rtt, ok := p.probeTarget(ctx, addr)
 
 		if ok {
 			resultsMu.Lock()
-			results[entry.addr] = uint64(bestRTT.Nanoseconds())
+			results[addr] = uint64(rtt.Nanoseconds())
 			resultsMu.Unlock()
-
-			p.log.Debug("Probe succeeded", "probe", entry.addr.String(), "rtt", bestRTT)
+			p.log.Debug("Probe succeeded", "probe", addr.String(), "rtt", rtt)
 		} else {
-			p.log.Debug("Probe failed", "probe", entry.addr.String())
+			p.log.Debug("Probe failed", "probe", addr.String())
 		}
 
 		if i < len(batch)-1 {
@@ -198,76 +189,45 @@ func (p *Pinger) probeWorker(
 
 // MeasureOne measures a single probe and returns the best RTT in nanoseconds.
 func (p *Pinger) MeasureOne(ctx context.Context, addr ProbeAddress) (uint64, bool) {
-	p.sendersMu.Lock()
-	entry, exists := p.senders[addr.String()]
-	p.sendersMu.Unlock()
+	p.targetsMu.Lock()
+	_, exists := p.targets[addr.String()]
+	p.targetsMu.Unlock()
 	if !exists {
 		p.log.Warn("MeasureOne called for unknown probe", "probe", addr.String())
 		return 0, false
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.ProbeTimeout)
-	defer cancel()
-
-	type probeResult struct {
-		rtt time.Duration
-		err error
-	}
-	ch := make(chan probeResult, 2)
-	go func() {
-		rtt, err := entry.warmupSender.Probe(probeCtx)
-		ch <- probeResult{rtt, err}
-	}()
-	go func() {
-		time.Sleep(DefaultWarmupDelay)
-		rtt, err := entry.sender.Probe(probeCtx)
-		ch <- probeResult{rtt, err}
-	}()
-
-	var bestRTT time.Duration
-	ok := false
-	for range 2 {
-		r := <-ch
-		if r.err == nil && (!ok || r.rtt < bestRTT) {
-			bestRTT = r.rtt
-			ok = true
-		}
-	}
-
+	rtt, ok := p.probeTarget(ctx, addr)
 	if ok {
-		p.log.Debug("MeasureOne succeeded", "probe", addr.String(), "rtt", bestRTT)
-	} else {
-		p.log.Debug("MeasureOne failed", "probe", addr.String())
+		p.log.Debug("MeasureOne succeeded", "probe", addr.String(), "rtt", rtt)
+		return uint64(rtt.Nanoseconds()), true
 	}
-
-	if !ok {
-		return 0, false
-	}
-	return uint64(bestRTT.Nanoseconds()), true
+	p.log.Debug("MeasureOne failed", "probe", addr.String())
+	return 0, false
 }
 
 func (p *Pinger) MeasureAll(ctx context.Context) (map[ProbeAddress]uint64, error) {
-	p.sendersMu.Lock()
-	sendersCopy := make([]*senderEntry, 0, len(p.senders))
-	for _, entry := range p.senders {
-		sendersCopy = append(sendersCopy, entry)
+	p.targetsMu.Lock()
+	targetsCopy := make([]ProbeAddress, 0, len(p.targets))
+	for _, addr := range p.targets {
+		targetsCopy = append(targetsCopy, addr)
 	}
-	p.sendersMu.Unlock()
+	p.targetsMu.Unlock()
 
-	if len(sendersCopy) == 0 {
+	if len(targetsCopy) == 0 {
 		return make(map[ProbeAddress]uint64), nil
 	}
 
-	totalProbes := len(sendersCopy)
+	totalProbes := len(targetsCopy)
 	results := make(map[ProbeAddress]uint64)
 	resultsMu := sync.Mutex{}
 	var wg sync.WaitGroup
 
-	numWorkers := min(MaxWorkers, (len(sendersCopy)+ProbesPerWorker-1)/ProbesPerWorker)
+	numWorkers := min(MaxWorkers, (len(targetsCopy)+ProbesPerWorker-1)/ProbesPerWorker)
 	if numWorkers == 0 {
 		numWorkers = 1
 	}
-	batchSize := (len(sendersCopy) + numWorkers - 1) / numWorkers
+	batchSize := (len(targetsCopy) + numWorkers - 1) / numWorkers
 
 	staggerDelay := p.cfg.StaggerDelay
 	if staggerDelay == 0 {
@@ -276,12 +236,12 @@ func (p *Pinger) MeasureAll(ctx context.Context) (map[ProbeAddress]uint64, error
 
 	for i := 0; i < numWorkers; i++ {
 		start := i * batchSize
-		end := min(start+batchSize, len(sendersCopy))
-		if start >= len(sendersCopy) {
+		end := min(start+batchSize, len(targetsCopy))
+		if start >= len(targetsCopy) {
 			break
 		}
 
-		batch := sendersCopy[start:end]
+		batch := targetsCopy[start:end]
 		wg.Add(1)
 		go p.probeWorker(ctx, batch, staggerDelay, results, &resultsMu, &wg)
 	}
@@ -300,23 +260,10 @@ func (p *Pinger) MeasureAll(ctx context.Context) (map[ProbeAddress]uint64, error
 }
 
 func (p *Pinger) Close() error {
-	p.sendersMu.Lock()
-	defer p.sendersMu.Unlock()
+	p.targetsMu.Lock()
+	defer p.targetsMu.Unlock()
 
-	var lastErr error
-	for key, entry := range p.senders {
-		if err := entry.sender.Close(); err != nil {
-			p.log.Warn("Failed to close sender", "probe", key, "error", err)
-			lastErr = err
-		}
-		if err := entry.warmupSender.Close(); err != nil {
-			p.log.Warn("Failed to close warmup sender", "probe", key, "error", err)
-			lastErr = err
-		}
-	}
-
-	p.senders = make(map[string]*senderEntry)
+	p.targets = make(map[string]ProbeAddress)
 	p.log.Info("Closed all probes")
-
-	return lastErr
+	return nil
 }

--- a/controlplane/telemetry/internal/geoprobe/pinger.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger.go
@@ -16,8 +16,21 @@ const (
 	ProbesPerWorker     = 512
 	DefaultStaggerDelay = 100 * time.Millisecond
 	DefaultWarmupDelay  = 2 * time.Millisecond
-	senderRetries       = 3
-	senderRetryMin      = 50 * time.Millisecond
+
+	// Bind-error retry budget; kept small because socket creation is now on the
+	// probe hot path and the transient EINVAL it guards clears quickly.
+	senderRetries  = 3
+	senderRetryMin = 20 * time.Millisecond
+
+	// maxPairBindBackoff is the backoff a successful createSenderPair incurs in
+	// the worst case: both sockets retry senderRetries-1 times before succeeding
+	// (senderRetryMin*(2^0+...+2^(senderRetries-2)) per socket, two sockets).
+	maxPairBindBackoff = 2 * senderRetryMin * ((1 << (senderRetries - 1)) - 1)
+
+	// slowSenderPairThreshold sits just below maxPairBindBackoff so the warning
+	// fires only on near-worst-case bind contention; the goal is to learn whether
+	// we hit that ceiling often, not to flag every retry.
+	slowSenderPairThreshold = maxPairBindBackoff - senderRetryMin
 )
 
 type senderFactory func(ctx context.Context, log *slog.Logger, iface string, local, remote *net.UDPAddr) (twamplight.Sender, error)
@@ -38,16 +51,12 @@ type Pinger struct {
 	newSender senderFactory
 }
 
-func defaultSenderFactory(ctx context.Context, log *slog.Logger, iface string, local, remote *net.UDPAddr) (twamplight.Sender, error) {
-	return newSenderWithRetry(ctx, log, iface, local, remote)
-}
-
 func NewPinger(cfg *PingerConfig) *Pinger {
 	return &Pinger{
 		log:       cfg.Logger,
 		cfg:       cfg,
 		targets:   make(map[string]ProbeAddress),
-		newSender: defaultSenderFactory,
+		newSender: newSenderWithRetry,
 	}
 }
 
@@ -95,6 +104,8 @@ func (p *Pinger) createSenderPair(ctx context.Context, addr ProbeAddress) (sende
 	resolvedAddr := &net.UDPAddr{IP: net.ParseIP(addr.Host), Port: int(addr.TWAMPPort)}
 	iface := p.cfg.ManagementNamespace
 
+	start := time.Now()
+
 	sender, err = p.newSender(ctx, p.log, iface, &net.UDPAddr{IP: net.IPv4zero, Port: 0}, resolvedAddr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create sender for %s: %w", addr.String(), err)
@@ -104,6 +115,13 @@ func (p *Pinger) createSenderPair(ctx context.Context, addr ProbeAddress) (sende
 	if err != nil {
 		sender.Close()
 		return nil, nil, fmt.Errorf("create warmup sender for %s: %w", addr.String(), err)
+	}
+
+	if elapsed := time.Since(start); elapsed > slowSenderPairThreshold {
+		p.log.Warn("Slow sender pair creation",
+			"probe", addr.String(),
+			"elapsed", elapsed,
+			"threshold", slowSenderPairThreshold)
 	}
 
 	return sender, warmup, nil
@@ -121,6 +139,10 @@ func (p *Pinger) probeTarget(ctx context.Context, addr ProbeAddress) (time.Durat
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.ProbeTimeout)
 	defer cancel()
 
+	// Send a warmup probe first to wake the reflector's thread, then send the
+	// measurement probe after a short delay. Both run on separate sockets so
+	// neither blocks the other; we take the min RTT. Note the naming: warmup
+	// fires immediately, while sender is the delayed measurement probe.
 	type probeResult struct {
 		rtt time.Duration
 		err error

--- a/controlplane/telemetry/internal/geoprobe/pinger_test.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	twamplight "github.com/malbeclabs/doublezero/tools/twamp/pkg/light"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +29,17 @@ func (m *mockSender) LocalAddr() *net.UDPAddr {
 	return &net.UDPAddr{IP: net.IPv4zero, Port: 0}
 }
 
+func mockFactory(sender, warmup *mockSender) senderFactory {
+	call := 0
+	return func(_ context.Context, _ *slog.Logger, _ string, _, _ *net.UDPAddr) (twamplight.Sender, error) {
+		call++
+		if call%2 == 1 {
+			return sender, nil
+		}
+		return warmup, nil
+	}
+}
+
 func TestNewPinger(t *testing.T) {
 	t.Parallel()
 
@@ -44,8 +56,8 @@ func TestNewPinger(t *testing.T) {
 	require.NotNil(t, pinger)
 	assert.NotNil(t, pinger.log)
 	assert.NotNil(t, pinger.cfg)
-	assert.NotNil(t, pinger.senders)
-	assert.Empty(t, pinger.senders)
+	assert.NotNil(t, pinger.targets)
+	assert.Empty(t, pinger.targets)
 }
 
 func TestPinger_AddProbe(t *testing.T) {
@@ -71,9 +83,9 @@ func TestPinger_AddProbe(t *testing.T) {
 	err := pinger.AddProbe(ctx, addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	_, exists := pinger.senders[addr.String()]
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	_, exists := pinger.targets[addr.String()]
+	pinger.targetsMu.Unlock()
 
 	assert.True(t, exists, "probe should exist after AddProbe")
 }
@@ -101,20 +113,14 @@ func TestPinger_AddProbe_Duplicate(t *testing.T) {
 	err := pinger.AddProbe(ctx, addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	firstSender := pinger.senders[addr.String()].sender
-	pinger.sendersMu.Unlock()
-
 	err = pinger.AddProbe(ctx, addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	secondSender := pinger.senders[addr.String()].sender
-	count := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 
-	assert.Equal(t, 1, count, "should only have one sender after duplicate AddProbe")
-	assert.Equal(t, firstSender, secondSender, "should reuse existing sender on duplicate")
+	assert.Equal(t, 1, count, "should only have one target after duplicate AddProbe")
 }
 
 func TestPinger_AddProbe_InvalidHost(t *testing.T) {
@@ -140,11 +146,11 @@ func TestPinger_AddProbe_InvalidHost(t *testing.T) {
 	err := pinger.AddProbe(ctx, addr)
 	assert.Error(t, err, "should fail with invalid IP address")
 
-	pinger.sendersMu.Lock()
-	count := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 
-	assert.Equal(t, 0, count, "should not add sender for invalid IP")
+	assert.Equal(t, 0, count, "should not add target for invalid IP")
 }
 
 func TestPinger_RemoveProbe(t *testing.T) {
@@ -173,9 +179,9 @@ func TestPinger_RemoveProbe(t *testing.T) {
 	err = pinger.RemoveProbe(addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	_, exists := pinger.senders[addr.String()]
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	_, exists := pinger.targets[addr.String()]
+	pinger.targetsMu.Unlock()
 
 	assert.False(t, exists, "probe should not exist after RemoveProbe")
 }
@@ -276,11 +282,11 @@ func TestPinger_Close(t *testing.T) {
 	err = pinger.Close()
 	assert.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	count := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 
-	assert.Equal(t, 0, count, "all senders should be removed after Close")
+	assert.Equal(t, 0, count, "all targets should be removed after Close")
 }
 
 func TestPinger_Concurrent(t *testing.T) {
@@ -324,9 +330,9 @@ func TestPinger_Concurrent(t *testing.T) {
 
 	wg.Wait()
 
-	pinger.sendersMu.Lock()
-	count := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 
 	assert.Equal(t, 0, count, "all probes should be removed after concurrent operations")
 }
@@ -354,25 +360,25 @@ func TestPinger_AddRemoveSequential(t *testing.T) {
 	err := pinger.AddProbe(ctx, addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	count1 := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count1 := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 	assert.Equal(t, 1, count1)
 
 	err = pinger.RemoveProbe(addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	count2 := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count2 := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 	assert.Equal(t, 0, count2)
 
 	err = pinger.AddProbe(ctx, addr)
 	require.NoError(t, err)
 
-	pinger.sendersMu.Lock()
-	count3 := len(pinger.senders)
-	pinger.sendersMu.Unlock()
+	pinger.targetsMu.Lock()
+	count3 := len(pinger.targets)
+	pinger.targetsMu.Unlock()
 	assert.Equal(t, 1, count3)
 }
 
@@ -579,13 +585,14 @@ func TestPinger_DualProbe_MinRTT(t *testing.T) {
 	}
 
 	pinger := NewPinger(cfg)
+	pinger.newSender = mockFactory(
+		&mockSender{rtt: 10 * time.Millisecond},
+		&mockSender{rtt: 50 * time.Millisecond},
+	)
 
 	addr := ProbeAddress{Host: "192.0.2.1", Port: 8923, TWAMPPort: 8925}
-	pinger.senders[addr.String()] = &senderEntry{
-		addr:         addr,
-		sender:       &mockSender{rtt: 10 * time.Millisecond},
-		warmupSender: &mockSender{rtt: 50 * time.Millisecond},
-	}
+	err := pinger.AddProbe(context.Background(), addr)
+	require.NoError(t, err)
 
 	results, err := pinger.MeasureAll(context.Background())
 	require.NoError(t, err)
@@ -606,13 +613,14 @@ func TestPinger_DualProbe_OneFailsUsesOther(t *testing.T) {
 	}
 
 	pinger := NewPinger(cfg)
+	pinger.newSender = mockFactory(
+		&mockSender{err: context.DeadlineExceeded},
+		&mockSender{rtt: 20 * time.Millisecond},
+	)
 
 	addr := ProbeAddress{Host: "192.0.2.1", Port: 8923, TWAMPPort: 8925}
-	pinger.senders[addr.String()] = &senderEntry{
-		addr:         addr,
-		sender:       &mockSender{err: context.DeadlineExceeded},
-		warmupSender: &mockSender{rtt: 20 * time.Millisecond},
-	}
+	err := pinger.AddProbe(context.Background(), addr)
+	require.NoError(t, err)
 
 	results, err := pinger.MeasureAll(context.Background())
 	require.NoError(t, err)
@@ -633,13 +641,14 @@ func TestPinger_DualProbe_BothFail(t *testing.T) {
 	}
 
 	pinger := NewPinger(cfg)
+	pinger.newSender = mockFactory(
+		&mockSender{err: context.DeadlineExceeded},
+		&mockSender{err: context.DeadlineExceeded},
+	)
 
 	addr := ProbeAddress{Host: "192.0.2.1", Port: 8923, TWAMPPort: 8925}
-	pinger.senders[addr.String()] = &senderEntry{
-		addr:         addr,
-		sender:       &mockSender{err: context.DeadlineExceeded},
-		warmupSender: &mockSender{err: context.DeadlineExceeded},
-	}
+	err := pinger.AddProbe(context.Background(), addr)
+	require.NoError(t, err)
 
 	results, err := pinger.MeasureAll(context.Background())
 	require.NoError(t, err)
@@ -675,12 +684,14 @@ func TestPinger_MeasureOne_Success(t *testing.T) {
 		StaggerDelay: 1 * time.Millisecond,
 	})
 
+	pinger.newSender = mockFactory(
+		&mockSender{rtt: 10 * time.Millisecond},
+		&mockSender{rtt: 50 * time.Millisecond},
+	)
+
 	addr := ProbeAddress{Host: "192.0.2.1", Port: 8923, TWAMPPort: 8925}
-	pinger.senders[addr.String()] = &senderEntry{
-		addr:         addr,
-		sender:       &mockSender{rtt: 10 * time.Millisecond},
-		warmupSender: &mockSender{rtt: 50 * time.Millisecond},
-	}
+	err := pinger.AddProbe(context.Background(), addr)
+	require.NoError(t, err)
 
 	rtt, ok := pinger.MeasureOne(context.Background(), addr)
 	assert.True(t, ok)
@@ -699,12 +710,14 @@ func TestPinger_MeasureOne_BothFail(t *testing.T) {
 		StaggerDelay: 1 * time.Millisecond,
 	})
 
+	pinger.newSender = mockFactory(
+		&mockSender{err: context.DeadlineExceeded},
+		&mockSender{err: context.DeadlineExceeded},
+	)
+
 	addr := ProbeAddress{Host: "192.0.2.1", Port: 8923, TWAMPPort: 8925}
-	pinger.senders[addr.String()] = &senderEntry{
-		addr:         addr,
-		sender:       &mockSender{err: context.DeadlineExceeded},
-		warmupSender: &mockSender{err: context.DeadlineExceeded},
-	}
+	err := pinger.AddProbe(context.Background(), addr)
+	require.NoError(t, err)
 
 	rtt, ok := pinger.MeasureOne(context.Background(), addr)
 	assert.False(t, ok)

--- a/controlplane/telemetry/internal/geoprobe/pinger_test.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger_test.go
@@ -29,6 +29,12 @@ func (m *mockSender) LocalAddr() *net.UDPAddr {
 	return &net.UDPAddr{IP: net.IPv4zero, Port: 0}
 }
 
+// mockFactory returns a senderFactory that hands out sender on the first call
+// and warmup on the second, matching createSenderPair's sender-then-warmup
+// order. The call counter is unsynchronized, so this is only correct with a
+// single registered target: createSenderPair then runs serially, making exactly
+// two ordered calls. A multi-target test would race on call under -race and
+// could mis-pair senders; add synchronization here before introducing one.
 func mockFactory(sender, warmup *mockSender) senderFactory {
 	call := 0
 	return func(_ context.Context, _ *slog.Logger, _ string, _, _ *net.UDPAddr) (twamplight.Sender, error) {

--- a/controlplane/telemetry/internal/geoprobe/retry.go
+++ b/controlplane/telemetry/internal/geoprobe/retry.go
@@ -17,9 +17,10 @@ func isBindError(err error) bool {
 	return strings.Contains(err.Error(), "bind:")
 }
 
-// retryOnBindError calls fn up to senderRetries times, retrying with
-// exponential backoff (senderRetryMin * 2^attempt) only when fn returns an
-// error classified by isBindError. Non-bind errors are returned immediately.
+// retryOnBindError calls fn up to senderRetries times, backing off between
+// attempts with exponential delay (senderRetryMin * 2^attempt) only when fn
+// returns an error classified by isBindError. Non-bind errors are returned
+// immediately. No delay follows the final attempt before giving up.
 func retryOnBindError[T any](ctx context.Context, log *slog.Logger, fn func() (T, error)) (T, error) {
 	var (
 		zero    T
@@ -33,6 +34,9 @@ func retryOnBindError[T any](ctx context.Context, log *slog.Logger, fn func() (T
 		lastErr = err
 		if !isBindError(err) {
 			return zero, err
+		}
+		if attempt == senderRetries-1 {
+			break
 		}
 		delay := senderRetryMin * time.Duration(1<<attempt)
 		log.Warn("Bind failed, retrying", "attempt", attempt+1, "delay", delay, "error", err)

--- a/controlplane/telemetry/internal/geoprobe/retry_test.go
+++ b/controlplane/telemetry/internal/geoprobe/retry_test.go
@@ -75,6 +75,27 @@ func TestRetryOnBindError_GivesUpAfterMaxAttempts(t *testing.T) {
 	assert.Equal(t, int32(senderRetries), calls.Load())
 }
 
+func TestRetryOnBindError_NoBackoffAfterFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	fn := func() (string, error) {
+		return "", errors.New("bind: invalid argument")
+	}
+
+	start := time.Now()
+	_, err := retryOnBindError(context.Background(), quietLogger(), fn)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+
+	// Backoff covers only the gaps between attempts: senderRetryMin*(2^0+...+2^(n-2)).
+	// A sleep after the final attempt would add senderRetryMin*2^(n-1) on top.
+	betweenAttempts := senderRetryMin * ((1 << (senderRetries - 1)) - 1)
+	finalSleep := senderRetryMin * (1 << (senderRetries - 1))
+	assert.Less(t, elapsed, betweenAttempts+finalSleep/2,
+		"must not back off after the final attempt before giving up")
+}
+
 func TestRetryOnBindError_HonorsContextCancellation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary of Changes
- Replace persistent per-target sender pairs with on-demand socket creation: sockets are created at probe time and closed immediately after, eliminating the long-lived ephemeral-port consumption that could exhaust the source-port range
- `Pinger` now tracks only target addresses; `probeTarget()` creates and closes a sender pair each measurement cycle via the extracted `createSenderPair()` helper
- Tighten `retryOnBindError` now that socket creation is on the probe hot path: drop the wasted backoff after the final attempt and lower the base delay 50ms→20ms, cutting worst-case bind-retry latency from ~350ms to ~60ms per socket (this helper is shared with the publisher's `AddProbe`, which benefits too)
- Warn when sender-pair creation nears the worst-case retry budget (~100ms, just under the ~120ms/pair ceiling), surfacing sustained bind contention without flagging every retry
- Consolidate duplicated probe logic from `probeWorker`/`MeasureOne` into `probeTarget()`, and inject sender creation through a `senderFactory` for testing

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic |     2 | +133 / -160 | -27 |
| Tests      |     2 | +103 / -63  | +40 |
| **Total**  |     4 | +236 / -223 | +13 |

Net reduction in core logic — removing persistent socket management outweighs the new on-demand lifecycle and instrumentation.

<details>
<summary>Key files (click to expand)</summary>

- [`controlplane/telemetry/internal/geoprobe/pinger.go`](https://github.com/malbeclabs/doublezero/pull/3378/files#diff-1b07aba6b82794f8591f10188a953966d4db60895d6480153bd5b4625750b8da) — on-demand socket lifecycle: `targets` map replaces `senders`; new `createSenderPair()`/`probeTarget()`; `senderFactory` injection; slow-creation WARN
- [`controlplane/telemetry/internal/geoprobe/pinger_test.go`](https://github.com/malbeclabs/doublezero/pull/3378/files#diff-9d4e81fe02e35b543010c3d773233311b087a01b71548840ec777864b35f5054) — switch tests to `senderFactory` injection (`mockFactory`); assertions moved from `senders` to `targets`
- [`controlplane/telemetry/internal/geoprobe/retry_test.go`](https://github.com/malbeclabs/doublezero/pull/3378/files#diff-023db9299a9c916153e34b7faa418a784cac133dd2360bdc02c91c0f1a0542ca) — add `TestRetryOnBindError_NoBackoffAfterFinalAttempt` pinning the no-trailing-sleep behavior
- [`controlplane/telemetry/internal/geoprobe/retry.go`](https://github.com/malbeclabs/doublezero/pull/3378/files#diff-c08e40de7d6876c3672d879649c5965dda661d2e9a357040901d1243d11a2ae5) — skip backoff after the final attempt; clarify doc comment

</details>

## Testing Verification
- Existing dual-probe scenarios preserved (min RTT, one-fails-uses-other, both-fail, `MeasureOne`, concurrent add/remove)
- Added `TestRetryOnBindError_NoBackoffAfterFinalAttempt`; the prior tests only asserted call count, so the wasted final-attempt sleep went uncaught
- Full `geoprobe` package passes under `-race`, including the 1000- and 2000-probe large-scale tests that create real sockets and exercise the bind-retry path under contention
