### PR TITLE
smartcontract: allow foundation members or sentinel to set custom owner on create subscribe user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
   - Top up contributor owner keys alongside device metrics publishers, multicast group owners, and the internet latency collector
 - Smartcontract
   - Fix multicast publisher/subscriber device counter divergence: `multicast_publishers_count` never decremented and `multicast_subscribers_count` over-decremented on user disconnect because the decrement logic checked `!publishers.is_empty()`, which is always false at delete time. Add a durable `tunnel_flags` field to the `User` struct with a `CreatedAsPublisher` bit, set at activation, and use it in the delete and closeaccount instructions.
+  - Allow foundation allowlist members and the sentinel to create multicast users with a custom `owner` via a new `owner` field on `CreateSubscribeUser`, enabling user creation on behalf of another identity's access pass
+- CLI
+  - Add `--owner` flag to `doublezero user create-subscribe` for specifying a custom user owner (foundation/sentinel only)
 
 ## [v0.14.0](https://github.com/malbeclabs/doublezero/compare/client/v0.13.0...client/v0.14.0) - 2026-03-24
 

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -625,6 +625,7 @@ impl ProvisioningCliCommand {
                     publisher: pub_group_pks.contains(first_group_pk),
                     subscriber: sub_group_pks.contains(first_group_pk),
                     tunnel_endpoint,
+                    owner: None,
                 });
 
                 let user_pk = match res {
@@ -763,6 +764,7 @@ impl ProvisioningCliCommand {
                     publisher: pub_group_pks.contains(first_group_pk),
                     subscriber: sub_group_pks.contains(first_group_pk),
                     tunnel_endpoint,
+                    owner: None,
                 });
 
                 let user_pk = match res {
@@ -1515,6 +1517,7 @@ mod tests {
                 publisher,
                 subscriber,
                 tunnel_endpoint: user.tunnel_endpoint,
+                owner: None,
             };
 
             let users = self.users.clone();

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -35,6 +35,9 @@ pub struct CreateSubscribeUserCliCommand {
     /// Wait for the user to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
+    /// Custom owner pubkey (foundation allowlist only)
+    #[arg(long)]
+    pub owner: Option<String>,
 }
 
 impl CreateSubscribeUserCliCommand {
@@ -84,6 +87,12 @@ impl CreateSubscribeUserCliCommand {
             },
         };
 
+        let owner_pk = self
+            .owner
+            .as_deref()
+            .map(|s| parse_pubkey(s).ok_or_else(|| eyre::eyre!("Invalid owner pubkey: {}", s)))
+            .transpose()?;
+
         let (signature, pubkey) = client.create_subscribe_user(CreateSubscribeUserCommand {
             user_type: UserType::Multicast,
             device_pk,
@@ -95,6 +104,7 @@ impl CreateSubscribeUserCliCommand {
                 .or(subscriber_pk)
                 .ok_or(eyre::eyre!("Subscriber is required if publisher is not"))?,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            owner: owner_pk,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -214,6 +224,7 @@ mod tests {
                 subscriber: true,
                 mgroup_pk: mgroup_pubkey,
                 tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+                owner: None,
             }))
             .times(1)
             .returning(move |_| Ok((signature, pda_pubkey)));
@@ -227,6 +238,7 @@ mod tests {
             publisher: None,
             subscriber: Some(mgroup_pubkey.to_string()),
             wait: false,
+            owner: None,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -1057,6 +1057,7 @@ mod tests {
                 subscriber: true,
                 tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
                 dz_prefix_count: 0,
+                owner: Pubkey::default(),
             }),
             "CreateSubscribeUser",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create.rs
@@ -104,6 +104,7 @@ pub fn process_create_user(
         value.client_ip,
         value.tunnel_endpoint,
         false,
+        None,
     )?;
 
     // Atomic create+allocate+activate if on-chain allocation is requested

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
@@ -67,6 +67,7 @@ pub fn create_user_core(
     client_ip: Ipv4Addr,
     tunnel_endpoint: Ipv4Addr,
     is_publisher: bool,
+    owner_override: Option<Pubkey>,
 ) -> Result<CreateUserCoreResult, ProgramError> {
     // Check if the payer is a signer
     assert!(core.payer_account.is_signer, "Payer must be a signer");
@@ -105,6 +106,25 @@ pub fn create_user_core(
     }
 
     let mut globalstate = GlobalState::try_from(core.globalstate_account)?;
+
+    // Determine effective owner: foundation allowlist members or sentinel can set a custom owner
+    let effective_owner = match owner_override {
+        Some(pk) if pk != Pubkey::default() => {
+            let is_foundation = globalstate
+                .foundation_allowlist
+                .contains(core.payer_account.key);
+            let is_sentinel = globalstate.sentinel_authority_pk == *core.payer_account.key;
+            if !is_foundation && !is_sentinel {
+                msg!(
+                    "Only foundation allowlist members or sentinel can set a custom owner, payer: {}",
+                    core.payer_account.key
+                );
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+            pk
+        }
+        _ => *core.payer_account.key,
+    };
     globalstate.account_index += 1;
 
     let (expected_old_pda_account, bump_old_seed) =
@@ -135,9 +155,9 @@ pub fn create_user_core(
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    let (accesspass_pda, _) = get_accesspass_pda(program_id, &client_ip, core.payer_account.key);
+    let (accesspass_pda, _) = get_accesspass_pda(program_id, &client_ip, &effective_owner);
     let (accesspass_dynamic_pda, _) =
-        get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, core.payer_account.key);
+        get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, &effective_owner);
     assert!(
         core.accesspass_account.key == &accesspass_pda
             || core.accesspass_account.key == &accesspass_dynamic_pda,
@@ -146,7 +166,7 @@ pub fn create_user_core(
 
     // Read Access Pass
     let mut accesspass = AccessPass::try_from(core.accesspass_account)?;
-    if accesspass.user_payer != *core.payer_account.key {
+    if accesspass.user_payer != effective_owner {
         msg!(
             "Invalid user_payer accesspass.{{user_payer: {}}} = {{ user_payer: {} }}",
             accesspass.user_payer,
@@ -310,7 +330,7 @@ pub fn create_user_core(
 
     let user = User {
         account_type: AccountType::User,
-        owner: *core.payer_account.key,
+        owner: effective_owner,
         bump_seed: if pda_ver == PDAVersion::V1 {
             bump_old_seed
         } else {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs
@@ -34,18 +34,23 @@ pub struct UserCreateSubscribeArgs {
     /// When 0, legacy behavior is used (Pending status). When > 0, atomic create+allocate+activate.
     #[incremental(default = 0)]
     pub dz_prefix_count: u8,
+    /// Custom owner pubkey. When set (non-default), the payer must be in the foundation allowlist.
+    /// The access pass is looked up using this owner instead of the payer.
+    #[incremental(default = Pubkey::default())]
+    pub owner: Pubkey,
 }
 
 impl fmt::Debug for UserCreateSubscribeArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "user_type: {}, cyoa_type: {}, client_ip: {}, tunnel_endpoint: {}, dz_prefix_count: {}",
+            "user_type: {}, cyoa_type: {}, client_ip: {}, tunnel_endpoint: {}, dz_prefix_count: {}, owner: {}",
             self.user_type,
             self.cyoa_type,
             &self.client_ip,
             &self.tunnel_endpoint,
             self.dz_prefix_count,
+            self.owner,
         )
     }
 }
@@ -87,6 +92,12 @@ pub fn process_create_subscribe_user(
         payer_account,
     };
 
+    let owner_override = if value.owner != Pubkey::default() {
+        Some(value.owner)
+    } else {
+        None
+    };
+
     let mut result = create_user_core(
         program_id,
         accounts,
@@ -96,6 +107,7 @@ pub fn process_create_subscribe_user(
         value.client_ip,
         value.tunnel_endpoint,
         value.publisher,
+        owner_override,
     )?;
 
     // Subscribe user to multicast group

--- a/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
@@ -7,6 +7,7 @@
 //! - Backward compatibility (old args without dz_prefix_count)
 //! - Feature flag enforcement for atomic path
 //! - Invalid multicast group status rejection (graceful error, not panic)
+//! - Foundation allowlist owner override (custom owner for user creation)
 
 use doublezero_serviceability::{
     entrypoint::process_instruction,
@@ -432,6 +433,7 @@ async fn test_create_subscribe_user_legacy_publisher() {
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -498,6 +500,7 @@ async fn test_create_subscribe_user_legacy_subscriber() {
             subscriber: true,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -560,6 +563,7 @@ async fn test_create_subscribe_user_legacy_publisher_and_subscriber() {
             subscriber: true,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -646,6 +650,7 @@ async fn test_create_subscribe_user_atomic_publisher() {
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 1,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -742,6 +747,7 @@ async fn test_create_subscribe_user_atomic_subscriber() {
             subscriber: true,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 1,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -825,6 +831,7 @@ async fn test_create_subscribe_user_atomic_feature_flag_disabled() {
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 1,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -920,6 +927,7 @@ async fn test_create_subscribe_user_inactive_mgroup_fails() {
             subscriber: true,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -1056,6 +1064,7 @@ async fn test_create_subscribe_user_ignores_tenant_allowlist() {
             subscriber: true,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -1125,6 +1134,7 @@ async fn test_publisher_multicast_publisher_persists_through_disconnect() {
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -1327,6 +1337,7 @@ async fn test_publisher_disconnect_delete_decrements_publishers_count() {
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             dz_prefix_count: 0,
+            owner: Pubkey::default(),
         }),
         vec![
             AccountMeta::new(user_pubkey, false),
@@ -1498,5 +1509,1022 @@ async fn test_publisher_disconnect_delete_decrements_publishers_count() {
     assert_eq!(
         device_after.multicast_subscribers_count, 0,
         "subscribers_count must remain 0 (was never incremented for publisher user)"
+    );
+}
+
+// ============================================================================
+// Owner Override Tests
+// ============================================================================
+
+/// Foundation allowlist member can create a user with a custom owner.
+/// The access pass must belong to the custom owner, not the payer.
+#[tokio::test]
+async fn test_create_subscribe_user_foundation_owner_override() {
+    let client_ip = [100, 0, 0, 30];
+    let program_id = Pubkey::new_unique();
+
+    let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    )
+    .start()
+    .await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (globalconfig_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // Init global state (payer is automatically in foundation_allowlist)
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Set global config
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.100.0.0/24".parse().unwrap(),
+            user_tunnel_block: "169.254.0.0/24".parse().unwrap(),
+            multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create Location, Exchange, Contributor
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
+            code: "test".to_string(),
+            name: "Test Location".to_string(),
+            country: "us".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
+            code: "test".to_string(),
+            name: "Test Exchange".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "test".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate Device
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "test-dev".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "110.1.0.0/24".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: None,
+            resource_count: 0,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (tunnel_ids, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(DeviceActivateArgs { resource_count: 2 }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate multicast group
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (mgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "group1".to_string(),
+            max_bandwidth: 1000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: "224.0.0.1".parse().unwrap(),
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The custom owner — a different pubkey from the payer
+    let custom_owner = Pubkey::new_unique();
+    let user_ip: Ipv4Addr = client_ip.into();
+
+    // Create access pass for the CUSTOM OWNER (not the payer)
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &user_ip, &custom_owner);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(custom_owner, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add mgroup to pub allowlist for custom owner's access pass
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: user_ip,
+            user_payer: custom_owner,
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Foundation payer creates user with custom owner
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::Multicast);
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: user_ip,
+            publisher: true,
+            subscriber: false,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+            owner: custom_owner,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Verify user was created with custom_owner as owner
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(
+        user.owner, custom_owner,
+        "User owner should be the custom owner, not the payer"
+    );
+    assert_eq!(user.status, UserStatus::Pending);
+    assert_eq!(user.publishers, vec![mgroup_pubkey]);
+}
+
+/// Sentinel can create a user with a custom owner.
+#[tokio::test]
+async fn test_create_subscribe_user_sentinel_owner_override() {
+    let client_ip = [100, 0, 0, 32];
+    let program_id = Pubkey::new_unique();
+
+    // Create a sentinel keypair (not in foundation_allowlist)
+    let sentinel = solana_sdk::signature::Keypair::new();
+
+    let mut program_test = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    // Fund the sentinel
+    program_test.add_account(
+        sentinel.pubkey(),
+        solana_sdk::account::Account {
+            lamports: 10_000_000_000,
+            data: vec![],
+            owner: solana_sdk::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (globalconfig_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // Init global state
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Set sentinel_authority_pk to our second keypair
+    use doublezero_serviceability::processors::globalstate::setauthority::SetAuthorityArgs;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            activator_authority_pk: None,
+            sentinel_authority_pk: Some(sentinel.pubkey()),
+            health_oracle_pk: None,
+            feed_authority_pk: None,
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // Set global config
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.100.0.0/24".parse().unwrap(),
+            user_tunnel_block: "169.254.0.0/24".parse().unwrap(),
+            multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create Location, Exchange, Contributor
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
+            code: "test".to_string(),
+            name: "Test Location".to_string(),
+            country: "us".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
+            code: "test".to_string(),
+            name: "Test Exchange".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "test".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate Device
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "test-dev".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "110.1.0.0/24".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: None,
+            resource_count: 0,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (tunnel_ids, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(DeviceActivateArgs { resource_count: 2 }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate multicast group
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (mgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "group1".to_string(),
+            max_bandwidth: 1000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: "224.0.0.1".parse().unwrap(),
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create access pass for the custom owner
+    let custom_owner = Pubkey::new_unique();
+    let user_ip: Ipv4Addr = client_ip.into();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &user_ip, &custom_owner);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(custom_owner, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add mgroup to pub allowlist for custom owner's access pass
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: user_ip,
+            user_payer: custom_owner,
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Sentinel creates user with custom owner
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::Multicast);
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: user_ip,
+            publisher: true,
+            subscriber: false,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+            owner: custom_owner,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &sentinel,
+    )
+    .await;
+
+    // Verify user was created with custom_owner as owner
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(
+        user.owner, custom_owner,
+        "User owner should be the custom owner, not the sentinel"
+    );
+    assert_eq!(user.status, UserStatus::Pending);
+    assert_eq!(user.publishers, vec![mgroup_pubkey]);
+}
+
+/// Non-foundation member cannot set a custom owner — should fail with NotAllowed.
+/// Uses a second keypair (not in foundation_allowlist) as the transaction payer.
+#[tokio::test]
+async fn test_create_subscribe_user_non_foundation_owner_override_rejected() {
+    let client_ip = [100, 0, 0, 31];
+    let program_id = Pubkey::new_unique();
+
+    // Create a second keypair that will NOT be in the foundation allowlist
+    let non_foundation_payer = solana_sdk::signature::Keypair::new();
+
+    let mut program_test = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    // Fund the non-foundation payer so it can sign transactions
+    program_test.add_account(
+        non_foundation_payer.pubkey(),
+        solana_sdk::account::Account {
+            lamports: 10_000_000_000,
+            data: vec![],
+            owner: solana_sdk::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (globalconfig_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // Init global state with foundation payer
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Set global config
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.100.0.0/24".parse().unwrap(),
+            user_tunnel_block: "169.254.0.0/24".parse().unwrap(),
+            multicastgroup_block: "239.0.0.0/24".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create Location, Exchange, Contributor (with foundation payer)
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
+            code: "test".to_string(),
+            name: "Test Location".to_string(),
+            country: "us".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
+            code: "test".to_string(),
+            name: "Test Exchange".to_string(),
+            lat: 0.0,
+            lng: 0.0,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "test".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate Device (payer is in foundation, allows on non-activated device)
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "test-dev".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "110.1.0.0/24".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: None,
+            resource_count: 0,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (tunnel_ids, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_block, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(DeviceActivateArgs { resource_count: 2 }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create and activate multicast group
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (mgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "group1".to_string(),
+            max_bandwidth: 1000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: "224.0.0.1".parse().unwrap(),
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create access pass for the non-foundation payer (so accesspass validation passes)
+    let user_ip: Ipv4Addr = client_ip.into();
+    let (accesspass_pubkey, _) =
+        get_accesspass_pda(&program_id, &user_ip, &non_foundation_payer.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(non_foundation_payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add mgroup to pub allowlist
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: user_ip,
+            user_payer: non_foundation_payer.pubkey(),
+        }),
+        vec![
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Non-foundation payer tries to create user with custom owner — should fail
+    let custom_owner = Pubkey::new_unique();
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::Multicast);
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: user_ip,
+            publisher: true,
+            subscriber: false,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+            owner: custom_owner,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &non_foundation_payer,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Non-foundation member should not be able to set custom owner"
     );
 }

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -30,6 +30,9 @@ pub struct CreateSubscribeUserCommand {
     pub publisher: bool,
     pub subscriber: bool,
     pub tunnel_endpoint: Ipv4Addr,
+    /// Custom owner pubkey (foundation allowlist only). When set, the access pass
+    /// is looked up for this owner instead of the payer.
+    pub owner: Option<Pubkey>,
 }
 
 impl CreateSubscribeUserCommand {
@@ -51,22 +54,25 @@ impl CreateSubscribeUserCommand {
             eyre::bail!("MulticastGroup not active");
         }
 
+        // When a custom owner is set, look up the access pass for that owner
+        let accesspass_payer = self.owner.unwrap_or_else(|| client.get_payer());
+
         // First try to get AccessPass for the client IP
         let (accesspass_pk, _) = GetAccessPassCommand {
             client_ip: self.client_ip,
-            user_payer: client.get_payer(),
+            user_payer: accesspass_payer,
         }
         .execute(client)?
         .or_else(|| {
             GetAccessPassCommand {
                 client_ip: Ipv4Addr::UNSPECIFIED,
-                user_payer: client.get_payer(),
+                user_payer: accesspass_payer,
             }
             .execute(client)
             .ok()
             .flatten()
         })
-        .ok_or_else(|| eyre::eyre!("You have no Access Pass"))?;
+        .ok_or_else(|| eyre::eyre!("No Access Pass found for owner"))?;
 
         let (pda_pubkey, _) =
             get_user_pda(&client.get_program_id(), &self.client_ip, self.user_type);
@@ -126,6 +132,7 @@ impl CreateSubscribeUserCommand {
                     subscriber: self.subscriber,
                     tunnel_endpoint: self.tunnel_endpoint,
                     dz_prefix_count,
+                    owner: self.owner.unwrap_or_default(),
                 }),
                 accounts,
             )
@@ -216,6 +223,7 @@ mod tests {
                         subscriber: false,
                         tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
                         dz_prefix_count: 0,
+                        owner: Pubkey::default(),
                     },
                 )),
                 predicate::eq(vec![
@@ -237,6 +245,7 @@ mod tests {
             publisher: true,
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            owner: None,
         }
         .execute(&client);
 
@@ -345,6 +354,7 @@ mod tests {
                         subscriber: false,
                         tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
                         dz_prefix_count: 1,
+                        owner: Pubkey::default(),
                     },
                 )),
                 predicate::eq(vec![
@@ -370,6 +380,7 @@ mod tests {
             publisher: true,
             subscriber: false,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            owner: None,
         }
         .execute(&client);
 


### PR DESCRIPTION
## Summary of Changes
- Foundation allowlist members and the sentinel can now specify a custom `owner` when creating a multicast user via `CreateSubscribeUser`, enabling user creation on behalf of another identity
- The access pass is validated against the custom owner (not the payer), and `User.owner` is set to the custom owner
- Non-authorized payers attempting to set a custom owner receive a `NotAllowed` error
- New `--owner` CLI flag on `doublezero user create-subscribe`

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +53 / -5    |  +48 |
| Scaffolding  |     3 | +18 / -0    |  +18 |
| Tests        |     2 | +1028 / -3  | +1025 |

Core change is ~48 lines; the rest is test coverage and plumbing the new field through callers.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs` — add `owner_override` param; derive effective owner from foundation allowlist or sentinel check; use it for access pass PDA, user_payer validation, and User.owner
- `smartcontract/programs/doublezero-serviceability/src/processors/user/create_subscribe.rs` — add `owner` field to `UserCreateSubscribeArgs` with backward-compatible incremental default
- `smartcontract/sdk/rs/src/commands/user/create_subscribe.rs` — add `owner: Option<Pubkey>` to SDK command; look up access pass for custom owner when set
- `smartcontract/cli/src/user/create_subscribe.rs` — add `--owner` CLI flag; parse and pass through to SDK command

</details>

## Testing Verification
- All 13 `create_subscribe_user_test` integration tests pass (10 existing + 3 new)
- New test: foundation member creates user with custom owner — verifies `User.owner` is set to the custom owner
- New test: sentinel creates user with custom owner — verifies sentinel is authorized
- New test: non-authorized payer attempts custom owner — verifies transaction fails with `NotAllowed`
- SDK and CLI unit tests updated and passing
- `cargo clippy` clean on all affected crates