### PR TITLE
release: add build-snapshot script and Dockerfile

### DIFF
--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -3,7 +3,7 @@ FROM golang:1.25.0
 # Rust toolchain (matches rust-toolchain.toml)
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:/go/bin:/usr/local/go/bin:$PATH
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain 1.90.0 \
     && rustup target add x86_64-unknown-linux-gnu

--- a/scripts/build-snapshot.sh
+++ b/scripts/build-snapshot.sh
@@ -107,14 +107,22 @@ echo ""
 # --- Build in Docker ---
 
 RELEASE_IMAGE="doublezero-release"
+DOCKERFILE="release/Dockerfile.release"
+DOCKERFILE_HASH=$(shasum -a 256 "$DOCKERFILE" | cut -d' ' -f1 | head -c 12)
 
-# Build the release Docker image if it doesn't exist.
-if ! docker image inspect "$RELEASE_IMAGE" >/dev/null 2>&1; then
-    echo -e "${BOLD}${CYAN}[0/1]${RESET} ${BOLD}Building release Docker image${RESET}"
+# Rebuild the Docker image if it doesn't exist or the Dockerfile has changed.
+EXISTING_HASH=$(docker image inspect "$RELEASE_IMAGE" --format '{{index .Config.Labels "dockerfile.hash"}}' 2>/dev/null || true)
+if [[ "$EXISTING_HASH" != "$DOCKERFILE_HASH" ]]; then
+    if [[ -n "$EXISTING_HASH" ]]; then
+        echo -e "${BOLD}${CYAN}[0/1]${RESET} ${BOLD}Rebuilding release Docker image (Dockerfile changed)${RESET}"
+    else
+        echo -e "${BOLD}${CYAN}[0/1]${RESET} ${BOLD}Building release Docker image${RESET}"
+    fi
     echo ""
     docker build --platform linux/amd64 \
         -t "$RELEASE_IMAGE" \
-        -f release/Dockerfile.release \
+        --label "dockerfile.hash=$DOCKERFILE_HASH" \
+        -f "$DOCKERFILE" \
         release/
     echo ""
 fi


### PR DESCRIPTION
## Summary of Changes
- Add a script (`scripts/build-snapshot.sh`) to build goreleaser snapshots locally in a linux/amd64 Docker container, so you don't have to be in a devcontainer when not on Linux
- Add a Dockerfile (`release/Dockerfile.release`) with Rust, Go, and goreleaser-pro pre-installed for reproducible snapshot builds
- Script takes an environment (devnet/testnet) and config name, uses named Docker volumes for build caching, and outputs artifacts to `dist/`

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Scaffolding  |     1 | +181 / -0   | +181  |
| Config/build |     1 | +23 / -0    |  +23  |

All new files — a build script and its supporting Dockerfile.

<details>
<summary>Key files (click to expand)</summary>

- `scripts/build-snapshot.sh` — goreleaser snapshot build script with env/config selection, Docker volume caching, and artifact listing
- `release/Dockerfile.release` — linux/amd64 build image with Rust 1.90.0, Go 1.25.0, and goreleaser-pro 2.14.3

</details>

## Testing Verification
- Verified script argument parsing and help output
- Confirmed devnet and testnet goreleaser configs are correctly resolved (e.g., `release/.goreleaser.devnet.controller.yaml`)