### PR TITLE
release: add openssl dev dependencies to release Dockerfile

### DIFF
--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -10,7 +10,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 # Cross-compiler for Rust linux builds + rpm packaging
 RUN apt-get update -qq \
-    && apt-get install -y -qq gcc-x86-64-linux-gnu rpm > /dev/null 2>&1 \
+    && apt-get install -y -qq gcc-x86-64-linux-gnu rpm pkg-config libssl-dev > /dev/null 2>&1 \
     && rm -rf /var/lib/apt/lists/*
 
 # goreleaser-pro


### PR DESCRIPTION
## Summary
- Add `pkg-config` and `libssl-dev` to the release Docker image so the Rust CLI (`openssl-sys` crate) can build successfully

## Testing Verification
- Ran `./scripts/build-snapshot.sh devnet client` and confirmed the Rust build fails without these packages (openssl-sys cannot find OpenSSL headers)