### PR TITLE
cli: handle SIGPIPE to prevent broken pipe panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - Reset SIGPIPE to SIG_DFL at the start of main() in all 3 CLI binaries (doublezero, doublezero-geolocation, doublezero-admin) so the process exits silently like standard CLI tools
+
 ## [v0.15.0](https://github.com/malbeclabs/doublezero/compare/client/v0.14.0...client/v0.15.0) - 2026-03-27
 
 - Client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,7 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "indicatif",
+ "libc",
  "mockall",
  "serde",
  "serde_json",
@@ -1610,6 +1611,7 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "indicatif",
+ "libc",
  "mockall",
  "serde",
  "serde_json",
@@ -1663,6 +1665,7 @@ dependencies = [
  "doublezero_cli",
  "doublezero_sdk",
  "eyre",
+ "libc",
  "solana-sdk",
 ]
 

--- a/client/doublezero-geolocation-cli/Cargo.toml
+++ b/client/doublezero-geolocation-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 eyre.workspace = true
+libc.workspace = true
 solana-sdk.workspace = true
 
 doublezero-config.workspace = true

--- a/client/doublezero-geolocation-cli/src/main.rs
+++ b/client/doublezero-geolocation-cli/src/main.rs
@@ -34,6 +34,10 @@ struct App {
 }
 
 fn main() -> eyre::Result<()> {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let app = App::parse();
 
     let stdout = std::io::stdout();

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -21,6 +21,7 @@ console.workspace = true
 eyre.workspace = true
 futures.workspace = true
 futures-util.workspace = true
+libc.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -54,6 +54,10 @@ struct App {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let app = App::parse();
 
     if let Some(keypair) = &app.keypair {

--- a/controlplane/doublezero-admin/Cargo.toml
+++ b/controlplane/doublezero-admin/Cargo.toml
@@ -20,6 +20,7 @@ console.workspace = true
 eyre.workspace = true
 futures.workspace = true
 futures-util.workspace = true
+libc.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/controlplane/doublezero-admin/src/main.rs
+++ b/controlplane/doublezero-admin/src/main.rs
@@ -47,6 +47,10 @@ struct App {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let app = App::parse();
 
     if let Some(keypair) = &app.keypair {


### PR DESCRIPTION
Resolves: #3387

## Summary
- Rust ignores `SIGPIPE` at startup, causing `println!` to panic with "Broken pipe" when piping CLI output to `head`, `grep`, etc.
- Reset `SIGPIPE` to `SIG_DFL` at the start of `main()` in all 3 CLI binaries (`doublezero`, `doublezero-geolocation`, `doublezero-admin`) so the process exits silently like standard CLI tools

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| client/doublezero | +5 | -0 |
| client/doublezero-geolocation-cli | +5 | -0 |
| controlplane/doublezero-admin | +5 | -0 |
| Cargo.lock | +3 | -0 |

## Testing Verification
- Companion fix for `doublezero-solana` in doublezerofoundation/doublezero-offchain#317
```
ubuntu@chi-dn-bm2:~$ doublezero device list | head -n 5
 account                                      | code                  | contributor | location | exchange | device_type | public_ip  | dz_prefixes    | users | max_users | status              | health          | mgmt_vrf   | owner                                        
 8PQkip3CxWhQTdP7doCyhT2kwjSL2csRTdnRg2zbDPs1 | chi-dn-dzd1           | co01        | chi      | xchi     | hybrid      | 100.0.0.1  | 198.18.0.0/24  | 0     | 128       | activated           | ready-for-users | management | DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan 
 4CkvmyquGN4qtXLNj3hpJcqYbb7PCanLbU1rQHHdp6xp | chi-dn-dzd3-delete-me | co01        | chi      | xchi     | hybrid      | 0.1.2.3    | 198.18.4.0/24  | 0     | 0         | activated           | ready-for-users |            | DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan 
 HzndSULmxcc95Zj8c3u3dKKt6YQN7fc1XW92cZvwyxC5 | greg-test-dev         | co01        | chi      | xchi     | hybrid      | 1.2.3.4    | 198.18.42.0/24 | 0     | 0         | activated           | ready-for-users | default    | DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan 
 GV98Pn3xZR3dyMsbD7VMRSrpoN3qj3ch9f69mmW6LHj3 | nikw-test             | co01        | chi      | xchi     | hybrid      | 1.2.3.8    | 198.18.9.0/24  | 0     | 0         | device-provisioning | ready-for-users | default    | DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan 
ubuntu@chi-dn-bm2:~$ 
```