### PR TITLE
geolocation: add distance conversion to geoprobe-target-sender and fix pubkey logging in geoprobe-agent

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -764,8 +764,8 @@ func runOffsetListener(
 			continue
 		}
 
-		senderPK := solana.PublicKeyFromBytes(offset.SenderPubkey[:])
-		authorityPK := solana.PublicKeyFromBytes(offset.AuthorityPubkey[:])
+		senderPK := solana.PublicKeyFromBytes(offset.SenderPubkey[:]).String()
+		authorityPK := solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String()
 
 		log.Debug("received UDP offset packet", "from", addr, "sender_pubkey", senderPK, "authority_pubkey", authorityPK)
 
@@ -779,7 +779,7 @@ func runOffsetListener(
 		if expectedAuthority != offset.AuthorityPubkey {
 			log.Warn("Rejecting offset with wrong authority for parent",
 				"sender_pubkey", senderPK,
-				"expected_authority", solana.PublicKeyFromBytes(expectedAuthority[:]),
+				"expected_authority", solana.PublicKeyFromBytes(expectedAuthority[:]).String(),
 				"actual_authority", authorityPK,
 				"addr", addr)
 			metrics.GeoProbeOffsetsRejected.WithLabelValues(metrics.GeoProbeRejectWrongAuthority).Inc()
@@ -998,8 +998,8 @@ func sendCompositeOffsets(
 			"total_rtt_ns", compositeOffset.RttNs,
 			"lat", compositeOffset.Lat,
 			"lng", compositeOffset.Lng,
-			"ref_authority_pubkey", solana.PublicKeyFromBytes(dzdOffset.AuthorityPubkey[:]),
-			"ref_sender_pubkey", solana.PublicKeyFromBytes(dzdOffset.SenderPubkey[:]))
+			"ref_authority_pubkey", solana.PublicKeyFromBytes(dzdOffset.AuthorityPubkey[:]).String(),
+			"ref_sender_pubkey", solana.PublicKeyFromBytes(dzdOffset.SenderPubkey[:]).String())
 	}
 
 	return sentCount

--- a/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-target-sender/main.go
@@ -26,6 +26,13 @@ const (
 	defaultProbePort = 8924
 	defaultInterval  = 30 * time.Second
 	defaultTimeout   = 2 * time.Second
+
+	// Illustrative speed-of-light constants for converting RTT to an upper-bound
+	// distance estimate. Real-world distance will be shorter because signals
+	// travel through fiber (~0.67c) and encounter switching/queuing delays.
+	speedOfLightMilesPerMs = 124.0
+	nanosecondsPerMs       = 1_000_000.0
+	kmPerMile              = 1.60934
 )
 
 var (
@@ -189,6 +196,7 @@ func logPairedResult(log *slog.Logger, seq uint32, probeMeasuredRttNs uint64, ta
 	offsets := parseOffsets(reply.Offsets)
 
 	if *logFormat == "json" {
+		distMiles := calculateMaxDistance(reply.RttNs)
 		output := probeOutput{
 			Timestamp:           time.Now().UTC().Format(time.RFC3339),
 			Seq:                 seq,
@@ -202,6 +210,8 @@ func logPairedResult(log *slog.Logger, seq uint32, probeMeasuredRttNs uint64, ta
 			Lat:                 reply.Lat,
 			Lng:                 reply.Lng,
 			RttNs:               reply.RttNs,
+			MaxDistanceMiles:    distMiles,
+			MaxDistanceKm:       distMiles * kmPerMile,
 			SinceLastRxNs:       reply.SinceLastRxNs,
 			AuthorityPubkey:     authorityPK.String(),
 			GeoprobePubkey:      geoprobePK.String(),
@@ -258,6 +268,8 @@ type probeOutput struct {
 	Lat                 float64        `json:"lat,omitempty"`
 	Lng                 float64        `json:"lng,omitempty"`
 	RttNs               uint64         `json:"rtt_ns,omitempty"`
+	MaxDistanceMiles    float64        `json:"max_distance_miles,omitempty"`
+	MaxDistanceKm       float64        `json:"max_distance_km,omitempty"`
 	SinceLastRxNs       uint64         `json:"since_last_rx_ns,omitempty"`
 	AuthorityPubkey     string         `json:"authority_pubkey,omitempty"`
 	GeoprobePubkey      string         `json:"geoprobe_pubkey,omitempty"`
@@ -266,13 +278,15 @@ type probeOutput struct {
 }
 
 type offsetOutput struct {
-	AuthorityPubkey string  `json:"authority_pubkey"`
-	SenderPubkey    string  `json:"sender_pubkey"`
-	Lat             float64 `json:"lat"`
-	Lng             float64 `json:"lng"`
-	RttNs           uint64  `json:"rtt_ns"`
-	MeasuredRttNs   uint64  `json:"measured_rtt_ns"`
-	SigValid        bool    `json:"sig_valid"`
+	AuthorityPubkey  string  `json:"authority_pubkey"`
+	SenderPubkey     string  `json:"sender_pubkey"`
+	Lat              float64 `json:"lat"`
+	Lng              float64 `json:"lng"`
+	RttNs            uint64  `json:"rtt_ns"`
+	MaxDistanceMiles float64 `json:"max_distance_miles"`
+	MaxDistanceKm    float64 `json:"max_distance_km"`
+	MeasuredRttNs    uint64  `json:"measured_rtt_ns"`
+	SigValid         bool    `json:"sig_valid"`
 }
 
 func validateFlags() error {
@@ -339,6 +353,14 @@ func formatNsAsMs(ns uint64) string {
 	return fmt.Sprintf("%.3fms", float64(ns)/1e6)
 }
 
+// calculateMaxDistance returns the theoretical maximum one-way distance in
+// miles for a given round-trip time, assuming vacuum speed of light. Actual
+// distances will be shorter (see constants above).
+func calculateMaxDistance(rttNs uint64) float64 {
+	rttMs := float64(rttNs) / (2 * nanosecondsPerMs)
+	return rttMs * speedOfLightMilesPerMs
+}
+
 func formatTextResult(seq uint32, probeMeasuredRttNs uint64, targetMeasuredRtt time.Duration, reply0ProbeSigValid, reply0SigValid, reply1ProbeSigValid, reply1SigValid bool, authorityPK, geoprobePK solana.PublicKey, reply *signed.ReplyPacket, offsets []offsetOutput) string {
 	var sb strings.Builder
 
@@ -346,8 +368,11 @@ func formatTextResult(seq uint32, probeMeasuredRttNs uint64, targetMeasuredRtt t
 	fmt.Fprintf(&sb, "[%s] Probe Pair #%d\n", time.Now().UTC().Format("2006-01-02 15:04:05 MST"), seq)
 	fmt.Fprintf(&sb, "  Probe-Measured RTT:  %s\n", formatNsAsMs(probeMeasuredRttNs))
 	fmt.Fprintf(&sb, "  Target-Measured RTT: %s\n", formatRTT(targetMeasuredRtt))
+	accumDistMiles := calculateMaxDistance(reply.RttNs)
+	accumDistKm := accumDistMiles * kmPerMile
 	fmt.Fprintf(&sb, "  Reference Point: %s\n", formatCoordinate(reply.Lat, reply.Lng))
 	fmt.Fprintf(&sb, "  Accumulated RTT: %s\n", formatNsAsMs(reply.RttNs))
+	fmt.Fprintf(&sb, "  Max Distance: %.0f miles (%.0f km)\n", accumDistMiles, accumDistKm)
 	fmt.Fprintf(&sb, "  Measurement Slot: %d\n", reply.MeasurementSlot)
 	fmt.Fprintf(&sb, "  Authority: %s\n", authorityPK.String())
 	fmt.Fprintf(&sb, "  GeoProbe:  %s\n", geoprobePK.String())
@@ -360,7 +385,10 @@ func formatTextResult(seq uint32, probeMeasuredRttNs uint64, targetMeasuredRtt t
 			fmt.Fprintf(&sb, "    [%d] Authority: %s\n", i+1, o.AuthorityPubkey)
 			fmt.Fprintf(&sb, "        Sender:    %s\n", o.SenderPubkey)
 			fmt.Fprintf(&sb, "        Location:  %s\n", formatCoordinate(o.Lat, o.Lng))
+			oDistMiles := calculateMaxDistance(o.RttNs)
+			oDistKm := oDistMiles * kmPerMile
 			fmt.Fprintf(&sb, "        RTT: %s  Measured RTT: %s\n", formatNsAsMs(o.RttNs), formatNsAsMs(o.MeasuredRttNs))
+			fmt.Fprintf(&sb, "        Max Distance: %.0f miles (%.0f km)\n", oDistMiles, oDistKm)
 			fmt.Fprintf(&sb, "        Signature: %s\n", sigMark(o.SigValid))
 		}
 	}
@@ -400,14 +428,17 @@ func parseOffsets(blobs [][]byte) []offsetOutput {
 			continue
 		}
 		sigValid := geoprobe.VerifyOffsetChain(&offset) == nil
+		oDistMiles := calculateMaxDistance(offset.RttNs)
 		results = append(results, offsetOutput{
-			AuthorityPubkey: solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String(),
-			SenderPubkey:    solana.PublicKeyFromBytes(offset.SenderPubkey[:]).String(),
-			Lat:             offset.Lat,
-			Lng:             offset.Lng,
-			RttNs:           offset.RttNs,
-			MeasuredRttNs:   offset.MeasuredRttNs,
-			SigValid:        sigValid,
+			AuthorityPubkey:  solana.PublicKeyFromBytes(offset.AuthorityPubkey[:]).String(),
+			SenderPubkey:     solana.PublicKeyFromBytes(offset.SenderPubkey[:]).String(),
+			Lat:              offset.Lat,
+			Lng:              offset.Lng,
+			RttNs:            offset.RttNs,
+			MaxDistanceMiles: oDistMiles,
+			MaxDistanceKm:    oDistMiles * kmPerMile,
+			MeasuredRttNs:    offset.MeasuredRttNs,
+			SigValid:         sigValid,
 		})
 	}
 	return results


### PR DESCRIPTION
Resolves: #3403

## Summary of Changes
- Add RTT-to-distance conversion in geoprobe-target-sender output (text and JSON), matching geoprobe-target's existing `Max Distance` display
- Fix geoprobe-agent log statements to call `.String()` on pubkeys so they render as base58 instead of byte arrays

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +50 / -19   | +31  |

All changes are core logic across two binaries.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/cmd/geoprobe-target-sender/main.go` — add speed-of-light constants, `calculateMaxDistance` function, `max_distance_miles`/`max_distance_km` fields to JSON structs, and `Max Distance` line to text output
- `controlplane/telemetry/cmd/geoprobe-agent/main.go` — append `.String()` to 5 pubkey log values so they serialize as base58

</details>

## Testing Verification
- `go test ./controlplane/telemetry/cmd/geoprobe-target-sender/...` passes
- `golangci-lint run` clean on both packages
- Distance formula and constants match the existing implementation in geoprobe-target
