### PR TITLE
geoprobe: chnage geoprobe-agent default outbound probe interval to 30s

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -32,7 +32,7 @@ const (
 	defaultTWAMPListenPort       = 8925
 	defaultSignedTWAMPListenPort = 8924
 	defaultUDPListenPort         = 8923
-	defaultProbeInterval         = 5 * time.Minute
+	defaultProbeInterval         = 30 * time.Second
 	defaultTWAMPSenderTimeout    = 1 * time.Second
 	defaultTWAMPReflectorTimeout = 1 * time.Second
 	defaultMaxOffsetAge          = 1 * time.Hour


### PR DESCRIPTION
## Summary of Changes
- Reduce the default outbound probe interval from 5 minutes to 30 seconds, enabling faster geolocation convergence for measured targets

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic |     1 | +1 / -1     |  0  |

Single constant change.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/cmd/geoprobe-agent/main.go` — change `defaultProbeInterval` from 5m to 30s

</details>

## Testing Verification
- Build, lint (0 issues), and all 27 unit tests passing in dev container
