### PR TITLE
e2e/qa: use multicast status in multicast settlement test

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -70,6 +70,16 @@ func FindIBRLStatus(statuses []*pb.Status) *pb.Status {
 	return nil
 }
 
+// FindMulticastStatus returns the first Multicast status from the given list.
+func FindMulticastStatus(statuses []*pb.Status) *pb.Status {
+	for _, s := range statuses {
+		if s.UserType == "Multicast" {
+			return s
+		}
+	}
+	return nil
+}
+
 type Device struct {
 	PubKey       string
 	Code         string

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -140,10 +140,10 @@ func TestQA_MulticastSettlement(t *testing.T) {
 	t.Run("validate_device_assignment", func(t *testing.T) {
 		statuses, err := client.GetUserStatuses(ctx)
 		require.NoError(t, err, "failed to get user statuses")
-		ibrlStatus := qa.FindIBRLStatus(statuses)
-		require.NotNil(t, ibrlStatus, "no IBRL status found after seat payment")
-		require.Equal(t, device.Code, ibrlStatus.CurrentDevice, "tunnel connected to wrong device")
-		log.Info("Tunnel up and device matches", "device", ibrlStatus.CurrentDevice, "dzIP", ibrlStatus.DoubleZeroIp)
+		mcastStatus := qa.FindMulticastStatus(statuses)
+		require.NotNil(t, mcastStatus, "no multicast status found after seat payment")
+		require.Equal(t, device.Code, mcastStatus.CurrentDevice, "tunnel connected to wrong device")
+		log.Info("Tunnel up and device matches", "device", mcastStatus.CurrentDevice, "dzIP", mcastStatus.DoubleZeroIp)
 	})
 
 	if !t.Run("withdraw_seat", func(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes
- Replace `FindIBRLStatus` with `FindMulticastStatus` in the `validate_device_assignment` subtest of `TestQA_MulticastSettlement`
- Add `FindMulticastStatus` helper to `e2e/internal/qa/client.go` that finds the first status with `UserType == "Multicast"`

## Testing Verification
- The `validate_device_assignment` subtest now correctly asserts against the multicast session rather than an IBRL (unicast) session