### PR TITLE
tools: add diff-breakdown script for Claude Code skills

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,9 +1,8 @@
 Generate a CHANGELOG.md entry for the current branch.
 
 Analyze the **net changes** between the current branch and origin/main by examining:
-1. First, run `git fetch origin` to ensure remote tracking is up to date
-2. The diff summary: `git diff origin/main...HEAD --stat`
-3. The actual changes: `git diff origin/main...HEAD` (focus on key changes, not every line)
+1. Run `scripts/diff-breakdown.sh` to get the automated categorization (see its JSON output for category tallies and unclassified files)
+2. The actual changes: `git diff origin/main...HEAD` (focus on key changes, not every line)
 
 IMPORTANT: Focus on what the branch adds/changes compared to origin/main as a whole. Do NOT describe individual commits or intermediate work. The reviewer only sees the final diff.
 

--- a/.claude/commands/diff-breakdown.md
+++ b/.claude/commands/diff-breakdown.md
@@ -1,22 +1,19 @@
 Analyze the diff between the current branch and origin/main and produce a categorized breakdown.
 
 Steps:
-1. Run `git fetch origin` to ensure remote tracking is up to date
-2. Run `git diff origin/main...HEAD --numstat` to get per-file added/removed line counts
-3. Categorize each changed file using these heuristics (applied in order, first match wins):
-   - **Tests**: files matching `*_test.go`, `*_test.rs`, `tests/`, `e2e/`, `*_test.py`, `*.test.ts`, `*.test.js`
-   - **Fixtures/snapshots**: paths containing `fixtures/`, `snapshots/`, or `.bin`/`.json` files within those directories
-   - **Config/build**: `Cargo.toml`, `go.mod`, `go.sum`, `Makefile`, `*.toml`, `*.yml`, `*.yaml`, `Dockerfile`, `*.lock`
-   - **Docs**: `*.md`, paths under `rfcs/`
-   - **Generated**: lock files (`Cargo.lock`, `go.sum`, `bun.lockb`, `package-lock.json`), protobuf generated output (`*.pb.go`, `*.pb.rs`)
+1. Run `scripts/diff-breakdown.sh` to get the automated categorization. The script outputs JSON with:
+   - `categories`: tallies (files, added, removed) for tests, fixtures, config, docs, generated, and unclassified
+   - `unclassified_files`: list of files not auto-categorized, with per-file added/removed counts
+   - `table`: a pre-formatted markdown table (use as a starting point)
+   - `total`: aggregate totals
+2. For each file in `unclassified_files`, read the diff (`git diff origin/main...HEAD -- <file>`) and classify as either:
    - **Scaffolding**: code that wires things together but contains little logic of its own:
      - Metrics/instrumentation definitions (`metrics.go`, prometheus boilerplate)
      - Thin CLI wrappers — files that are mostly clap/cobra struct definitions + a single function call (e.g. `enable.rs`, `disable.rs` that just call one controller method)
      - Subcommand/route registration (`mod.rs` adding a `pub mod`, `command.rs` adding a variant, `main.go` wiring a new dependency)
      - Interface/trait definitions that are pure signatures with no logic
    - **Core logic**: everything else — the files where the real business logic and algorithms live
-4. Tally lines added and removed per category, and count distinct files per category
-5. Omit categories with zero changes
+3. Rebuild the table replacing "Unclassified" with the Scaffolding and Core logic rows. Omit categories with zero changes.
 
 Output the breakdown as plain text (NOT inside a code block) so it's readable in the terminal. Use this format:
 

--- a/.claude/commands/pr-text.md
+++ b/.claude/commands/pr-text.md
@@ -1,9 +1,10 @@
 Generate a PR description for the current branch.
 
 Analyze the **net changes** between the current branch and origin/main by examining:
-1. First, run `git fetch origin` to ensure remote tracking is up to date
-2. The diff summary: `git diff origin/main...HEAD --stat`
-3. The actual changes: `git diff origin/main...HEAD` (focus on key changes, not every line)
+1. Run `scripts/diff-breakdown.sh` to get the automated categorization (see its JSON output for category tallies, unclassified files, and a pre-formatted table)
+2. The actual changes: `git diff origin/main...HEAD` (focus on key changes, not every line)
+
+For each file in the script's `unclassified_files`, read the diff and classify as Scaffolding (wiring, metrics, thin CLI wrappers, registrations, interface-only) or Core logic (business logic, algorithms, state management).
 
 IMPORTANT: Focus on what the branch adds/changes compared to origin/main as a whole. Do NOT describe individual commits or intermediate work. The reviewer only sees the final diff - they don't care about bugs introduced and fixed within the same branch.
 
@@ -50,9 +51,9 @@ PR Title guidelines:
 Guidelines:
 - Summary should describe the net result: what does this branch add or change compared to origin/main?
 - Ignore commit history - only describe what the final diff shows
-- Include a Diff Breakdown table categorizing changes using `git diff origin/main...HEAD --numstat`. Categorize files as: Core logic, Scaffolding (metrics, thin CLI wrappers, subcommand registration, interface-only files), Tests, Fixtures, Config/build, Docs, Generated. Omit categories with zero changes. Add a one-line summary below the table characterizing the balance of changes.
+- Include a Diff Breakdown table categorizing changes (use the script output as a base, replacing Unclassified with Scaffolding and Core logic rows). Omit categories with zero changes. Add a one-line summary below the table characterizing the balance of changes.
 - Include a "Key files" list after the diff breakdown showing the most important core logic files (up to 8), sorted by lines changed descending. Each entry should have a brief description of what changed. This helps reviewers know where to focus.
-- Link each key file to its diff in the PR. Use `gh pr view --json number,url` to get the PR URL, then link to `<PR_URL>/files#diff-<SHA256_OF_FILE_PATH>` where the hash is `echo -n "path/to/file" | shasum -a 256`. If no PR exists yet, use plain backtick paths instead.
+- Link each key file to its diff in the PR using the `pr_url` and `diff_hash` fields from the script output: `<pr_url>/files#diff-<diff_hash>`. If no PR exists yet (`pr_url` is empty), use plain backtick paths instead.
 - Testing Verification should describe how the changes were tested (e.g., unit tests added/passing, manual testing performed, build verified)
 - Focus on the "what" and "why", not the "how"
 - Group related changes together

--- a/scripts/diff-breakdown.sh
+++ b/scripts/diff-breakdown.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# scripts/diff-breakdown.sh — Categorize git diff between current branch and a base ref.
+#
+# Outputs a JSON object with categorized files and tallies, plus a pre-formatted
+# markdown table. Designed to be consumed by Claude Code skills (diff-breakdown,
+# pr-text, changelog) so the mechanical work isn't repeated by the LLM.
+#
+# Usage:
+#   scripts/diff-breakdown.sh [base_ref]
+#
+# base_ref defaults to origin/main. The script runs `git fetch origin` first.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Fetch to ensure remote tracking is current.
+git fetch origin --quiet 2>/dev/null
+
+# --- Collect numstat --------------------------------------------------------
+
+numstat=$(git diff "${BASE_REF}...HEAD" --numstat)
+
+if [[ -z "$numstat" ]]; then
+  echo '{"categories":{},"table":"No changes found.","unclassified":[]}'
+  exit 0
+fi
+
+# --- Categorize files -------------------------------------------------------
+# Categories: tests, fixtures, config, docs, generated, unclassified
+# "unclassified" = files the caller (skill) must judge as scaffolding vs core logic.
+
+declare -A cat_added cat_removed cat_files
+for cat in tests fixtures config docs generated unclassified; do
+  cat_added[$cat]=0
+  cat_removed[$cat]=0
+  cat_files[$cat]=0
+done
+
+# Collect file details for JSON output.
+unclassified_json="["
+first_unclassified=true
+all_files_json="["
+first_all=true
+
+while IFS=$'\t' read -r added removed file; do
+  # Binary files show as "-" in numstat.
+  [[ "$added" == "-" ]] && added=0
+  [[ "$removed" == "-" ]] && removed=0
+
+  category="unclassified"
+
+  # Order matters — first match wins.
+
+  # Tests
+  if [[ "$file" == *_test.go ]] || [[ "$file" == *_test.rs ]] || \
+     [[ "$file" == *_test.py ]] || [[ "$file" == *.test.ts ]] || \
+     [[ "$file" == *.test.js ]] || [[ "$file" == tests/* ]] || \
+     [[ "$file" == */tests/* ]] || [[ "$file" == e2e/* ]]; then
+    category="tests"
+
+  # Fixtures/snapshots
+  elif [[ "$file" == *fixtures/* ]] || [[ "$file" == *snapshots/* ]]; then
+    category="fixtures"
+
+  # Generated (before config, since go.sum and lock files overlap)
+  elif [[ "$file" == *.pb.go ]] || [[ "$file" == *.pb.rs ]] || \
+       [[ "$file" == Cargo.lock ]] || [[ "$file" == */Cargo.lock ]] || \
+       [[ "$file" == go.sum ]] || [[ "$file" == */go.sum ]] || \
+       [[ "$file" == bun.lockb ]] || [[ "$file" == */bun.lockb ]] || \
+       [[ "$file" == package-lock.json ]] || [[ "$file" == */package-lock.json ]]; then
+    category="generated"
+
+  # Config/build
+  elif [[ "$file" == Cargo.toml ]] || [[ "$file" == */Cargo.toml ]] || \
+       [[ "$file" == go.mod ]] || [[ "$file" == */go.mod ]] || \
+       [[ "$file" == Makefile ]] || [[ "$file" == */Makefile ]] || \
+       [[ "$file" == *.toml ]] || [[ "$file" == *.yml ]] || \
+       [[ "$file" == *.yaml ]] || [[ "$file" == Dockerfile ]] || \
+       [[ "$file" == */Dockerfile ]] || [[ "$file" == *.lock ]]; then
+    category="config"
+
+  # Docs
+  elif [[ "$file" == *.md ]] || [[ "$file" == rfcs/* ]] || [[ "$file" == */rfcs/* ]]; then
+    category="docs"
+  fi
+
+  cat_added[$category]=$(( ${cat_added[$category]} + added ))
+  cat_removed[$category]=$(( ${cat_removed[$category]} + removed ))
+  cat_files[$category]=$(( ${cat_files[$category]} + 1 ))
+
+  # Compute SHA256 of the file path (used for GitHub PR diff links).
+  diff_hash=$(printf '%s' "$file" | shasum -a 256 | cut -d' ' -f1)
+  escaped_file=$(printf '%s' "$file" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+  # All files list.
+  if $first_all; then
+    first_all=false
+  else
+    all_files_json+=","
+  fi
+  all_files_json+="{\"file\":\"${escaped_file}\",\"added\":${added},\"removed\":${removed},\"category\":\"${category}\",\"diff_hash\":\"${diff_hash}\"}"
+
+  if [[ "$category" == "unclassified" ]]; then
+    if $first_unclassified; then
+      first_unclassified=false
+    else
+      unclassified_json+=","
+    fi
+    unclassified_json+="{\"file\":\"${escaped_file}\",\"added\":${added},\"removed\":${removed},\"diff_hash\":\"${diff_hash}\"}"
+  fi
+done <<< "$numstat"
+
+unclassified_json+="]"
+all_files_json+="]"
+
+# --- Build markdown table ---------------------------------------------------
+
+total_added=0
+total_removed=0
+total_files=0
+
+table="| Category          | Files | Lines (+/-)     | Net    |\n"
+table+="|-------------------|-------|-----------------|--------|\n"
+
+for cat in tests fixtures config docs generated unclassified; do
+  files=${cat_files[$cat]}
+  added=${cat_added[$cat]}
+  removed=${cat_removed[$cat]}
+  (( files == 0 )) && continue
+
+  net=$(( added - removed ))
+  total_added=$(( total_added + added ))
+  total_removed=$(( total_removed + removed ))
+  total_files=$(( total_files + files ))
+
+  # Pretty-print category name.
+  case $cat in
+    tests)        label="Tests" ;;
+    fixtures)     label="Fixtures" ;;
+    config)       label="Config/build" ;;
+    docs)         label="Docs" ;;
+    generated)    label="Generated" ;;
+    unclassified) label="Unclassified" ;;
+  esac
+
+  net_str=$(( net >= 0 )) && net_str="+${net}" || net_str="${net}"
+  printf -v row "| %-17s | %5d | +%-5d / -%-5d | %+6d |" "$label" "$files" "$added" "$removed" "$net"
+  table+="${row}\n"
+done
+
+total_net=$(( total_added - total_removed ))
+printf -v total_row "| %-17s | %5d | +%-5d / -%-5d | %+6d |" "**Total**" "$total_files" "$total_added" "$total_removed" "$total_net"
+table+="${total_row}"
+
+# --- Detect PR URL ----------------------------------------------------------
+
+pr_url=""
+pr_number=""
+if pr_json=$(gh pr view --json number,url 2>/dev/null); then
+  pr_url=$(echo "$pr_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+  pr_number=$(echo "$pr_json" | sed -n 's/.*"number":\([0-9]*\).*/\1/p')
+fi
+
+# --- Output JSON ------------------------------------------------------------
+
+cat <<ENDJSON
+{
+  "base_ref": "${BASE_REF}",
+  "categories": {
+    "tests":        {"files": ${cat_files[tests]},        "added": ${cat_added[tests]},        "removed": ${cat_removed[tests]}},
+    "fixtures":     {"files": ${cat_files[fixtures]},     "added": ${cat_added[fixtures]},     "removed": ${cat_removed[fixtures]}},
+    "config":       {"files": ${cat_files[config]},       "added": ${cat_added[config]},       "removed": ${cat_removed[config]}},
+    "docs":         {"files": ${cat_files[docs]},         "added": ${cat_added[docs]},         "removed": ${cat_removed[docs]}},
+    "generated":    {"files": ${cat_files[generated]},    "added": ${cat_added[generated]},    "removed": ${cat_removed[generated]}},
+    "unclassified": {"files": ${cat_files[unclassified]}, "added": ${cat_added[unclassified]}, "removed": ${cat_removed[unclassified]}}
+  },
+  "all_files": ${all_files_json},
+  "unclassified_files": ${unclassified_json},
+  "total": {"files": ${total_files}, "added": ${total_added}, "removed": ${total_removed}, "net": ${total_net}},
+  "pr_url": "${pr_url}",
+  "pr_number": "${pr_number}",
+  "table": "$(echo -e "$table" | sed 's/"/\\"/g')"
+}
+ENDJSON


### PR DESCRIPTION
## Summary of Changes
- Add `scripts/diff-breakdown.sh` that handles the mechanical parts of diff categorization: git fetch, numstat, pattern-based file classification, line tallying, table generation, SHA256 diff hashes, and PR URL detection
- Update `diff-breakdown`, `pr-text`, and `changelog` skills to call the script instead of re-doing this work each invocation

## Testing Verification
- Ran the script against an active feature branch and verified JSON output includes correct categorization, diff hashes, and PR URL