### PR TITLE
telemetry/state-ingest: fix shutdown race in multi-listener server

### DIFF
--- a/telemetry/state-ingest/pkg/server/server.go
+++ b/telemetry/state-ingest/pkg/server/server.go
@@ -15,10 +15,6 @@ type Server struct {
 
 	svc     *ServiceabilityView
 	handler *Handler
-
-	httpSrvsMu   sync.Mutex
-	httpSrvs     []*http.Server
-	shutdownOnce sync.Once
 }
 
 func New(log *slog.Logger, cfg Config) (*Server, error) {
@@ -85,13 +81,11 @@ func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 
 	httpSrv := &http.Server{Handler: mux}
 
-	s.httpSrvsMu.Lock()
-	s.httpSrvs = append(s.httpSrvs, httpSrv)
-	s.httpSrvsMu.Unlock()
-
 	go func() {
 		<-ctx.Done()
-		s.shutdown()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout)
+		defer cancel()
+		_ = httpSrv.Shutdown(shutdownCtx)
 	}()
 
 	err := httpSrv.Serve(listener)
@@ -99,17 +93,4 @@ func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 		return nil
 	}
 	return err
-}
-
-func (s *Server) shutdown() {
-	s.shutdownOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout)
-		defer cancel()
-		s.httpSrvsMu.Lock()
-		srvs := s.httpSrvs
-		s.httpSrvsMu.Unlock()
-		for _, srv := range srvs {
-			_ = srv.Shutdown(ctx)
-		}
-	})
 }


### PR DESCRIPTION
## Summary
- Fix race condition where `shutdownOnce` could execute before all HTTP servers were registered, leaving late-registered servers stuck in `Accept` forever
- Each `Serve` goroutine now manages its own HTTP server shutdown when the context is canceled, eliminating the shared `httpSrvs` slice and `shutdownOnce` entirely

## Testing Verification
- `TestTelemetry_StateIngest_Server_Start_MultiListener_OneErrorCancelsOther` — previously hanging in CI consistently — passes reliably with `-count=3` and `-race`