### PR TITLE
geolocation: onchain portion of alternate offset-destinations

### DIFF
--- a/smartcontract/cli/src/geolocation/user/add_target.rs
+++ b/smartcontract/cli/src/geolocation/user/add_target.rs
@@ -166,6 +166,7 @@ mod tests {
                     }),
                     status: GeolocationUserStatus::Activated,
                     targets: vec![],
+                    result_destination: String::new(),
                 },
             ))
         });

--- a/smartcontract/cli/src/geolocation/user/delete.rs
+++ b/smartcontract/cli/src/geolocation/user/delete.rs
@@ -91,6 +91,7 @@ mod tests {
                         }),
                         status: GeolocationUserStatus::Activated,
                         targets: vec![],
+                        result_destination: String::new(),
                     },
                 ))
             });

--- a/smartcontract/cli/src/geolocation/user/get.rs
+++ b/smartcontract/cli/src/geolocation/user/get.rs
@@ -35,6 +35,7 @@ struct GeolocationUserGetDisplay {
     pub status: String,
     pub payment_status: String,
     pub billing: String,
+    pub result_destination: String,
     pub target_count: usize,
     pub targets: Vec<TargetDisplay>,
 }
@@ -88,6 +89,12 @@ impl GetGeolocationUserCliCommand {
             }
         };
 
+        let result_dest_str = if user.result_destination.is_empty() {
+            "none".to_string()
+        } else {
+            user.result_destination.clone()
+        };
+
         let display = GeolocationUserGetDisplay {
             account: pubkey,
             code: user.code,
@@ -96,6 +103,7 @@ impl GetGeolocationUserCliCommand {
             status: user.status.to_string(),
             payment_status: user.payment_status.to_string(),
             billing: billing_str,
+            result_destination: result_dest_str,
             target_count: targets.len(),
             targets,
         };
@@ -116,6 +124,7 @@ impl GetGeolocationUserCliCommand {
                 ("status", display.status.clone()),
                 ("payment_status", display.payment_status.clone()),
                 ("billing", display.billing.clone()),
+                ("result_destination", display.result_destination.clone()),
                 ("target_count", display.target_count.to_string()),
             ];
             let max_len = rows.iter().map(|(h, _)| h.len()).max().unwrap_or(0);
@@ -165,6 +174,7 @@ mod tests {
             }),
             status: GeolocationUserStatus::Activated,
             targets,
+            result_destination: String::new(),
         }
     }
 
@@ -210,6 +220,7 @@ mod tests {
         assert!(has_row("code", "geo-user-01"));
         assert!(has_row("status", "activated"));
         assert!(has_row("payment_status", "paid"));
+        assert!(has_row("result_destination", "none"));
         assert!(has_row("target_count", "1"));
         assert!(output_str.contains("Targets:"));
         assert!(output_str.contains("8.8.8.8"));
@@ -243,6 +254,7 @@ mod tests {
         assert_eq!(json["code"].as_str().unwrap(), "geo-user-01");
         assert_eq!(json["status"].as_str().unwrap(), "activated");
         assert_eq!(json["payment_status"].as_str().unwrap(), "paid");
+        assert_eq!(json["result_destination"].as_str().unwrap(), "none");
         assert_eq!(json["target_count"].as_u64().unwrap(), 0);
         assert!(json["targets"].as_array().unwrap().is_empty());
     }

--- a/smartcontract/cli/src/geolocation/user/list.rs
+++ b/smartcontract/cli/src/geolocation/user/list.rs
@@ -87,6 +87,7 @@ mod tests {
             billing: GeolocationBillingConfig::default(),
             status: GeolocationUserStatus::Activated,
             targets: vec![],
+            result_destination: String::new(),
         }
     }
 

--- a/smartcontract/cli/src/geolocation/user/remove_target.rs
+++ b/smartcontract/cli/src/geolocation/user/remove_target.rs
@@ -113,6 +113,7 @@ mod tests {
                     }),
                     status: GeolocationUserStatus::Activated,
                     targets: vec![],
+                    result_destination: String::new(),
                 },
             ))
         });

--- a/smartcontract/cli/src/geolocation/user/update_payment_status.rs
+++ b/smartcontract/cli/src/geolocation/user/update_payment_status.rs
@@ -80,6 +80,7 @@ mod tests {
                     }),
                     status: GeolocationUserStatus::Activated,
                     targets: vec![],
+                    result_destination: String::new(),
                 },
             ))
         });

--- a/smartcontract/programs/doublezero-geolocation/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/entrypoint.rs
@@ -9,6 +9,7 @@ use crate::{
         geolocation_user::{
             add_target::process_add_target, create::process_create_geolocation_user,
             delete::process_delete_geolocation_user, remove_target::process_remove_target,
+            set_result_destination::process_set_result_destination,
             update::process_update_geolocation_user,
             update_payment_status::process_update_payment_status,
         },
@@ -69,6 +70,9 @@ pub fn process_instruction(
         }
         GeolocationInstruction::UpdatePaymentStatus(args) => {
             process_update_payment_status(program_id, accounts, &args)?
+        }
+        GeolocationInstruction::SetResultDestination(args) => {
+            process_set_result_destination(program_id, accounts, &args)?
         }
     };
 

--- a/smartcontract/programs/doublezero-geolocation/src/error.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/error.rs
@@ -40,6 +40,8 @@ pub enum GeolocationError {
     TargetAlreadyExists = 23,
     #[error("Invalid payment status")]
     InvalidPaymentStatus = 24,
+    #[error("Too many referenced probes to update in a single transaction")]
+    TooManyReferencedProbes = 25,
 }
 
 impl From<GeolocationError> for ProgramError {
@@ -72,6 +74,7 @@ mod tests {
             (GeolocationError::TargetNotFound, 22),
             (GeolocationError::TargetAlreadyExists, 23),
             (GeolocationError::InvalidPaymentStatus, 24),
+            (GeolocationError::TooManyReferencedProbes, 25),
         ]
     }
 

--- a/smartcontract/programs/doublezero-geolocation/src/instructions.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/instructions.rs
@@ -7,8 +7,8 @@ pub use crate::processors::{
     },
     geolocation_user::{
         add_target::AddTargetArgs, create::CreateGeolocationUserArgs,
-        remove_target::RemoveTargetArgs, update::UpdateGeolocationUserArgs,
-        update_payment_status::UpdatePaymentStatusArgs,
+        remove_target::RemoveTargetArgs, set_result_destination::SetResultDestinationArgs,
+        update::UpdateGeolocationUserArgs, update_payment_status::UpdatePaymentStatusArgs,
     },
     program_config::{init::InitProgramConfigArgs, update::UpdateProgramConfigArgs},
 };
@@ -28,6 +28,7 @@ pub enum GeolocationInstruction {
     AddTarget(AddTargetArgs),
     RemoveTarget(RemoveTargetArgs),
     UpdatePaymentStatus(UpdatePaymentStatusArgs),
+    SetResultDestination(SetResultDestinationArgs),
 }
 
 #[cfg(test)]
@@ -122,6 +123,16 @@ mod tests {
             UpdatePaymentStatusArgs {
                 payment_status: GeolocationPaymentStatus::Delinquent,
                 last_deduction_dz_epoch: None,
+            },
+        ));
+        test_instruction(GeolocationInstruction::SetResultDestination(
+            SetResultDestinationArgs {
+                destination: "185.199.108.1:9000".to_string(),
+            },
+        ));
+        test_instruction(GeolocationInstruction::SetResultDestination(
+            SetResultDestinationArgs {
+                destination: String::new(),
             },
         ));
     }

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/create.rs
@@ -20,7 +20,6 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
 };
-
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
 pub struct CreateGeolocationUserArgs {
     pub code: String,
@@ -66,6 +65,7 @@ pub fn process_create_geolocation_user(
         billing: GeolocationBillingConfig::default(),
         status: GeolocationUserStatus::Activated,
         targets: vec![],
+        result_destination: String::new(),
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/mod.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/mod.rs
@@ -2,5 +2,6 @@ pub mod add_target;
 pub mod create;
 pub mod delete;
 pub mod remove_target;
+pub mod set_result_destination;
 pub mod update;
 pub mod update_payment_status;

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
@@ -1,0 +1,215 @@
+use crate::{
+    error::GeolocationError,
+    serializer::try_acc_write,
+    state::{geo_probe::GeoProbe, geolocation_user::GeolocationUser},
+    validation::validate_public_ip,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+use std::{collections::HashSet, net::Ipv4Addr};
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
+pub struct SetResultDestinationArgs {
+    pub destination: String,
+}
+
+// RFC 1035 §2.3.4
+const MAX_DOMAIN_LENGTH: usize = 253;
+const MAX_LABEL_LENGTH: usize = 63;
+
+fn validate_domain(host: &str) -> Result<(), ProgramError> {
+    if host.len() > MAX_DOMAIN_LENGTH {
+        msg!("Domain too long: {} chars", host.len());
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 2 {
+        msg!("Domain must have at least two labels");
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    for label in &labels {
+        if label.is_empty() || label.len() > MAX_LABEL_LENGTH {
+            msg!("Invalid domain label length: {}", label.len());
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            msg!("Domain label cannot start or end with hyphen");
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            msg!("Domain label contains invalid characters");
+            return Err(ProgramError::InvalidInstructionData);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_destination(destination: &str) -> Result<(), ProgramError> {
+    let colon_pos = destination.rfind(':').ok_or_else(|| {
+        msg!("Invalid destination format: missing port separator");
+        ProgramError::InvalidInstructionData
+    })?;
+    let host = &destination[..colon_pos];
+    let port_str = &destination[colon_pos + 1..];
+
+    let _port: u16 = port_str.parse().map_err(|_| {
+        msg!("Invalid destination port: {}", port_str);
+        ProgramError::InvalidInstructionData
+    })?;
+
+    // Try as IP first
+    if let Ok(ip) = host.parse::<Ipv4Addr>() {
+        validate_public_ip(&ip)?;
+        return Ok(());
+    }
+
+    // Validate as domain
+    validate_domain(host)?;
+    Ok(())
+}
+
+pub fn process_set_result_destination(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    args: &SetResultDestinationArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let user_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    if !payer_account.is_signer {
+        msg!("Payer must be a signer");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if user_account.owner != program_id {
+        msg!("Invalid GeolocationUser account owner");
+        return Err(ProgramError::IllegalOwner);
+    }
+    if !user_account.is_writable {
+        msg!("GeolocationUser account must be writable");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let mut user = GeolocationUser::try_from(user_account)?;
+
+    if user.owner != *payer_account.key {
+        msg!("Signer is not the account owner");
+        return Err(GeolocationError::Unauthorized.into());
+    }
+
+    if args.destination.is_empty() {
+        user.result_destination = String::new();
+    } else {
+        validate_destination(&args.destination)?;
+        user.result_destination = args.destination.clone();
+    }
+
+    // Collect unique probe pubkeys from the user's targets.
+    let mut unique_probes: HashSet<Pubkey> = HashSet::new();
+    for target in &user.targets {
+        if !unique_probes.contains(&target.geoprobe_pk) {
+            unique_probes.insert(target.geoprobe_pk);
+        }
+    }
+
+    // Remaining accounts are the probe accounts to bump target_update_count on.
+    let remaining: Vec<&AccountInfo> = accounts_iter.collect();
+    if remaining.len() != unique_probes.len() {
+        msg!(
+            "Expected {} probe accounts, got {}",
+            unique_probes.len(),
+            remaining.len()
+        );
+        return Err(GeolocationError::TooManyReferencedProbes.into());
+    }
+
+    for probe_account in &remaining {
+        if probe_account.owner != program_id {
+            msg!("Invalid GeoProbe account owner");
+            return Err(ProgramError::IllegalOwner);
+        }
+        if !probe_account.is_writable {
+            msg!("GeoProbe account must be writable");
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if !unique_probes.contains(probe_account.key) {
+            msg!(
+                "Probe account {} not referenced by user targets",
+                probe_account.key
+            );
+            return Err(ProgramError::InvalidAccountData);
+        }
+    }
+
+    try_acc_write(&user, user_account, payer_account, accounts)?;
+
+    for probe_account in &remaining {
+        let mut probe = GeoProbe::try_from(*probe_account)?;
+        probe.target_update_count = probe.target_update_count.wrapping_add(1); // Probe uses change in this value to check for updates.
+        try_acc_write(&probe, probe_account, payer_account, accounts)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_destination_ip_port() {
+        assert!(validate_destination("185.199.108.1:9000").is_ok());
+        assert!(validate_destination("8.8.8.8:443").is_ok());
+    }
+
+    #[test]
+    fn test_validate_destination_domain_port() {
+        assert!(validate_destination("results.example.com:9000").is_ok());
+        assert!(validate_destination("a.b:1").is_ok());
+    }
+
+    #[test]
+    fn test_validate_destination_missing_port() {
+        assert!(validate_destination("no-port").is_err());
+    }
+
+    #[test]
+    fn test_validate_destination_invalid_port() {
+        assert!(validate_destination("example.com:99999").is_err());
+        assert!(validate_destination("example.com:abc").is_err());
+    }
+
+    #[test]
+    fn test_validate_destination_private_ip() {
+        assert!(validate_destination("10.0.0.1:9000").is_err());
+        assert!(validate_destination("192.168.1.1:9000").is_err());
+    }
+
+    #[test]
+    fn test_validate_destination_single_label_domain() {
+        assert!(validate_destination("localhost:9000").is_err());
+    }
+
+    #[test]
+    fn test_validate_destination_hyphen_label() {
+        assert!(validate_destination("-bad.example.com:9000").is_err());
+        assert!(validate_destination("bad-.example.com:9000").is_err());
+    }
+
+    #[test]
+    fn test_validate_destination_underscore_label() {
+        assert!(validate_destination("bad_label.example.com:9000").is_err());
+    }
+}

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs
@@ -1,5 +1,6 @@
 use crate::state::accounttype::AccountType;
 use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_incremental::BorshDeserializeIncremental;
 use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
 use std::{fmt, net::Ipv4Addr};
 
@@ -161,7 +162,7 @@ impl fmt::Display for GeolocationTarget {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
+#[derive(BorshSerialize, BorshDeserializeIncremental, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeolocationUser {
     pub account_type: AccountType, // 1
@@ -186,14 +187,22 @@ pub struct GeolocationUser {
     pub billing: GeolocationBillingConfig, // 1 + 16 = 17
     pub status: GeolocationUserStatus, // 1
     pub targets: Vec<GeolocationTarget>, // 4 + 71 * len
+    #[incremental(default = String::new())]
+    pub result_destination: String, // 4 + len
 }
 
 impl fmt::Display for GeolocationUser {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let dest = if self.result_destination.is_empty() {
+            "none"
+        } else {
+            &self.result_destination
+        };
         write!(
             f,
             "account_type: {}, owner: {}, code: {}, token_account: {}, \
-            payment_status: {}, billing: {}, status: {}, targets: {:?}",
+            payment_status: {}, billing: {}, status: {}, targets: {:?}, \
+            result_destination: {}",
             self.account_type,
             self.owner,
             self.code,
@@ -202,21 +211,8 @@ impl fmt::Display for GeolocationUser {
             self.billing,
             self.status,
             self.targets,
+            dest,
         )
-    }
-}
-
-impl TryFrom<&[u8]> for GeolocationUser {
-    type Error = ProgramError;
-
-    fn try_from(mut data: &[u8]) -> Result<Self, Self::Error> {
-        let out = Self::deserialize(&mut data).map_err(|_| ProgramError::InvalidAccountData)?;
-
-        if out.account_type != AccountType::GeolocationUser {
-            return Err(ProgramError::InvalidAccountData);
-        }
-
-        Ok(out)
     }
 }
 
@@ -225,20 +221,22 @@ impl TryFrom<&AccountInfo<'_>> for GeolocationUser {
 
     fn try_from(account: &AccountInfo) -> Result<Self, Self::Error> {
         let data = account.try_borrow_data()?;
-        let res = Self::try_from(&data[..]);
-        if res.is_err() {
-            msg!(
-                "Failed to deserialize GeolocationUser: {:?}",
-                res.as_ref().err()
-            );
+        let user = Self::try_from(&data[..]).map_err(|e| {
+            msg!("Failed to deserialize GeolocationUser: {}", e);
+            ProgramError::InvalidAccountData
+        })?;
+        if user.account_type != AccountType::GeolocationUser {
+            msg!("Invalid account type: {}", user.account_type);
+            return Err(ProgramError::InvalidAccountData);
         }
-        res
+        Ok(user)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv4Addr;
 
     #[test]
     fn test_state_geolocation_user_serialization() {
@@ -269,6 +267,7 @@ mod tests {
                     geoprobe_pk: Pubkey::new_unique(),
                 },
             ],
+            result_destination: "185.199.108.1:9000".to_string(),
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -280,13 +279,6 @@ mod tests {
             borsh::object_length(&val).unwrap(),
             "Invalid Size"
         );
-    }
-
-    #[test]
-    fn test_state_geolocation_user_try_from_invalid_account_type() {
-        let data = [AccountType::None as u8];
-        let result = GeolocationUser::try_from(&data[..]);
-        assert_eq!(result.unwrap_err(), ProgramError::InvalidAccountData);
     }
 
     #[test]
@@ -346,5 +338,39 @@ mod tests {
                 last_deduction_dz_epoch: 0,
             })
         );
+    }
+
+    #[test]
+    fn test_state_geolocation_user_backward_compat_without_result_destination() {
+        let old = GeolocationUser {
+            account_type: AccountType::GeolocationUser,
+            owner: Pubkey::new_unique(),
+            code: "geo-user-01".to_string(),
+            token_account: Pubkey::new_unique(),
+            payment_status: GeolocationPaymentStatus::Paid,
+            billing: GeolocationBillingConfig::FlatPerEpoch(FlatPerEpochConfig {
+                rate: 1000,
+                last_deduction_dz_epoch: 42,
+            }),
+            status: GeolocationUserStatus::Activated,
+            targets: vec![GeolocationTarget {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: [8, 8, 8, 8].into(),
+                location_offset_port: 8923,
+                target_pk: Pubkey::default(),
+                geoprobe_pk: Pubkey::new_unique(),
+            }],
+            result_destination: String::new(),
+        };
+
+        // Serialize, then truncate the trailing 4 bytes (empty Borsh string = 4-byte length
+        // prefix) to simulate old data without the result_destination field.
+        let mut data = borsh::to_vec(&old).unwrap();
+        data.truncate(data.len() - 4);
+
+        let deserialized = GeolocationUser::try_from(&data[..]).unwrap();
+        assert_eq!(deserialized.result_destination, "");
+        assert_eq!(deserialized.targets.len(), 1);
+        assert_eq!(deserialized.owner, old.owner);
     }
 }

--- a/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
@@ -11,8 +11,8 @@ use doublezero_geolocation::{
         geo_probe::create::CreateGeoProbeArgs,
         geolocation_user::{
             add_target::AddTargetArgs, create::CreateGeolocationUserArgs,
-            remove_target::RemoveTargetArgs, update::UpdateGeolocationUserArgs,
-            update_payment_status::UpdatePaymentStatusArgs,
+            remove_target::RemoveTargetArgs, set_result_destination::SetResultDestinationArgs,
+            update::UpdateGeolocationUserArgs, update_payment_status::UpdatePaymentStatusArgs,
         },
     },
     serviceability_program_id,
@@ -112,6 +112,7 @@ async fn test_create_geolocation_user_success() {
         billing: GeolocationBillingConfig::default(),
         status: GeolocationUserStatus::Activated,
         targets: vec![],
+        result_destination: String::new(),
     };
     assert_eq!(user, expected);
 }
@@ -1441,6 +1442,448 @@ async fn test_update_payment_status_invalid_value() {
 
     let tx = Transaction::new_signed_with_payer(
         &[update_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::InvalidInstructionData) => {}
+        _ => panic!("Expected InvalidInstructionData error, got: {:?}", err),
+    }
+}
+
+// --- SetResultDestination tests ---
+
+fn build_set_result_destination_ix(
+    program_id: &Pubkey,
+    user_pda: &Pubkey,
+    payer: &Pubkey,
+    probe_pdas: &[Pubkey],
+    args: SetResultDestinationArgs,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(*user_pda, false),
+        AccountMeta::new(*payer, true),
+        AccountMeta::new_readonly(solana_program::system_program::id(), false),
+    ];
+    for probe_pda in probe_pdas {
+        accounts.push(AccountMeta::new(*probe_pda, false));
+    }
+    Instruction::new_with_borsh(
+        *program_id,
+        &GeolocationInstruction::SetResultDestination(args),
+        accounts,
+    )
+}
+
+#[tokio::test]
+async fn test_set_result_destination_success() {
+    let (mut banks_client, program_id, recent_blockhash, payer, exchange_pubkey) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let probe_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-srd-ok",
+    )
+    .await;
+
+    let user_code = "user-srd-ok";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Add an outbound target
+    let add_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe_pda,
+        &payer.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Set result destination
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[probe_pda],
+        SetResultDestinationArgs {
+            destination: "185.199.108.1:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Verify user fields updated
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, "185.199.108.1:9000");
+
+    // Verify probe target_update_count bumped (1 from add + 1 from set_result_destination)
+    let probe_account = banks_client.get_account(probe_pda).await.unwrap().unwrap();
+    let probe = GeoProbe::try_from(&probe_account.data[..]).unwrap();
+    assert_eq!(probe.target_update_count, 2);
+}
+
+#[tokio::test]
+async fn test_set_result_destination_clear() {
+    let (mut banks_client, program_id, recent_blockhash, payer, exchange_pubkey) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let probe_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-srd-clr",
+    )
+    .await;
+
+    let user_code = "user-srd-clr";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Add an outbound target
+    let add_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe_pda,
+        &payer.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Set a destination first
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[probe_pda],
+        SetResultDestinationArgs {
+            destination: "185.199.108.1:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Clear it with empty string
+    let clear_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[probe_pda],
+        SetResultDestinationArgs {
+            destination: String::new(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[clear_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Verify fields reset
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, "");
+}
+
+#[tokio::test]
+async fn test_set_result_destination_unauthorized() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let user_code = "user-srd-auth";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Fund a wrong signer
+    let wrong_signer = Keypair::new();
+    let transfer_ix = solana_program::system_instruction::transfer(
+        &payer.pubkey(),
+        &wrong_signer.pubkey(),
+        1_000_000_000,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Try set_result_destination with wrong signer (no targets, so no probe accounts needed)
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &wrong_signer.pubkey(),
+        &[],
+        SetResultDestinationArgs {
+            destination: "185.199.108.1:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&wrong_signer.pubkey()),
+        &[&wrong_signer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::Unauthorized as u32);
+        }
+        _ => panic!("Expected Unauthorized error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_set_result_destination_invalid_ip() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let user_code = "user-srd-badip";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Try with private IP (no targets, so no probe accounts needed)
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[],
+        SetResultDestinationArgs {
+            destination: "10.0.0.1:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    let result = banks_client.process_transaction(tx).await;
+    let err = result.unwrap_err().unwrap();
+    match err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(code, GeolocationError::InvalidIpAddress as u32);
+        }
+        _ => panic!("Expected InvalidIpAddress error, got: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_set_result_destination_no_targets() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let user_code = "user-srd-notgt";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Set destination with no targets and no probe accounts
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[],
+        SetResultDestinationArgs {
+            destination: "185.199.108.1:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Verify fields set
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, "185.199.108.1:9000");
+}
+
+#[tokio::test]
+async fn test_set_result_destination_domain() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let user_code = "user-srd-dom";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[],
+        SetResultDestinationArgs {
+            destination: "results.example.com:9000".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, "results.example.com:9000");
+}
+
+#[tokio::test]
+async fn test_set_result_destination_invalid_format() {
+    let (mut banks_client, program_id, recent_blockhash, payer) = setup_test().await;
+
+    let user_code = "user-srd-badfmt";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[],
+        SetResultDestinationArgs {
+            destination: "no-port".to_string(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
         Some(&payer.pubkey()),
         &[&payer],
         *recent_blockhash.read().await,

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/get.rs
@@ -60,6 +60,7 @@ mod tests {
             billing: GeolocationBillingConfig::default(),
             status: GeolocationUserStatus::Activated,
             targets: vec![],
+            result_destination: String::new(),
         }
     }
 

--- a/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
+++ b/smartcontract/sdk/rs/src/geolocation/geolocation_user/list.rs
@@ -67,6 +67,7 @@ mod tests {
             billing: GeolocationBillingConfig::default(),
             status: GeolocationUserStatus::Activated,
             targets: vec![],
+            result_destination: String::new(),
         }
     }
 


### PR DESCRIPTION
## Summary of Changes
- Add a `result_destination` field to the `GeolocationUser` onchain account, allowing users to specify an IP:port or domain:port where geoprobe results should be sent
- Add a new `SetResultDestination` instruction that validates the destination (public IP or valid domain + port), updates the user account, and bumps `target_update_count` on all referenced probe accounts so they pick up the change
- Use `BorshDeserializeIncremental` for backward-compatible deserialization of existing accounts that lack the new field

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Core logic   |     6 | +292 / -26  | +266  |
| Scaffolding  |     4 | +16 / -1    | +15   |
| Tests        |     2 | +445 / -2   | +443  |

~60% tests, ~37% core logic — well-covered new instruction.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs` — integration tests for set/clear/unauthorized/invalid-IP/missing-probe/domain scenarios
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs` — new processor: validates destination, updates user, bumps probe target_update_count
- `smartcontract/programs/doublezero-geolocation/src/state/geolocation_user.rs` — add `result_destination` field with incremental deserialization, refactor TryFrom impls
- `smartcontract/programs/doublezero-geolocation/src/instructions.rs` — register SetResultDestination variant and args
- `smartcontract/programs/doublezero-geolocation/src/entrypoint.rs` — route new instruction to processor
- `smartcontract/cli/src/geolocation/user/get.rs` — display result_destination in CLI get output
- `smartcontract/programs/doublezero-geolocation/src/error.rs` — add TooManyReferencedProbes error variant

</details>

## Testing Verification
- Unit tests for destination validation (IP:port, domain:port, private IP rejection, missing port, invalid port, single-label domain, hyphen/underscore edge cases)
- Backward-compatibility unit test: deserializing old account data without the new field defaults to empty string
- Integration tests via BanksClient: successful set, clear (empty string), unauthorized signer rejection, invalid IP rejection, missing probe account rejection, domain destination
