### PR TITLE
device-health-oracle: add controller_success device activation criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-  
+
 ### Breaking
 
 ### Changes
 
+- Controlplane
+  - Add `controller_success` activation criterion to device-health-oracle that verifies devices have consistent controller call coverage over a configurable burn-in period by querying ClickHouse
 - Smartcontract
   - Allow `SubscribeMulticastGroup` for users in `Pending` status so that `CreateSubscribeUser` can be followed by additional subscribe calls before the activator runs ([#3521](https://github.com/malbeclabs/doublezero/pull/3521))
 

--- a/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
+++ b/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
@@ -129,6 +129,43 @@ func main() {
 	serviceabilityExecutor := serviceability.NewExecutor(log, rpcClient, &signer, networkConfig.ServiceabilityProgramID)
 	telemetryClient := telemetry.New(log, rpcClient, nil, networkConfig.TelemetryProgramID)
 
+	// Initialize ClickHouse-dependent criteria.
+	var deviceCriteria []worker.DeviceCriterion
+	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {
+		chDB := os.Getenv("CLICKHOUSE_DB")
+		if chDB == "" {
+			chDB = *env
+		}
+		chUser := os.Getenv("CLICKHOUSE_USER")
+		if chUser == "" {
+			chUser = "default"
+		}
+		chPass := os.Getenv("CLICKHOUSE_PASS")
+		chTLSDisabled := os.Getenv("CLICKHOUSE_TLS_DISABLED") == "true"
+
+		chClient, err := worker.NewClickHouseClient(chAddr, chDB, chUser, chPass, chTLSDisabled)
+		if err != nil {
+			log.Warn("ClickHouse connection failed, continuing without controller_success criterion", "addr", chAddr, "error", err)
+		} else {
+			defer chClient.Close()
+			log.Info("ClickHouse enabled", "addr", chAddr, "db", chDB, "user", chUser, "tls", !chTLSDisabled)
+			controllerSuccess := worker.NewControllerSuccessCriterion(chClient, log)
+			deviceCriteria = append(deviceCriteria, controllerSuccess)
+		}
+	} else {
+		log.Error("ClickHouse disabled (CLICKHOUSE_ADDR not set), no controller_success criterion")
+	}
+
+	deviceEvaluator := &worker.DeviceHealthEvaluator{
+		ReadyForLinksCriteria: deviceCriteria,
+		ReadyForUsersCriteria: nil,
+		Log:                   log,
+	}
+	linkEvaluator := &worker.LinkHealthEvaluator{
+		ReadyForServiceCriteria: nil,
+		Log:                     log,
+	}
+
 	worker.MetricBuildInfo.WithLabelValues(version, commit, date).Set(1)
 	go func() {
 		listener, err := net.Listen("tcp", *metricsAddr)
@@ -155,6 +192,8 @@ func main() {
 		Env:                     *env,
 		ProvisioningSlotCount:   *provisioningSlotCount,
 		DrainedSlotCount:        *drainedSlotCount,
+		DeviceEvaluator:         deviceEvaluator,
+		LinkEvaluator:           linkEvaluator,
 	})
 	if err != nil {
 		log.Error("Failed to create worker", "error", err)

--- a/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
+++ b/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
@@ -134,7 +134,7 @@ func main() {
 	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {
 		chDB := os.Getenv("CLICKHOUSE_DB")
 		if chDB == "" {
-			chDB = *env
+			chDB = "default"
 		}
 		chUser := os.Getenv("CLICKHOUSE_USER")
 		if chUser == "" {

--- a/controlplane/device-health-oracle/internal/worker/clickhouse.go
+++ b/controlplane/device-health-oracle/internal/worker/clickhouse.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ControllerCallChecker queries ClickHouse for controller call records.
+type ControllerCallChecker interface {
+	ControllerCallCoverage(ctx context.Context, devicePubkey string, start, end time.Time) (minutesWithCalls int64, err error)
+	Close() error
+}
+
+// ClickHouseClient wraps a ClickHouse connection for reading controller call data.
+type ClickHouseClient struct {
+	conn clickhouse.Conn
+	db   string
+}
+
+func NewClickHouseClient(addr, db, user, pass string, disableTLS bool) (*ClickHouseClient, error) {
+	if !validDBName.MatchString(db) {
+		return nil, fmt.Errorf("invalid clickhouse database name: %q", db)
+	}
+
+	addr = strings.TrimPrefix(addr, "https://")
+	addr = strings.TrimPrefix(addr, "http://")
+
+	opts := &clickhouse.Options{
+		Protocol: clickhouse.HTTP,
+		Addr:     []string{addr},
+		Auth: clickhouse.Auth{
+			Database: db,
+			Username: user,
+			Password: pass,
+		},
+		MaxOpenConns: 5,
+		DialTimeout:  30 * time.Second,
+	}
+	if !disableTLS {
+		opts.TLS = &tls.Config{}
+	}
+
+	conn, err := clickhouse.Open(opts)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse open: %w", err)
+	}
+	if err := conn.Ping(context.Background()); err != nil {
+		return nil, fmt.Errorf("clickhouse ping: %w", err)
+	}
+
+	return &ClickHouseClient{conn: conn, db: db}, nil
+}
+
+// ControllerCallCoverage returns the number of distinct minutes in [start, end] that have
+// at least one controller_grpc_getconfig_success record for the given device.
+func (c *ClickHouseClient) ControllerCallCoverage(ctx context.Context, devicePubkey string, start, end time.Time) (int64, error) {
+	query := fmt.Sprintf(
+		`SELECT count(DISTINCT toStartOfMinute(timestamp)) AS minutes_with_calls
+		 FROM "%s".controller_grpc_getconfig_success
+		 WHERE device_pubkey = ?
+		   AND timestamp >= ?
+		   AND timestamp <= ?`,
+		c.db,
+	)
+
+	var minutesWithCalls uint64
+	err := c.conn.QueryRow(ctx, query, devicePubkey, start, end).Scan(&minutesWithCalls)
+	if err != nil {
+		return 0, fmt.Errorf("clickhouse query: %w", err)
+	}
+
+	return int64(minutesWithCalls), nil
+}
+
+func (c *ClickHouseClient) Close() error {
+	return c.conn.Close()
+}

--- a/controlplane/device-health-oracle/internal/worker/clickhouse_test.go
+++ b/controlplane/device-health-oracle/internal/worker/clickhouse_test.go
@@ -1,0 +1,118 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRow implements driver.Row for testing.
+type mockRow struct {
+	scanFunc func(dest ...any) error
+}
+
+func (r *mockRow) Err() error             { return nil }
+func (r *mockRow) Scan(dest ...any) error { return r.scanFunc(dest...) }
+func (r *mockRow) ScanStruct(_ any) error { return nil }
+
+// mockConn implements the subset of driver.Conn used by ClickHouseClient.
+type mockConn struct {
+	driver.Conn
+	queryRowFunc func(ctx context.Context, query string, args ...any) driver.Row
+}
+
+func (c *mockConn) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
+	return c.queryRowFunc(ctx, query, args...)
+}
+
+func TestControllerCallCoverage_ReturnsCount(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, query string, args ...any) driver.Row {
+			assert.Contains(t, query, `"testdb".controller_grpc_getconfig_success`)
+			assert.Len(t, args, 3)
+			assert.Equal(t, "device123", args[0])
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					p := dest[0].(*uint64)
+					*p = 42
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Hour)
+
+	minutes, err := client.ControllerCallCoverage(context.Background(), "device123", start, end)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), minutes)
+}
+
+func TestControllerCallCoverage_QueryError(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(_ ...any) error {
+					return errors.New("connection reset")
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	start := time.Now().Add(-1 * time.Hour)
+	end := time.Now()
+
+	_, err := client.ControllerCallCoverage(context.Background(), "device123", start, end)
+	assert.ErrorContains(t, err, "connection reset")
+}
+
+func TestControllerCallCoverage_QuotesDatabaseName(t *testing.T) {
+	// Verify that database names with hyphens (mainnet-beta) are quoted.
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, query string, _ ...any) driver.Row {
+			assert.Contains(t, query, `"mainnet-beta".controller_grpc_getconfig_success`)
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					p := dest[0].(*uint64)
+					*p = 0
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "mainnet-beta"}
+	start := time.Now().Add(-1 * time.Hour)
+	end := time.Now()
+
+	minutes, err := client.ControllerCallCoverage(context.Background(), "device123", start, end)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), minutes)
+}
+
+func TestNewClickHouseClient_StripsScheme(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{"plain host:port", "localhost:8123"},
+		{"https prefix", "https://clickhouse.example.com:8443"},
+		{"http prefix", "http://localhost:8123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewClickHouseClient(tt.addr, "default", "default", "", true)
+			// Connection will fail (no server) — verify no panic and an error is returned.
+			assert.Error(t, err)
+		})
+	}
+}

--- a/controlplane/device-health-oracle/internal/worker/config.go
+++ b/controlplane/device-health-oracle/internal/worker/config.go
@@ -47,6 +47,10 @@ type Config struct {
 	// DrainedSlotCount is used for reactivated devices/links (status = Drained, HardDrained, SoftDrained).
 	ProvisioningSlotCount uint64
 	DrainedSlotCount      uint64
+
+	// Health evaluators determine target health based on criteria.
+	DeviceEvaluator *DeviceHealthEvaluator
+	LinkEvaluator   *LinkHealthEvaluator
 }
 
 func (c *Config) Validate() error {
@@ -70,6 +74,12 @@ func (c *Config) Validate() error {
 	}
 	if c.Interval <= 0 {
 		return errors.New("interval must be greater than 0")
+	}
+	if c.DeviceEvaluator == nil {
+		return errors.New("device evaluator is required")
+	}
+	if c.LinkEvaluator == nil {
+		return errors.New("link evaluator is required")
 	}
 	return nil
 }

--- a/controlplane/device-health-oracle/internal/worker/controller_success.go
+++ b/controlplane/device-health-oracle/internal/worker/controller_success.go
@@ -1,0 +1,62 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+)
+
+// ControllerSuccessCriterion checks that a device has called the controller
+// at least once per minute over the burn-in period by querying the ClickHouse
+// controller_grpc_getconfig_success table.
+//
+// The burn-in start times are resolved from ledger slot numbers via GetBlockTime
+// and passed through the context (see BurnInTimes / ContextWithBurnInTimes).
+type ControllerSuccessCriterion struct {
+	checker ControllerCallChecker
+	log     *slog.Logger
+}
+
+func NewControllerSuccessCriterion(checker ControllerCallChecker, log *slog.Logger) *ControllerSuccessCriterion {
+	return &ControllerSuccessCriterion{
+		checker: checker,
+		log:     log,
+	}
+}
+
+func (c *ControllerSuccessCriterion) Name() string {
+	return "controller_success"
+}
+
+func (c *ControllerSuccessCriterion) Check(ctx context.Context, device serviceability.Device) (bool, string) {
+	start, now, expectedMinutes, ok := DeviceBurnIn(ctx, device.Status)
+	if !ok {
+		return false, "burn-in times not available in context"
+	}
+	if expectedMinutes == 0 {
+		return true, ""
+	}
+
+	pubkey := solana.PublicKeyFromBytes(device.PubKey[:]).String()
+	minutesWithCalls, err := c.checker.ControllerCallCoverage(ctx, pubkey, start, now)
+	if err != nil {
+		c.log.Error("Failed to query controller call coverage",
+			"device", pubkey, "code", device.Code, "error", err)
+		return false, fmt.Sprintf("clickhouse query failed: %v", err)
+	}
+
+	c.log.Debug("Controller call coverage",
+		"device", pubkey, "code", device.Code,
+		"minutesWithCalls", minutesWithCalls,
+		"expectedMinutes", expectedMinutes,
+		"start", start)
+
+	if minutesWithCalls < expectedMinutes {
+		return false, fmt.Sprintf("controller calls cover %d/%d minutes", minutesWithCalls, expectedMinutes)
+	}
+
+	return true, ""
+}

--- a/controlplane/device-health-oracle/internal/worker/controller_success_test.go
+++ b/controlplane/device-health-oracle/internal/worker/controller_success_test.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockControllerCallChecker struct {
+	minutesWithCalls int64
+	err              error
+}
+
+func (m *mockControllerCallChecker) ControllerCallCoverage(_ context.Context, _ string, _, _ time.Time) (int64, error) {
+	return m.minutesWithCalls, m.err
+}
+
+func (m *mockControllerCallChecker) Close() error { return nil }
+
+func testLoggerSlog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+}
+
+func TestControllerSuccessCriterion_Name(t *testing.T) {
+	c := NewControllerSuccessCriterion(nil, testLoggerSlog())
+	assert.Equal(t, "controller_success", c.Name())
+}
+
+func TestControllerSuccessCriterion_Passes(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-33 * time.Minute)
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: start,
+		Now:          now,
+	})
+
+	checker := &mockControllerCallChecker{minutesWithCalls: 33}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDrained}
+	passed, reason := c.Check(ctx, device)
+	assert.True(t, passed)
+	assert.Empty(t, reason)
+}
+
+func TestControllerSuccessCriterion_Fails_InsufficientCoverage(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-33 * time.Minute)
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: start,
+		Now:          now,
+	})
+
+	checker := &mockControllerCallChecker{minutesWithCalls: 20}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDrained}
+	passed, reason := c.Check(ctx, device)
+	assert.False(t, passed)
+	assert.Contains(t, reason, "controller calls cover 20/33 minutes")
+}
+
+func TestControllerSuccessCriterion_Fails_ClickHouseError(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-1 * time.Hour)
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		ProvisioningStart: start,
+		Now:               now,
+	})
+
+	checker := &mockControllerCallChecker{err: errors.New("connection refused")}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDeviceProvisioning}
+	passed, reason := c.Check(ctx, device)
+	assert.False(t, passed)
+	assert.Contains(t, reason, "clickhouse query failed")
+}
+
+func TestControllerSuccessCriterion_Fails_NoBurnInTimes(t *testing.T) {
+	checker := &mockControllerCallChecker{minutesWithCalls: 100}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDeviceProvisioning}
+	passed, reason := c.Check(context.Background(), device)
+	assert.False(t, passed)
+	assert.Contains(t, reason, "burn-in times not available")
+}
+
+func TestControllerSuccessCriterion_UsesProvisioningStart(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		ProvisioningStart: now.Add(-60 * time.Minute),
+		DrainedStart:      now.Add(-10 * time.Minute),
+		Now:               now,
+	})
+
+	// Provide enough coverage for provisioning (60 min) but check that
+	// DeviceProvisioning status uses ProvisioningStart, not DrainedStart.
+	checker := &mockControllerCallChecker{minutesWithCalls: 60}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDeviceProvisioning}
+	passed, _ := c.Check(ctx, device)
+	assert.True(t, passed)
+}
+
+func TestControllerSuccessCriterion_UsesDrainedStart(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		ProvisioningStart: now.Add(-60 * time.Minute),
+		DrainedStart:      now.Add(-10 * time.Minute),
+		Now:               now,
+	})
+
+	// Only 10 minutes of coverage — enough for drained but not provisioning.
+	checker := &mockControllerCallChecker{minutesWithCalls: 10}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDrained}
+	passed, _ := c.Check(ctx, device)
+	assert.True(t, passed)
+}
+
+func TestControllerSuccessCriterion_ZeroBurnIn_Passes(t *testing.T) {
+	// When burn-in start == now (zero-length window), the criterion should pass
+	// without querying ClickHouse. This happens in newly created environments
+	// where the burn-in slot is 0.
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		ProvisioningStart: now,
+		Now:               now,
+	})
+
+	checker := &mockControllerCallChecker{err: errors.New("should not be called")}
+	c := NewControllerSuccessCriterion(checker, testLoggerSlog())
+
+	device := serviceability.Device{Status: serviceability.DeviceStatusDeviceProvisioning}
+	passed, reason := c.Check(ctx, device)
+	assert.True(t, passed)
+	assert.Empty(t, reason)
+}

--- a/controlplane/device-health-oracle/internal/worker/criteria.go
+++ b/controlplane/device-health-oracle/internal/worker/criteria.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
@@ -93,7 +94,7 @@ func (e *DeviceHealthEvaluator) Evaluate(ctx context.Context, device serviceabil
 }
 
 func (e *DeviceHealthEvaluator) checkAll(ctx context.Context, device serviceability.Device, criteria []DeviceCriterion) bool {
-	devicePubkey := device.PubKey[:]
+	devicePubkey := solana.PublicKeyFromBytes(device.PubKey[:]).String()
 	for _, c := range criteria {
 		passed, reason := c.Check(ctx, device)
 		if !passed {
@@ -125,7 +126,7 @@ func (e *LinkHealthEvaluator) Evaluate(ctx context.Context, link serviceability.
 		return current
 	}
 
-	linkPubkey := link.PubKey[:]
+	linkPubkey := solana.PublicKeyFromBytes(link.PubKey[:]).String()
 	for _, c := range e.ReadyForServiceCriteria {
 		passed, reason := c.Check(ctx, link)
 		if !passed {

--- a/controlplane/device-health-oracle/internal/worker/criteria.go
+++ b/controlplane/device-health-oracle/internal/worker/criteria.go
@@ -1,0 +1,142 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+)
+
+type burnInTimesKey struct{}
+
+// BurnInTimes holds the wall-clock start times for each burn-in category,
+// resolved from ledger slot numbers via GetBlockTime once per tick.
+type BurnInTimes struct {
+	ProvisioningStart time.Time
+	DrainedStart      time.Time
+	Now               time.Time // tick timestamp, used as the end of the burn-in window
+}
+
+// ContextWithBurnInTimes returns a new context carrying the given BurnInTimes.
+func ContextWithBurnInTimes(ctx context.Context, times BurnInTimes) context.Context {
+	return context.WithValue(ctx, burnInTimesKey{}, times)
+}
+
+// DeviceBurnIn extracts BurnInTimes from the context and returns the burn-in
+// start time and expected number of minutes for the given device status.
+// Returns ok=false if the context has no BurnInTimes, and expectedMinutes=0
+// when the burn-in window has zero length (e.g. a newly created environment).
+func DeviceBurnIn(ctx context.Context, status serviceability.DeviceStatus) (start time.Time, now time.Time, expectedMinutes int64, ok bool) {
+	burnIn, ok := ctx.Value(burnInTimesKey{}).(BurnInTimes)
+	if !ok {
+		return time.Time{}, time.Time{}, 0, false
+	}
+	start = burnIn.ProvisioningStart
+	if status.IsDrained() {
+		start = burnIn.DrainedStart
+	}
+	expectedMinutes = max(int64(burnIn.Now.Sub(start).Minutes()), 0)
+	return start, burnIn.Now, expectedMinutes, true
+}
+
+// DeviceCriterion evaluates whether a device meets a specific readiness requirement.
+// Check returns (passed, reason). Reason is a human-readable explanation when passed is false.
+type DeviceCriterion interface {
+	Name() string
+	Check(ctx context.Context, device serviceability.Device) (bool, string)
+}
+
+// LinkCriterion evaluates whether a link meets a specific readiness requirement.
+type LinkCriterion interface {
+	Name() string
+	Check(ctx context.Context, link serviceability.Link) (bool, string)
+}
+
+// DeviceHealthEvaluator evaluates a device's health based on stage-specific criteria.
+// Devices must progress through stages in order: Pending → ReadyForLinks → ReadyForUsers.
+type DeviceHealthEvaluator struct {
+	ReadyForLinksCriteria []DeviceCriterion
+	ReadyForUsersCriteria []DeviceCriterion
+	Log                   *slog.Logger
+}
+
+// Evaluate determines the target health for a device based on its current health and criteria results.
+// It returns the device's current health if criteria are not met, or the next stage if they are.
+func (e *DeviceHealthEvaluator) Evaluate(ctx context.Context, device serviceability.Device) serviceability.DeviceHealth {
+	current := device.DeviceHealth
+
+	// Already at highest level — nothing to do.
+	if current == serviceability.DeviceHealthReadyForUsers {
+		return current
+	}
+
+	// Stage 1: Pending/Unknown → ReadyForLinks.
+	// Evaluate advances at most one stage per call, so a device needs a minimum
+	// of two ticks (two worker intervals) to go from Pending to ReadyForUsers.
+	if current < serviceability.DeviceHealthReadyForLinks {
+		if !e.checkAll(ctx, device, e.ReadyForLinksCriteria) {
+			return current
+		}
+		return serviceability.DeviceHealthReadyForLinks
+	}
+
+	// Stage 2: ReadyForLinks → ReadyForUsers
+	// Re-check links criteria (device must still be calling controller) plus any user-specific criteria.
+	if !e.checkAll(ctx, device, e.ReadyForLinksCriteria) {
+		return current
+	}
+	if !e.checkAll(ctx, device, e.ReadyForUsersCriteria) {
+		return current
+	}
+	return serviceability.DeviceHealthReadyForUsers
+}
+
+func (e *DeviceHealthEvaluator) checkAll(ctx context.Context, device serviceability.Device, criteria []DeviceCriterion) bool {
+	devicePubkey := device.PubKey[:]
+	for _, c := range criteria {
+		passed, reason := c.Check(ctx, device)
+		if !passed {
+			e.Log.Info("Device criterion not met",
+				"device", devicePubkey,
+				"code", device.Code,
+				"criterion", c.Name(),
+				"reason", reason)
+			MetricCriterionResults.WithLabelValues(c.Name(), "fail").Inc()
+			return false
+		}
+		MetricCriterionResults.WithLabelValues(c.Name(), "pass").Inc()
+	}
+	return true
+}
+
+// LinkHealthEvaluator evaluates a link's health based on criteria.
+// Links have a single stage: Pending → ReadyForService.
+type LinkHealthEvaluator struct {
+	ReadyForServiceCriteria []LinkCriterion
+	Log                     *slog.Logger
+}
+
+// Evaluate determines the target health for a link based on its current health and criteria results.
+func (e *LinkHealthEvaluator) Evaluate(ctx context.Context, link serviceability.Link) serviceability.LinkHealth {
+	current := link.LinkHealth
+
+	if current == serviceability.LinkHealthReadyForService {
+		return current
+	}
+
+	linkPubkey := link.PubKey[:]
+	for _, c := range e.ReadyForServiceCriteria {
+		passed, reason := c.Check(ctx, link)
+		if !passed {
+			e.Log.Info("Link criterion not met",
+				"link", linkPubkey,
+				"code", link.Code,
+				"criterion", c.Name(),
+				"reason", reason)
+			return current
+		}
+	}
+
+	return serviceability.LinkHealthReadyForService
+}

--- a/controlplane/device-health-oracle/internal/worker/criteria_test.go
+++ b/controlplane/device-health-oracle/internal/worker/criteria_test.go
@@ -1,0 +1,171 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDeviceCriterion struct {
+	name   string
+	result bool
+	reason string
+}
+
+func (m *mockDeviceCriterion) Name() string { return m.name }
+func (m *mockDeviceCriterion) Check(_ context.Context, _ serviceability.Device) (bool, string) {
+	return m.result, m.reason
+}
+
+type mockLinkCriterion struct {
+	name   string
+	result bool
+	reason string
+}
+
+func (m *mockLinkCriterion) Name() string { return m.name }
+func (m *mockLinkCriterion) Check(_ context.Context, _ serviceability.Link) (bool, string) {
+	return m.result, m.reason
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestDeviceHealthEvaluator_NoCriteria_AdvancesToReadyForUsers(t *testing.T) {
+	eval := &DeviceHealthEvaluator{Log: testLogger()}
+
+	tests := []struct {
+		name           string
+		currentHealth  serviceability.DeviceHealth
+		expectedHealth serviceability.DeviceHealth
+	}{
+		{"unknown advances to ready-for-links", serviceability.DeviceHealthUnknown, serviceability.DeviceHealthReadyForLinks},
+		{"pending advances to ready-for-links", serviceability.DeviceHealthPending, serviceability.DeviceHealthReadyForLinks},
+		{"ready-for-links advances to ready-for-users", serviceability.DeviceHealthReadyForLinks, serviceability.DeviceHealthReadyForUsers},
+		{"ready-for-users stays at ready-for-users", serviceability.DeviceHealthReadyForUsers, serviceability.DeviceHealthReadyForUsers},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			device := serviceability.Device{DeviceHealth: tt.currentHealth}
+			result := eval.Evaluate(context.Background(), device)
+			assert.Equal(t, tt.expectedHealth, result)
+		})
+	}
+}
+
+func TestDeviceHealthEvaluator_CriterionFails_BlocksAdvancement(t *testing.T) {
+	failingCriterion := &mockDeviceCriterion{name: "test_fail", result: false, reason: "test failure"}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{failingCriterion},
+		Log:                   testLogger(),
+	}
+
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthPending}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthPending, result, "should not advance when criterion fails")
+}
+
+func TestDeviceHealthEvaluator_CriterionPasses_Advances(t *testing.T) {
+	passingCriterion := &mockDeviceCriterion{name: "test_pass", result: true}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{passingCriterion},
+		Log:                   testLogger(),
+	}
+
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthPending}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthReadyForLinks, result)
+}
+
+func TestDeviceHealthEvaluator_StagesNotSkipped(t *testing.T) {
+	passingCriterion := &mockDeviceCriterion{name: "test_pass", result: true}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{passingCriterion},
+		ReadyForUsersCriteria: []DeviceCriterion{passingCriterion},
+		Log:                   testLogger(),
+	}
+
+	// A device at Pending should advance to ReadyForLinks, not ReadyForUsers.
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthPending}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthReadyForLinks, result, "should advance one stage at a time")
+}
+
+func TestDeviceHealthEvaluator_ReadyForLinks_UserCriterionFails(t *testing.T) {
+	passingCriterion := &mockDeviceCriterion{name: "links_pass", result: true}
+	failingCriterion := &mockDeviceCriterion{name: "users_fail", result: false, reason: "not ready"}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{passingCriterion},
+		ReadyForUsersCriteria: []DeviceCriterion{failingCriterion},
+		Log:                   testLogger(),
+	}
+
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthReadyForLinks}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthReadyForLinks, result, "should stay at ReadyForLinks when user criterion fails")
+}
+
+func TestDeviceHealthEvaluator_ReadyForLinks_LinkCriterionFails(t *testing.T) {
+	failingCriterion := &mockDeviceCriterion{name: "links_fail", result: false, reason: "regressed"}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{failingCriterion},
+		Log:                   testLogger(),
+	}
+
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthReadyForLinks}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthReadyForLinks, result, "should stay at ReadyForLinks when links criterion regresses")
+}
+
+func TestDeviceHealthEvaluator_MultipleCriteria_AllMustPass(t *testing.T) {
+	passing := &mockDeviceCriterion{name: "pass", result: true}
+	failing := &mockDeviceCriterion{name: "fail", result: false, reason: "nope"}
+	eval := &DeviceHealthEvaluator{
+		ReadyForLinksCriteria: []DeviceCriterion{passing, failing},
+		Log:                   testLogger(),
+	}
+
+	device := serviceability.Device{DeviceHealth: serviceability.DeviceHealthPending}
+	result := eval.Evaluate(context.Background(), device)
+	assert.Equal(t, serviceability.DeviceHealthPending, result, "should not advance when any criterion fails")
+}
+
+func TestLinkHealthEvaluator_NoCriteria_AdvancesToReadyForService(t *testing.T) {
+	eval := &LinkHealthEvaluator{Log: testLogger()}
+
+	tests := []struct {
+		name           string
+		currentHealth  serviceability.LinkHealth
+		expectedHealth serviceability.LinkHealth
+	}{
+		{"unknown advances", serviceability.LinkHealthUnknown, serviceability.LinkHealthReadyForService},
+		{"pending advances", serviceability.LinkHealthPending, serviceability.LinkHealthReadyForService},
+		{"ready stays", serviceability.LinkHealthReadyForService, serviceability.LinkHealthReadyForService},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			link := serviceability.Link{LinkHealth: tt.currentHealth}
+			result := eval.Evaluate(context.Background(), link)
+			assert.Equal(t, tt.expectedHealth, result)
+		})
+	}
+}
+
+func TestLinkHealthEvaluator_CriterionFails_BlocksAdvancement(t *testing.T) {
+	failingCriterion := &mockLinkCriterion{name: "test_fail", result: false, reason: "nope"}
+	eval := &LinkHealthEvaluator{
+		ReadyForServiceCriteria: []LinkCriterion{failingCriterion},
+		Log:                     testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthPending}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthPending, result, "should not advance when criterion fails")
+}

--- a/controlplane/device-health-oracle/internal/worker/metrics.go
+++ b/controlplane/device-health-oracle/internal/worker/metrics.go
@@ -6,13 +6,18 @@ import (
 )
 
 const (
-	MetricNameBuildInfo = "doublezero_device_health_oracle_build_info"
-	MetricNameErrors    = "doublezero_device_health_oracle_errors_total"
+	MetricNameBuildInfo        = "doublezero_device_health_oracle_build_info"
+	MetricNameErrors           = "doublezero_device_health_oracle_errors_total"
+	MetricNameCriterionResults = "doublezero_device_health_oracle_criterion_results_total"
+	MetricNameUpdatesSkipped   = "doublezero_device_health_oracle_updates_skipped_total"
 
 	MetricLabelVersion   = "version"
 	MetricLabelCommit    = "commit"
 	MetricLabelDate      = "date"
 	MetricLabelErrorType = "error_type"
+	MetricLabelCriterion = "criterion"
+	MetricLabelResult    = "result"
+	MetricLabelKind      = "kind"
 )
 
 var (
@@ -30,5 +35,21 @@ var (
 			Help: "Number of errors encountered",
 		},
 		[]string{MetricLabelErrorType},
+	)
+
+	MetricCriterionResults = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameCriterionResults,
+			Help: "Results of health criterion evaluations",
+		},
+		[]string{MetricLabelCriterion, MetricLabelResult},
+	)
+
+	MetricUpdatesSkipped = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameUpdatesSkipped,
+			Help: "Number of health updates skipped because the value was already set",
+		},
+		[]string{MetricLabelKind},
 	)
 )

--- a/controlplane/device-health-oracle/internal/worker/worker.go
+++ b/controlplane/device-health-oracle/internal/worker/worker.go
@@ -74,6 +74,26 @@ func (w *Worker) tick(ctx context.Context) {
 		"drainedSlotCount", w.cfg.DrainedSlotCount,
 		"drainedSlot", drainedSlot)
 
+	// Resolve burn-in boundary slots to wall-clock times for criteria evaluation.
+	burnIn := BurnInTimes{Now: time.Now()}
+	if provisioningSlot > 0 {
+		bt, err := w.cfg.LedgerRPCClient.GetBlockTime(ctx, provisioningSlot)
+		if err != nil {
+			w.log.Error("Failed to get block time for provisioning slot", "slot", provisioningSlot, "error", err)
+			return
+		}
+		burnIn.ProvisioningStart = time.Unix(int64(*bt), 0)
+	}
+	if drainedSlot > 0 {
+		bt, err := w.cfg.LedgerRPCClient.GetBlockTime(ctx, drainedSlot)
+		if err != nil {
+			w.log.Error("Failed to get block time for drained slot", "slot", drainedSlot, "error", err)
+			return
+		}
+		burnIn.DrainedStart = time.Unix(int64(*bt), 0)
+	}
+	ctx = ContextWithBurnInTimes(ctx, burnIn)
+
 	programData, err := w.cfg.Serviceability.GetProgramData(ctx)
 	if err != nil {
 		w.log.Error("Failed to get program data", "error", err)
@@ -105,14 +125,23 @@ func (w *Worker) updatePendingDeviceHealth(ctx context.Context, devices []servic
 			"health", device.DeviceHealth,
 			"healthValue", int(device.DeviceHealth))
 
+		targetHealth := w.cfg.DeviceEvaluator.Evaluate(ctx, device)
+
+		if targetHealth == device.DeviceHealth {
+			MetricUpdatesSkipped.WithLabelValues("device").Inc()
+			continue
+		}
+
 		updates = append(updates, serviceability.DeviceHealthUpdate{
 			DevicePubkey: devicePubkey,
-			Health:       serviceability.DeviceHealthReadyForUsers,
+			Health:       targetHealth,
 		})
 		w.log.Info("Queuing device health update",
 			"device", devicePubkey.String(),
 			"code", device.Code,
-			"status", device.Status.String())
+			"status", device.Status.String(),
+			"currentHealth", device.DeviceHealth.String(),
+			"targetHealth", targetHealth.String())
 	}
 
 	if len(updates) == 0 {
@@ -143,14 +172,24 @@ func (w *Worker) updatePendingLinkHealth(ctx context.Context, links []serviceabi
 	var updates []serviceability.LinkHealthUpdate
 	for _, link := range links {
 		linkPubkey := solana.PublicKeyFromBytes(link.PubKey[:])
+
+		targetHealth := w.cfg.LinkEvaluator.Evaluate(ctx, link)
+
+		if targetHealth == link.LinkHealth {
+			MetricUpdatesSkipped.WithLabelValues("link").Inc()
+			continue
+		}
+
 		updates = append(updates, serviceability.LinkHealthUpdate{
 			LinkPubkey: linkPubkey,
-			Health:     serviceability.LinkHealthReadyForService,
+			Health:     targetHealth,
 		})
 		w.log.Info("Queuing link health update",
 			"link", linkPubkey.String(),
 			"code", link.Code,
-			"status", link.Status.String())
+			"status", link.Status.String(),
+			"currentHealth", link.LinkHealth.String(),
+			"targetHealth", targetHealth.String())
 	}
 
 	if len(updates) == 0 {

--- a/controlplane/device-health-oracle/internal/worker/worker.go
+++ b/controlplane/device-health-oracle/internal/worker/worker.go
@@ -52,6 +52,10 @@ func (w *Worker) Run(ctx context.Context) error {
 }
 
 func (w *Worker) tick(ctx context.Context) {
+	if len(w.cfg.DeviceEvaluator.ReadyForLinksCriteria) == 0 {
+		w.log.Error("No device health criteria configured (is CLICKHOUSE_ADDR set?)")
+	}
+
 	currentSlot, err := w.cfg.LedgerRPCClient.GetSlot(ctx, solanarpc.CommitmentFinalized)
 	if err != nil {
 		w.log.Error("Failed to get current slot", "error", err)
@@ -75,6 +79,8 @@ func (w *Worker) tick(ctx context.Context) {
 		"drainedSlot", drainedSlot)
 
 	// Resolve burn-in boundary slots to wall-clock times for criteria evaluation.
+	// When a slot is 0 (environment too new for the full burn-in window), set the
+	// start to Now so the window has zero length and criteria pass immediately.
 	burnIn := BurnInTimes{Now: time.Now()}
 	if provisioningSlot > 0 {
 		bt, err := w.cfg.LedgerRPCClient.GetBlockTime(ctx, provisioningSlot)
@@ -83,6 +89,8 @@ func (w *Worker) tick(ctx context.Context) {
 			return
 		}
 		burnIn.ProvisioningStart = time.Unix(int64(*bt), 0)
+	} else {
+		burnIn.ProvisioningStart = burnIn.Now
 	}
 	if drainedSlot > 0 {
 		bt, err := w.cfg.LedgerRPCClient.GetBlockTime(ctx, drainedSlot)
@@ -91,6 +99,8 @@ func (w *Worker) tick(ctx context.Context) {
 			return
 		}
 		burnIn.DrainedStart = time.Unix(int64(*bt), 0)
+	} else {
+		burnIn.DrainedStart = burnIn.Now
 	}
 	ctx = ContextWithBurnInTimes(ctx, burnIn)
 

--- a/rfcs/rfc12-network-provisioning.md
+++ b/rfcs/rfc12-network-provisioning.md
@@ -324,7 +324,7 @@ These criteria must be met before links connected to the device can be activated
     1. At least 1 DIA interface defined on chain with status = activated
     1. At least 1 DIA interface up for `<burn-in slots>` with zero errors and non-zero utilization
 1. Device is reporting to InfluxDB for `<burn-in slots>` (already established by link RFS criteria)
-1. Config agent installed and running for `<burn-in slots>`
+1. Config agent installed and calling the controller consistently for `<burn-in slots>`. Verified by querying the ClickHouse `controller_grpc_getconfig_success` table (database per environment: `devnet`, `testnet`, `mainnet-beta`) and checking that the device has at least one record per minute over the burn-in window. The burn-in window start time is determined by calling `GetBlockTime` on the boundary slot (`current_slot - burn_in_slots`).
 1. Telemetry agent installed and running for `<burn-in slots>` (already established by link RFS criteria)
 
 #### Device onboarding - RFS (users) criteria


### PR DESCRIPTION
Resolves: #3493

## Summary of Changes

- Add `controller_success` device activation criterion that queries ClickHouse to verify devices have called the controller at least once per minute over the burn-in period before advancing health
- Introduce criteria-based evaluation pattern with stage-aware health progression (`Pending → ReadyForLinks → ReadyForUsers`) to support the many criteria planned in [RFC-12](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc12-network-provisioning.md)
- Skip onchain health writes when the value is already at the desired state
- ClickHouse connection is optional via `CLICKHOUSE_ADDR` env var — backward compatible when not set

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     4 | +332 / -4   | +328 |
| Scaffolding  |     3 | +72 / -2    |  +70 |
| Tests        |     3 | +437 / -0   | +437 |
| Docs         |     2 | +4 / -2     |   +2 |

~330 lines of core logic implementing the criteria pattern and ClickHouse integration, well-covered by ~440 lines of tests.

<details>
<summary>Key files (click to expand)</summary>

- [`criteria.go`](https://github.com/malbeclabs/doublezero/pull/3503/files#diff-4fd40f530c225ddc7f12656d12ff3edacdf21e045027f1c1444c6e3a3bfca64c) — DeviceCriterion/LinkCriterion interfaces, BurnInTimes context helpers, and stage-aware evaluators
- [`clickhouse.go`](https://github.com/malbeclabs/doublezero/pull/3503/files#diff-4e66562452cebb316aec46805cd7345d34a82fbc3d17cec0b2509bc7895f5ec6) — ClickHouse client with ControllerCallCoverage query and database name validation
- [`controller_success.go`](https://github.com/malbeclabs/doublezero/pull/3503/files#diff-79edd4570aac4cdcdfb6d26e555134aeca31259c4984f3cfd04b6bf445bcd525) — ControllerSuccessCriterion querying ClickHouse for per-minute call coverage
- [`worker.go`](https://github.com/malbeclabs/doublezero/pull/3503/files#diff-cb4d126aa894fbc1f5b6dec64090e91f14bee1fa90b19535ada50dc4afd9ca02) — Evaluator integration, GetBlockTime burn-in resolution, skip-update optimization

</details>

## Testing Verification

- Evaluator enforces stage progression — devices at `Pending` advance to `ReadyForLinks` (not directly to `ReadyForUsers`), and failing criteria block advancement
- ClickHouse client tested via mocked `driver.Conn`, verifying query construction, database name quoting, and error propagation
- Burn-in slot count correctly selects provisioning (200K) vs drained (5K) based on `status.IsDrained()`
- Zero-length burn-in window (new environment) short-circuits to pass without querying ClickHouse