### PR TITLE
activator: register legacy tunnel endpoints on reload to prevent duplicate underlay pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,21 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Telemetry
-  - Device telemetry agent now posts `agent_version` and `agent_commit` in the `DeviceLatencySamplesHeader` when initializing new sample accounts, enabling version attribution of onchain telemetry data
-- Smartcontract
-  - Add `agent_version` (`[u8; 16]`) and `agent_commit` (`[u8; 8]`) fields to `DeviceLatencySamplesHeader`, carved from the existing reserved region; accept both fields in the `InitializeDeviceLatencySamples` instruction via incremental deserialization (fully backward compatible)
-- SDK
-  - Deserialize `agent_version` and `agent_commit` from device latency samples in Go, TypeScript, and Python SDKs
+- Activator
+  - Fix duplicate tunnel underlay pairs after restart by registering `device.public_ip` as in-use for legacy users with unset `tunnel_endpoint` during allocation reload
 - Client
   - Rank devices and tunnel endpoints by minimum observed latency (`min_latency_ns`) instead of average when selecting a connection target, preferring paths with the best achievable round-trip time
-- Tools
-  - Add `IsRetryableFunc` field to `RetryOptions` for configurable retry criteria in the Solana JSON-RPC client; add `"rate limited"` string match and RPC code `-32429` to the default implementation
-- Telemetry
-  - Add optional TLS support to state-ingest server via `--tls-cert-file` and `--tls-key-file` flags; when set, the server listens on both HTTP (`:8080`) and HTTPS (`:8443`) simultaneously
-  - Remove `--additional-child-probes` CLI flag from telemetry-agent; child geoprobe discovery now relies entirely on the onchain Geolocation program
-  - Add BGP status submitter: on each tick, reads BGP socket state from the device namespace, maps each activated user to their tunnel peer IP, and submits `SetUserBGPStatus` onchain; supports a configurable down grace period and periodic keepalive refresh; enabled via `--bgp-status-enable` with `--bgp-status-interval`, `--bgp-status-refresh-interval`, and `--bgp-status-down-grace-period` flags
-- Monitor
-  - Add ClickHouse as a telemetry backend for the global monitor alongside existing InfluxDB
 - E2E tests
   - Add `TestE2E_GeoprobeIcmpTargets` verifying end-to-end ICMP outbound offset delivery via onchain `outbound-icmp` targets
   - Refactor geoprobe E2E tests to use testcontainers entrypoints and onchain target discovery
   - Add `TestE2E_UserBGPStatus` verifying that the telemetry BGP status submitter correctly reports onchain status transitions as clients connect and establish BGP sessions
+- Monitor
+  - Add ClickHouse as a telemetry backend for the global monitor alongside existing InfluxDB
 - SDK
+  - Deserialize `agent_version` and `agent_commit` from device latency samples in Go, TypeScript, and Python SDKs
   - Add `BGPStatus` type (Unknown/Up/Down) and `SetUserBGPStatus` executor instruction to the Go serviceability SDK
 - Smartcontract
+  - Add `agent_version` (`[u8; 16]`) and `agent_commit` (`[u8; 8]`) fields to `DeviceLatencySamplesHeader`, carved from the existing reserved region; accept both fields in the `InitializeDeviceLatencySamples` instruction via incremental deserialization (fully backward compatible)
   - Implement `SetUserBGPStatus` processor: validates metrics publisher authorization, updates `bgp_status`, `last_bgp_reported_at`, and `last_bgp_up_at` fields on the user account
   - Add human-readable error messages for serviceability program errors in the Go SDK, including program log extraction for enhanced debugging
   - `user get` no longer fails when no Access Pass exists; it prints a warning to stderr and continues, showing an empty access pass field
@@ -38,6 +30,13 @@ All notable changes to this project will be documented in this file.
   - Extend `validate_program_account!` migration to remaining user and multicastgroup allowlist processors (`set_bgp_status`, `delete`, `closeaccount`, publisher/subscriber `add`/`remove`)
   - Add `OutboundIcmp` target type (`= 2`) to the geolocation onchain program, enabling ICMP-based probing as an alternative to TWAMP for outbound geolocation targets
   - Allow pending users with subs to be deleted
+- Telemetry
+  - Device telemetry agent now posts `agent_version` and `agent_commit` in the `DeviceLatencySamplesHeader` when initializing new sample accounts, enabling version attribution of onchain telemetry data
+  - Add optional TLS support to state-ingest server via `--tls-cert-file` and `--tls-key-file` flags; when set, the server listens on both HTTP (`:8080`) and HTTPS (`:8443`) simultaneously
+  - Remove `--additional-child-probes` CLI flag from telemetry-agent; child geoprobe discovery now relies entirely on the onchain Geolocation program
+  - Add BGP status submitter: on each tick, reads BGP socket state from the device namespace, maps each activated user to their tunnel peer IP, and submits `SetUserBGPStatus` onchain; supports a configurable down grace period and periodic keepalive refresh; enabled via `--bgp-status-enable` with `--bgp-status-interval`, `--bgp-status-refresh-interval`, and `--bgp-status-down-grace-period` flags
+- Tools
+  - Add `IsRetryableFunc` field to `RetryOptions` for configurable retry criteria in the Solana JSON-RPC client; add `"rate limited"` string match and RPC code `-32429` to the default implementation
 - Geolocation
   - Standardize CLI flag naming: probe mutation commands use `--probe` (was `--code`) accepting pubkey or code; rename `--signing-keypair` → `--signing-pubkey` and `--target-pk` → `--target-signing-pubkey`; add `--json-compact` to `get` commands
   - geoprobe-target can now store LocationOffset messages in ClickHouse

--- a/activator/src/processor.rs
+++ b/activator/src/processor.rs
@@ -143,9 +143,15 @@ fn reserve_user_allocations(
                         );
                     }
                 }
-                // Register tunnel endpoint if set
+                // Register tunnel endpoint as in use for this client.
+                // Legacy users with tunnel_endpoint=0.0.0.0 are effectively using
+                // device.public_ip, so register that to prevent the activator from
+                // handing out the same endpoint to a second tunnel for the same client.
                 if user.has_tunnel_endpoint() {
                     device_state.register_tunnel_endpoint(user.client_ip, user.tunnel_endpoint);
+                } else {
+                    device_state
+                        .register_tunnel_endpoint(user.client_ip, device_state.device.public_ip);
                 }
             }
             Ok::<(), eyre::Error>(())


### PR DESCRIPTION
## Summary of Changes
- Fix duplicate tunnel underlay pairs caused by activator restarts not tracking legacy users' effective tunnel endpoints
- Users with `tunnel_endpoint=0.0.0.0` (pre-UTE feature) use `device.public_ip` in the controller, but the activator's reload path skipped registering that endpoint as in-use — allowing a second tunnel for the same client to be assigned the same IP

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +6 / -1     |  +5  |

Minimal targeted fix in the startup reservation path.

<details>
<summary>Key files (click to expand)</summary>

- `activator/src/processor.rs` — register `device.public_ip` as in-use for legacy users during `reserve_user_allocations`

</details>

## Testing Verification
- All 76 existing activator unit tests pass
- The `DeviceState` endpoint tracking tests cover the underlying allocation/dedup logic; this fix ensures the reload path feeds it correctly
