### PR TITLE
bugfix(activator): prevent duplicate IP allocation (#3510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Telemetry
-  - Device telemetry agent now posts `agent_version` and `agent_commit` in the `DeviceLatencySamplesHeader` when initializing new sample accounts, enabling version attribution of onchain telemetry data
+- Activator
+  - Register tunnel endpoint to prevent duplicate IP allocation  ([#3511](https://github.com/malbeclabs/doublezero/pull/3511/))
 - Smartcontract
   - Add `agent_version` (`[u8; 16]`) and `agent_commit` (`[u8; 8]`) fields to `DeviceLatencySamplesHeader`, carved from the existing reserved region; accept both fields in the `InitializeDeviceLatencySamples` instruction via incremental deserialization (fully backward compatible)
 - SDK
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
   - Add optional TLS support to state-ingest server via `--tls-cert-file` and `--tls-key-file` flags; when set, the server listens on both HTTP (`:8080`) and HTTPS (`:8443`) simultaneously
   - Remove `--additional-child-probes` CLI flag from telemetry-agent; child geoprobe discovery now relies entirely on the onchain Geolocation program
   - Add BGP status submitter: on each tick, reads BGP socket state from the device namespace, maps each activated user to their tunnel peer IP, and submits `SetUserBGPStatus` onchain; supports a configurable down grace period and periodic keepalive refresh; enabled via `--bgp-status-enable` with `--bgp-status-interval`, `--bgp-status-refresh-interval`, and `--bgp-status-down-grace-period` flags
+  - Device telemetry agent now posts `agent_version` and `agent_commit` in the `DeviceLatencySamplesHeader` when initializing new sample accounts, enabling version attribution of onchain telemetry data
 - Monitor
   - Add ClickHouse as a telemetry backend for the global monitor alongside existing InfluxDB
 - E2E tests

--- a/activator/src/processor.rs
+++ b/activator/src/processor.rs
@@ -143,10 +143,14 @@ fn reserve_user_allocations(
                         );
                     }
                 }
-                // Register tunnel endpoint if set
-                if user.has_tunnel_endpoint() {
-                    device_state.register_tunnel_endpoint(user.client_ip, user.tunnel_endpoint);
-                }
+                // Register tunnel endpoint (explicit or implicit via device public_ip)
+                // so that get_available_tunnel_endpoint knows what's already in use.
+                let effective_endpoint = if user.has_tunnel_endpoint() {
+                    user.tunnel_endpoint
+                } else {
+                    device_state.device.public_ip
+                };
+                device_state.register_tunnel_endpoint(user.client_ip, effective_endpoint);
             }
             Ok::<(), eyre::Error>(())
         })
@@ -625,6 +629,106 @@ mod tests {
             next_block.ip().to_string(),
             "2.0.0.0",
             "BUG: allocated tunnel_net collides with Updating user's 2.0.0.0/31"
+        );
+    }
+
+    /// Regression test: reserve_user_allocations must register implicit tunnel endpoints
+    /// (device public_ip) for users with unspecified tunnel_endpoint. Otherwise a second
+    /// user from the same client_ip gets the same endpoint, creating a duplicate GRE tunnel pair.
+    #[test]
+    fn test_implicit_tunnel_endpoint_reserved_at_startup() {
+        use crate::{ipblockallocator::IPBlockAllocator, states::devicestate::DeviceState};
+        use doublezero_sdk::{
+            AccountType, Device, DeviceStatus, DeviceType, User, UserStatus, UserType,
+        };
+        use doublezero_serviceability::state::user::UserCYOA;
+        use std::net::Ipv4Addr;
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = Device {
+            account_type: AccountType::Device,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            reference_count: 0,
+            bump_seed: 0,
+            contributor_pk: Pubkey::new_unique(),
+            location_pk: Pubkey::new_unique(),
+            exchange_pk: Pubkey::new_unique(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [88, 216, 220, 195].into(),
+            status: DeviceStatus::Activated,
+            metrics_publisher_pk: Pubkey::default(),
+            code: "TestDevice".to_string(),
+            dz_prefixes: "10.0.0.0/24".parse().unwrap(),
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: 0,
+            max_multicast_publishers: 0,
+        };
+
+        let client_ip: Ipv4Addr = [64, 130, 32, 201].into();
+
+        let mut device_map: DeviceMap = DeviceMap::new();
+        device_map.insert(device_pubkey, DeviceState::new(&device));
+
+        // Existing activated user with unspecified tunnel_endpoint (uses device public_ip implicitly)
+        let existing_user = User {
+            account_type: AccountType::User,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            bump_seed: 0,
+            user_type: UserType::IBRL,
+            tenant_pk: Pubkey::new_unique(),
+            device_pk: device_pubkey,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip,
+            dz_ip: [10, 0, 0, 1].into(),
+            tunnel_id: 509,
+            tunnel_net: "169.254.2.14/31".parse().unwrap(),
+            status: UserStatus::Activated,
+            publishers: vec![],
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+        };
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        users.insert(Pubkey::new_unique(), existing_user);
+
+        let mut user_tunnel_ips = IPBlockAllocator::new("169.254.0.0/16".parse().unwrap());
+        let mut publisher_dz_ips = IPBlockAllocator::new("148.51.120.0/21".parse().unwrap());
+
+        reserve_user_allocations(
+            &users,
+            &mut device_map,
+            &mut user_tunnel_ips,
+            &mut publisher_dz_ips,
+        )
+        .expect("reserve_user_allocations should succeed");
+
+        // A second user from the same client_ip should NOT get device public_ip
+        // because the first user is already using it
+        let device_state = device_map.get(&device_pubkey).unwrap();
+        let next_endpoint = device_state.get_available_tunnel_endpoint(client_ip);
+        assert_eq!(
+            next_endpoint, None,
+            "BUG: get_available_tunnel_endpoint returned device public_ip which is already \
+             in use by existing user with unspecified tunnel_endpoint — this creates a \
+             duplicate GRE tunnel pair"
         );
     }
 


### PR DESCRIPTION
## Summary of Changes

We had an [issue](https://malbeclabs.slack.com/archives/C0804H5R7JP/p1775760432506799) where two users had the same device `public_ip` which was causing the controller to repeatedly error. 

 1. Activator starts, loads existing users
 2. User 509 (5AGV...) has tunnel_endpoint = 0.0.0.0 → has_tunnel_endpoint() is  false → not registered in tunnel_endpoints_in_use
 3. User 573 (3QNM...) arrives as Pending with client_ip = 64.130.32.201
 4. get_available_tunnel_endpoint(64.130.32.201) checks the map → empty for this client_ip
 5. Device has no UserTunnelEndpoint interfaces → falls back to device.public_ip
 6. Returns public_ip (same endpoint user 509 is already using) → duplicate tunnel pair

Fix is to register the effective tunnel endpoint rather than race. 

## Testing Verification
* Added regression test
