### PR TITLE
smartcontract,client: add topology CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to this project will be documented in this file.
   - Extend `validate_program_account!` migration to remaining user and multicastgroup allowlist processors (`set_bgp_status`, `delete`, `closeaccount`, publisher/subscriber `add`/`remove`)
   - Add `OutboundIcmp` target type (`= 2`) to the geolocation onchain program, enabling ICMP-based probing as an alternative to TWAMP for outbound geolocation targets
   - Allow pending users with subs to be deleted
+  - Add `doublezero link topology {create,delete,clear,backfill,list}` subcommands for managing flex-algo topologies; `topology clear` auto-discovers tagged links when `--links` is omitted
   - Add `TopologyInfo` onchain account for IS-IS flex-algo link classification: auto-assigned TE admin-group bit (1–62), derived flex-algo number (128 + bit), and constraint type (`include-any`/`include-all`); capped at 62 topologies via `AdminGroupBits` resource extension
   - Add `link_topologies: Vec<Pubkey>` (capped at 8) and `link_flags: u32` (bit 0 = unicast-drained) to the `Link` account
   - Add `include_topologies` to the `Tenant` account for topology-filtered routing opt-in

--- a/client/doublezero/src/cli/link.rs
+++ b/client/doublezero/src/cli/link.rs
@@ -1,8 +1,15 @@
 use clap::{Args, Subcommand};
-use doublezero_cli::link::{
-    accept::AcceptLinkCliCommand, delete::*, dzx_create::CreateDZXLinkCliCommand, get::*,
-    latency::LinkLatencyCliCommand, list::*, sethealth::SetLinkHealthCliCommand, update::*,
-    wan_create::*,
+use doublezero_cli::{
+    link::{
+        accept::AcceptLinkCliCommand, delete::*, dzx_create::CreateDZXLinkCliCommand, get::*,
+        latency::LinkLatencyCliCommand, list::*, sethealth::SetLinkHealthCliCommand, update::*,
+        wan_create::*,
+    },
+    topology::{
+        backfill::BackfillTopologyCliCommand, clear::ClearTopologyCliCommand,
+        create::CreateTopologyCliCommand, delete::DeleteTopologyCliCommand,
+        list::ListTopologyCliCommand,
+    },
 };
 
 #[derive(Args, Debug)]
@@ -53,4 +60,27 @@ pub enum LinkCommands {
     // Hidden because this is an internal/operational command not intended for general CLI users.
     #[clap(hide = true)]
     SetHealth(SetLinkHealthCliCommand),
+    /// Manage link topologies
+    #[clap()]
+    Topology(TopologyLinkCommand),
+}
+
+#[derive(Args, Debug)]
+pub struct TopologyLinkCommand {
+    #[command(subcommand)]
+    pub command: TopologyCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TopologyCommands {
+    /// Create a new topology
+    Create(CreateTopologyCliCommand),
+    /// Delete a topology
+    Delete(DeleteTopologyCliCommand),
+    /// Clear a topology from links
+    Clear(ClearTopologyCliCommand),
+    /// Backfill FlexAlgoNodeSegment entries on existing Vpnv4 loopbacks
+    Backfill(BackfillTopologyCliCommand),
+    /// List all topologies
+    List(ListTopologyCliCommand),
 }

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -17,7 +17,7 @@ use crate::cli::{
         AirdropCommands, AuthorityCommands, FeatureFlagsCommands, FoundationAllowlistCommands,
         GlobalConfigCommands, QaAllowlistCommands,
     },
-    link::LinkCommands,
+    link::{LinkCommands, TopologyCommands},
     location::LocationCommands,
     user::UserCommands,
 };
@@ -232,6 +232,13 @@ async fn main() -> eyre::Result<()> {
             LinkCommands::Latency(args) => args.execute(&client, &mut handle),
             LinkCommands::Delete(args) => args.execute(&client, &mut handle),
             LinkCommands::SetHealth(args) => args.execute(&client, &mut handle),
+            LinkCommands::Topology(args) => match args.command {
+                TopologyCommands::Create(args) => args.execute(&client, &mut handle),
+                TopologyCommands::Delete(args) => args.execute(&client, &mut handle),
+                TopologyCommands::Clear(args) => args.execute(&client, &mut handle),
+                TopologyCommands::Backfill(args) => args.execute(&client, &mut handle),
+                TopologyCommands::List(args) => args.execute(&client, &mut handle),
+            },
         },
         Command::AccessPass(command) => match command.command {
             cli::accesspass::AccessPassCommands::Set(args) => args.execute(&client, &mut handle),

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -99,6 +99,11 @@ use doublezero_sdk::{
             remove_administrator::RemoveAdministratorTenantCommand, update::UpdateTenantCommand,
             update_payment_status::UpdatePaymentStatusCommand,
         },
+        topology::{
+            backfill::BackfillTopologyCommand, clear::ClearTopologyCommand,
+            create::CreateTopologyCommand, delete::DeleteTopologyCommand,
+            list::ListTopologyCommand,
+        },
         user::{
             create::CreateUserCommand, create_subscribe::CreateSubscribeUserCommand,
             delete::DeleteUserCommand, get::GetUserCommand, list::ListUserCommand,
@@ -107,7 +112,8 @@ use doublezero_sdk::{
     },
     telemetry::LinkLatencyStats,
     DZClient, Device, DoubleZeroClient, Exchange, GetGlobalConfigCommand, GetGlobalStateCommand,
-    GlobalConfig, GlobalState, Link, Location, MulticastGroup, ResourceExtensionOwned, User,
+    GlobalConfig, GlobalState, Link, Location, MulticastGroup, ResourceExtensionOwned,
+    TopologyInfo, User,
 };
 use doublezero_serviceability::state::{
     accesspass::AccessPass, accountdata::AccountData, contributor::Contributor,
@@ -337,6 +343,15 @@ pub trait CliCommand {
         cmd: GetResourceCommand,
     ) -> eyre::Result<(Pubkey, ResourceExtensionOwned)>;
     fn close_resource(&self, cmd: CloseResourceCommand) -> eyre::Result<Signature>;
+
+    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<(Signature, Pubkey)>;
+    fn delete_topology(&self, cmd: DeleteTopologyCommand) -> eyre::Result<Signature>;
+    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Signature>;
+    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Signature>;
+    fn list_topology(
+        &self,
+        cmd: ListTopologyCommand,
+    ) -> eyre::Result<HashMap<Pubkey, TopologyInfo>>;
 }
 
 pub struct CliCommandImpl<'a> {
@@ -801,6 +816,24 @@ impl CliCommand for CliCommandImpl<'_> {
         cmd.execute(self.client)
     }
     fn close_resource(&self, cmd: CloseResourceCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<(Signature, Pubkey)> {
+        cmd.execute(self.client)
+    }
+    fn delete_topology(&self, cmd: DeleteTopologyCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn list_topology(
+        &self,
+        cmd: ListTopologyCommand,
+    ) -> eyre::Result<HashMap<Pubkey, TopologyInfo>> {
         cmd.execute(self.client)
     }
 }

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -100,8 +100,10 @@ use doublezero_sdk::{
             update_payment_status::UpdatePaymentStatusCommand,
         },
         topology::{
-            backfill::BackfillTopologyCommand, clear::ClearTopologyCommand,
-            create::CreateTopologyCommand, delete::DeleteTopologyCommand,
+            backfill::BackfillTopologyCommand,
+            clear::ClearTopologyCommand,
+            create::{CreateTopologyCommand, CreateTopologyResult},
+            delete::DeleteTopologyCommand,
             list::ListTopologyCommand,
         },
         user::{
@@ -344,10 +346,10 @@ pub trait CliCommand {
     ) -> eyre::Result<(Pubkey, ResourceExtensionOwned)>;
     fn close_resource(&self, cmd: CloseResourceCommand) -> eyre::Result<Signature>;
 
-    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<(Signature, Pubkey)>;
+    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<CreateTopologyResult>;
     fn delete_topology(&self, cmd: DeleteTopologyCommand) -> eyre::Result<Signature>;
-    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Signature>;
-    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Signature>;
+    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Vec<Signature>>;
+    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Vec<Signature>>;
     fn list_topology(
         &self,
         cmd: ListTopologyCommand,
@@ -818,16 +820,16 @@ impl CliCommand for CliCommandImpl<'_> {
     fn close_resource(&self, cmd: CloseResourceCommand) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }
-    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<(Signature, Pubkey)> {
+    fn create_topology(&self, cmd: CreateTopologyCommand) -> eyre::Result<CreateTopologyResult> {
         cmd.execute(self.client)
     }
     fn delete_topology(&self, cmd: DeleteTopologyCommand) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }
-    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Signature> {
+    fn clear_topology(&self, cmd: ClearTopologyCommand) -> eyre::Result<Vec<Signature>> {
         cmd.execute(self.client)
     }
-    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Signature> {
+    fn backfill_topology(&self, cmd: BackfillTopologyCommand) -> eyre::Result<Vec<Signature>> {
         cmd.execute(self.client)
     }
     fn list_topology(

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -30,6 +30,7 @@ pub mod resource;
 pub mod subscribe;
 pub mod tenant;
 pub mod tests;
+pub mod topology;
 pub mod user;
 pub mod util;
 pub mod validators;

--- a/smartcontract/cli/src/topology/backfill.rs
+++ b/smartcontract/cli/src/topology/backfill.rs
@@ -27,15 +27,16 @@ impl BackfillTopologyCliCommand {
             ));
         }
 
-        let sig = client.backfill_topology(BackfillTopologyCommand {
+        let sigs = client.backfill_topology(BackfillTopologyCommand {
             name: self.name.clone(),
             device_pubkeys: self.device_pubkeys,
         })?;
 
         writeln!(
             out,
-            "Backfilled topology '{}'. Signature: {}",
-            self.name, sig
+            "Backfilled topology '{}' across {} transaction(s).",
+            self.name,
+            sigs.len()
         )?;
 
         Ok(())
@@ -62,7 +63,7 @@ mod tests {
                 name: "unicast-default".to_string(),
                 device_pubkeys: vec![device1],
             }))
-            .returning(|_| Ok(Signature::new_unique()));
+            .returning(|_| Ok(vec![Signature::new_unique()]));
 
         let cmd = BackfillTopologyCliCommand {
             name: "unicast-default".to_string(),
@@ -72,7 +73,7 @@ mod tests {
         let result = cmd.execute(&mock, &mut out);
         assert!(result.is_ok());
         let output = String::from_utf8(out.into_inner()).unwrap();
-        assert!(output.contains("Backfilled topology 'unicast-default'."));
+        assert!(output.contains("Backfilled topology 'unicast-default' across 1 transaction(s)."));
     }
 
     #[test]

--- a/smartcontract/cli/src/topology/backfill.rs
+++ b/smartcontract/cli/src/topology/backfill.rs
@@ -1,0 +1,95 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::topology::backfill::BackfillTopologyCommand;
+use solana_sdk::pubkey::Pubkey;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct BackfillTopologyCliCommand {
+    /// Name of the topology to backfill
+    #[arg(long)]
+    pub name: String,
+    /// Device account pubkeys to backfill (one or more)
+    #[arg(long = "device", value_name = "PUBKEY")]
+    pub device_pubkeys: Vec<Pubkey>,
+}
+
+impl BackfillTopologyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        if self.device_pubkeys.is_empty() {
+            return Err(eyre::eyre!(
+                "at least one --device pubkey is required for backfill"
+            ));
+        }
+
+        let sig = client.backfill_topology(BackfillTopologyCommand {
+            name: self.name.clone(),
+            device_pubkeys: self.device_pubkeys,
+        })?;
+
+        writeln!(
+            out,
+            "Backfilled topology '{}'. Signature: {}",
+            self.name, sig
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doublezerocommand::MockCliCommand;
+    use doublezero_sdk::commands::topology::backfill::BackfillTopologyCommand;
+    use mockall::predicate::eq;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::io::Cursor;
+
+    #[test]
+    fn test_backfill_topology_execute_success() {
+        let mut mock = MockCliCommand::new();
+        let device1 = Pubkey::new_unique();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_backfill_topology()
+            .with(eq(BackfillTopologyCommand {
+                name: "unicast-default".to_string(),
+                device_pubkeys: vec![device1],
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let cmd = BackfillTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            device_pubkeys: vec![device1],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("Backfilled topology 'unicast-default'."));
+    }
+
+    #[test]
+    fn test_backfill_topology_requires_at_least_one_device() {
+        let mut mock = MockCliCommand::new();
+        mock.expect_check_requirements().returning(|_| Ok(()));
+
+        let cmd = BackfillTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            device_pubkeys: vec![],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("at least one --device pubkey is required"));
+    }
+}

--- a/smartcontract/cli/src/topology/clear.rs
+++ b/smartcontract/cli/src/topology/clear.rs
@@ -7,10 +7,6 @@ use doublezero_sdk::commands::topology::clear::ClearTopologyCommand;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
 
-// Solana transactions have a 32-account limit. With 3 fixed accounts (topology PDA,
-// globalstate, payer), we can fit at most 29 link accounts per transaction.
-const CLEAR_BATCH_SIZE: usize = 29;
-
 #[derive(Args, Debug)]
 pub struct ClearTopologyCliCommand {
     /// Name of the topology to clear from links
@@ -63,13 +59,10 @@ impl ClearTopologyCliCommand {
             return Ok(());
         }
 
-        // Batch into chunks that fit within Solana's account limit.
-        for chunk in link_pubkeys.chunks(CLEAR_BATCH_SIZE) {
-            client.clear_topology(ClearTopologyCommand {
-                name: self.name.clone(),
-                link_pubkeys: chunk.to_vec(),
-            })?;
-        }
+        client.clear_topology(ClearTopologyCommand {
+            name: self.name.clone(),
+            link_pubkeys,
+        })?;
 
         writeln!(
             out,
@@ -139,7 +132,7 @@ mod tests {
                 name: "unicast-default".to_string(),
                 link_pubkeys: vec![link1, link2],
             }))
-            .returning(|_| Ok(Signature::new_unique()));
+            .returning(|_| Ok(vec![Signature::new_unique()]));
 
         let cmd = ClearTopologyCliCommand {
             name: "unicast-default".to_string(),

--- a/smartcontract/cli/src/topology/clear.rs
+++ b/smartcontract/cli/src/topology/clear.rs
@@ -1,0 +1,190 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::topology::clear::ClearTopologyCommand;
+use solana_sdk::pubkey::Pubkey;
+use std::io::Write;
+
+// Solana transactions have a 32-account limit. With 3 fixed accounts (topology PDA,
+// globalstate, payer), we can fit at most 29 link accounts per transaction.
+const CLEAR_BATCH_SIZE: usize = 29;
+
+#[derive(Args, Debug)]
+pub struct ClearTopologyCliCommand {
+    /// Name of the topology to clear from links
+    #[arg(long)]
+    pub name: String,
+    /// Comma-separated list of link pubkeys to clear the topology from.
+    /// If omitted, all links currently tagged with this topology are discovered automatically.
+    #[arg(long, value_delimiter = ',')]
+    pub links: Vec<String>,
+}
+
+impl ClearTopologyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let link_pubkeys: Vec<Pubkey> = if self.links.is_empty() {
+            // Auto-discover: find all links tagged with this topology.
+            let topology_map = client
+                .list_topology(doublezero_sdk::commands::topology::list::ListTopologyCommand)?;
+            let topology_pk = topology_map
+                .iter()
+                .find(|(_, t)| t.name == self.name)
+                .map(|(pk, _)| *pk)
+                .ok_or_else(|| eyre::eyre!("Topology '{}' not found", self.name))?;
+
+            let links = client.list_link(doublezero_sdk::commands::link::list::ListLinkCommand)?;
+            links
+                .into_iter()
+                .filter(|(_, link)| link.link_topologies.contains(&topology_pk))
+                .map(|(pk, _)| pk)
+                .collect()
+        } else {
+            self.links
+                .iter()
+                .map(|s| {
+                    s.parse::<Pubkey>()
+                        .map_err(|_| eyre::eyre!("invalid link pubkey: {}", s))
+                })
+                .collect::<eyre::Result<Vec<_>>>()?
+        };
+
+        let total = link_pubkeys.len();
+
+        if total == 0 {
+            writeln!(
+                out,
+                "No links tagged with topology '{}'. Nothing to clear.",
+                self.name
+            )?;
+            return Ok(());
+        }
+
+        // Batch into chunks that fit within Solana's account limit.
+        for chunk in link_pubkeys.chunks(CLEAR_BATCH_SIZE) {
+            client.clear_topology(ClearTopologyCommand {
+                name: self.name.clone(),
+                link_pubkeys: chunk.to_vec(),
+            })?;
+        }
+
+        writeln!(
+            out,
+            "Cleared topology '{}' from {} link(s).",
+            self.name, total
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doublezerocommand::MockCliCommand;
+    use doublezero_sdk::TopologyInfo;
+    use mockall::predicate::eq;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::{collections::HashMap, io::Cursor};
+
+    #[test]
+    fn test_clear_topology_execute_no_links_auto_discover_empty() {
+        let mut mock = MockCliCommand::new();
+        let topology_pk = Pubkey::new_unique();
+
+        let mut topology_map: HashMap<Pubkey, TopologyInfo> = HashMap::new();
+        topology_map.insert(
+            topology_pk,
+            TopologyInfo {
+                account_type: doublezero_sdk::AccountType::Topology,
+                owner: Pubkey::default(),
+                bump_seed: 0,
+                name: "unicast-default".to_string(),
+                admin_group_bit: 1,
+                flex_algo_number: 129,
+                constraint:
+                    doublezero_serviceability::state::topology::TopologyConstraint::IncludeAny,
+                reference_count: 0,
+            },
+        );
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_list_topology()
+            .returning(move |_| Ok(topology_map.clone()));
+        mock.expect_list_link().returning(|_| Ok(HashMap::new()));
+
+        let cmd = ClearTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            links: vec![],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("No links tagged with topology 'unicast-default'."));
+    }
+
+    #[test]
+    fn test_clear_topology_execute_with_links() {
+        let mut mock = MockCliCommand::new();
+        let link1 = Pubkey::new_unique();
+        let link2 = Pubkey::new_unique();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_clear_topology()
+            .with(eq(ClearTopologyCommand {
+                name: "unicast-default".to_string(),
+                link_pubkeys: vec![link1, link2],
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let cmd = ClearTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            links: vec![link1.to_string(), link2.to_string()],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("Cleared topology 'unicast-default' from 2 link(s)."));
+    }
+
+    #[test]
+    fn test_clear_topology_invalid_pubkey() {
+        let mut mock = MockCliCommand::new();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+
+        let cmd = ClearTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            links: vec!["not-a-pubkey".to_string()],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_clear_topology_auto_discover_not_found() {
+        let mut mock = MockCliCommand::new();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_list_topology()
+            .returning(|_| Ok(HashMap::new()));
+
+        let cmd = ClearTopologyCliCommand {
+            name: "nonexistent".to_string(),
+            links: vec![],
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Topology 'nonexistent' not found"));
+    }
+}

--- a/smartcontract/cli/src/topology/create.rs
+++ b/smartcontract/cli/src/topology/create.rs
@@ -1,0 +1,123 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::commands::topology::create::CreateTopologyCommand;
+use doublezero_serviceability::state::topology::TopologyConstraint;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct CreateTopologyCliCommand {
+    /// Name of the topology (max 32 bytes)
+    #[arg(long)]
+    pub name: String,
+    /// Constraint type: include-any or exclude
+    #[arg(long, value_parser = parse_constraint)]
+    pub constraint: TopologyConstraint,
+}
+
+fn parse_constraint(s: &str) -> Result<TopologyConstraint, String> {
+    match s {
+        "include-any" => Ok(TopologyConstraint::IncludeAny),
+        "exclude" => Ok(TopologyConstraint::Exclude),
+        _ => Err(format!(
+            "invalid constraint '{}': expected 'include-any' or 'exclude'",
+            s
+        )),
+    }
+}
+
+impl CreateTopologyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        if self.name.len() > 32 {
+            eyre::bail!(
+                "topology name must be 32 characters or fewer (got {})",
+                self.name.len()
+            );
+        }
+
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        let (_, topology_pda) = client.create_topology(CreateTopologyCommand {
+            name: self.name.clone(),
+            constraint: self.constraint,
+        })?;
+        writeln!(
+            out,
+            "Created topology '{}' successfully. PDA: {}",
+            self.name, topology_pda
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doublezerocommand::MockCliCommand;
+    use doublezero_serviceability::state::topology::TopologyConstraint;
+    use mockall::predicate::eq;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::io::Cursor;
+
+    #[test]
+    fn test_create_topology_execute_success() {
+        let mut mock = MockCliCommand::new();
+        let topology_pda = Pubkey::new_unique();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_create_topology()
+            .with(eq(CreateTopologyCommand {
+                name: "unicast-default".to_string(),
+                constraint: TopologyConstraint::IncludeAny,
+            }))
+            .returning(move |_| Ok((Signature::new_unique(), topology_pda)));
+
+        let cmd = CreateTopologyCliCommand {
+            name: "unicast-default".to_string(),
+            constraint: TopologyConstraint::IncludeAny,
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("Created topology 'unicast-default' successfully."));
+        assert!(output.contains(&topology_pda.to_string()));
+    }
+
+    #[test]
+    fn test_parse_constraint_include_any() {
+        assert_eq!(
+            parse_constraint("include-any"),
+            Ok(TopologyConstraint::IncludeAny)
+        );
+    }
+
+    #[test]
+    fn test_parse_constraint_exclude() {
+        assert_eq!(parse_constraint("exclude"), Ok(TopologyConstraint::Exclude));
+    }
+
+    #[test]
+    fn test_parse_constraint_invalid() {
+        assert!(parse_constraint("unknown").is_err());
+    }
+
+    #[test]
+    fn test_create_topology_name_too_long() {
+        let cmd = CreateTopologyCliCommand {
+            name: "a".repeat(33),
+            constraint: TopologyConstraint::IncludeAny,
+        };
+        let mock = MockCliCommand::new();
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("32 characters or fewer"));
+    }
+}

--- a/smartcontract/cli/src/topology/create.rs
+++ b/smartcontract/cli/src/topology/create.rs
@@ -39,14 +39,16 @@ impl CreateTopologyCliCommand {
 
         client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
 
-        let (_, topology_pda) = client.create_topology(CreateTopologyCommand {
+        let result = client.create_topology(CreateTopologyCommand {
             name: self.name.clone(),
             constraint: self.constraint,
         })?;
         writeln!(
             out,
-            "Created topology '{}' successfully. PDA: {}",
-            self.name, topology_pda
+            "Created topology '{}' successfully. PDA: {}. Backfilled {} transaction(s).",
+            self.name,
+            result.topology_pda,
+            result.backfill_signatures.len()
         )?;
 
         Ok(())
@@ -57,6 +59,7 @@ impl CreateTopologyCliCommand {
 mod tests {
     use super::*;
     use crate::doublezerocommand::MockCliCommand;
+    use doublezero_sdk::commands::topology::create::CreateTopologyResult;
     use doublezero_serviceability::state::topology::TopologyConstraint;
     use mockall::predicate::eq;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
@@ -73,7 +76,13 @@ mod tests {
                 name: "unicast-default".to_string(),
                 constraint: TopologyConstraint::IncludeAny,
             }))
-            .returning(move |_| Ok((Signature::new_unique(), topology_pda)));
+            .returning(move |_| {
+                Ok(CreateTopologyResult {
+                    signature: Signature::new_unique(),
+                    topology_pda,
+                    backfill_signatures: vec![],
+                })
+            });
 
         let cmd = CreateTopologyCliCommand {
             name: "unicast-default".to_string(),
@@ -85,6 +94,7 @@ mod tests {
         let output = String::from_utf8(out.into_inner()).unwrap();
         assert!(output.contains("Created topology 'unicast-default' successfully."));
         assert!(output.contains(&topology_pda.to_string()));
+        assert!(output.contains("Backfilled 0 transaction(s)."));
     }
 
     #[test]

--- a/smartcontract/cli/src/topology/delete.rs
+++ b/smartcontract/cli/src/topology/delete.rs
@@ -1,0 +1,141 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_sdk::{
+    commands::{link::list::ListLinkCommand, topology::delete::DeleteTopologyCommand},
+    get_topology_pda,
+};
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct DeleteTopologyCliCommand {
+    /// Name of the topology to delete
+    #[arg(long)]
+    pub name: String,
+}
+
+impl DeleteTopologyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        // Guard: check if any links still reference this topology
+        let program_id = client.get_program_id();
+        let topology_pda = get_topology_pda(&program_id, &self.name).0;
+        let links = client.list_link(ListLinkCommand)?;
+        let referencing_count = links
+            .values()
+            .filter(|link| link.link_topologies.contains(&topology_pda))
+            .count();
+        if referencing_count > 0 {
+            return Err(eyre::eyre!(
+                "Cannot delete topology '{}': {} link(s) still reference it. Run 'doublezero link topology clear --name {}' first.",
+                self.name,
+                referencing_count,
+                self.name,
+            ));
+        }
+
+        client.delete_topology(DeleteTopologyCommand {
+            name: self.name.clone(),
+        })?;
+        writeln!(out, "Deleted topology '{}' successfully.", self.name)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{doublezerocommand::MockCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::{
+        commands::topology::delete::DeleteTopologyCommand, get_topology_pda, Link, LinkLinkType,
+        LinkStatus,
+    };
+    use doublezero_serviceability::state::{
+        accounttype::AccountType,
+        link::{LinkDesiredStatus, LinkHealth},
+    };
+    use mockall::predicate::eq;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::{collections::HashMap, io::Cursor};
+
+    #[test]
+    fn test_delete_topology_execute_success() {
+        let mut mock = MockCliCommand::new();
+
+        mock.expect_check_requirements().returning(|_| Ok(()));
+        mock.expect_get_program_id()
+            .returning(|| Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah"));
+        mock.expect_list_link().returning(|_| Ok(HashMap::new()));
+        mock.expect_delete_topology()
+            .with(eq(DeleteTopologyCommand {
+                name: "unicast-default".to_string(),
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let cmd = DeleteTopologyCliCommand {
+            name: "unicast-default".to_string(),
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("Deleted topology 'unicast-default' successfully."));
+    }
+
+    #[test]
+    fn test_delete_topology_blocked_by_referencing_links() {
+        let mut client = create_test_client();
+
+        client.expect_check_requirements().returning(|_| Ok(()));
+
+        let program_id = Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+        let topology_pda = get_topology_pda(&program_id, "unicast-default").0;
+
+        let link = Link {
+            account_type: AccountType::Link,
+            index: 1,
+            bump_seed: 2,
+            code: "link1".to_string(),
+            contributor_pk: Pubkey::new_unique(),
+            side_a_pk: Pubkey::new_unique(),
+            side_z_pk: Pubkey::new_unique(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 10_000_000_000,
+            mtu: 4500,
+            delay_ns: 0,
+            jitter_ns: 0,
+            delay_override_ns: 0,
+            tunnel_id: 1,
+            tunnel_net: "10.0.0.0/30".parse().unwrap(),
+            status: LinkStatus::Activated,
+            owner: Pubkey::new_unique(),
+            side_a_iface_name: "eth0".to_string(),
+            side_z_iface_name: "eth1".to_string(),
+            link_health: LinkHealth::ReadyForService,
+            desired_status: LinkDesiredStatus::Activated,
+            link_topologies: vec![topology_pda],
+            link_flags: 0,
+        };
+
+        client.expect_list_link().returning(move |_| {
+            let mut links = HashMap::new();
+            links.insert(Pubkey::new_unique(), link.clone());
+            Ok(links)
+        });
+
+        let cmd = DeleteTopologyCliCommand {
+            name: "unicast-default".to_string(),
+        };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&client, &mut out);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Cannot delete topology 'unicast-default'"));
+        assert!(err.contains("1 link(s) still reference it"));
+        assert!(err.contains("doublezero link topology clear --name unicast-default"));
+    }
+}

--- a/smartcontract/cli/src/topology/list.rs
+++ b/smartcontract/cli/src/topology/list.rs
@@ -1,0 +1,258 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_sdk::commands::{link::list::ListLinkCommand, topology::list::ListTopologyCommand};
+use serde::Serialize;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct ListTopologyCliCommand {
+    /// Output as pretty JSON.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Serialize)]
+pub struct TopologyDisplay {
+    pub name: String,
+    pub bit: u8,
+    pub algo: u8,
+    pub color: u16,
+    pub constraint: String,
+    pub links: usize,
+}
+
+impl ListTopologyCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let topologies = client.list_topology(ListTopologyCommand)?;
+
+        if topologies.is_empty() {
+            writeln!(out, "No topologies found.")?;
+            return Ok(());
+        }
+
+        let links = client.list_link(ListLinkCommand)?;
+
+        let mut entries: Vec<_> = topologies.into_iter().collect();
+        entries.sort_by_key(|(_, t)| t.admin_group_bit);
+
+        let displays: Vec<TopologyDisplay> = entries
+            .iter()
+            .map(|(pda, t)| {
+                let link_count = links
+                    .values()
+                    .filter(|link| link.link_topologies.contains(pda))
+                    .count();
+                TopologyDisplay {
+                    name: t.name.clone(),
+                    bit: t.admin_group_bit,
+                    algo: t.flex_algo_number,
+                    color: t.admin_group_bit as u16 + 1,
+                    constraint: format!("{:?}", t.constraint),
+                    links: link_count,
+                }
+            })
+            .collect();
+
+        if self.json {
+            serde_json::to_writer_pretty(&mut *out, &displays)?;
+            writeln!(out)?;
+            return Ok(());
+        }
+
+        writeln!(
+            out,
+            "{:<32}  {:>3}  {:>4}  {:>5}  {:>5}  {:?}",
+            "NAME", "BIT", "ALGO", "COLOR", "LINKS", "CONSTRAINT"
+        )?;
+        for d in &displays {
+            writeln!(
+                out,
+                "{:<32}  {:>3}  {:>4}  {:>5}  {:>5}  {}",
+                d.name, d.bit, d.algo, d.color, d.links, d.constraint,
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{doublezerocommand::MockCliCommand, tests::utils::create_test_client};
+    use doublezero_sdk::{get_topology_pda, Link, LinkLinkType, LinkStatus};
+    use doublezero_serviceability::state::{
+        accounttype::AccountType,
+        link::{LinkDesiredStatus, LinkHealth},
+        topology::{TopologyConstraint, TopologyInfo},
+    };
+    use solana_sdk::pubkey::Pubkey;
+    use std::{collections::HashMap, io::Cursor};
+
+    #[test]
+    fn test_list_topology_empty() {
+        let mut mock = MockCliCommand::new();
+
+        mock.expect_list_topology()
+            .with(mockall::predicate::eq(ListTopologyCommand))
+            .returning(|_| Ok(HashMap::new()));
+
+        let cmd = ListTopologyCliCommand { json: false };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&mock, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("No topologies found."));
+    }
+
+    #[test]
+    fn test_list_topology_with_entries() {
+        let mut client = create_test_client();
+
+        let program_id = Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+        let (topology_pda, _) = get_topology_pda(&program_id, "unicast-default");
+
+        let topology = TopologyInfo {
+            account_type: AccountType::Topology,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            name: "unicast-default".to_string(),
+            admin_group_bit: 0,
+            flex_algo_number: 128,
+            constraint: TopologyConstraint::IncludeAny,
+            reference_count: 0,
+        };
+
+        client
+            .expect_list_topology()
+            .with(mockall::predicate::eq(ListTopologyCommand))
+            .returning(move |_| {
+                let mut map = HashMap::new();
+                map.insert(topology_pda, topology.clone());
+                Ok(map)
+            });
+
+        client.expect_list_link().returning(|_| Ok(HashMap::new()));
+
+        let cmd = ListTopologyCliCommand { json: false };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&client, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(output.contains("unicast-default"));
+        assert!(output.contains("128"));
+        assert!(output.contains("LINKS"));
+    }
+
+    #[test]
+    fn test_list_topology_link_count() {
+        let mut client = create_test_client();
+
+        let program_id = Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+        let (topology_pda, _) = get_topology_pda(&program_id, "unicast-default");
+
+        let topology = TopologyInfo {
+            account_type: AccountType::Topology,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            name: "unicast-default".to_string(),
+            admin_group_bit: 0,
+            flex_algo_number: 128,
+            constraint: TopologyConstraint::IncludeAny,
+            reference_count: 0,
+        };
+
+        client
+            .expect_list_topology()
+            .with(mockall::predicate::eq(ListTopologyCommand))
+            .returning(move |_| {
+                let mut map = HashMap::new();
+                map.insert(topology_pda, topology.clone());
+                Ok(map)
+            });
+
+        let link = Link {
+            account_type: AccountType::Link,
+            index: 1,
+            bump_seed: 2,
+            code: "link1".to_string(),
+            contributor_pk: Pubkey::new_unique(),
+            side_a_pk: Pubkey::new_unique(),
+            side_z_pk: Pubkey::new_unique(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 10_000_000_000,
+            mtu: 4500,
+            delay_ns: 0,
+            jitter_ns: 0,
+            delay_override_ns: 0,
+            tunnel_id: 1,
+            tunnel_net: "10.0.0.0/30".parse().unwrap(),
+            status: LinkStatus::Activated,
+            owner: Pubkey::new_unique(),
+            side_a_iface_name: "eth0".to_string(),
+            side_z_iface_name: "eth1".to_string(),
+            link_health: LinkHealth::ReadyForService,
+            desired_status: LinkDesiredStatus::Activated,
+            link_topologies: vec![topology_pda],
+            link_flags: 0,
+        };
+
+        client.expect_list_link().returning(move |_| {
+            let mut links = HashMap::new();
+            links.insert(Pubkey::new_unique(), link.clone());
+            Ok(links)
+        });
+
+        let cmd = ListTopologyCliCommand { json: false };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&client, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        assert!(
+            output.contains("    1"),
+            "expected link count 1 in output: {output}"
+        );
+    }
+
+    #[test]
+    fn test_list_topology_json_output() {
+        let mut client = create_test_client();
+
+        let program_id = Pubkey::from_str_const("GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah");
+        let (topology_pda, _) = get_topology_pda(&program_id, "unicast-default");
+
+        let topology = TopologyInfo {
+            account_type: AccountType::Topology,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            name: "unicast-default".to_string(),
+            admin_group_bit: 0,
+            flex_algo_number: 128,
+            constraint: TopologyConstraint::IncludeAny,
+            reference_count: 0,
+        };
+
+        client
+            .expect_list_topology()
+            .with(mockall::predicate::eq(ListTopologyCommand))
+            .returning(move |_| {
+                let mut map = HashMap::new();
+                map.insert(topology_pda, topology.clone());
+                Ok(map)
+            });
+
+        client.expect_list_link().returning(|_| Ok(HashMap::new()));
+
+        let cmd = ListTopologyCliCommand { json: true };
+        let mut out = Cursor::new(Vec::new());
+        let result = cmd.execute(&client, &mut out);
+        assert!(result.is_ok());
+        let output = String::from_utf8(out.into_inner()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert!(parsed.is_array());
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "unicast-default");
+        assert_eq!(arr[0]["links"], 0);
+    }
+}

--- a/smartcontract/cli/src/topology/mod.rs
+++ b/smartcontract/cli/src/topology/mod.rs
@@ -1,0 +1,5 @@
+pub mod backfill;
+pub mod clear;
+pub mod create;
+pub mod delete;
+pub mod list;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/topology/backfill.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/topology/backfill.rs
@@ -1,10 +1,7 @@
 use crate::{
     error::DoubleZeroError,
-    pda::{get_device_pda, get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
-    processors::{
-        resource::{allocate_id, allocate_specific_id},
-        validation::validate_program_account,
-    },
+    pda::{get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
+    processors::{resource::allocate_id, validation::validate_program_account},
     resource::ResourceType,
     serializer::try_acc_write,
     state::{
@@ -111,35 +108,9 @@ pub fn process_topology_backfill(
     let mut backfilled_count: usize = 0;
     let mut skipped_count: usize = 0;
 
-    // Collect device accounts for two-pass processing.
     let device_accounts: Vec<&AccountInfo> = accounts_iter.collect();
 
-    // First pass: pre-mark all existing node_segment_idx values as used in the
-    // SegmentRoutingIds resource. This prevents collisions when the activator
-    // manages SR IDs in-memory (use_onchain_allocation=false) and the on-chain
-    // resource hasn't been updated to reflect those allocations.
-    for device_account in &device_accounts {
-        validate_program_account!(*device_account, program_id, writable = true, "Device");
-        let device = Device::try_from(&device_account.data.borrow()[..])?;
-        assert_eq!(
-            device_account.key,
-            &get_device_pda(program_id, device.index).0,
-            "Invalid Device PDA"
-        );
-        for iface in device.interfaces.iter() {
-            let current = iface.into_current_version();
-            if current.node_segment_idx > 0 {
-                // Ignore error: ID may already be marked (idempotent pre-mark).
-                let _ = allocate_specific_id(segment_routing_ids_account, current.node_segment_idx);
-            }
-            for fas in &current.flex_algo_node_segments {
-                let _ = allocate_specific_id(segment_routing_ids_account, fas.node_segment_idx);
-            }
-        }
-    }
-
-    // Second pass: allocate new IDs for loopbacks missing this topology's segment.
-    // Device accounts were fully validated in the first pass above.
+    // Allocate new IDs for loopbacks missing this topology's segment.
     for device_account in &device_accounts {
         let mut device = Device::try_from(&device_account.data.borrow()[..])?;
         let mut modified = false;

--- a/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
@@ -1824,13 +1824,17 @@ async fn test_topology_backfill_nonexistent_topology_rejected() {
 }
 
 #[tokio::test]
-async fn test_topology_backfill_avoids_collision_with_existing_node_segment_idx() {
-    // Regression test: BackfillTopology must not re-use the base node_segment_idx
-    // when the on-chain SegmentRoutingIds resource was never updated by the activator
-    // (use_onchain_allocation=false path). Before the fix, backfill would allocate
-    // ID 1 for the flex-algo segment even though ID 1 was already used as the base
-    // node_segment_idx on the loopback.
-    println!("[TEST] test_topology_backfill_avoids_collision_with_existing_node_segment_idx");
+async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
+    // BackfillTopology allocates the flex-algo node_segment_idx from the on-chain
+    // SegmentRoutingIds resource. Keeping the resource in sync with off-chain base
+    // node_segment_idx values is the activator's responsibility (see the
+    // use_onchain_allocation path); backfill does not second-guess it.
+    //
+    // This scenario exercises the use_onchain_allocation=false setup: the loopback
+    // is activated with base node_segment_idx=1 without updating the on-chain SR
+    // resource, so backfill's allocate_id call also returns 1. That is the expected
+    // behavior — the activator must reconcile.
+    println!("[TEST] test_topology_backfill_allocates_sr_id_from_onchain_resource");
 
     let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
         setup_program_with_globalconfig().await;
@@ -2035,8 +2039,9 @@ async fn test_topology_backfill_avoids_collision_with_existing_node_segment_idx(
     )
     .await;
 
-    // Step 9: Call BackfillTopology. With the fix, the pre-mark pass marks ID 1 as used
-    // before allocating, so the flex-algo segment receives ID 2 (not 1).
+    // Step 9: Call BackfillTopology. allocate_id draws from the on-chain SR resource,
+    // which still believes ID 1 is free (the activator took the off-chain path in
+    // step 7), so the flex-algo segment also receives ID 1.
     let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
     let base_accounts = vec![
         AccountMeta::new_readonly(topology_pda, false),
@@ -2056,7 +2061,8 @@ async fn test_topology_backfill_avoids_collision_with_existing_node_segment_idx(
     tx.try_sign(&[&payer], recent_blockhash).unwrap();
     banks_client.process_transaction(tx).await.unwrap();
 
-    // Verify: flex-algo segment has node_segment_idx=2, NOT 1 (which is the base idx).
+    // Verify: backfill ran and stored a flex-algo segment for this topology, with
+    // an idx allocated from the on-chain SR resource (which still had ID 1 free).
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found after backfill");
@@ -2075,11 +2081,12 @@ async fn test_topology_backfill_avoids_collision_with_existing_node_segment_idx(
         "Segment should point to the backfilled topology"
     );
     assert_eq!(
-        iface.flex_algo_node_segments[0].node_segment_idx, 2,
-        "flex-algo node_segment_idx must be 2 (fresh allocation), not 1 (base)"
+        iface.flex_algo_node_segments[0].node_segment_idx, 1,
+        "flex-algo node_segment_idx is allocated from the on-chain SR resource; \
+         ID 1 is still free there because the activator did not sync it"
     );
 
-    println!("[PASS] test_topology_backfill_avoids_collision_with_existing_node_segment_idx");
+    println!("[PASS] test_topology_backfill_allocates_sr_id_from_onchain_resource");
 }
 
 // ============================================================================

--- a/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
@@ -1826,14 +1826,15 @@ async fn test_topology_backfill_nonexistent_topology_rejected() {
 #[tokio::test]
 async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     // BackfillTopology allocates the flex-algo node_segment_idx from the on-chain
-    // SegmentRoutingIds resource. Keeping the resource in sync with off-chain base
-    // node_segment_idx values is the activator's responsibility (see the
-    // use_onchain_allocation path); backfill does not second-guess it.
+    // SegmentRoutingIds resource. Keeping that resource in sync with the base
+    // node_segment_idx stored on an interface only happens when the interface is
+    // activated with onchain allocation enabled; backfill does not second-guess
+    // the resource.
     //
-    // This scenario exercises the use_onchain_allocation=false setup: the loopback
-    // is activated with base node_segment_idx=1 without updating the on-chain SR
-    // resource, so backfill's allocate_id call also returns 1. That is the expected
-    // behavior — the activator must reconcile.
+    // This scenario activates the loopback with onchain allocation disabled: the
+    // base node_segment_idx is set to 1 directly on the interface, and the on-chain
+    // SR resource is left untouched. Backfill's allocate_id call therefore also
+    // returns 1 — the expected behavior when the SR resource was never updated.
     println!("[TEST] test_topology_backfill_allocates_sr_id_from_onchain_resource");
 
     let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
@@ -1989,9 +1990,9 @@ async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     .await;
 
     // Step 7: Activate the loopback with explicit node_segment_idx=1, WITHOUT providing
-    // the SegmentRoutingIds account. This simulates the activator's use_onchain_allocation=false
-    // path: the base SR ID is set to 1 but the on-chain resource is never updated, so the
-    // resource still believes ID 1 is free.
+    // the SegmentRoutingIds account. This is the use_onchain_allocation=false path:
+    // the base SR ID is stored directly on the interface and the on-chain resource
+    // is never updated, so the resource still believes ID 1 is free.
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -2040,8 +2041,8 @@ async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     .await;
 
     // Step 9: Call BackfillTopology. allocate_id draws from the on-chain SR resource,
-    // which still believes ID 1 is free (the activator took the off-chain path in
-    // step 7), so the flex-algo segment also receives ID 1.
+    // which still believes ID 1 is free (step 7 used the off-chain allocation path),
+    // so the flex-algo segment also receives ID 1.
     let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
     let base_accounts = vec![
         AccountMeta::new_readonly(topology_pda, false),
@@ -2083,7 +2084,8 @@ async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     assert_eq!(
         iface.flex_algo_node_segments[0].node_segment_idx, 1,
         "flex-algo node_segment_idx is allocated from the on-chain SR resource; \
-         ID 1 is still free there because the activator did not sync it"
+         ID 1 is still free there because the interface was activated with onchain \
+         allocation disabled"
     );
 
     println!("[PASS] test_topology_backfill_allocates_sr_id_from_onchain_resource");

--- a/smartcontract/sdk/rs/src/commands/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/mod.rs
@@ -14,4 +14,5 @@ pub mod permission;
 pub mod programconfig;
 pub mod resource;
 pub mod tenant;
+pub mod topology;
 pub mod user;

--- a/smartcontract/sdk/rs/src/commands/topology/backfill.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/backfill.rs
@@ -1,0 +1,138 @@
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_resource_extension_pda, get_topology_pda},
+    processors::topology::backfill::TopologyBackfillArgs,
+    resource::ResourceType,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BackfillTopologyCommand {
+    pub name: String,
+    pub device_pubkeys: Vec<Pubkey>,
+}
+
+impl BackfillTopologyCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), &self.name);
+        let (segment_routing_ids_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
+
+        let payer = client.get_payer();
+
+        let mut accounts = vec![
+            AccountMeta::new_readonly(topology_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+            AccountMeta::new(payer, true),
+        ];
+
+        for device_pk in &self.device_pubkeys {
+            accounts.push(AccountMeta::new(*device_pk, false));
+        }
+
+        client.execute_transaction(
+            DoubleZeroInstruction::BackfillTopology(TopologyBackfillArgs {
+                name: self.name.clone(),
+            }),
+            accounts,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::topology::backfill::BackfillTopologyCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
+        processors::topology::backfill::TopologyBackfillArgs,
+        resource::ResourceType,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_topology_backfill_no_devices() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "unicast-default");
+        let (sr_ids_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
+        let payer = client.get_payer();
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::BackfillTopology(
+                    TopologyBackfillArgs {
+                        name: "unicast-default".to_string(),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new_readonly(topology_pda, false),
+                    AccountMeta::new(sr_ids_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(payer, true),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = BackfillTopologyCommand {
+            name: "unicast-default".to_string(),
+            device_pubkeys: vec![],
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_commands_topology_backfill_with_devices() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "algo128");
+        let (sr_ids_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
+        let payer = client.get_payer();
+        let device1 = Pubkey::new_unique();
+        let device2 = Pubkey::new_unique();
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::BackfillTopology(
+                    TopologyBackfillArgs {
+                        name: "algo128".to_string(),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new_readonly(topology_pda, false),
+                    AccountMeta::new(sr_ids_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(payer, true),
+                    AccountMeta::new(device1, false),
+                    AccountMeta::new(device2, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = BackfillTopologyCommand {
+            name: "algo128".to_string(),
+            device_pubkeys: vec![device1, device2],
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/topology/backfill.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/backfill.rs
@@ -7,6 +7,11 @@ use doublezero_serviceability::{
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
+/// Max device accounts per backfill transaction. Solana caps transactions at
+/// 32 accounts; with 4 fixed accounts (topology PDA, segment_routing_ids PDA,
+/// globalstate, payer) we stay well under that limit at 16.
+pub const BACKFILL_BATCH_SIZE: usize = 16;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct BackfillTopologyCommand {
     pub name: String,
@@ -14,7 +19,7 @@ pub struct BackfillTopologyCommand {
 }
 
 impl BackfillTopologyCommand {
-    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Vec<Signature>> {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
@@ -25,30 +30,38 @@ impl BackfillTopologyCommand {
 
         let payer = client.get_payer();
 
-        let mut accounts = vec![
+        let fixed_accounts = [
             AccountMeta::new_readonly(topology_pda, false),
             AccountMeta::new(segment_routing_ids_pda, false),
             AccountMeta::new_readonly(globalstate_pubkey, false),
             AccountMeta::new(payer, true),
         ];
 
-        for device_pk in &self.device_pubkeys {
-            accounts.push(AccountMeta::new(*device_pk, false));
+        let mut signatures = Vec::new();
+        for chunk in self.device_pubkeys.chunks(BACKFILL_BATCH_SIZE) {
+            let mut accounts = fixed_accounts.to_vec();
+            for device_pk in chunk {
+                accounts.push(AccountMeta::new(*device_pk, false));
+            }
+
+            let sig = client.execute_transaction(
+                DoubleZeroInstruction::BackfillTopology(TopologyBackfillArgs {
+                    name: self.name.clone(),
+                }),
+                accounts,
+            )?;
+            signatures.push(sig);
         }
 
-        client.execute_transaction(
-            DoubleZeroInstruction::BackfillTopology(TopologyBackfillArgs {
-                name: self.name.clone(),
-            }),
-            accounts,
-        )
+        Ok(signatures)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        commands::topology::backfill::BackfillTopologyCommand, tests::utils::create_test_client,
+        commands::topology::backfill::{BackfillTopologyCommand, BACKFILL_BATCH_SIZE},
+        tests::utils::create_test_client,
         DoubleZeroClient,
     };
     use doublezero_serviceability::{
@@ -57,35 +70,12 @@ mod tests {
         processors::topology::backfill::TopologyBackfillArgs,
         resource::ResourceType,
     };
-    use mockall::predicate;
+    use mockall::{predicate, Sequence};
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
-    fn test_commands_topology_backfill_no_devices() {
-        let mut client = create_test_client();
-
-        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
-        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "unicast-default");
-        let (sr_ids_pda, _, _) =
-            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
-        let payer = client.get_payer();
-
-        client
-            .expect_execute_transaction()
-            .with(
-                predicate::eq(DoubleZeroInstruction::BackfillTopology(
-                    TopologyBackfillArgs {
-                        name: "unicast-default".to_string(),
-                    },
-                )),
-                predicate::eq(vec![
-                    AccountMeta::new_readonly(topology_pda, false),
-                    AccountMeta::new(sr_ids_pda, false),
-                    AccountMeta::new_readonly(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                ]),
-            )
-            .returning(|_, _| Ok(Signature::new_unique()));
+    fn test_commands_topology_backfill_no_devices_sends_no_tx() {
+        let client = create_test_client();
 
         let res = BackfillTopologyCommand {
             name: "unicast-default".to_string(),
@@ -93,7 +83,7 @@ mod tests {
         }
         .execute(&client);
 
-        assert!(res.is_ok());
+        assert!(res.unwrap().is_empty());
     }
 
     #[test]
@@ -133,6 +123,55 @@ mod tests {
         }
         .execute(&client);
 
-        assert!(res.is_ok());
+        assert_eq!(res.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_commands_topology_backfill_batches_at_16() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "algo128");
+        let (sr_ids_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
+        let payer = client.get_payer();
+
+        let devices: Vec<Pubkey> = (0..33).map(|_| Pubkey::new_unique()).collect();
+
+        let fixed_accounts = vec![
+            AccountMeta::new_readonly(topology_pda, false),
+            AccountMeta::new(sr_ids_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+            AccountMeta::new(payer, true),
+        ];
+
+        let expected_args = DoubleZeroInstruction::BackfillTopology(TopologyBackfillArgs {
+            name: "algo128".to_string(),
+        });
+
+        let mut seq = Sequence::new();
+        for chunk in devices.chunks(BACKFILL_BATCH_SIZE) {
+            let mut expected_accounts = fixed_accounts.clone();
+            for device_pk in chunk {
+                expected_accounts.push(AccountMeta::new(*device_pk, false));
+            }
+            client
+                .expect_execute_transaction()
+                .times(1)
+                .in_sequence(&mut seq)
+                .with(
+                    predicate::eq(expected_args.clone()),
+                    predicate::eq(expected_accounts),
+                )
+                .returning(|_, _| Ok(Signature::new_unique()));
+        }
+
+        let res = BackfillTopologyCommand {
+            name: "algo128".to_string(),
+            device_pubkeys: devices,
+        }
+        .execute(&client);
+
+        assert_eq!(res.unwrap().len(), 3);
     }
 }

--- a/smartcontract/sdk/rs/src/commands/topology/clear.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/clear.rs
@@ -1,0 +1,122 @@
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_topology_pda,
+    processors::topology::clear::TopologyClearArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClearTopologyCommand {
+    pub name: String,
+    pub link_pubkeys: Vec<Pubkey>,
+}
+
+impl ClearTopologyCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), &self.name);
+
+        let payer = client.get_payer();
+
+        let mut accounts = vec![
+            AccountMeta::new_readonly(topology_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+            AccountMeta::new(payer, true),
+        ];
+
+        for link_pk in &self.link_pubkeys {
+            accounts.push(AccountMeta::new(*link_pk, false));
+        }
+
+        client.execute_transaction(
+            DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
+                name: self.name.clone(),
+            }),
+            accounts,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::topology::clear::ClearTopologyCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_topology_pda},
+        processors::topology::clear::TopologyClearArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_topology_clear_command_no_links() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "my-topology");
+        let payer = client.get_payer();
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
+                    name: "my-topology".to_string(),
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new_readonly(topology_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(payer, true),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = ClearTopologyCommand {
+            name: "my-topology".to_string(),
+            link_pubkeys: vec![],
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_commands_topology_clear_command_with_links() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "my-topology");
+        let payer = client.get_payer();
+        let link1 = Pubkey::new_unique();
+        let link2 = Pubkey::new_unique();
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
+                    name: "my-topology".to_string(),
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new_readonly(topology_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(payer, true),
+                    AccountMeta::new(link1, false),
+                    AccountMeta::new(link2, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = ClearTopologyCommand {
+            name: "my-topology".to_string(),
+            link_pubkeys: vec![link1, link2],
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/topology/clear.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/clear.rs
@@ -5,6 +5,11 @@ use doublezero_serviceability::{
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
+/// Max link accounts per clear transaction. Solana caps transactions at 32
+/// accounts; with 3 fixed accounts (topology PDA, globalstate, payer) we
+/// stay well under that limit at 16 (same constant as backfill).
+pub const CLEAR_BATCH_SIZE: usize = 16;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct ClearTopologyCommand {
     pub name: String,
@@ -12,7 +17,7 @@ pub struct ClearTopologyCommand {
 }
 
 impl ClearTopologyCommand {
-    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Vec<Signature>> {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
@@ -21,29 +26,37 @@ impl ClearTopologyCommand {
 
         let payer = client.get_payer();
 
-        let mut accounts = vec![
+        let fixed_accounts = [
             AccountMeta::new_readonly(topology_pda, false),
             AccountMeta::new_readonly(globalstate_pubkey, false),
             AccountMeta::new(payer, true),
         ];
 
-        for link_pk in &self.link_pubkeys {
-            accounts.push(AccountMeta::new(*link_pk, false));
+        let mut signatures = Vec::new();
+        for chunk in self.link_pubkeys.chunks(CLEAR_BATCH_SIZE) {
+            let mut accounts = fixed_accounts.to_vec();
+            for link_pk in chunk {
+                accounts.push(AccountMeta::new(*link_pk, false));
+            }
+
+            let sig = client.execute_transaction(
+                DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
+                    name: self.name.clone(),
+                }),
+                accounts,
+            )?;
+            signatures.push(sig);
         }
 
-        client.execute_transaction(
-            DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
-                name: self.name.clone(),
-            }),
-            accounts,
-        )
+        Ok(signatures)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        commands::topology::clear::ClearTopologyCommand, tests::utils::create_test_client,
+        commands::topology::clear::{ClearTopologyCommand, CLEAR_BATCH_SIZE},
+        tests::utils::create_test_client,
         DoubleZeroClient,
     };
     use doublezero_serviceability::{
@@ -51,30 +64,12 @@ mod tests {
         pda::{get_globalstate_pda, get_topology_pda},
         processors::topology::clear::TopologyClearArgs,
     };
-    use mockall::predicate;
+    use mockall::{predicate, Sequence};
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
     #[test]
-    fn test_commands_topology_clear_command_no_links() {
-        let mut client = create_test_client();
-
-        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
-        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "my-topology");
-        let payer = client.get_payer();
-
-        client
-            .expect_execute_transaction()
-            .with(
-                predicate::eq(DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
-                    name: "my-topology".to_string(),
-                })),
-                predicate::eq(vec![
-                    AccountMeta::new_readonly(topology_pda, false),
-                    AccountMeta::new_readonly(globalstate_pubkey, false),
-                    AccountMeta::new(payer, true),
-                ]),
-            )
-            .returning(|_, _| Ok(Signature::new_unique()));
+    fn test_commands_topology_clear_command_no_links_sends_no_tx() {
+        let client = create_test_client();
 
         let res = ClearTopologyCommand {
             name: "my-topology".to_string(),
@@ -82,7 +77,7 @@ mod tests {
         }
         .execute(&client);
 
-        assert!(res.is_ok());
+        assert!(res.unwrap().is_empty());
     }
 
     #[test]
@@ -117,6 +112,52 @@ mod tests {
         }
         .execute(&client);
 
-        assert!(res.is_ok());
+        assert_eq!(res.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_commands_topology_clear_batches_at_16() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "my-topology");
+        let payer = client.get_payer();
+
+        let links: Vec<Pubkey> = (0..33).map(|_| Pubkey::new_unique()).collect();
+
+        let fixed_accounts = vec![
+            AccountMeta::new_readonly(topology_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+            AccountMeta::new(payer, true),
+        ];
+
+        let expected_args = DoubleZeroInstruction::ClearTopology(TopologyClearArgs {
+            name: "my-topology".to_string(),
+        });
+
+        let mut seq = Sequence::new();
+        for chunk in links.chunks(CLEAR_BATCH_SIZE) {
+            let mut expected_accounts = fixed_accounts.clone();
+            for link_pk in chunk {
+                expected_accounts.push(AccountMeta::new(*link_pk, false));
+            }
+            client
+                .expect_execute_transaction()
+                .times(1)
+                .in_sequence(&mut seq)
+                .with(
+                    predicate::eq(expected_args.clone()),
+                    predicate::eq(expected_accounts),
+                )
+                .returning(|_, _| Ok(Signature::new_unique()));
+        }
+
+        let res = ClearTopologyCommand {
+            name: "my-topology".to_string(),
+            link_pubkeys: links,
+        }
+        .execute(&client);
+
+        assert_eq!(res.unwrap().len(), 3);
     }
 }

--- a/smartcontract/sdk/rs/src/commands/topology/create.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/create.rs
@@ -1,10 +1,16 @@
-use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use crate::{
+    commands::{
+        device::list::ListDeviceCommand, globalstate::get::GetGlobalStateCommand,
+        topology::backfill::BackfillTopologyCommand,
+    },
+    DoubleZeroClient,
+};
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
     pda::{get_resource_extension_pda, get_topology_pda},
     processors::topology::create::TopologyCreateArgs,
     resource::ResourceType,
-    state::topology::TopologyConstraint,
+    state::{interface::LoopbackType, topology::TopologyConstraint},
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
@@ -14,8 +20,15 @@ pub struct CreateTopologyCommand {
     pub constraint: TopologyConstraint,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTopologyResult {
+    pub signature: Signature,
+    pub topology_pda: Pubkey,
+    pub backfill_signatures: Vec<Signature>,
+}
+
 impl CreateTopologyCommand {
-    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Signature, Pubkey)> {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<CreateTopologyResult> {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
@@ -33,24 +46,52 @@ impl CreateTopologyCommand {
             )
         })?;
 
-        client
-            .execute_transaction(
-                DoubleZeroInstruction::CreateTopology(TopologyCreateArgs {
-                    name: self.name.clone(),
-                    constraint: self.constraint,
-                }),
-                vec![
-                    AccountMeta::new(topology_pda, false),
-                    AccountMeta::new(admin_group_bits_pda, false),
-                    AccountMeta::new_readonly(globalstate_pubkey, false),
-                ],
-            )
-            .map(|sig| (sig, topology_pda))
+        let signature = client.execute_transaction(
+            DoubleZeroInstruction::CreateTopology(TopologyCreateArgs {
+                name: self.name.clone(),
+                constraint: self.constraint,
+            }),
+            vec![
+                AccountMeta::new(topology_pda, false),
+                AccountMeta::new(admin_group_bits_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )?;
+
+        // Enumerate devices and backfill FlexAlgoNodeSegment entries on Vpnv4
+        // loopbacks. Mirrors the processor's filter at
+        // programs/doublezero-serviceability/src/processors/topology/backfill.rs
+        let devices = ListDeviceCommand.execute(client)?;
+        let mut device_pubkeys: Vec<Pubkey> = devices
+            .into_iter()
+            .filter(|(_, device)| {
+                device
+                    .interfaces
+                    .iter()
+                    .any(|i| i.into_current_version().loopback_type == LoopbackType::Vpnv4)
+            })
+            .map(|(pk, _)| pk)
+            .collect();
+        device_pubkeys.sort();
+
+        let backfill_signatures = BackfillTopologyCommand {
+            name: self.name.clone(),
+            device_pubkeys,
+        }
+        .execute(client)?;
+
+        Ok(CreateTopologyResult {
+            signature,
+            topology_pda,
+            backfill_signatures,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::{
         commands::topology::create::CreateTopologyCommand, tests::utils::create_test_client,
         DoubleZeroClient,
@@ -58,12 +99,20 @@ mod tests {
     use doublezero_serviceability::{
         instructions::DoubleZeroInstruction,
         pda::{get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
-        processors::topology::create::TopologyCreateArgs,
+        processors::topology::{backfill::TopologyBackfillArgs, create::TopologyCreateArgs},
         resource::ResourceType,
-        state::topology::TopologyConstraint,
+        state::{
+            accountdata::AccountData,
+            accounttype::AccountType,
+            device::Device,
+            interface::{Interface, InterfaceV3, LoopbackType},
+            topology::TopologyConstraint,
+        },
     };
-    use mockall::predicate;
-    use solana_sdk::{account::Account, instruction::AccountMeta, signature::Signature};
+    use mockall::{predicate, Sequence};
+    use solana_sdk::{
+        account::Account, instruction::AccountMeta, pubkey::Pubkey, signature::Signature,
+    };
 
     #[test]
     fn test_commands_topology_create_command() {
@@ -94,6 +143,11 @@ mod tests {
             )
             .returning(|_, _| Ok(Signature::new_unique()));
 
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Device))
+            .returning(|_| Ok(HashMap::new()));
+
         let res = CreateTopologyCommand {
             name: "unicast-default".to_string(),
             constraint: TopologyConstraint::IncludeAny,
@@ -101,7 +155,103 @@ mod tests {
         .execute(&client);
 
         assert!(res.is_ok());
-        let (_, pda) = res.unwrap();
-        assert_eq!(pda, topology_pda);
+        let result = res.unwrap();
+        assert_eq!(result.topology_pda, topology_pda);
+        assert!(result.backfill_signatures.is_empty());
+    }
+
+    #[test]
+    fn test_commands_topology_create_runs_backfill_for_vpnv4_devices() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "algo128");
+        let (admin_group_bits_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::AdminGroupBits);
+        let (sr_ids_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::SegmentRoutingIds);
+        let payer = client.get_payer();
+
+        let vpnv4_device_pk = Pubkey::new_unique();
+        let vpnv4_device = Device {
+            interfaces: vec![Interface::V3(InterfaceV3 {
+                loopback_type: LoopbackType::Vpnv4,
+                ..Default::default()
+            })],
+            ..Default::default()
+        };
+
+        let other_device_pk = Pubkey::new_unique();
+        let other_device = Device {
+            interfaces: vec![Interface::V3(InterfaceV3 {
+                loopback_type: LoopbackType::None,
+                ..Default::default()
+            })],
+            ..Default::default()
+        };
+
+        client
+            .expect_get_account()
+            .with(predicate::eq(admin_group_bits_pda))
+            .returning(|_| Ok(Account::default()));
+
+        let mut seq = Sequence::new();
+
+        client
+            .expect_execute_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq(DoubleZeroInstruction::CreateTopology(TopologyCreateArgs {
+                    name: "algo128".to_string(),
+                    constraint: TopologyConstraint::IncludeAny,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(topology_pda, false),
+                    AccountMeta::new(admin_group_bits_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Device))
+            .returning(move |_| {
+                let mut devices = HashMap::new();
+                devices.insert(vpnv4_device_pk, AccountData::Device(vpnv4_device.clone()));
+                devices.insert(other_device_pk, AccountData::Device(other_device.clone()));
+                Ok(devices)
+            });
+
+        client
+            .expect_execute_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq(DoubleZeroInstruction::BackfillTopology(
+                    TopologyBackfillArgs {
+                        name: "algo128".to_string(),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new_readonly(topology_pda, false),
+                    AccountMeta::new(sr_ids_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(payer, true),
+                    AccountMeta::new(vpnv4_device_pk, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = CreateTopologyCommand {
+            name: "algo128".to_string(),
+            constraint: TopologyConstraint::IncludeAny,
+        }
+        .execute(&client);
+
+        let result = res.unwrap();
+        assert_eq!(result.topology_pda, topology_pda);
+        assert_eq!(result.backfill_signatures.len(), 1);
     }
 }

--- a/smartcontract/sdk/rs/src/commands/topology/create.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/create.rs
@@ -1,0 +1,107 @@
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_resource_extension_pda, get_topology_pda},
+    processors::topology::create::TopologyCreateArgs,
+    resource::ResourceType,
+    state::topology::TopologyConstraint,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CreateTopologyCommand {
+    pub name: String,
+    pub constraint: TopologyConstraint,
+}
+
+impl CreateTopologyCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Signature, Pubkey)> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), &self.name);
+        let (admin_group_bits_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::AdminGroupBits);
+
+        // Pre-flight: verify admin-group-bits resource account exists
+        client.get_account(admin_group_bits_pda).map_err(|_| {
+            eyre::eyre!(
+                "admin-group-bits resource account not found ({}). \
+                Run 'doublezero resource create --resource-type admin-group-bits' first.",
+                admin_group_bits_pda
+            )
+        })?;
+
+        client
+            .execute_transaction(
+                DoubleZeroInstruction::CreateTopology(TopologyCreateArgs {
+                    name: self.name.clone(),
+                    constraint: self.constraint,
+                }),
+                vec![
+                    AccountMeta::new(topology_pda, false),
+                    AccountMeta::new(admin_group_bits_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ],
+            )
+            .map(|sig| (sig, topology_pda))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::topology::create::CreateTopologyCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
+        processors::topology::create::TopologyCreateArgs,
+        resource::ResourceType,
+        state::topology::TopologyConstraint,
+    };
+    use mockall::predicate;
+    use solana_sdk::{account::Account, instruction::AccountMeta, signature::Signature};
+
+    #[test]
+    fn test_commands_topology_create_command() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "unicast-default");
+        let (admin_group_bits_pda, _, _) =
+            get_resource_extension_pda(&client.get_program_id(), ResourceType::AdminGroupBits);
+
+        client
+            .expect_get_account()
+            .with(predicate::eq(admin_group_bits_pda))
+            .returning(|_| Ok(Account::default()));
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::CreateTopology(TopologyCreateArgs {
+                    name: "unicast-default".to_string(),
+                    constraint: TopologyConstraint::IncludeAny,
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(topology_pda, false),
+                    AccountMeta::new(admin_group_bits_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = CreateTopologyCommand {
+            name: "unicast-default".to_string(),
+            constraint: TopologyConstraint::IncludeAny,
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+        let (_, pda) = res.unwrap();
+        assert_eq!(pda, topology_pda);
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/topology/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/delete.rs
@@ -1,0 +1,74 @@
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_topology_pda,
+    processors::topology::delete::TopologyDeleteArgs,
+};
+use solana_sdk::{instruction::AccountMeta, signature::Signature};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeleteTopologyCommand {
+    pub name: String,
+}
+
+impl DeleteTopologyCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), &self.name);
+
+        client.execute_transaction(
+            DoubleZeroInstruction::DeleteTopology(TopologyDeleteArgs {
+                name: self.name.clone(),
+            }),
+            vec![
+                AccountMeta::new(topology_pda, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::topology::delete::DeleteTopologyCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_topology_pda},
+        processors::topology::delete::TopologyDeleteArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, signature::Signature};
+
+    #[test]
+    fn test_commands_topology_delete_command() {
+        let mut client = create_test_client();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (topology_pda, _) = get_topology_pda(&client.get_program_id(), "unicast-default");
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::DeleteTopology(TopologyDeleteArgs {
+                    name: "unicast-default".to_string(),
+                })),
+                predicate::eq(vec![
+                    AccountMeta::new(topology_pda, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = DeleteTopologyCommand {
+            name: "unicast-default".to_string(),
+        }
+        .execute(&client);
+
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/topology/list.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/list.rs
@@ -1,0 +1,87 @@
+use crate::DoubleZeroClient;
+use doublezero_serviceability::{
+    error::DoubleZeroError,
+    state::{accountdata::AccountData, accounttype::AccountType, topology::TopologyInfo},
+};
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ListTopologyCommand;
+
+impl ListTopologyCommand {
+    pub fn execute(
+        &self,
+        client: &dyn DoubleZeroClient,
+    ) -> eyre::Result<HashMap<Pubkey, TopologyInfo>> {
+        client
+            .gets(AccountType::Topology)?
+            .into_iter()
+            .map(|(k, v)| match v {
+                AccountData::Topology(topology) => Ok((k, topology)),
+                _ => Err(DoubleZeroError::InvalidAccountType.into()),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{commands::topology::list::ListTopologyCommand, tests::utils::create_test_client};
+    use doublezero_serviceability::state::{
+        accountdata::AccountData,
+        accounttype::AccountType,
+        topology::{TopologyConstraint, TopologyInfo},
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_commands_topology_list_command() {
+        let mut client = create_test_client();
+
+        let topology1_pubkey = Pubkey::new_unique();
+        let topology1 = TopologyInfo {
+            account_type: AccountType::Topology,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            name: "unicast-default".to_string(),
+            admin_group_bit: 0,
+            flex_algo_number: 128,
+            constraint: TopologyConstraint::IncludeAny,
+            reference_count: 0,
+        };
+
+        let topology2_pubkey = Pubkey::new_unique();
+        let topology2 = TopologyInfo {
+            account_type: AccountType::Topology,
+            owner: Pubkey::new_unique(),
+            bump_seed: 2,
+            name: "exclude-test".to_string(),
+            admin_group_bit: 2,
+            flex_algo_number: 130,
+            constraint: TopologyConstraint::Exclude,
+            reference_count: 0,
+        };
+
+        client
+            .expect_gets()
+            .with(predicate::eq(AccountType::Topology))
+            .returning(move |_| {
+                let mut topologies = HashMap::new();
+                topologies.insert(topology1_pubkey, AccountData::Topology(topology1.clone()));
+                topologies.insert(topology2_pubkey, AccountData::Topology(topology2.clone()));
+                Ok(topologies)
+            });
+
+        let res = ListTopologyCommand.execute(&client);
+
+        assert!(res.is_ok());
+        let list = res.unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.contains_key(&topology1_pubkey));
+        assert!(list.contains_key(&topology2_pubkey));
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/topology/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/mod.rs
@@ -1,0 +1,5 @@
+pub mod backfill;
+pub mod clear;
+pub mod create;
+pub mod delete;
+pub mod list;


### PR DESCRIPTION
RFC-18 flex-algo · PR 2 of 5 · see `rfcs/rfc-0018-flex-algo.md`
Depends on: #3497 (PR 1)
Series: #3497 · #3512 · #3513 · #3514 · #3515

## Summary of Changes
- Adds five `doublezero link topology` subcommands: `create`, `delete`, `clear`, `list`, `backfill`
- Backs each with a Rust SDK command in `doublezero_sdk::commands::topology`
- `topology list` displays name, admin-group bit, flex-algo number, BGP color community, constraint, and linked link count
- `topology clear` removes a topology from all links that reference it; `topology backfill` allocates flex-algo node segments on all activated devices for a given topology
- Wires the `link topology` subcommand group into the existing `doublezero link` command tree

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net    |
|-------------|-------|-------------|--------|
| Core logic  |    10 | +1,329 / -0 | +1,329 |
| Scaffolding |     8 | +89 / -6    |   +83  |

Heavy on new code — all five CLI commands and five SDK commands are new files with no prior equivalent.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/topology/list.rs` — lists all TopologyInfo accounts; shows BGP color (128 + admin_group_bit), constraint, and how many links are tagged with each topology
- `smartcontract/cli/src/topology/clear.rs` — removes a topology from all links that reference it; confirms or dry-runs before submitting transactions
- `smartcontract/cli/src/topology/create.rs` — creates a topology with name, constraint (`include-any` or `exclude`); admin-group bit and flex-algo number are allocated automatically onchain
- `smartcontract/cli/src/topology/backfill.rs` — calls `BackfillTopology` for a named topology, optionally scoped to specific device pubkeys
- `smartcontract/sdk/rs/src/commands/topology/backfill.rs` — SDK command for `BackfillTopology`; includes unit tests with mock client
- `smartcontract/sdk/rs/src/commands/topology/list.rs` — SDK command for listing topology accounts; includes unit tests

</details>

## Testing Verification
- `cargo test -p doublezero_sdk -p doublezero_cli` passes
- `cargo clippy -- -D warnings` clean
- `make rust-fmt` applied before commit