### PR TITLE
sdk/go,controller: add TopologyInfo deserialization and flex-algo controller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Controller
-  - Add `--features-config` flag accepting a YAML file with a `flex_algo.enabled` toggle; when enabled, populates topology data into the state cache, resolves tenant color communities from `Tenant.include_topologies`, and emits IS-IS flex-algo node segment and BGP color community stamping blocks into the Arista EOS template (disabled by default)
+  - Auto-loads `/etc/doublezero-controller/features.yaml` at startup if present (silently skips if absent); when `flex_algo.enabled: true`, populates topology data into the state cache, resolves tenant color communities from `Tenant.include_topologies`, and emits IS-IS flex-algo node segment and BGP color community stamping blocks into the Arista EOS template (disabled by default)
 - SDK
-  - Go serviceability SDK adds `TopologyInfo` account type with `TopologyConstraint`, `IndexType` / `TopologyType` account-type constants, and `ListTopologies` client method; extends `Link` with `LinkTopologies` and `LinkFlags`; extends `Tenant` with `IncludeTopologies`
+  - Go serviceability SDK adds `TopologyInfo` account type with `TopologyConstraint`, `IndexType` / `TopologyType` account-type constants, and `GetProgramData` dispatch case; extends `Link` with `LinkTopologies` and `LinkFlags`; extends `Tenant` with `IncludeTopologies`
 - CLI
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
   - Fix `doublezero resource verify` to report missing `TunnelIds` resource extensions for all devices, including those without any users; previously the discrepancy was suppressed when a device had no users, hiding unallocated extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Controller
+  - Add `--features-config` flag accepting a YAML file with a `flex_algo.enabled` toggle; when enabled, populates topology data into the state cache, resolves tenant color communities from `Tenant.include_topologies`, and emits IS-IS flex-algo node segment and BGP color community stamping blocks into the Arista EOS template (disabled by default)
+- SDK
+  - Go serviceability SDK adds `TopologyInfo` account type with `TopologyConstraint`, `IndexType` / `TopologyType` account-type constants, and `ListTopologies` client method; extends `Link` with `LinkTopologies` and `LinkFlags`; extends `Tenant` with `IncludeTopologies`
 - CLI
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
 - Client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Controller
+  - Add `--features-config` flag accepting a YAML file with a `flex_algo.enabled` toggle; when enabled, populates topology data into the state cache, resolves tenant color communities from `Tenant.include_topologies`, and emits IS-IS flex-algo node segment and BGP color community stamping blocks into the Arista EOS template (disabled by default)
+- SDK
+  - Go serviceability SDK adds `TopologyInfo` account type with `TopologyConstraint`, `IndexType` / `TopologyType` account-type constants, and `ListTopologies` client method; extends `Link` with `LinkTopologies` and `LinkFlags`; extends `Tenant` with `IncludeTopologies`
 - CLI
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
   - Fix `doublezero resource verify` to report missing `TunnelIds` resource extensions for all devices, including those without any users; previously the discrepancy was suppressed when a device had no users, hiding unallocated extensions

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -129,24 +129,26 @@ func NewControllerCommand() *ControllerCommand {
 	c.fs.StringVar(&c.tlsKeyFile, "tls-key", "", "path to tls key file")
 	c.fs.BoolVar(&c.enablePprof, "enable-pprof", false, "enable pprof server")
 	c.fs.StringVar(&c.tlsListenPort, "tls-listen-port", "", "listening port for controller grpc server")
+	c.fs.StringVar(&c.featuresConfigPath, "features-config", "", "path to features YAML config file (optional)")
 	return c
 }
 
 type ControllerCommand struct {
-	fs             *flag.FlagSet
-	description    string
-	listenAddr     string
-	listenPort     string
-	env            string
-	programID      string
-	rpcEndpoint    string
-	deviceLocalASN uint64
-	noHardware     bool
-	showVersion    bool
-	tlsCertFile    string
-	tlsKeyFile     string
-	tlsListenPort  string
-	enablePprof    bool
+	fs                 *flag.FlagSet
+	description        string
+	listenAddr         string
+	listenPort         string
+	env                string
+	programID          string
+	rpcEndpoint        string
+	deviceLocalASN     uint64
+	noHardware         bool
+	showVersion        bool
+	tlsCertFile        string
+	tlsKeyFile         string
+	tlsListenPort      string
+	enablePprof        bool
+	featuresConfigPath string
 }
 
 func (c *ControllerCommand) Fs() *flag.FlagSet {
@@ -226,6 +228,22 @@ func (c *ControllerCommand) Run() error {
 	defer ledgerRPCClient.Close()
 
 	options = append(options, controller.WithDeviceLocalASN(deviceLocalASN))
+
+	if c.featuresConfigPath != "" {
+		f, err := os.Open(c.featuresConfigPath)
+		if err != nil {
+			log.Error("failed to open features config", "path", c.featuresConfigPath, "error", err)
+			os.Exit(1)
+		}
+		cfg, err := controller.LoadFeaturesConfig(f)
+		f.Close()
+		if err != nil {
+			log.Error("failed to parse features config", "path", c.featuresConfigPath, "error", err)
+			os.Exit(1)
+		}
+		options = append(options, controller.WithFeaturesConfig(cfg))
+		log.Info("loaded features config", "path", c.featuresConfigPath, "flex_algo_enabled", cfg.Features.FlexAlgo.Enabled)
+	}
 
 	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {
 		chDB := os.Getenv("CLICKHOUSE_DB")

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -129,26 +129,24 @@ func NewControllerCommand() *ControllerCommand {
 	c.fs.StringVar(&c.tlsKeyFile, "tls-key", "", "path to tls key file")
 	c.fs.BoolVar(&c.enablePprof, "enable-pprof", false, "enable pprof server")
 	c.fs.StringVar(&c.tlsListenPort, "tls-listen-port", "", "listening port for controller grpc server")
-	c.fs.StringVar(&c.featuresConfigPath, "features-config", "", "path to features YAML config file (optional)")
 	return c
 }
 
 type ControllerCommand struct {
-	fs                 *flag.FlagSet
-	description        string
-	listenAddr         string
-	listenPort         string
-	env                string
-	programID          string
-	rpcEndpoint        string
-	deviceLocalASN     uint64
-	noHardware         bool
-	showVersion        bool
-	tlsCertFile        string
-	tlsKeyFile         string
-	tlsListenPort      string
-	enablePprof        bool
-	featuresConfigPath string
+	fs             *flag.FlagSet
+	description    string
+	listenAddr     string
+	listenPort     string
+	env            string
+	programID      string
+	rpcEndpoint    string
+	deviceLocalASN uint64
+	noHardware     bool
+	showVersion    bool
+	tlsCertFile    string
+	tlsKeyFile     string
+	tlsListenPort  string
+	enablePprof    bool
 }
 
 func (c *ControllerCommand) Fs() *flag.FlagSet {
@@ -229,20 +227,19 @@ func (c *ControllerCommand) Run() error {
 
 	options = append(options, controller.WithDeviceLocalASN(deviceLocalASN))
 
-	if c.featuresConfigPath != "" {
-		f, err := os.Open(c.featuresConfigPath)
-		if err != nil {
-			log.Error("failed to open features config", "path", c.featuresConfigPath, "error", err)
-			os.Exit(1)
-		}
+	const defaultFeaturesConfigPath = "/etc/doublezero-controller/features.yaml"
+	if f, err := os.Open(defaultFeaturesConfigPath); err == nil {
 		cfg, err := controller.LoadFeaturesConfig(f)
 		f.Close()
 		if err != nil {
-			log.Error("failed to parse features config", "path", c.featuresConfigPath, "error", err)
+			log.Error("failed to parse features config", "path", defaultFeaturesConfigPath, "error", err)
 			os.Exit(1)
 		}
 		options = append(options, controller.WithFeaturesConfig(cfg))
-		log.Info("loaded features config", "path", c.featuresConfigPath, "flex_algo_enabled", cfg.Features.FlexAlgo.Enabled)
+		log.Info("loaded features config", "path", defaultFeaturesConfigPath, "flex_algo_enabled", cfg.Features.FlexAlgo.Enabled)
+	} else if !os.IsNotExist(err) {
+		log.Error("failed to open features config", "path", defaultFeaturesConfigPath, "error", err)
+		os.Exit(1)
 	}
 
 	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {

--- a/controlplane/controller/internal/controller/features_config.go
+++ b/controlplane/controller/internal/controller/features_config.go
@@ -7,7 +7,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// FeaturesConfig is loaded from a YAML file at controller startup.
+// FeaturesConfig is optionally loaded from /etc/doublezero-controller/features.yaml at
+// controller startup. If the file is absent the controller runs with all features disabled.
 // It gates flex-algo topology config, link tagging, and BGP color community stamping.
 type FeaturesConfig struct {
 	Features struct {

--- a/controlplane/controller/internal/controller/features_config.go
+++ b/controlplane/controller/internal/controller/features_config.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"io"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FeaturesConfig is loaded from a YAML file at controller startup.
+// It gates flex-algo topology config, link tagging, and BGP color community stamping.
+type FeaturesConfig struct {
+	Features struct {
+		FlexAlgo FlexAlgoConfig `yaml:"flex_algo"`
+	} `yaml:"features"`
+}
+
+// FlexAlgoConfig controls IS-IS Flex-Algo and BGP color extended community behaviour.
+type FlexAlgoConfig struct {
+	Enabled           bool                    `yaml:"enabled"`
+	LinkTagging       LinkTaggingConfig       `yaml:"link_tagging"`
+	CommunityStamping CommunityStampingConfig `yaml:"community_stamping"`
+}
+
+// LinkTaggingConfig controls which links receive IS-IS TE admin-group attributes.
+type LinkTaggingConfig struct {
+	Exclude struct {
+		Links []string `yaml:"links"` // link pubkeys to skip
+	} `yaml:"exclude"`
+}
+
+// IsExcluded returns true if the given link pubkey is in the exclude list.
+func (c *LinkTaggingConfig) IsExcluded(linkPubKey string) bool {
+	return slices.Contains(c.Exclude.Links, linkPubKey)
+}
+
+// CommunityStampingConfig controls BGP color extended community stamping per tenant/device.
+// A device is stamped if All is true, OR its pubkey is in Devices, OR the tenant's pubkey
+// is in Tenants — unless the device pubkey is in Exclude.Devices (overrides all).
+type CommunityStampingConfig struct {
+	All     bool     `yaml:"all"`
+	Tenants []string `yaml:"tenants"` // tenant pubkeys
+	Devices []string `yaml:"devices"` // device pubkeys
+	Exclude struct {
+		Devices []string `yaml:"devices"`
+	} `yaml:"exclude"`
+}
+
+// ShouldStamp returns true if BGP color communities should be stamped for the
+// given (tenantPubKey, devicePubKey) pair.
+func (c *CommunityStampingConfig) ShouldStamp(tenantPubKey, devicePubKey string) bool {
+	if slices.Contains(c.Exclude.Devices, devicePubKey) {
+		return false
+	}
+	if c.All {
+		return true
+	}
+	return slices.Contains(c.Tenants, tenantPubKey) || slices.Contains(c.Devices, devicePubKey)
+}
+
+// LoadFeaturesConfig parses a features YAML config from the given reader.
+func LoadFeaturesConfig(r io.Reader) (*FeaturesConfig, error) {
+	var cfg FeaturesConfig
+	if err := yaml.NewDecoder(r).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/controlplane/controller/internal/controller/features_config_test.go
+++ b/controlplane/controller/internal/controller/features_config_test.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeaturesConfigLoad(t *testing.T) {
+	yaml := `
+features:
+  flex_algo:
+    enabled: true
+    link_tagging:
+      exclude:
+        links:
+          - ABC123pubkey
+    community_stamping:
+      all: false
+      tenants:
+        - TenantPubkey1
+      devices:
+        - DevicePubkey1
+      exclude:
+        devices:
+          - ExcludedDevicePubkey
+`
+	config, err := LoadFeaturesConfig(strings.NewReader(yaml))
+	require.NoError(t, err)
+	assert.True(t, config.Features.FlexAlgo.Enabled)
+	assert.Len(t, config.Features.FlexAlgo.LinkTagging.Exclude.Links, 1)
+	assert.Equal(t, "ABC123pubkey", config.Features.FlexAlgo.LinkTagging.Exclude.Links[0])
+	assert.False(t, config.Features.FlexAlgo.CommunityStamping.All)
+	assert.Len(t, config.Features.FlexAlgo.CommunityStamping.Tenants, 1)
+	assert.Len(t, config.Features.FlexAlgo.CommunityStamping.Devices, 1)
+	assert.Len(t, config.Features.FlexAlgo.CommunityStamping.Exclude.Devices, 1)
+}
+
+func TestFeaturesConfigEmpty(t *testing.T) {
+	yaml := `features: {}`
+	config, err := LoadFeaturesConfig(strings.NewReader(yaml))
+	require.NoError(t, err)
+	assert.False(t, config.Features.FlexAlgo.Enabled)
+	assert.Empty(t, config.Features.FlexAlgo.LinkTagging.Exclude.Links)
+}
+
+func TestLinkTaggingIsExcluded(t *testing.T) {
+	cfg := LinkTaggingConfig{}
+	cfg.Exclude.Links = []string{"pubkey1", "pubkey2"}
+	assert.True(t, cfg.IsExcluded("pubkey1"))
+	assert.True(t, cfg.IsExcluded("pubkey2"))
+	assert.False(t, cfg.IsExcluded("pubkey3"))
+	assert.False(t, cfg.IsExcluded(""))
+}
+
+func TestShouldStamp(t *testing.T) {
+	cfg := CommunityStampingConfig{
+		All:     false,
+		Tenants: []string{"tenant1"},
+		Devices: []string{"device1"},
+	}
+	cfg.Exclude.Devices = []string{"excluded_device"}
+
+	// tenant in list, device not excluded → stamp
+	assert.True(t, cfg.ShouldStamp("tenant1", "any_device"))
+	// device in list, tenant not in list → stamp
+	assert.True(t, cfg.ShouldStamp("other_tenant", "device1"))
+	// excluded device — always false regardless of tenant/device match
+	assert.False(t, cfg.ShouldStamp("tenant1", "excluded_device"))
+	// not in any list
+	assert.False(t, cfg.ShouldStamp("other_tenant", "other_device"))
+}
+
+func TestShouldStampAllTrue(t *testing.T) {
+	cfg := CommunityStampingConfig{All: true}
+	assert.True(t, cfg.ShouldStamp("any_tenant", "any_device"))
+
+	cfg.Exclude.Devices = []string{"excluded"}
+	assert.False(t, cfg.ShouldStamp("any_tenant", "excluded"))
+	assert.True(t, cfg.ShouldStamp("any_tenant", "other_device"))
+}
+
+func TestShouldStampExcludeOverridesAll(t *testing.T) {
+	cfg := CommunityStampingConfig{
+		All:     true,
+		Tenants: []string{"tenant1"},
+		Devices: []string{"device1"},
+	}
+	cfg.Exclude.Devices = []string{"device1"}
+	// device1 is both in Devices and Exclude.Devices — exclude wins
+	assert.False(t, cfg.ShouldStamp("tenant1", "device1"))
+}

--- a/controlplane/controller/internal/controller/fixtures/base.config.flex-algo-disabled.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.flex-algo-disabled.txt
@@ -1,0 +1,201 @@
+!
+hardware counter feature gre tunnel interface out
+hardware counter feature gre tunnel interface in
+!
+hardware access-list update default-result permit
+!
+logging buffered 128000
+no logging console
+logging facility local7
+!
+ip name-server vrf default 1.1.1.1
+ip name-server vrf default 9.9.9.9
+clock timezone UTC
+!
+ip multicast-routing
+!
+router pim sparse-mode
+   ipv4
+      rp address 10.0.0.0 239.0.0.0/24 override
+!
+vrf instance vrf1
+ip routing
+ip routing vrf vrf1
+!
+ntp server 0.pool.ntp.org
+ntp server 1.pool.ntp.org
+ntp server 2.pool.ntp.org
+!
+hardware access-list update default-result permit
+!
+no ip access-list MAIN-CONTROL-PLANE-ACL
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
+interface Ethernet1/1
+   mtu 2048
+   no switchport
+   ip address 172.16.0.2/31
+   pim ipv4 sparse-mode
+   isis enable 1
+   isis circuit-type level-2
+   isis hello-interval 1
+   isis metric 40000
+   no isis passive
+   isis hello padding
+   isis network point-to-point
+   no traffic-engineering administrative-group
+   no traffic-engineering
+!
+interface Loopback255
+   ip address 14.14.14.14/32
+   node-segment ipv4 index 100
+   no node-segment ipv4 index 200 flex-algo UNICAST-DEFAULT
+   isis enable 1
+!
+interface Loopback1000
+   description RP Address
+   ip address 10.0.0.0/32
+!
+mpls ip
+!
+mpls icmp ttl-exceeded tunneling
+mpls icmp ip source-interface Loopback255
+!
+default interface Tunnel500
+interface Tunnel500
+   description USER-UCAST-500
+   ip access-group SEC-USER-500-IN in
+   vrf vrf1
+   mtu 9216
+   ip address 169.254.0.0/31
+   tunnel mode gre
+   tunnel source 1.1.1.1
+   tunnel destination 2.2.2.2
+   tunnel path-mtu-discovery
+   tunnel ttl 32
+   no shutdown
+!
+router bgp 65342
+   router-id 14.14.14.14
+   timers bgp 1 3
+   distance bgp 20 200 200
+   address-family ipv4
+   !
+   address-family vpn-ipv4
+      no next-hop resolution ribs
+   !
+   vrf vrf1
+      rd 65342:1
+      route-target import vpn-ipv4 65342:1
+      route-target export vpn-ipv4 65342:1
+      router-id 7.7.7.7
+      no neighbor 169.254.0.1
+      neighbor 169.254.0.1 remote-as 65000
+      neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
+      neighbor 169.254.0.1 passive
+      neighbor 169.254.0.1 description USER-500
+      neighbor 169.254.0.1 route-map RM-USER-500-IN in
+      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 maximum-routes 1
+      neighbor 169.254.0.1 maximum-accepted-routes 1
+!
+router isis 1
+   net 49.0000.0e0e.0e0e.0000.00
+   router-id ipv4 14.14.14.14
+   log-adjacency-changes
+   !
+   address-family ipv4 unicast
+   !
+   segment-routing mpls
+      no shutdown
+      no flex-algo UNICAST-DEFAULT level-2
+   no traffic-engineering
+   no set-overload-bit
+!
+no router traffic-engineering
+!
+ip community-list COMM-ALL_USERS permit 21682:1200
+ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
+ip community-list COMM-TST_USERS permit 21682:10050
+!
+no route-map RM-USER-500-OUT
+route-map RM-USER-500-OUT deny 10
+   match community COMM-TST_USERS
+route-map RM-USER-500-OUT permit 20
+   match community COMM-ALL_USERS
+!
+no route-map RM-USER-500-IN
+route-map RM-USER-500-IN permit 10
+   match ip address prefix-list PL-USER-500
+   match as-path length = 1
+   set community 21682:1200 21682:10050
+!
+no ip prefix-list PL-USER-500
+ip prefix-list PL-USER-500 seq 10 permit 100.0.0.0/32
+!
+no ip access-list SEC-USER-500-IN
+ip access-list SEC-USER-500-IN
+   counters per-entry
+   !ICMP
+   permit icmp 169.254.0.1/32 any
+   !TRACEROUTE
+   permit udp 169.254.0.1/32 any range 33434 33534
+   !Allow TTL Exceeded for traceroute return packets
+   permit icmp 169.254.0.1/32 any time-exceeded
+   !PERMIT BGP
+   permit tcp 169.254.0.1/32 169.254.0.0/32 eq 179
+   !PERMIT USER DZ_IP as a source only
+   permit ip 100.0.0.0/32 any
+   deny ip any any
+!
+no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
+no ip access-list SEC-USER-PUB-MCAST-IN
+ip access-list SEC-USER-PUB-MCAST-IN
+   counters per-entry
+   permit icmp any any
+   permit tcp any any eq bgp
+   permit ip any 224.0.0.13/32
+   permit ip any 239.0.0.0/24
+   deny ip any any
+!
+no ip access-list SEC-USER-SUB-MCAST-IN
+ip access-list SEC-USER-SUB-MCAST-IN
+   counters per-entry
+   permit icmp any any
+   permit tcp any any eq bgp
+   permit ip any 224.0.0.13/32
+   deny ip any any
+!

--- a/controlplane/controller/internal/controller/fixtures/base.config.flex-algo.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.flex-algo.txt
@@ -1,0 +1,214 @@
+!
+hardware counter feature gre tunnel interface out
+hardware counter feature gre tunnel interface in
+!
+hardware access-list update default-result permit
+!
+logging buffered 128000
+no logging console
+logging facility local7
+!
+ip name-server vrf default 1.1.1.1
+ip name-server vrf default 9.9.9.9
+clock timezone UTC
+!
+ip multicast-routing
+!
+router pim sparse-mode
+   ipv4
+      rp address 10.0.0.0 239.0.0.0/24 override
+!
+vrf instance vrf1
+ip routing
+ip routing vrf vrf1
+!
+ntp server 0.pool.ntp.org
+ntp server 1.pool.ntp.org
+ntp server 2.pool.ntp.org
+!
+hardware access-list update default-result permit
+!
+no ip access-list MAIN-CONTROL-PLANE-ACL
+ip access-list MAIN-CONTROL-PLANE-ACL
+   counters per-entry
+   10 permit icmp any any
+   20 permit ip any any tracked
+   30 permit udp any any eq bfd ttl eq 255
+   40 permit udp any any eq bfd-echo ttl eq 254
+   50 permit udp any any eq multihop-bfd micro-bfd sbfd
+   60 permit udp any eq sbfd any eq sbfd-initiator
+   70 permit ospf any any
+   80 permit tcp any any eq ssh telnet www snmp bgp https msdp ldp netconf-ssh gnmi
+   90 permit udp any any eq bootps bootpc snmp rip ntp ldp ptp-event ptp-general
+   100 permit tcp any any eq mlag ttl eq 255
+   110 permit udp any any eq mlag ttl eq 255
+   120 permit vrrp any any
+   130 permit ahp any any
+   140 permit pim any any
+   150 permit igmp any any
+   160 permit tcp any any range 5900 5910
+   170 permit tcp any any range 50000 50100
+   180 permit udp any any range 51000 51100
+   190 permit tcp any any eq 3333
+   200 permit tcp any any eq nat ttl eq 255
+   210 permit tcp any eq bgp any
+   220 permit rsvp any any
+   230 permit tcp any any eq 9340
+   240 permit tcp any any eq 9559
+   250 permit udp any any eq 8503
+   260 permit udp any any eq lsp-ping
+   270 permit udp any eq lsp-ping any
+   280 remark Permit TWAMP (UDP 862)
+   290 permit udp any any eq 862
+!
+system control-plane
+   ip access-group MAIN-CONTROL-PLANE-ACL in
+!
+interface Ethernet1/1
+   mtu 2048
+   no switchport
+   ip address 172.16.0.2/31
+   pim ipv4 sparse-mode
+   isis enable 1
+   isis circuit-type level-2
+   isis hello-interval 1
+   isis metric 40000
+   no isis passive
+   isis hello padding
+   isis network point-to-point
+   traffic-engineering
+   traffic-engineering administrative-group UNICAST-DEFAULT
+!
+interface Loopback255
+   ip address 14.14.14.14/32
+   node-segment ipv4 index 100
+   node-segment ipv4 index 200 flex-algo UNICAST-DEFAULT
+   isis enable 1
+!
+interface Loopback1000
+   description RP Address
+   ip address 10.0.0.0/32
+!
+mpls ip
+!
+mpls icmp ttl-exceeded tunneling
+mpls icmp ip source-interface Loopback255
+!
+default interface Tunnel500
+interface Tunnel500
+   description USER-UCAST-500
+   ip access-group SEC-USER-500-IN in
+   vrf vrf1
+   mtu 9216
+   ip address 169.254.0.0/31
+   tunnel mode gre
+   tunnel source 1.1.1.1
+   tunnel destination 2.2.2.2
+   tunnel path-mtu-discovery
+   tunnel ttl 32
+   no shutdown
+!
+router bgp 65342
+   router-id 14.14.14.14
+   timers bgp 1 3
+   distance bgp 20 200 200
+   address-family ipv4
+   !
+   address-family vpn-ipv4
+      next-hop resolution ribs tunnel-rib colored system-colored-tunnel-rib tunnel-rib system-tunnel-rib
+   !
+   vrf vrf1
+      rd 65342:1
+      route-target import vpn-ipv4 65342:1
+      route-target export vpn-ipv4 65342:1
+      router-id 7.7.7.7
+      no neighbor 169.254.0.1
+      neighbor 169.254.0.1 remote-as 65000
+      neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
+      neighbor 169.254.0.1 passive
+      neighbor 169.254.0.1 description USER-500
+      neighbor 169.254.0.1 route-map RM-USER-500-IN in
+      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 maximum-routes 1
+      neighbor 169.254.0.1 maximum-accepted-routes 1
+!
+router isis 1
+   net 49.0000.0e0e.0e0e.0000.00
+   router-id ipv4 14.14.14.14
+   log-adjacency-changes
+   !
+   address-family ipv4 unicast
+   !
+   segment-routing mpls
+      no shutdown
+      flex-algo UNICAST-DEFAULT level-2 advertised
+   traffic-engineering
+      no shutdown
+      is-type level-2
+   no set-overload-bit
+!
+router traffic-engineering
+   router-id ipv4 14.14.14.14
+   segment-routing
+      rib system-colored-tunnel-rib
+   administrative-group alias UNICAST-DRAINED group 0
+   administrative-group alias UNICAST-DEFAULT group 1
+   flex-algo
+      flex-algo 129 UNICAST-DEFAULT
+         administrative-group include any 1 exclude 0
+         color 2
+      !
+!
+ip community-list COMM-ALL_USERS permit 21682:1200
+ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
+ip community-list COMM-TST_USERS permit 21682:10050
+!
+no route-map RM-USER-500-OUT
+route-map RM-USER-500-OUT deny 10
+   match community COMM-TST_USERS
+route-map RM-USER-500-OUT permit 20
+   match community COMM-ALL_USERS
+!
+no route-map RM-USER-500-IN
+route-map RM-USER-500-IN permit 10
+   match ip address prefix-list PL-USER-500
+   match as-path length = 1
+   set community 21682:1200 21682:10050
+   set extcommunity color 2
+!
+no ip prefix-list PL-USER-500
+ip prefix-list PL-USER-500 seq 10 permit 100.0.0.0/32
+!
+no ip access-list SEC-USER-500-IN
+ip access-list SEC-USER-500-IN
+   counters per-entry
+   !ICMP
+   permit icmp 169.254.0.1/32 any
+   !TRACEROUTE
+   permit udp 169.254.0.1/32 any range 33434 33534
+   !Allow TTL Exceeded for traceroute return packets
+   permit icmp 169.254.0.1/32 any time-exceeded
+   !PERMIT BGP
+   permit tcp 169.254.0.1/32 169.254.0.0/32 eq 179
+   !PERMIT USER DZ_IP as a source only
+   permit ip 100.0.0.0/32 any
+   deny ip any any
+!
+no ip access-list standard SEC-USER-MCAST-BOUNDARY-500-OUT
+no ip access-list SEC-USER-PUB-MCAST-IN
+ip access-list SEC-USER-PUB-MCAST-IN
+   counters per-entry
+   permit icmp any any
+   permit tcp any any eq bgp
+   permit ip any 224.0.0.13/32
+   permit ip any 239.0.0.0/24
+   deny ip any any
+!
+no ip access-list SEC-USER-SUB-MCAST-IN
+ip access-list SEC-USER-SUB-MCAST-IN
+   counters per-entry
+   permit icmp any any
+   permit tcp any any eq bgp
+   permit ip any 224.0.0.13/32
+   deny ip any any
+!

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -45,6 +45,12 @@ type Interface struct {
 	LinkStatus           serviceability.LinkStatus
 	IsCYOA               bool
 	IsDIA                bool
+	// RFC-18: set when the interface is an activated link with topology assignments
+	LinkTopologies []string // topology names (resolved from link.link_topologies pubkeys)
+	UnicastDrained bool
+	PubKey         string // base58-encoded link pubkey (set when IsLink is true)
+	// RFC-18: flex-algo node-segment data for VPNv4 loopback interfaces
+	FlexAlgoNodeSegments []FlexAlgoNodeSegmentModel
 }
 
 // toInterface validates onchain data for a serviceability interface and converts it to a controller interface.
@@ -242,6 +248,9 @@ type Tunnel struct {
 	MulticastBoundaryList []net.IP
 	MulticastSubscribers  []net.IP
 	MulticastPublishers   []net.IP
+	// RFC-18: tenant identification and topology color stamping
+	TenantPubKey         string
+	TenantTopologyColors string // e.g. "color 1" or "color 1 color 3", empty if flex-algo disabled
 }
 
 // bgpMartianNets contains the standard BGP martian prefixes — addresses that
@@ -292,6 +301,18 @@ func (StringsHelper) ToUpper(s string) string {
 	return strings.ToUpper(s)
 }
 
+func (StringsHelper) Join(sep string, parts []string) string {
+	return strings.Join(parts, sep)
+}
+
+func (StringsHelper) ToUpperEach(parts []string) []string {
+	result := make([]string, len(parts))
+	for i, s := range parts {
+		result[i] = strings.ToUpper(s)
+	}
+	return result
+}
+
 type templateData struct {
 	Device                   *Device
 	Vpnv4BgpPeers            []BgpPeer
@@ -303,4 +324,26 @@ type templateData struct {
 	LocalASN                 uint32
 	UnicastVrfs              []uint16
 	Strings                  StringsHelper
+	AllTopologies            []TopologyModel
+	Config                   *FeaturesConfig // nil when no features config is loaded
+}
+
+// FlexAlgoEnabled returns true if a features config is loaded and flex_algo.enabled is set.
+func (d templateData) FlexAlgoEnabled() bool {
+	return d.Config != nil && d.Config.Features.FlexAlgo.Enabled
+}
+
+// TopologyModel holds pre-computed topology data for template rendering.
+type TopologyModel struct {
+	Name           string
+	AdminGroupBit  uint8
+	FlexAlgoNumber uint8
+	Color          int    // AdminGroupBit + 1
+	ConstraintStr  string // "include-any" or "exclude"
+}
+
+// FlexAlgoNodeSegmentModel holds pre-computed flex-algo node-segment data for template rendering.
+type FlexAlgoNodeSegmentModel struct {
+	NodeSegmentIdx uint16
+	TopologyName   string
 }

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -797,6 +797,146 @@ func TestRenderConfig(t *testing.T) {
 			},
 			Want: "fixtures/multi.vrf.mixed.metro.routing.tunnel.tmpl",
 		},
+		{
+			Name:        "render_flex_algo_enabled_successfully",
+			Description: "render config with flex-algo enabled: interface admin-groups, node-segments, router TE block, BGP color stamping",
+			Data: templateData{
+				Strings:                  StringsHelper{},
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
+				LocalASN:                 65342,
+				UnicastVrfs:              []uint16{1},
+				Config: func() *FeaturesConfig {
+					cfg := &FeaturesConfig{}
+					cfg.Features.FlexAlgo.Enabled = true
+					cfg.Features.FlexAlgo.CommunityStamping.All = true
+					return cfg
+				}(),
+				AllTopologies: []TopologyModel{
+					{
+						Name:           "unicast-default",
+						AdminGroupBit:  1,
+						FlexAlgoNumber: 129,
+						Color:          2,
+						ConstraintStr:  "include-any",
+					},
+				},
+				Device: &Device{
+					PubKey:                "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM",
+					PublicIP:              net.IP{7, 7, 7, 7},
+					Vpn4vLoopbackIP:       net.IP{14, 14, 14, 14},
+					Vpn4vLoopbackIntfName: "Loopback255",
+					IsisNet:               "49.0000.0e0e.0e0e.0000.00",
+					ExchangeCode:          "tst",
+					BgpCommunity:          10050,
+					Interfaces: []Interface{
+						{
+							Name:           "Ethernet1/1",
+							Ip:             netip.MustParsePrefix("172.16.0.2/31"),
+							Mtu:            2048,
+							InterfaceType:  InterfaceTypePhysical,
+							Metric:         40000,
+							IsLink:         true,
+							LinkStatus:     serviceability.LinkStatusActivated,
+							LinkTopologies: []string{"unicast-default"},
+						},
+						{
+							Name:           "Loopback255",
+							Ip:             netip.MustParsePrefix("14.14.14.14/32"),
+							NodeSegmentIdx: 100,
+							InterfaceType:  InterfaceTypeLoopback,
+							LoopbackType:   LoopbackTypeVpnv4,
+							FlexAlgoNodeSegments: []FlexAlgoNodeSegmentModel{
+								{NodeSegmentIdx: 200, TopologyName: "unicast-default"},
+							},
+						},
+					},
+					Tunnels: []*Tunnel{
+						{
+							Id:                   500,
+							UnderlaySrcIP:        net.IP{1, 1, 1, 1},
+							UnderlayDstIP:        net.IP{2, 2, 2, 2},
+							OverlaySrcIP:         net.IP{169, 254, 0, 0},
+							OverlayDstIP:         net.IP{169, 254, 0, 1},
+							DzIp:                 net.IP{100, 0, 0, 0},
+							Allocated:            true,
+							VrfId:                1,
+							MetroRouting:         true,
+							TenantPubKey:         "g35TxFqwMx95vCk63fTxGTHb6ei4W24qg5t2x6xD3cT",
+							TenantTopologyColors: "color 2",
+						},
+					},
+				},
+			},
+			Want: "fixtures/base.config.flex-algo.txt",
+		},
+		{
+			Name:        "render_flex_algo_disabled_cleanup_successfully",
+			Description: "render config with flex-algo disabled but topologies present: cleanup commands emitted, no TE config",
+			Data: templateData{
+				Strings:                  StringsHelper{},
+				MulticastGroupBlock:      "239.0.0.0/24",
+				TelemetryTWAMPListenPort: 862,
+				LocalASN:                 65342,
+				UnicastVrfs:              []uint16{1},
+				Config:                   &FeaturesConfig{},
+				AllTopologies: []TopologyModel{
+					{
+						Name:           "unicast-default",
+						AdminGroupBit:  0,
+						FlexAlgoNumber: 128,
+						Color:          1,
+						ConstraintStr:  "include-any",
+					},
+				},
+				Device: &Device{
+					PublicIP:              net.IP{7, 7, 7, 7},
+					Vpn4vLoopbackIP:       net.IP{14, 14, 14, 14},
+					Vpn4vLoopbackIntfName: "Loopback255",
+					IsisNet:               "49.0000.0e0e.0e0e.0000.00",
+					ExchangeCode:          "tst",
+					BgpCommunity:          10050,
+					Interfaces: []Interface{
+						{
+							Name:           "Ethernet1/1",
+							Ip:             netip.MustParsePrefix("172.16.0.2/31"),
+							Mtu:            2048,
+							InterfaceType:  InterfaceTypePhysical,
+							Metric:         40000,
+							IsLink:         true,
+							LinkStatus:     serviceability.LinkStatusActivated,
+							LinkTopologies: []string{"unicast-default"},
+						},
+						{
+							Name:           "Loopback255",
+							Ip:             netip.MustParsePrefix("14.14.14.14/32"),
+							NodeSegmentIdx: 100,
+							InterfaceType:  InterfaceTypeLoopback,
+							LoopbackType:   LoopbackTypeVpnv4,
+							FlexAlgoNodeSegments: []FlexAlgoNodeSegmentModel{
+								{NodeSegmentIdx: 200, TopologyName: "unicast-default"},
+							},
+						},
+					},
+					Tunnels: []*Tunnel{
+						{
+							Id:                   500,
+							UnderlaySrcIP:        net.IP{1, 1, 1, 1},
+							UnderlayDstIP:        net.IP{2, 2, 2, 2},
+							OverlaySrcIP:         net.IP{169, 254, 0, 0},
+							OverlayDstIP:         net.IP{169, 254, 0, 1},
+							DzIp:                 net.IP{100, 0, 0, 0},
+							Allocated:            true,
+							VrfId:                1,
+							MetroRouting:         true,
+							TenantPubKey:         "g35TxFqwMx95vCk63fTxGTHb6ei4W24qg5t2x6xD3cT",
+							TenantTopologyColors: "color 1",
+						},
+					},
+				},
+			},
+			Want: "fixtures/base.config.flex-algo-disabled.txt",
+		},
 	}
 
 	for _, test := range tests {

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -412,7 +412,7 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 			}
 			d.Interfaces[i].IsLink = true
 			d.Interfaces[i].LinkStatus = link.Status
-			d.Interfaces[i].UnicastDrained = link.LinkFlags&0x01 != 0
+			d.Interfaces[i].UnicastDrained = link.LinkFlags&serviceability.LinkFlagUnicastDrained != 0
 			d.Interfaces[i].PubKey = base58.Encode(link.PubKey[:])
 
 			// Resolve topology names from link_topologies pubkeys
@@ -774,6 +774,8 @@ func (c *Controller) deduplicateTunnels(device *Device) []*Tunnel {
 	return unique
 }
 
+const defaultTopologyName = "unicast-default"
+
 // resolveTenantColors computes the "color N color M ..." string for a tenant's include_topologies.
 // If include_topologies is empty, uses the unicast-default topology.
 // Returns empty string if no topologies can be resolved.
@@ -788,7 +790,7 @@ func resolveTenantColors(includeTopologies [][32]byte, topologyMap map[string]se
 	} else {
 		// default: use unicast-default topology
 		for _, topo := range topologyMap {
-			if strings.EqualFold(topo.Name, "unicast-default") {
+			if strings.EqualFold(topo.Name, defaultTopologyName) {
 				colors = append(colors, fmt.Sprintf("color %d", int(topo.AdminGroupBit)+1))
 				break
 			}

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -53,6 +54,7 @@ type stateCache struct {
 	Devices         map[string]*Device
 	MulticastGroups map[string]serviceability.MulticastGroup
 	Tenants         map[string]serviceability.Tenant
+	Topologies      map[string]serviceability.TopologyInfo // keyed by base58 pubkey
 	UnicastVrfs     []uint16
 	Vpnv4BgpPeers   []BgpPeer
 	Ipv4BgpPeers    []BgpPeer
@@ -72,6 +74,7 @@ type Controller struct {
 	environment    string
 	deviceLocalASN uint32
 	clickhouse     *ClickhouseWriter
+	featuresConfig *FeaturesConfig
 }
 
 type Option func(*Controller)
@@ -157,6 +160,13 @@ func WithDeviceLocalASN(asn uint32) Option {
 func WithClickhouse(cw *ClickhouseWriter) Option {
 	return func(c *Controller) {
 		c.clickhouse = cw
+	}
+}
+
+// WithFeaturesConfig provides a loaded FeaturesConfig to the controller.
+func WithFeaturesConfig(cfg *FeaturesConfig) Option {
+	return func(c *Controller) {
+		c.featuresConfig = cfg
 	}
 }
 
@@ -260,6 +270,11 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 		GlobalConfig:    data.GlobalConfig,
 		Devices:         make(map[string]*Device),
 		MulticastGroups: make(map[string]serviceability.MulticastGroup),
+		Topologies:      make(map[string]serviceability.TopologyInfo),
+	}
+
+	for _, t := range data.Topologies {
+		cache.Topologies[base58.Encode(t.PubKey[:])] = t
 	}
 
 	// TODO: valid interface checks:
@@ -348,22 +363,22 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 		cache.Ipv4BgpPeers = append(cache.Ipv4BgpPeers, candidateIpv4BgpPeer)
 
 		// determine if interface is in an onchain link and assign metrics
-		findLink := func(intf Interface) serviceability.Link {
+		findLink := func(intf Interface) (serviceability.Link, bool) {
 			for _, link := range links {
 				if d.PubKey == base58.Encode(link.SideAPubKey[:]) && intf.Name == link.SideAIfaceName {
-					return link
+					return link, true
 				}
 				if d.PubKey == base58.Encode(link.SideZPubKey[:]) && intf.Name == link.SideZIfaceName {
-					return link
+					return link, true
 				}
 			}
-			return serviceability.Link{}
+			return serviceability.Link{}, false
 		}
 
 		for i, iface := range d.Interfaces {
-			link := findLink(iface)
+			link, linkFound := findLink(iface)
 
-			if link == (serviceability.Link{}) || (link.Status != serviceability.LinkStatusActivated && link.Status != serviceability.LinkStatusSoftDrained && link.Status != serviceability.LinkStatusHardDrained) {
+			if !linkFound || (link.Status != serviceability.LinkStatusActivated && link.Status != serviceability.LinkStatusSoftDrained && link.Status != serviceability.LinkStatusHardDrained) {
 				d.Interfaces[i].IsLink = false
 				d.Interfaces[i].Metric = 0
 				d.Interfaces[i].LinkStatus = serviceability.LinkStatusPending
@@ -397,7 +412,43 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 			}
 			d.Interfaces[i].IsLink = true
 			d.Interfaces[i].LinkStatus = link.Status
+			d.Interfaces[i].UnicastDrained = link.LinkFlags&0x01 != 0
+			d.Interfaces[i].PubKey = base58.Encode(link.PubKey[:])
+
+			// Resolve topology names from link_topologies pubkeys
+			for _, topoKey := range link.LinkTopologies {
+				pk := base58.Encode(topoKey[:])
+				if topo, ok := cache.Topologies[pk]; ok {
+					d.Interfaces[i].LinkTopologies = append(d.Interfaces[i].LinkTopologies, topo.Name)
+				}
+			}
+
 			linkMetrics.WithLabelValues(device.Code, iface.Name, d.PubKey).Set(float64(d.Interfaces[i].Metric))
+		}
+
+		// Populate flex-algo node-segment data for VPNv4 loopback interfaces.
+		// Populated whenever a features config is loaded (not just when enabled) so that
+		// the template can emit cleanup ("no node-segment") lines on rollback.
+		if c.featuresConfig != nil {
+			for i, intf := range d.Interfaces {
+				if !intf.IsVpnv4Loopback() {
+					continue
+				}
+				for _, onchainIface := range device.Interfaces {
+					if onchainIface.Name == intf.Name {
+						for _, seg := range onchainIface.FlexAlgoNodeSegments {
+							pk := base58.Encode(seg.Topology[:])
+							if topo, ok := cache.Topologies[pk]; ok {
+								d.Interfaces[i].FlexAlgoNodeSegments = append(d.Interfaces[i].FlexAlgoNodeSegments, FlexAlgoNodeSegmentModel{
+									NodeSegmentIdx: seg.NodeSegmentIdx,
+									TopologyName:   topo.Name,
+								})
+							}
+						}
+						break
+					}
+				}
+			}
 		}
 
 		cache.Devices[devicePubKey] = d
@@ -512,6 +563,8 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 		tunnel.PubKey = userPubKey
 		tunnel.Allocated = true
 
+		tunnel.TenantPubKey = base58.Encode(user.TenantPubKey[:])
+
 		if user.UserType != serviceability.UserTypeMulticast {
 			// Set the VRF ID and metro routing from the user's tenant. Default to VRF 1 with metro routing enabled.
 			tunnel.VrfId = 1
@@ -519,6 +572,10 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 			if tenant, ok := cache.Tenants[base58.Encode(user.TenantPubKey[:])]; ok {
 				tunnel.VrfId = tenant.VrfId
 				tunnel.MetroRouting = tenant.MetroRouting
+
+				if c.featuresConfig != nil && c.featuresConfig.Features.FlexAlgo.Enabled {
+					tunnel.TenantTopologyColors = resolveTenantColors(tenant.IncludeTopologies, cache.Topologies)
+				}
 			}
 		}
 
@@ -553,6 +610,22 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 			sort.Slice(tunnel.MulticastBoundaryList, func(i, j int) bool {
 				return tunnel.MulticastBoundaryList[i].String() < tunnel.MulticastBoundaryList[j].String()
 			})
+		}
+	}
+
+	// Check for VPNv4 loopbacks missing flex-algo node-segment data when flex-algo is enabled
+	if c.featuresConfig != nil && c.featuresConfig.Features.FlexAlgo.Enabled && len(cache.Topologies) > 0 {
+		for devicePubKey, d := range cache.Devices {
+			if len(d.DevicePathologies) > 0 {
+				continue
+			}
+			for _, intf := range d.Interfaces {
+				if intf.IsVpnv4Loopback() && len(intf.FlexAlgoNodeSegments) == 0 {
+					c.log.Error("flex_algo.enabled=true but VPNv4 loopback has no flex_algo_node_segments — run 'doublezero-admin migrate' and restart",
+						"device_pubkey", devicePubKey,
+						"interface", intf.Name)
+				}
+			}
 		}
 	}
 
@@ -600,6 +673,13 @@ func (c *Controller) Run(ctx context.Context) error {
 			c.log.Error("error fetching accounts", "error", err)
 		}
 		cacheUpdateOps.Inc()
+		if c.featuresConfig != nil && c.featuresConfig.Features.FlexAlgo.Enabled {
+			c.mu.RLock()
+			if len(c.cache.Topologies) == 0 {
+				c.log.Warn("flex_algo.enabled=true but no topology accounts found on-chain — verify doublezero-admin migrate has been run")
+			}
+			c.mu.RUnlock()
+		}
 		ticker := time.NewTicker(10 * time.Second)
 		for {
 			select {
@@ -692,6 +772,29 @@ func (c *Controller) deduplicateTunnels(device *Device) []*Tunnel {
 	}
 
 	return unique
+}
+
+// resolveTenantColors computes the "color N color M ..." string for a tenant's include_topologies.
+// If include_topologies is empty, uses the unicast-default topology.
+// Returns empty string if no topologies can be resolved.
+func resolveTenantColors(includeTopologies [][32]byte, topologyMap map[string]serviceability.TopologyInfo) string {
+	var colors []string
+	if len(includeTopologies) > 0 {
+		for _, pk := range includeTopologies {
+			if topo, ok := topologyMap[base58.Encode(pk[:])]; ok {
+				colors = append(colors, fmt.Sprintf("color %d", int(topo.AdminGroupBit)+1))
+			}
+		}
+	} else {
+		// default: use unicast-default topology
+		for _, topo := range topologyMap {
+			if strings.EqualFold(topo.Name, "unicast-default") {
+				colors = append(colors, fmt.Sprintf("color %d", int(topo.AdminGroupBit)+1))
+				break
+			}
+		}
+	}
+	return strings.Join(colors, " ")
 }
 
 // GetConfig renders the latest device configuration based on cached device data
@@ -797,6 +900,20 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		return nil, err
 	}
 
+	var allTopologies []TopologyModel
+	for _, topo := range c.cache.Topologies {
+		allTopologies = append(allTopologies, TopologyModel{
+			Name:           topo.Name,
+			AdminGroupBit:  topo.AdminGroupBit,
+			FlexAlgoNumber: topo.FlexAlgoNumber,
+			Color:          int(topo.AdminGroupBit) + 1,
+			ConstraintStr:  topo.Constraint.String(),
+		})
+	}
+	sort.Slice(allTopologies, func(i, j int) bool {
+		return allTopologies[i].AdminGroupBit < allTopologies[j].AdminGroupBit
+	})
+
 	data := templateData{
 		MulticastGroupBlock:      multicastGroupBlock,
 		Device:                   &deviceForRender,
@@ -808,6 +925,8 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		LocalASN:                 localASN,
 		UnicastVrfs:              c.cache.UnicastVrfs,
 		Strings:                  StringsHelper{},
+		AllTopologies:            allTopologies,
+		Config:                   c.featuresConfig,
 	}
 
 	config, err := renderConfig(data)

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -2600,3 +2600,223 @@ func Test_GetConfig_DuplicateTunnelPairs_Integration(t *testing.T) {
 		t.Errorf("expected 2 tunnels in config (2 'tunnel source' lines), got %d", tunnelSourceCount)
 	}
 }
+
+func TestGetConfig_FlexAlgo(t *testing.T) {
+	// A minimal physical link interface with topology assignments (RFC-18 fields).
+	const linkPubKey = "linkpubkey123"
+	taggedLink := Interface{
+		Name:           "Ethernet2",
+		Ip:             netip.MustParsePrefix("10.0.0.1/30"),
+		InterfaceType:  InterfaceTypePhysical,
+		Metric:         10,
+		IsLink:         true,
+		PubKey:         linkPubKey,
+		LinkTopologies: []string{"unicast-default"},
+	}
+	untaggedLink := Interface{
+		Name:          "Ethernet2",
+		Ip:            netip.MustParsePrefix("10.0.0.1/30"),
+		InterfaceType: InterfaceTypePhysical,
+		Metric:        10,
+		IsLink:        true,
+		PubKey:        linkPubKey,
+	}
+
+	minimalDevice := func(ifaces ...Interface) *Device {
+		return &Device{
+			ExchangeCode:          "tst",
+			BgpCommunity:          10050,
+			PublicIP:              net.IP{7, 7, 7, 7},
+			Vpn4vLoopbackIP:       net.IP{5, 5, 5, 5},
+			Vpn4vLoopbackIntfName: "Loopback255",
+			IsisNet:               "49.0000.0505.0505.0000.00",
+			Tunnels:               []*Tunnel{},
+			DevicePathologies:     []string{},
+			Interfaces:            ifaces,
+		}
+	}
+
+	allTopologies := []TopologyModel{
+		{
+			Name:           "unicast-default",
+			AdminGroupBit:  67,
+			FlexAlgoNumber: 128,
+			Color:          68,
+			ConstraintStr:  "include-any",
+		},
+		{
+			Name:           "fast-path",
+			AdminGroupBit:  68,
+			FlexAlgoNumber: 129,
+			Color:          69,
+			ConstraintStr:  "exclude",
+		},
+	}
+
+	enabledCfg := &FeaturesConfig{}
+	enabledCfg.Features.FlexAlgo.Enabled = true
+
+	disabledCfg := &FeaturesConfig{}
+	disabledCfg.Features.FlexAlgo.Enabled = false
+
+	excludedCfg := &FeaturesConfig{}
+	excludedCfg.Features.FlexAlgo.Enabled = true
+	excludedCfg.Features.FlexAlgo.LinkTagging.Exclude.Links = []string{linkPubKey}
+
+	tests := []struct {
+		name         string
+		data         templateData
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "flex_algo_disabled_emits_no_router_traffic_engineering",
+			data: templateData{
+				Device:              minimalDevice(untaggedLink),
+				Config:              disabledCfg,
+				AllTopologies:       allTopologies,
+				LocalASN:            65342,
+				MulticastGroupBlock: "239.0.0.0/24",
+				Strings:             StringsHelper{},
+			},
+			wantContains: []string{
+				"no router traffic-engineering",
+				"no traffic-engineering administrative-group",
+				"no traffic-engineering",
+			},
+			wantAbsent: []string{
+				"\nrouter traffic-engineering\n",
+				"flex-algo 128",
+			},
+		},
+		{
+			name: "flex_algo_enabled_emits_full_te_block_for_both_constraint_types",
+			data: templateData{
+				Device:              minimalDevice(taggedLink),
+				Config:              enabledCfg,
+				AllTopologies:       allTopologies,
+				LocalASN:            65342,
+				MulticastGroupBlock: "239.0.0.0/24",
+				Strings:             StringsHelper{},
+			},
+			wantContains: []string{
+				"\nrouter traffic-engineering\n",
+				"administrative-group alias UNICAST-DRAINED group 0",
+				"administrative-group alias UNICAST-DEFAULT group 67",
+				"administrative-group alias FAST-PATH group 68",
+				"flex-algo 128 UNICAST-DEFAULT",
+				"administrative-group include any 67 exclude 0",
+				"flex-algo 129 FAST-PATH",
+				"administrative-group exclude 68,0",
+				"traffic-engineering administrative-group UNICAST-DEFAULT",
+			},
+			wantAbsent: []string{
+				"no router traffic-engineering",
+				"no traffic-engineering administrative-group",
+			},
+		},
+		{
+			name: "flex_algo_enabled_excluded_link_emits_no_administrative_group",
+			data: templateData{
+				Device:              minimalDevice(taggedLink),
+				Config:              excludedCfg,
+				AllTopologies:       allTopologies,
+				LocalASN:            65342,
+				MulticastGroupBlock: "239.0.0.0/24",
+				Strings:             StringsHelper{},
+			},
+			wantContains: []string{
+				"\nrouter traffic-engineering\n",
+				"no traffic-engineering administrative-group",
+			},
+			wantAbsent: []string{
+				"traffic-engineering administrative-group UNICAST-DEFAULT",
+				"no router traffic-engineering",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderConfig(tt.data)
+			if err != nil {
+				t.Fatalf("renderConfig() error: %v", err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected config to contain %q\nfull config:\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("expected config NOT to contain %q\nfull config:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_resolveTenantColors(t *testing.T) {
+	// Use solana.PublicKey (which is [32]byte) to get base58-encoded map keys
+	// that match what resolveTenantColors uses internally.
+	pk1 := [32]byte{1}
+	pk2 := [32]byte{2}
+	pkUnicast := [32]byte{100}
+
+	pk1str := solana.PublicKey(pk1).String()
+	pk2str := solana.PublicKey(pk2).String()
+	pkUnicastStr := solana.PublicKey(pkUnicast).String()
+
+	fullMap := map[string]serviceability.TopologyInfo{
+		pk1str:       {Name: "FOO", AdminGroupBit: 67},
+		pk2str:       {Name: "BAR", AdminGroupBit: 71},
+		pkUnicastStr: {Name: defaultTopologyName, AdminGroupBit: 10},
+	}
+
+	tests := []struct {
+		name              string
+		includeTopologies [][32]byte
+		topologyMap       map[string]serviceability.TopologyInfo
+		want              string
+	}{
+		{
+			name:              "empty include_topologies falls back to unicast-default",
+			includeTopologies: nil,
+			topologyMap:       map[string]serviceability.TopologyInfo{pkUnicastStr: {Name: defaultTopologyName, AdminGroupBit: 10}},
+			want:              "color 11",
+		},
+		{
+			name:              "empty include_topologies with no unicast-default returns empty",
+			includeTopologies: nil,
+			topologyMap:       map[string]serviceability.TopologyInfo{pk1str: {Name: "FOO", AdminGroupBit: 67}},
+			want:              "",
+		},
+		{
+			name:              "single known pubkey returns its color",
+			includeTopologies: [][32]byte{pk1},
+			topologyMap:       fullMap,
+			want:              "color 68",
+		},
+		{
+			name:              "multiple known pubkeys returns colors in slice order",
+			includeTopologies: [][32]byte{pk1, pk2},
+			topologyMap:       fullMap,
+			want:              "color 68 color 72",
+		},
+		{
+			name:              "unknown pubkey is silently skipped",
+			includeTopologies: [][32]byte{{99}},
+			topologyMap:       fullMap,
+			want:              "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTenantColors(tt.includeTopologies, tt.topologyMap)
+			if got != tt.want {
+				t.Errorf("resolveTenantColors() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -925,6 +925,7 @@ func TestStateCache(t *testing.T) {
 					},
 				},
 				Tenants:     map[string]serviceability.Tenant{},
+				Topologies:  map[string]serviceability.TopologyInfo{},
 				UnicastVrfs: []uint16{1},
 				Vpnv4BgpPeers: []BgpPeer{
 					{
@@ -960,6 +961,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "11111111111111111111111111111111",
 							},
 							{
 								Id:            501,
@@ -971,6 +973,7 @@ func TestStateCache(t *testing.T) {
 								PubKey:        "11111111111111111111111111111111",
 								Allocated:     true,
 								IsMulticast:   true,
+								TenantPubKey:  "11111111111111111111111111111111",
 								MulticastBoundaryList: []net.IP{
 									{239, 0, 0, 1},
 								},
@@ -989,6 +992,7 @@ func TestStateCache(t *testing.T) {
 								IsLink:        true,
 								Metric:        400000,
 								LinkStatus:    serviceability.LinkStatusActivated,
+								PubKey:        "11111111111111111111111111111111",
 							},
 							{
 								InterfaceType: InterfaceTypePhysical,
@@ -998,6 +1002,7 @@ func TestStateCache(t *testing.T) {
 								IsLink:        true,
 								Metric:        1,
 								LinkStatus:    serviceability.LinkStatusActivated,
+								PubKey:        "11111111111111111111111111111111",
 							},
 							{
 								InterfaceType: InterfaceTypePhysical,
@@ -1007,6 +1012,7 @@ func TestStateCache(t *testing.T) {
 								IsLink:        true,
 								Metric:        50,
 								LinkStatus:    serviceability.LinkStatusActivated,
+								PubKey:        "11111111111111111111111111111111",
 							},
 							{
 								InterfaceType: InterfaceTypeLoopback,
@@ -1077,6 +1083,7 @@ func TestStateCache(t *testing.T) {
 				},
 				MulticastGroups: map[string]serviceability.MulticastGroup{},
 				Tenants:         map[string]serviceability.Tenant{},
+				Topologies:      map[string]serviceability.TopologyInfo{},
 				UnicastVrfs:     []uint16{1},
 				Vpnv4BgpPeers:   nil, // No BGP peers since device has pathologies
 				Devices: map[string]*Device{
@@ -1106,6 +1113,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "11111111111111111111111111111111",
 							},
 						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.MaxUserTunnelSlots-1)...),
 						TunnelSlots: config.MaxUserTunnelSlots,
@@ -1173,6 +1181,7 @@ func TestStateCache(t *testing.T) {
 				},
 				MulticastGroups: map[string]serviceability.MulticastGroup{},
 				Tenants:         map[string]serviceability.Tenant{},
+				Topologies:      map[string]serviceability.TopologyInfo{},
 				UnicastVrfs:     []uint16{1},
 				Devices: map[string]*Device{
 					"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM": {
@@ -1218,6 +1227,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "11111111111111111111111111111111",
 							},
 						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.MaxUserTunnelSlots-1)...),
 						TunnelSlots: config.MaxUserTunnelSlots,
@@ -1299,6 +1309,7 @@ func TestStateCache(t *testing.T) {
 				},
 				MulticastGroups: map[string]serviceability.MulticastGroup{},
 				Tenants:         map[string]serviceability.Tenant{},
+				Topologies:      map[string]serviceability.TopologyInfo{},
 				UnicastVrfs:     []uint16{1},
 				Vpnv4BgpPeers: []BgpPeer{
 					{
@@ -1354,6 +1365,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "11111111111111111111111111111111",
 							},
 							{
 								Id:            501,
@@ -1366,6 +1378,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "11111111111111111111111111111111",
 							},
 						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+2, config.MaxUserTunnelSlots-2)...),
 						TunnelSlots: config.MaxUserTunnelSlots,
@@ -1479,6 +1492,7 @@ func TestStateCache(t *testing.T) {
 						VrfId:  2,
 					},
 				},
+				Topologies:  map[string]serviceability.TopologyInfo{},
 				UnicastVrfs: []uint16{1, 2},
 				Vpnv4BgpPeers: []BgpPeer{
 					{
@@ -1513,6 +1527,7 @@ func TestStateCache(t *testing.T) {
 								PubKey:        "11111111111111111111111111111111",
 								Allocated:     true,
 								VrfId:         1,
+								TenantPubKey:  "g35TxFqwMx95vCk63fTxGTHb6ei4W24qg5t2x6xD3cT",
 							},
 							{
 								Id:            501,
@@ -1524,6 +1539,7 @@ func TestStateCache(t *testing.T) {
 								PubKey:        "11111111111111111111111111111111",
 								Allocated:     true,
 								VrfId:         2,
+								TenantPubKey:  "2M59vuWgsiuHAqQVB6KvuXuaBCJR8138gMAm4uCuR6Du",
 							},
 							{
 								Id:            502,
@@ -1536,6 +1552,7 @@ func TestStateCache(t *testing.T) {
 								Allocated:     true,
 								VrfId:         1,
 								MetroRouting:  true,
+								TenantPubKey:  "7fTN12qMUn1gSUuTMxNCdjndcxwJu45kosXuqJiXMeT9",
 							},
 						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+3, config.MaxUserTunnelSlots-3)...),
 						TunnelSlots: config.MaxUserTunnelSlots,

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -107,6 +107,15 @@ interface {{ .Name }}
    {{- end }}
    {{- if and .IsVpnv4Loopback .NodeSegmentIdx}}
    node-segment ipv4 index {{ .NodeSegmentIdx }}
+   {{- if $.FlexAlgoEnabled }}
+   {{- range .FlexAlgoNodeSegments }}
+   node-segment ipv4 index {{ .NodeSegmentIdx }} flex-algo {{ $.Strings.ToUpper .TopologyName }}
+   {{- end }}
+   {{- else }}
+   {{- range .FlexAlgoNodeSegments }}
+   no node-segment ipv4 index {{ .NodeSegmentIdx }} flex-algo {{ $.Strings.ToUpper .TopologyName }}
+   {{- end }}
+   {{- end }}
    {{- end }}
    {{- if and .Ip.IsValid .IsLoopback }}
    isis enable 1
@@ -123,6 +132,21 @@ interface {{ .Name }}
    {{- end }}
    isis hello padding
    isis network point-to-point
+   {{- if and .Ip.IsValid .IsPhysical .Metric .IsLink (not .IsSubInterfaceParent) (not .IsCYOA) (not .IsDIA) }}
+   {{- if $.FlexAlgoEnabled }}
+   traffic-engineering
+   {{- if and .LinkTopologies (not ($.Config.Features.FlexAlgo.LinkTagging.IsExcluded .PubKey)) }}
+   traffic-engineering administrative-group {{ $.Strings.Join " " ($.Strings.ToUpperEach .LinkTopologies) }}{{ if .UnicastDrained }} UNICAST-DRAINED{{ end }}
+   {{- else if .UnicastDrained }}
+   traffic-engineering administrative-group UNICAST-DRAINED
+   {{- else }}
+   no traffic-engineering administrative-group
+   {{- end }}
+   {{- else if $.Config }}
+   no traffic-engineering administrative-group
+   no traffic-engineering
+   {{- end }}
+   {{- end }}
    {{- end }}
 !
 {{- end }}
@@ -247,6 +271,11 @@ router bgp 65342
       {{- range .UnknownBgpPeers }}
       no neighbor {{ . }}
       {{- end }}
+      {{- if $.FlexAlgoEnabled }}
+      next-hop resolution ribs tunnel-rib colored system-colored-tunnel-rib tunnel-rib system-tunnel-rib
+      {{- else if $.Config }}
+      no next-hop resolution ribs
+      {{- end }}
    !
 {{- range $vrfId := .UnicastVrfs }}
    vrf vrf{{ $vrfId }}
@@ -284,12 +313,51 @@ router isis 1
    !
    segment-routing mpls
       no shutdown
+      {{- if $.FlexAlgoEnabled }}
+      {{- range $.AllTopologies }}
+      flex-algo {{ $.Strings.ToUpper .Name }} level-2 advertised
+      {{- end }}
+      {{- else }}
+      {{- range $.AllTopologies }}
+      no flex-algo {{ $.Strings.ToUpper .Name }} level-2
+      {{- end }}
+      {{- end }}
+   {{- if $.FlexAlgoEnabled }}
+   traffic-engineering
+      no shutdown
+      is-type level-2
+   {{- else if $.Config }}
+   no traffic-engineering
+   {{- end }}
 {{- if $.Device.Status.IsDrained }}
    set-overload-bit
 {{- else }}
    no set-overload-bit
 {{- end }}
 !
+{{- if $.FlexAlgoEnabled }}
+router traffic-engineering
+   router-id ipv4 {{ $.Device.Vpn4vLoopbackIP }}
+   segment-routing
+      rib system-colored-tunnel-rib
+   administrative-group alias UNICAST-DRAINED group 0
+   {{- range $.AllTopologies }}
+   administrative-group alias {{ $.Strings.ToUpper .Name }} group {{ .AdminGroupBit }}
+   {{- end }}
+   flex-algo
+   {{- range $.AllTopologies }}
+      {{- if eq .ConstraintStr "include-any" }}
+      flex-algo {{ .FlexAlgoNumber }} {{ $.Strings.ToUpper .Name }}
+         administrative-group include any {{ .AdminGroupBit }} exclude 0
+         color {{ .Color }}
+      !
+      {{- end }}
+   {{- end }}
+!
+{{- else if $.Config }}
+no router traffic-engineering
+!
+{{- end }}
 ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-{{ .Strings.ToUpper .Device.ExchangeCode }}_USERS permit 21682:{{ .Device.BgpCommunity }}
@@ -313,6 +381,11 @@ route-map RM-USER-{{ .Id }}-IN permit 10
    match ip address prefix-list PL-USER-{{ .Id }}
    match as-path length = 1
    set community 21682:{{ if eq true .IsMulticast }}1300{{ else }}1200{{ end }} 21682:{{ $.Device.BgpCommunity }}
+   {{- if and $.FlexAlgoEnabled (not .IsMulticast) .TenantTopologyColors }}
+   {{- if $.Config.Features.FlexAlgo.CommunityStamping.ShouldStamp .TenantPubKey $.Device.PubKey }}
+   set extcommunity {{ .TenantTopologyColors }}
+   {{- end }}
+   {{- end }}
 {{- end }}
 !
 {{- end }}

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -132,7 +132,6 @@ interface {{ .Name }}
    {{- end }}
    isis hello padding
    isis network point-to-point
-   {{- if and .Ip.IsValid .IsPhysical .Metric .IsLink (not .IsSubInterfaceParent) (not .IsCYOA) (not .IsDIA) }}
    {{- if $.FlexAlgoEnabled }}
    traffic-engineering
    {{- if and .LinkTopologies (not ($.Config.Features.FlexAlgo.LinkTagging.IsExcluded .PubKey)) }}
@@ -145,7 +144,6 @@ interface {{ .Name }}
    {{- else if $.Config }}
    no traffic-engineering administrative-group
    no traffic-engineering
-   {{- end }}
    {{- end }}
    {{- end }}
 !
@@ -349,6 +347,11 @@ router traffic-engineering
       {{- if eq .ConstraintStr "include-any" }}
       flex-algo {{ .FlexAlgoNumber }} {{ $.Strings.ToUpper .Name }}
          administrative-group include any {{ .AdminGroupBit }} exclude 0
+         color {{ .Color }}
+      !
+      {{- else if eq .ConstraintStr "exclude" }}
+      flex-algo {{ .FlexAlgoNumber }} {{ $.Strings.ToUpper .Name }}
+         administrative-group exclude {{ .AdminGroupBit }},0
          color {{ .Color }}
       !
       {{- end }}

--- a/smartcontract/sdk/go/serviceability/client.go
+++ b/smartcontract/sdk/go/serviceability/client.go
@@ -27,6 +27,7 @@ type ProgramData struct {
 	AccessPasses       []AccessPass
 	ResourceExtensions []ResourceExtension
 	Permissions        []Permission
+	Topologies         []TopologyInfo
 }
 
 func New(rpc RPCClient, programID solana.PublicKey) *Client {
@@ -59,6 +60,7 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 		AccessPasses:       []AccessPass{},
 		ResourceExtensions: []ResourceExtension{},
 		Permissions:        []Permission{},
+		Topologies:         []TopologyInfo{},
 	}
 
 	for _, element := range out {
@@ -138,6 +140,11 @@ func (c *Client) GetProgramData(ctx context.Context) (*ProgramData, error) {
 			DeserializePermission(reader, &perm)
 			perm.PubKey = element.Pubkey
 			pd.Permissions = append(pd.Permissions, perm)
+		case TopologyType:
+			var t TopologyInfo
+			DeserializeTopologyInfo(reader, &t)
+			t.PubKey = element.Pubkey
+			pd.Topologies = append(pd.Topologies, t)
 		}
 	}
 

--- a/smartcontract/sdk/go/serviceability/client_test.go
+++ b/smartcontract/sdk/go/serviceability/client_test.go
@@ -59,7 +59,7 @@ f8198607689246e25c9403fba46e89122ff5d0fcc1febb51d4b
 00007479322d647a30313a6c61322d647a30310001020304050
 60708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 0b000000737769746368312f312f31030000006c6f30ffc99a3
-b00000000ad2570a0cf27761cab55a3f26d85fb20
+b00000000ad250000000000000000
 `
 
 var userPayload = `
@@ -86,7 +86,7 @@ var tenantPayload = `
 00050000000100000000000000000000000000000000000000
 0000000000000000000000000000000001aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0100
-000000000000000000000000000000000000
+000000000000000000000000000000000000000000
 `
 
 var programconfigPayload = `
@@ -199,6 +199,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -240,6 +241,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -303,6 +305,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -337,6 +340,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -373,6 +377,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -416,6 +421,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -449,6 +455,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -487,6 +494,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 		{
@@ -514,6 +522,7 @@ func TestSDK_Serviceability_GetProgramData(t *testing.T) {
 				AccessPasses:       []AccessPass{},
 				ResourceExtensions: []ResourceExtension{},
 				Permissions:        []Permission{},
+				Topologies:         []TopologyInfo{},
 			},
 		},
 	}

--- a/smartcontract/sdk/go/serviceability/deserialize.go
+++ b/smartcontract/sdk/go/serviceability/deserialize.go
@@ -207,6 +207,8 @@ func DeserializeLink(reader *ByteReader, link *Link) {
 	link.DelayOverrideNs = reader.ReadU64()
 	link.LinkHealth = LinkHealth(reader.ReadU8())
 	link.LinkDesiredStatus = LinkDesiredStatus(reader.ReadU8())
+	link.LinkTopologies = reader.ReadPubkeySlice()
+	link.LinkFlags = reader.ReadU32()
 }
 
 func DeserializeUser(reader *ByteReader, user *User) {
@@ -263,6 +265,7 @@ func DeserializeTenant(reader *ByteReader, tenant *Tenant) {
 	tenant.BillingDiscriminant = reader.ReadU8()
 	tenant.BillingRate = reader.ReadU64()
 	tenant.BillingLastDeductionDzEpoch = reader.ReadU64()
+	tenant.IncludeTopologies = reader.ReadPubkeySlice()
 	// Note: tenant.PubKey is set separately in client.go after deserialization
 }
 
@@ -371,4 +374,16 @@ func DeserializePermission(reader *ByteReader, perm *Permission) {
 	perm.UserPayer = reader.ReadPubkey()
 	perm.PermissionsLo = reader.ReadU64() // bits 0-63 (low u64 of u128)
 	perm.PermissionsHi = reader.ReadU64() // bits 64-127 (high u64 of u128)
+}
+
+func DeserializeTopologyInfo(reader *ByteReader, t *TopologyInfo) {
+	t.AccountType = AccountType(reader.ReadU8())
+	t.Owner = reader.ReadPubkey()
+	t.BumpSeed = reader.ReadU8()
+	t.Name = reader.ReadString()
+	t.AdminGroupBit = reader.ReadU8()
+	t.FlexAlgoNumber = reader.ReadU8()
+	t.Constraint = TopologyConstraint(reader.ReadU8())
+	t.ReferenceCount = reader.ReadU32()
+	// Note: t.PubKey is set from the account address in client.go after deserialization
 }

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -26,6 +26,8 @@ const (
 	TenantType            // 13
 	// 14 is reserved
 	PermissionType AccountType = 15
+	IndexType      AccountType = 16
+	TopologyType   AccountType = 17
 )
 
 type LocationStatus uint8
@@ -681,6 +683,8 @@ type Link struct {
 	DelayOverrideNs   uint64            `influx:"field,delay_override_ns"`
 	LinkHealth        LinkHealth        `influx:"field,link_health"`
 	LinkDesiredStatus LinkDesiredStatus `influx:"tag,link_desired_status"`
+	LinkTopologies    [][32]byte        `json:",omitempty"`
+	LinkFlags         uint32            `json:",omitempty"`
 	PubKey            [32]byte          `influx:"tag,pubkey,pubkey"`
 }
 
@@ -808,6 +812,7 @@ type Tenant struct {
 	BillingDiscriminant         uint8               `influx:"-"`
 	BillingRate                 uint64              `influx:"field,billing_rate"`
 	BillingLastDeductionDzEpoch uint64              `influx:"field,billing_last_deduction_dz_epoch"`
+	IncludeTopologies           [][32]byte          `json:",omitempty"`
 	PubKey                      [32]byte            `influx:"tag,pubkey,pubkey"`
 }
 
@@ -1320,4 +1325,34 @@ func (r ResourceExtension) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(jsonExt)
+}
+
+type TopologyConstraint uint8
+
+const (
+	TopologyConstraintIncludeAny TopologyConstraint = 0
+	TopologyConstraintExclude    TopologyConstraint = 1
+)
+
+func (c TopologyConstraint) String() string {
+	switch c {
+	case TopologyConstraintIncludeAny:
+		return "include-any"
+	case TopologyConstraintExclude:
+		return "exclude"
+	default:
+		return "unknown"
+	}
+}
+
+type TopologyInfo struct {
+	AccountType    AccountType
+	Owner          [32]byte
+	BumpSeed       uint8
+	Name           string
+	AdminGroupBit  uint8
+	FlexAlgoNumber uint8
+	Constraint     TopologyConstraint
+	ReferenceCount uint32
+	PubKey         [32]byte
 }

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -688,6 +688,9 @@ type Link struct {
 	PubKey            [32]byte          `influx:"tag,pubkey,pubkey"`
 }
 
+// LinkFlagUnicastDrained is set in LinkFlags when the link is marked as unicast-drained.
+const LinkFlagUnicastDrained uint32 = 0x01
+
 func (l Link) MarshalJSON() ([]byte, error) {
 	type LinkAlias Link
 


### PR DESCRIPTION
RFC-18 flex-algo · PR 5 of 5 · see `rfcs/rfc-0018-flex-algo.md`
Depends on: #3497 (PR 1) — does not require PRs 2–4; can merge after PR 1
Series: #3497 · #3512 · #3513 · #3514 · #3515

## Summary of Changes
- Adds `TopologyInfo` account type to the Go SDK (`state.go`, `deserialize.go`, `client.go`), including `TopologyType`, `TopologyConstraint`, `LinkFlagUnicastDrained`, `LinkTopologies`/`LinkFlags` on `Link`, and `IncludeTopologies` on `Tenant`
- Auto-loads `/etc/doublezero-controller/features.yaml` at startup if present (silently skips if absent); when `flex_algo.enabled: true`, populates topology data into the state cache, resolves tenant color communities via `resolveTenantColors`, and emits IS-IS flex-algo node segment and link configuration into the Arista EOS template
- Template emits correct flex-algo definitions for both `include-any` constraint (`administrative-group include any N exclude 0`) and `exclude` constraint (`administrative-group exclude N,0`) topologies; gated per-link via `link_tagging.exclude` and per-tenant via `community_stamping`
- Updates `e2e/compatibility_test.go` to set the mandatory upgrade boundary for RFC-18 interface/link operations to `before: "0.18.0"`

## Diff Breakdown
| Category    | Files | Lines (+/-)  | Net   |
|-------------|-------|--------------|-------|
| Core logic  |     6 | +368 / -6    | +362  |
| Scaffolding |     2 | +22 / -0     |  +22  |
| Tests       |     4 | +482 / -2    | +480  |
| Fixtures    |     2 | +415 / -0    | +415  |
| Docs        |     1 | +4 / -0      |   +4  |

Most of the weight is tests and fixtures; core logic is the controller cache/template and Go SDK deserialization.

> **Note on diff size:** The full diff vs `main` is large because this branch is stacked on PR 1 (#3497), which has not yet merged. The table above reflects only PR 5's contribution. After PR 1 merges and this branch is rebased, the diff shrinks to the ~15 files shown here.

<details>
<summary>Key files (click to expand)</summary>

- [`controlplane/controller/internal/controller/server.go`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-f5e715ed1377ac408a4ecde2c60cbcb98327512c7d1496114ef143cb27e7afaf) — populates `Topologies` map in state cache; resolves `LinkTopologies` pubkeys to topology names and `UnicastDrained` from `LinkFlags`; computes `TenantTopologyColors`; `resolveTenantColors` falls back to `unicast-default` when tenant has no explicit topology assignments
- [`controlplane/controller/internal/controller/templates/tunnel.tmpl`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-d67a980326aca35fdabdd5445fbbab4716f1ae412af4540770d5a9ee116b04d9) — IS-IS flex-algo node segment config, link admin-group tagging, BGP `next-hop resolution ribs` and `set extcommunity` stamping, and full rollback (`no` commands) when disabled; handles both `include-any` and `exclude` constraint topologies
- [`controlplane/controller/internal/controller/features_config.go`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-24f09aab331b4d309662e5ee6550fd38fa173676ae868db381d9af23cf645f1d) — `FeaturesConfig` struct with `flex_algo.enabled`, `link_tagging.exclude`, and `community_stamping` controls; auto-loaded from `/etc/doublezero-controller/features.yaml`
- [`controlplane/controller/internal/controller/models.go`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-bdc4e34592a7435dcde7dab78ffd735dcb9847447f0113bd9f3afc8d3d01f864) — adds `LinkTopologies`, `UnicastDrained`, `FlexAlgoNodeSegments`, `TenantTopologyColors` to controller model types; `TopologyModel` and `FlexAlgoEnabled()` for template rendering
- [`smartcontract/sdk/go/serviceability/state.go`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-057f627e5f2629b35f1976fba6eaa1b3c507c511b0f47d2f80a3a1d0c684c4a1) — adds `TopologyType`, `TopologyConstraint`, `TopologyInfo`, `LinkFlagUnicastDrained`; extends `Link` with `LinkTopologies`/`LinkFlags` and `Tenant` with `IncludeTopologies`
- [`smartcontract/sdk/go/serviceability/deserialize.go`](https://github.com/malbeclabs/doublezero/pull/3515/files#diff-b71f90b1b3e00de9bd820920e63f5615edb9b7d110c2b39f38895847509a7844) — adds `DeserializeTopologyInfo`; extends `DeserializeLink` with `LinkTopologies`/`LinkFlags` and `DeserializeTenant` with `IncludeTopologies`

</details>

## Testing Verification
- `TestGetConfig_FlexAlgo` (new): render tests for flex-algo disabled, enabled with both constraint types (`include-any` and `exclude`), and link excluded from tagging — all pass
- `Test_resolveTenantColors` (new): 5 table-driven cases covering fallback to `unicast-default`, missing topology, single/multiple known pubkeys, and unknown pubkey — all pass
- `TestE2E_IBRL`, `TestE2E_IBRL_WithAllocatedAddr`, `TestE2E_Multicast` — all pass; flex-algo config is suppressed in e2e (no `features.yaml` present)
- `exclude` constraint flex-algo syntax validated on physical lab switches (chi-dn-dzd5–dzd8)