### PR TITLE
edge: add Top-of-Book parser framework

### DIFF
--- a/client/doublezerod/internal/edge/parser.go
+++ b/client/doublezerod/internal/edge/parser.go
@@ -1,0 +1,63 @@
+package edge
+
+import "time"
+
+// Record represents a single decoded feed message ready for output.
+type Record struct {
+	Type           string         `json:"type"`
+	Timestamp      time.Time      `json:"ts"`
+	ChannelID      uint8          `json:"channel_id"`
+	SequenceNumber uint64         `json:"seq"`
+	InstrumentID   uint32         `json:"instrument_id,omitempty"`
+	Symbol         string         `json:"symbol,omitempty"`
+	Fields         map[string]any `json:"fields,omitempty"`
+}
+
+// Parser decodes raw UDP datagrams into structured records.
+// Implementations are stateful: they maintain instrument definitions
+// to enrich marketdata messages with refdata (e.g. symbol, exponents).
+type Parser interface {
+	// Name returns the parser identifier (e.g. "topofbook").
+	Name() string
+
+	// Parse decodes a single UDP datagram and returns zero or more records.
+	// Messages for instruments whose definitions have not yet been received
+	// are buffered internally until the definition arrives.
+	Parse(data []byte) ([]Record, error)
+
+	// Buffered returns the number of messages currently buffered
+	// waiting for instrument definitions.
+	Buffered() int
+
+	// InstrumentCount returns the number of instrument definitions
+	// the parser has learned so far.
+	InstrumentCount() int
+}
+
+// ParserFactory creates a new Parser instance.
+type ParserFactory func() Parser
+
+var parserRegistry = map[string]ParserFactory{}
+
+// RegisterParser registers a parser factory under the given name.
+func RegisterParser(name string, factory ParserFactory) {
+	parserRegistry[name] = factory
+}
+
+// NewParser creates a parser by name from the registry.
+func NewParser(name string) (Parser, bool) {
+	factory, ok := parserRegistry[name]
+	if !ok {
+		return nil, false
+	}
+	return factory(), true
+}
+
+// RegisteredParsers returns the names of all registered parsers.
+func RegisteredParsers() []string {
+	names := make([]string, 0, len(parserRegistry))
+	for name := range parserRegistry {
+		names = append(names, name)
+	}
+	return names
+}

--- a/client/doublezerod/internal/edge/topofbook.go
+++ b/client/doublezerod/internal/edge/topofbook.go
@@ -1,0 +1,575 @@
+package edge
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"sync"
+	"time"
+)
+
+func init() {
+	RegisterParser("topofbook", func() Parser { return NewTopOfBookParser() })
+}
+
+// instrumentInfo holds refdata needed to interpret Quote/Trade messages.
+type instrumentInfo struct {
+	Symbol        string
+	PriceExponent int8
+	QtyExponent   int8
+}
+
+// bufferedMsg holds a raw datagram message that arrived before its
+// instrument definition was available.
+type bufferedMsg struct {
+	channelID uint8
+	seq       uint64
+	sendTS    uint64
+	msg       *topOfBookAppMessage
+}
+
+// TopOfBookParser decodes DoubleZero Top-of-Book v0.1.0 frames.
+type TopOfBookParser struct {
+	mu          sync.RWMutex
+	instruments map[uint32]*instrumentInfo
+	// buffer holds at most one pending message per unknown instrument_id.
+	// Newer messages for the same instrument overwrite older ones, so we
+	// only ever retain the most recent state per instrument. Capped at
+	// maxBufferedInstruments to bound memory during the refdata gap.
+	buffer map[uint32]bufferedMsg
+	// bufferDropped counts messages dropped because buffer was full.
+	bufferDropped uint64
+	// bufferingLogged tracks instruments for which we've already emitted
+	// an INFO log about first-time buffering, to avoid log spam.
+	bufferingLogged map[uint32]bool
+	// bufferFullLogged records whether we've already emitted an INFO log
+	// about hitting the cap; further drops log at DEBUG.
+	bufferFullLogged bool
+}
+
+func NewTopOfBookParser() *TopOfBookParser {
+	return &TopOfBookParser{
+		instruments:     make(map[uint32]*instrumentInfo),
+		buffer:          make(map[uint32]bufferedMsg),
+		bufferingLogged: make(map[uint32]bool),
+	}
+}
+
+func (p *TopOfBookParser) Name() string { return "topofbook" }
+
+func (p *TopOfBookParser) Buffered() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.buffer)
+}
+
+func (p *TopOfBookParser) InstrumentCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.instruments)
+}
+
+const (
+	frameHeaderSize   = 24
+	maxSchemaVersion  = 1
+	maxReasonableMsgs = 200
+
+	// maxBufferedInstruments caps the number of distinct instruments for
+	// which we hold a pending marketdata message while awaiting refdata.
+	// Exceeding this cap causes new unknown-instrument messages to be
+	// dropped.
+	maxBufferedInstruments = 1000
+)
+
+func (p *TopOfBookParser) Parse(data []byte) ([]Record, error) {
+	frame, err := decodeTopOfBookFrame(data)
+	if err != nil {
+		return nil, fmt.Errorf("decoding frame: %w", err)
+	}
+
+	if err := p.validateHeader(frame, len(data)); err != nil {
+		return nil, err
+	}
+
+	channelID := frame.Header.ChannelID
+	seq := frame.Header.SequenceNumber
+	sendTS := frame.Header.SendTimestamp
+
+	var records []Record
+	for i := range frame.Messages {
+		msg := &frame.Messages[i]
+		recs, err := p.processMessage(channelID, seq, sendTS, msg)
+		if err != nil {
+			return records, fmt.Errorf("processing message type 0x%02x: %w", msg.MsgType, err)
+		}
+		records = append(records, recs...)
+	}
+
+	// Try to flush buffered messages now that we may have new definitions.
+	flushed := p.flushBuffer()
+	records = append(records, flushed...)
+
+	return records, nil
+}
+
+// validateHeader performs sanity checks on the frame header that go beyond
+// what the wire-format decoder validates (magic bytes only).
+func (p *TopOfBookParser) validateHeader(frame *topOfBookFrame, datagramLen int) error {
+	h := frame.Header
+
+	if h.SchemaVersion == 0 || h.SchemaVersion > maxSchemaVersion {
+		return fmt.Errorf("unsupported schema version %d (expected 1..%d)", h.SchemaVersion, maxSchemaVersion)
+	}
+
+	if int(h.FrameLength) != datagramLen {
+		return fmt.Errorf("frame length mismatch: header says %d, datagram is %d bytes", h.FrameLength, datagramLen)
+	}
+
+	if h.MsgCount == 0 {
+		return fmt.Errorf("frame has zero messages")
+	}
+	if h.MsgCount > maxReasonableMsgs {
+		return fmt.Errorf("frame claims %d messages (max %d)", h.MsgCount, maxReasonableMsgs)
+	}
+
+	return nil
+}
+
+func (p *TopOfBookParser) processMessage(channelID uint8, seq uint64, sendTS uint64, msg *topOfBookAppMessage) ([]Record, error) {
+	switch body := msg.Body.(type) {
+	case *topOfBookInstrumentDef:
+		return p.handleInstrumentDef(channelID, seq, sendTS, msg, body), nil
+	case *topOfBookQuote:
+		return p.handleQuote(channelID, seq, sendTS, msg, body), nil
+	case *topOfBookTrade:
+		return p.handleTrade(channelID, seq, sendTS, msg, body), nil
+	case *topOfBookHeartbeat:
+		return p.handleHeartbeat(channelID, seq, body), nil
+	case *topOfBookChannelReset:
+		return p.handleChannelReset(channelID, seq, body), nil
+	case *topOfBookEndOfSession:
+		return p.handleEndOfSession(channelID, seq, body), nil
+	case *topOfBookManifestSummary:
+		return p.handleManifestSummary(channelID, seq, body), nil
+	default:
+		// Unknown message type — skip per spec.
+		return nil, nil
+	}
+}
+
+func (p *TopOfBookParser) handleInstrumentDef(channelID uint8, seq uint64, sendTS uint64, msg *topOfBookAppMessage, body *topOfBookInstrumentDef) []Record {
+	info := &instrumentInfo{
+		Symbol:        trimNull(body.Symbol),
+		PriceExponent: body.PriceExponent,
+		QtyExponent:   body.QtyExponent,
+	}
+
+	p.mu.Lock()
+	_, existed := p.instruments[body.InstrumentID]
+	p.instruments[body.InstrumentID] = info
+	// Clear the first-time-buffering flag so a future gap is logged again.
+	delete(p.bufferingLogged, body.InstrumentID)
+	p.mu.Unlock()
+
+	if existed {
+		slog.Debug("edge: instrument redefined",
+			"parser", "topofbook",
+			"instrument_id", body.InstrumentID,
+			"symbol", info.Symbol)
+	} else {
+		slog.Info("edge: instrument defined",
+			"parser", "topofbook",
+			"instrument_id", body.InstrumentID,
+			"symbol", info.Symbol)
+	}
+
+	return []Record{{
+		Type:           "instrument_definition",
+		Timestamp:      nsToTime(sendTS),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+		InstrumentID:   body.InstrumentID,
+		Symbol:         info.Symbol,
+		Fields: map[string]any{
+			"leg1":           trimNull(body.Leg1),
+			"leg2":           trimNull(body.Leg2),
+			"asset_class":    body.AssetClass,
+			"price_exponent": body.PriceExponent,
+			"qty_exponent":   body.QtyExponent,
+			"market_model":   body.MarketModel,
+			"tick_size":      body.TickSize,
+			"lot_size":       body.LotSize,
+			"contract_value": body.ContractValue,
+			"settle_type":    body.SettleType,
+			"price_bound":    body.PriceBound,
+			"manifest_seq":   body.ManifestSeq,
+		},
+	}}
+}
+
+func (p *TopOfBookParser) handleQuote(channelID uint8, seq uint64, sendTS uint64, msg *topOfBookAppMessage, body *topOfBookQuote) []Record {
+	p.mu.RLock()
+	info, ok := p.instruments[body.InstrumentID]
+	p.mu.RUnlock()
+
+	if !ok {
+		p.mu.Lock()
+		ev := p.bufferPendingLocked(body.InstrumentID, "quote", bufferedMsg{
+			channelID: channelID,
+			seq:       seq,
+			sendTS:    sendTS,
+			msg:       msg,
+		})
+		p.mu.Unlock()
+		ev.emit()
+		return nil
+	}
+
+	return []Record{{
+		Type:           "quote",
+		Timestamp:      nsToTime(body.SourceTimestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+		InstrumentID:   body.InstrumentID,
+		Symbol:         info.Symbol,
+		Fields: map[string]any{
+			"source_id":        body.SourceID,
+			"bid_price":        applyExponent(body.BidPrice, info.PriceExponent),
+			"bid_qty":          applyExponentUnsigned(body.BidQty, info.QtyExponent),
+			"ask_price":        applyExponent(body.AskPrice, info.PriceExponent),
+			"ask_qty":          applyExponentUnsigned(body.AskQty, info.QtyExponent),
+			"bid_source_count": body.BidSourceCount,
+			"ask_source_count": body.AskSourceCount,
+			"update_flags":     body.UpdateFlags,
+			"snapshot":         msg.Flags&1 == 1,
+		},
+	}}
+}
+
+func (p *TopOfBookParser) handleTrade(channelID uint8, seq uint64, sendTS uint64, msg *topOfBookAppMessage, body *topOfBookTrade) []Record {
+	p.mu.RLock()
+	info, ok := p.instruments[body.InstrumentID]
+	p.mu.RUnlock()
+
+	if !ok {
+		p.mu.Lock()
+		ev := p.bufferPendingLocked(body.InstrumentID, "trade", bufferedMsg{
+			channelID: channelID,
+			seq:       seq,
+			sendTS:    sendTS,
+			msg:       msg,
+		})
+		p.mu.Unlock()
+		ev.emit()
+		return nil
+	}
+
+	side := "unknown"
+	switch body.AggressorSide {
+	case 1:
+		side = "buy"
+	case 2:
+		side = "sell"
+	}
+
+	return []Record{{
+		Type:           "trade",
+		Timestamp:      nsToTime(body.SourceTimestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+		InstrumentID:   body.InstrumentID,
+		Symbol:         info.Symbol,
+		Fields: map[string]any{
+			"source_id":         body.SourceID,
+			"trade_price":       applyExponent(body.TradePrice, info.PriceExponent),
+			"trade_qty":         applyExponentUnsigned(body.TradeQty, info.QtyExponent),
+			"aggressor_side":    side,
+			"trade_id":          body.TradeID,
+			"cumulative_volume": applyExponentUnsigned(body.CumulativeVolume, info.QtyExponent),
+			"snapshot":          msg.Flags&1 == 1,
+		},
+	}}
+}
+
+func (p *TopOfBookParser) handleHeartbeat(channelID uint8, seq uint64, body *topOfBookHeartbeat) []Record {
+	return []Record{{
+		Type:           "heartbeat",
+		Timestamp:      nsToTime(body.Timestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+	}}
+}
+
+func (p *TopOfBookParser) handleChannelReset(channelID uint8, seq uint64, body *topOfBookChannelReset) []Record {
+	p.mu.Lock()
+	p.instruments = make(map[uint32]*instrumentInfo)
+	p.buffer = make(map[uint32]bufferedMsg)
+	p.bufferingLogged = make(map[uint32]bool)
+	p.bufferFullLogged = false
+	p.mu.Unlock()
+
+	return []Record{{
+		Type:           "channel_reset",
+		Timestamp:      nsToTime(body.Timestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+	}}
+}
+
+func (p *TopOfBookParser) handleEndOfSession(channelID uint8, seq uint64, body *topOfBookEndOfSession) []Record {
+	return []Record{{
+		Type:           "end_of_session",
+		Timestamp:      nsToTime(body.Timestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+	}}
+}
+
+func (p *TopOfBookParser) handleManifestSummary(channelID uint8, seq uint64, body *topOfBookManifestSummary) []Record {
+	return []Record{{
+		Type:           "manifest_summary",
+		Timestamp:      nsToTime(body.Timestamp),
+		ChannelID:      channelID,
+		SequenceNumber: seq,
+		Fields: map[string]any{
+			"manifest_seq":     body.ManifestSeq,
+			"instrument_count": body.InstrumentCount,
+		},
+	}}
+}
+
+// bufferPendingLocked stores a pending marketdata message for an unknown
+// instrument. If a message for that instrument is already buffered, it is
+// overwritten (keeping only the most recent). If the buffer is at capacity
+// and this is a new instrument, the message is dropped.
+//
+// Caller must hold p.mu.
+//
+// Returns a pendingLogEvent describing what should be logged once the
+// lock is released. Callers must emit the log outside the critical
+// section to keep slog off the hot path while the mutex is held.
+func (p *TopOfBookParser) bufferPendingLocked(instrumentID uint32, msgType string, bm bufferedMsg) pendingLogEvent {
+	if _, exists := p.buffer[instrumentID]; exists {
+		p.buffer[instrumentID] = bm
+		return pendingLogEvent{
+			kind:         logBufferReplaced,
+			instrumentID: instrumentID,
+			msgType:      msgType,
+			bufferDepth:  len(p.buffer),
+		}
+	}
+	if len(p.buffer) >= maxBufferedInstruments {
+		p.bufferDropped++
+		first := !p.bufferFullLogged
+		p.bufferFullLogged = true
+		return pendingLogEvent{
+			kind:         logBufferFull,
+			instrumentID: instrumentID,
+			msgType:      msgType,
+			bufferDepth:  len(p.buffer),
+			dropCount:    p.bufferDropped,
+			firstTime:    first,
+		}
+	}
+	p.buffer[instrumentID] = bm
+	firstTime := !p.bufferingLogged[instrumentID]
+	if firstTime {
+		p.bufferingLogged[instrumentID] = true
+	}
+	return pendingLogEvent{
+		kind:         logBufferInserted,
+		instrumentID: instrumentID,
+		msgType:      msgType,
+		bufferDepth:  len(p.buffer),
+		firstTime:    firstTime,
+	}
+}
+
+// pendingLogEvent carries data about a buffer-transition event that the
+// caller of bufferPendingLocked should log after releasing p.mu.
+type pendingLogEvent struct {
+	kind         pendingLogKind
+	instrumentID uint32
+	msgType      string
+	bufferDepth  int
+	dropCount    uint64
+	firstTime    bool
+}
+
+type pendingLogKind int
+
+const (
+	logBufferInserted pendingLogKind = iota
+	logBufferReplaced
+	logBufferFull
+)
+
+func (e pendingLogEvent) emit() {
+	switch e.kind {
+	case logBufferInserted:
+		if e.firstTime {
+			slog.Info("edge: buffering messages, awaiting instrument definition",
+				"parser", "topofbook",
+				"msg_type", e.msgType,
+				"instrument_id", e.instrumentID,
+				"buffer_depth", e.bufferDepth)
+		} else {
+			slog.Debug("edge: buffering message",
+				"parser", "topofbook",
+				"msg_type", e.msgType,
+				"instrument_id", e.instrumentID,
+				"buffer_depth", e.bufferDepth)
+		}
+	case logBufferReplaced:
+		slog.Debug("edge: buffered message replaced",
+			"parser", "topofbook",
+			"msg_type", e.msgType,
+			"instrument_id", e.instrumentID,
+			"buffer_depth", e.bufferDepth)
+	case logBufferFull:
+		if e.firstTime {
+			slog.Warn("edge: buffer full, dropping message",
+				"parser", "topofbook",
+				"msg_type", e.msgType,
+				"instrument_id", e.instrumentID,
+				"buffer_depth", e.bufferDepth,
+				"cap", maxBufferedInstruments,
+				"total_dropped", e.dropCount)
+		} else {
+			slog.Debug("edge: buffer full, dropping message",
+				"parser", "topofbook",
+				"msg_type", e.msgType,
+				"instrument_id", e.instrumentID,
+				"total_dropped", e.dropCount)
+		}
+	}
+}
+
+func (p *TopOfBookParser) flushBuffer() []Record {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var records []Record
+	for instrumentID, bm := range p.buffer {
+		recs, err := p.processBufferedMessage(bm)
+		if err != nil || recs == nil {
+			continue
+		}
+		records = append(records, recs...)
+		delete(p.buffer, instrumentID)
+	}
+
+	if len(records) > 0 {
+		slog.Info("edge: flushed buffered messages",
+			"parser", "topofbook",
+			"flushed", len(records),
+			"remaining", len(p.buffer))
+	}
+
+	return records
+}
+
+// processBufferedMessage processes a buffered message without acquiring locks
+// (caller must hold p.mu).
+func (p *TopOfBookParser) processBufferedMessage(bm bufferedMsg) ([]Record, error) {
+	switch body := bm.msg.Body.(type) {
+	case *topOfBookQuote:
+		info, ok := p.instruments[body.InstrumentID]
+		if !ok {
+			return nil, nil
+		}
+		return []Record{{
+			Type:           "quote",
+			Timestamp:      nsToTime(body.SourceTimestamp),
+			ChannelID:      bm.channelID,
+			SequenceNumber: bm.seq,
+			InstrumentID:   body.InstrumentID,
+			Symbol:         info.Symbol,
+			Fields: map[string]any{
+				"source_id":        body.SourceID,
+				"bid_price":        applyExponent(body.BidPrice, info.PriceExponent),
+				"bid_qty":          applyExponentUnsigned(body.BidQty, info.QtyExponent),
+				"ask_price":        applyExponent(body.AskPrice, info.PriceExponent),
+				"ask_qty":          applyExponentUnsigned(body.AskQty, info.QtyExponent),
+				"bid_source_count": body.BidSourceCount,
+				"ask_source_count": body.AskSourceCount,
+				"update_flags":     body.UpdateFlags,
+				"snapshot":         bm.msg.Flags&1 == 1,
+			},
+		}}, nil
+	case *topOfBookTrade:
+		info, ok := p.instruments[body.InstrumentID]
+		if !ok {
+			return nil, nil
+		}
+		side := "unknown"
+		switch body.AggressorSide {
+		case 1:
+			side = "buy"
+		case 2:
+			side = "sell"
+		}
+		return []Record{{
+			Type:           "trade",
+			Timestamp:      nsToTime(body.SourceTimestamp),
+			ChannelID:      bm.channelID,
+			SequenceNumber: bm.seq,
+			InstrumentID:   body.InstrumentID,
+			Symbol:         info.Symbol,
+			Fields: map[string]any{
+				"source_id":         body.SourceID,
+				"trade_price":       applyExponent(body.TradePrice, info.PriceExponent),
+				"trade_qty":         applyExponentUnsigned(body.TradeQty, info.QtyExponent),
+				"aggressor_side":    side,
+				"trade_id":          body.TradeID,
+				"cumulative_volume": applyExponentUnsigned(body.CumulativeVolume, info.QtyExponent),
+				"snapshot":          bm.msg.Flags&1 == 1,
+			},
+		}}, nil
+	default:
+		return nil, nil
+	}
+}
+
+// trimNull removes trailing null bytes from a fixed-size ASCII string.
+func trimNull(s string) string {
+	return strings.TrimRight(s, "\x00")
+}
+
+// nsToTime converts nanoseconds since Unix epoch to time.Time.
+func nsToTime(ns uint64) time.Time {
+	return time.Unix(0, int64(ns)).UTC()
+}
+
+// maxExponent is the largest exponent we accept. Financial instruments
+// use small exponents (typically -8 to +2). Anything outside [-18, 18]
+// is almost certainly garbage and would produce unreasonable float values.
+const maxExponent = 18
+
+// applyExponent converts a raw signed integer with an implied decimal exponent
+// to a float64. For example, raw=6743250 with exponent=-2 yields 67432.50.
+// Returns 0 if the exponent is out of the reasonable range or the result
+// would be Inf or NaN.
+func applyExponent(raw int64, exp int8) float64 {
+	if exp > maxExponent || exp < -maxExponent {
+		return 0
+	}
+	v := float64(raw) * math.Pow(10, float64(exp))
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return 0
+	}
+	return v
+}
+
+// applyExponentUnsigned is the unsigned variant of applyExponent.
+func applyExponentUnsigned(raw uint64, exp int8) float64 {
+	if exp > maxExponent || exp < -maxExponent {
+		return 0
+	}
+	v := float64(raw) * math.Pow(10, float64(exp))
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return 0
+	}
+	return v
+}

--- a/client/doublezerod/internal/edge/topofbook_test.go
+++ b/client/doublezerod/internal/edge/topofbook_test.go
@@ -1,0 +1,577 @@
+package edge
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+	"time"
+)
+
+// buildFrame constructs a raw Top-of-Book frame from a header and message payloads.
+func buildFrame(channelID uint8, seq uint64, sendTS uint64, msgs ...[]byte) []byte {
+	headerSize := 24
+	bodySize := 0
+	for _, m := range msgs {
+		bodySize += len(m)
+	}
+	frameLen := headerSize + bodySize
+
+	buf := make([]byte, frameLen)
+	// Magic "DZ" = 0x445A little-endian → bytes 0x5A, 0x44
+	buf[0] = 0x5A
+	buf[1] = 0x44
+	buf[2] = 1 // schema version
+	buf[3] = channelID
+	binary.LittleEndian.PutUint64(buf[4:], seq)
+	binary.LittleEndian.PutUint64(buf[12:], sendTS)
+	buf[20] = uint8(len(msgs)) // msg count
+	buf[21] = 0                // reserved
+	binary.LittleEndian.PutUint16(buf[22:], uint16(frameLen))
+
+	off := headerSize
+	for _, m := range msgs {
+		copy(buf[off:], m)
+		off += len(m)
+	}
+	return buf
+}
+
+// buildInstrumentDef constructs a 80-byte InstrumentDefinition message.
+func buildInstrumentDef(instID uint32, symbol string, leg1, leg2 string, priceExp, qtyExp int8) []byte {
+	buf := make([]byte, 80)
+	buf[0] = 0x02                             // type
+	buf[1] = 80                               // length
+	binary.LittleEndian.PutUint16(buf[2:], 0) // flags
+
+	binary.LittleEndian.PutUint32(buf[4:], instID)
+	copy(buf[8:24], padNull(symbol, 16))
+	copy(buf[24:32], padNull(leg1, 8))
+	copy(buf[32:40], padNull(leg2, 8))
+	buf[40] = 1                                // asset class: crypto spot
+	buf[41] = byte(priceExp)                   // price exponent (signed)
+	buf[42] = byte(qtyExp)                     // qty exponent (signed)
+	buf[43] = 1                                // market model: CLOB
+	binary.LittleEndian.PutUint64(buf[44:], 1) // tick size
+	binary.LittleEndian.PutUint64(buf[52:], 1) // lot size
+	binary.LittleEndian.PutUint64(buf[60:], 0) // contract value
+	binary.LittleEndian.PutUint64(buf[68:], 0) // expiry
+	buf[76] = 0                                // settle type
+	buf[77] = 0                                // price bound
+	binary.LittleEndian.PutUint16(buf[78:], 1) // manifest seq
+	return buf
+}
+
+// buildQuote constructs a 60-byte Quote message.
+func buildQuote(instID uint32, sourceID uint16, srcTS uint64, bidPrice int64, bidQty uint64, askPrice int64, askQty uint64, flags uint16) []byte {
+	buf := make([]byte, 60)
+	buf[0] = 0x03 // type
+	buf[1] = 60   // length
+	binary.LittleEndian.PutUint16(buf[2:], flags)
+
+	binary.LittleEndian.PutUint32(buf[4:], instID)
+	binary.LittleEndian.PutUint16(buf[8:], sourceID)
+	buf[10] = 0x03 // update flags: bid + ask updated
+	buf[11] = 0    // reserved
+
+	binary.LittleEndian.PutUint64(buf[12:], srcTS)
+	putInt64LE(buf[20:], bidPrice)
+	binary.LittleEndian.PutUint64(buf[28:], bidQty)
+	putInt64LE(buf[36:], askPrice)
+	binary.LittleEndian.PutUint64(buf[44:], askQty)
+	binary.LittleEndian.PutUint16(buf[52:], 5) // bid source count
+	binary.LittleEndian.PutUint16(buf[54:], 3) // ask source count
+	// 4 bytes reserved at 56-59
+	return buf
+}
+
+// buildTrade constructs a 52-byte Trade message.
+func buildTrade(instID uint32, sourceID uint16, srcTS uint64, price int64, qty uint64, side uint8) []byte {
+	buf := make([]byte, 52)
+	buf[0] = 0x04                             // type
+	buf[1] = 52                               // length
+	binary.LittleEndian.PutUint16(buf[2:], 0) // flags
+
+	binary.LittleEndian.PutUint32(buf[4:], instID)
+	binary.LittleEndian.PutUint16(buf[8:], sourceID)
+	buf[10] = side // aggressor side
+	buf[11] = 0    // trade flags
+
+	binary.LittleEndian.PutUint64(buf[12:], srcTS)
+	putInt64LE(buf[20:], price)
+	binary.LittleEndian.PutUint64(buf[28:], qty)
+	binary.LittleEndian.PutUint64(buf[36:], 12345) // trade ID
+	binary.LittleEndian.PutUint64(buf[44:], qty)   // cumulative volume
+	return buf
+}
+
+// buildHeartbeat constructs a 16-byte Heartbeat message.
+func buildHeartbeat(channelID uint8, ts uint64) []byte {
+	buf := make([]byte, 16)
+	buf[0] = 0x01                             // type
+	buf[1] = 16                               // length
+	binary.LittleEndian.PutUint16(buf[2:], 0) // flags
+	buf[4] = channelID
+	// 3 bytes reserved
+	binary.LittleEndian.PutUint64(buf[8:], ts)
+	return buf
+}
+
+// buildChannelReset constructs a 12-byte ChannelReset message.
+func buildChannelReset(ts uint64) []byte {
+	buf := make([]byte, 12)
+	buf[0] = 0x05 // type
+	buf[1] = 12   // length
+	binary.LittleEndian.PutUint16(buf[2:], 0)
+	binary.LittleEndian.PutUint64(buf[4:], ts)
+	return buf
+}
+
+func padNull(s string, n int) []byte {
+	buf := make([]byte, n)
+	copy(buf, s)
+	return buf
+}
+
+func putInt64LE(buf []byte, v int64) {
+	binary.LittleEndian.PutUint64(buf, uint64(v))
+}
+
+func TestTopOfBookParser_InstrumentDefinition(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+	instDef := buildInstrumentDef(42, "BTC-USDT", "BTC", "USDT", -2, -8)
+	frame := buildFrame(1, 100, ts, instDef)
+
+	records, err := p.Parse(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	r := records[0]
+	if r.Type != "instrument_definition" {
+		t.Errorf("expected type instrument_definition, got %s", r.Type)
+	}
+	if r.InstrumentID != 42 {
+		t.Errorf("expected instrument ID 42, got %d", r.InstrumentID)
+	}
+	if r.Symbol != "BTC-USDT" {
+		t.Errorf("expected symbol BTC-USDT, got %q", r.Symbol)
+	}
+	if r.ChannelID != 1 {
+		t.Errorf("expected channel ID 1, got %d", r.ChannelID)
+	}
+	if r.SequenceNumber != 100 {
+		t.Errorf("expected sequence number 100, got %d", r.SequenceNumber)
+	}
+	if r.Fields["price_exponent"] != int8(-2) {
+		t.Errorf("expected price_exponent -2, got %v", r.Fields["price_exponent"])
+	}
+	if r.Fields["leg1"] != "BTC" {
+		t.Errorf("expected leg1 BTC, got %v", r.Fields["leg1"])
+	}
+}
+
+func TestTopOfBookParser_QuoteWithDefinition(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// First send instrument definition.
+	instDef := buildInstrumentDef(42, "BTC-USDT", "BTC", "USDT", -2, -8)
+	frame1 := buildFrame(1, 100, ts, instDef)
+	_, err := p.Parse(frame1)
+	if err != nil {
+		t.Fatalf("error parsing instrument def: %v", err)
+	}
+
+	// Now send a quote.
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 1, 0, time.UTC).UnixNano())
+	quote := buildQuote(42, 1, srcTS, 6743250, 125000000, 6743300, 80000000, 0)
+	frame2 := buildFrame(1, 101, ts, quote)
+
+	records, err := p.Parse(frame2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	r := records[0]
+	if r.Type != "quote" {
+		t.Errorf("expected type quote, got %s", r.Type)
+	}
+	if r.Symbol != "BTC-USDT" {
+		t.Errorf("expected symbol BTC-USDT, got %q", r.Symbol)
+	}
+
+	// With price exponent -2: 6743250 * 10^-2 = 67432.50
+	bidPrice := r.Fields["bid_price"].(float64)
+	if math.Abs(bidPrice-67432.50) > 0.001 {
+		t.Errorf("expected bid_price 67432.50, got %f", bidPrice)
+	}
+
+	// With qty exponent -8: 125000000 * 10^-8 = 1.25
+	bidQty := r.Fields["bid_qty"].(float64)
+	if math.Abs(bidQty-1.25) > 0.0001 {
+		t.Errorf("expected bid_qty 1.25, got %f", bidQty)
+	}
+}
+
+func TestTopOfBookParser_QuoteBuffering(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Send a quote BEFORE the instrument definition — should be buffered.
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 1, 0, time.UTC).UnixNano())
+	quote := buildQuote(42, 1, srcTS, 6743250, 125000000, 6743300, 80000000, 0)
+	frame1 := buildFrame(1, 101, ts, quote)
+
+	records, err := p.Parse(frame1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records (buffered), got %d", len(records))
+	}
+	if p.Buffered() != 1 {
+		t.Fatalf("expected 1 buffered message, got %d", p.Buffered())
+	}
+
+	// Now send the instrument definition — buffered quote should flush.
+	instDef := buildInstrumentDef(42, "BTC-USDT", "BTC", "USDT", -2, -8)
+	frame2 := buildFrame(1, 102, ts, instDef)
+
+	records, err = p.Parse(frame2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should get the instrument def + the flushed quote.
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records (def + flushed quote), got %d", len(records))
+	}
+	if records[0].Type != "instrument_definition" {
+		t.Errorf("expected first record to be instrument_definition, got %s", records[0].Type)
+	}
+	if records[1].Type != "quote" {
+		t.Errorf("expected second record to be quote, got %s", records[1].Type)
+	}
+	if p.Buffered() != 0 {
+		t.Errorf("expected 0 buffered after flush, got %d", p.Buffered())
+	}
+}
+
+func TestTopOfBookParser_Trade(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Register instrument first.
+	instDef := buildInstrumentDef(42, "ETH-USDT", "ETH", "USDT", -2, -6)
+	frame1 := buildFrame(1, 100, ts, instDef)
+	p.Parse(frame1)
+
+	// Send a trade (sell aggressor).
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 5, 0, time.UTC).UnixNano())
+	trade := buildTrade(42, 1, srcTS, 350025, 1500000, 2)
+	frame2 := buildFrame(1, 101, ts, trade)
+
+	records, err := p.Parse(frame2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	r := records[0]
+	if r.Type != "trade" {
+		t.Errorf("expected type trade, got %s", r.Type)
+	}
+	if r.Fields["aggressor_side"] != "sell" {
+		t.Errorf("expected aggressor_side sell, got %v", r.Fields["aggressor_side"])
+	}
+
+	// 350025 * 10^-2 = 3500.25
+	price := r.Fields["trade_price"].(float64)
+	if math.Abs(price-3500.25) > 0.001 {
+		t.Errorf("expected trade_price 3500.25, got %f", price)
+	}
+}
+
+func TestTopOfBookParser_Heartbeat(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+	hb := buildHeartbeat(3, ts)
+	frame := buildFrame(3, 50, ts, hb)
+
+	records, err := p.Parse(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Type != "heartbeat" {
+		t.Errorf("expected type heartbeat, got %s", records[0].Type)
+	}
+	if records[0].ChannelID != 3 {
+		t.Errorf("expected channel ID 3, got %d", records[0].ChannelID)
+	}
+}
+
+func TestTopOfBookParser_ChannelReset(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Add an instrument definition.
+	instDef := buildInstrumentDef(42, "BTC-USDT", "BTC", "USDT", -2, -8)
+	frame1 := buildFrame(1, 100, ts, instDef)
+	p.Parse(frame1)
+
+	// Channel reset should clear instruments.
+	reset := buildChannelReset(ts)
+	frame2 := buildFrame(1, 101, ts, reset)
+	records, err := p.Parse(frame2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Type != "channel_reset" {
+		t.Errorf("expected type channel_reset, got %s", records[0].Type)
+	}
+
+	// A quote for the same instrument should now be buffered (definition was cleared).
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 1, 0, time.UTC).UnixNano())
+	quote := buildQuote(42, 1, srcTS, 100, 200, 300, 400, 0)
+	frame3 := buildFrame(1, 102, ts, quote)
+	records, err = p.Parse(frame3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records (buffered after reset), got %d", len(records))
+	}
+	if p.Buffered() != 1 {
+		t.Errorf("expected 1 buffered, got %d", p.Buffered())
+	}
+}
+
+func TestTopOfBookParser_MultipleMessagesInFrame(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Build a frame with an instrument definition + a quote for that instrument.
+	instDef := buildInstrumentDef(1, "SOL-USDT", "SOL", "USDT", -4, -6)
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 1, 0, time.UTC).UnixNano())
+	quote := buildQuote(1, 1, srcTS, 1850000, 5000000, 1860000, 3000000, 0)
+
+	frame := buildFrame(1, 200, ts, instDef, quote)
+
+	records, err := p.Parse(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Instrument def is processed first, so the quote should be decoded immediately
+	// (either directly or via buffer flush).
+	if len(records) < 2 {
+		t.Fatalf("expected at least 2 records, got %d", len(records))
+	}
+
+	var foundDef, foundQuote bool
+	for _, r := range records {
+		switch r.Type {
+		case "instrument_definition":
+			foundDef = true
+			if r.Symbol != "SOL-USDT" {
+				t.Errorf("expected symbol SOL-USDT, got %q", r.Symbol)
+			}
+		case "quote":
+			foundQuote = true
+			// 1850000 * 10^-4 = 185.0000
+			bidPrice := r.Fields["bid_price"].(float64)
+			if math.Abs(bidPrice-185.0) > 0.001 {
+				t.Errorf("expected bid_price 185.0, got %f", bidPrice)
+			}
+		}
+	}
+	if !foundDef {
+		t.Error("expected instrument_definition record")
+	}
+	if !foundQuote {
+		t.Error("expected quote record")
+	}
+}
+
+func TestTopOfBookParser_SnapshotFlag(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Register instrument.
+	instDef := buildInstrumentDef(1, "BTC-USDT", "BTC", "USDT", -2, -8)
+	frame1 := buildFrame(1, 100, ts, instDef)
+	p.Parse(frame1)
+
+	// Send a quote with snapshot flag set (flags bit 0 = 1).
+	srcTS := uint64(time.Date(2026, 4, 10, 12, 0, 1, 0, time.UTC).UnixNano())
+	quote := buildQuote(1, 1, srcTS, 100, 200, 300, 400, 1) // flags=1 → snapshot
+	frame2 := buildFrame(1, 101, ts, quote)
+
+	records, err := p.Parse(frame2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Fields["snapshot"] != true {
+		t.Errorf("expected snapshot=true, got %v", records[0].Fields["snapshot"])
+	}
+}
+
+func TestTopOfBookParser_UnknownMessageTypeSkipped(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	ts := uint64(time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC).UnixNano())
+
+	// Build an unknown message type (0xFF) with 12-byte body.
+	unknownMsg := make([]byte, 12)
+	unknownMsg[0] = 0xFF // unknown type
+	unknownMsg[1] = 12   // length
+	// rest is zeros
+
+	hb := buildHeartbeat(1, ts)
+	frame := buildFrame(1, 100, ts, unknownMsg, hb)
+
+	records, err := p.Parse(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the heartbeat should produce a record; unknown type is skipped.
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Type != "heartbeat" {
+		t.Errorf("expected heartbeat, got %s", records[0].Type)
+	}
+}
+
+func TestTopOfBookParser_GarbageData(t *testing.T) {
+	p := NewTopOfBookParser()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"too short", []byte{0x5A, 0x44, 0x01}},
+		{"wrong magic", append(make([]byte, 24), 0x00)},
+		{"zero messages", func() []byte {
+			buf := make([]byte, 24)
+			buf[0] = 0x5A
+			buf[1] = 0x44
+			buf[2] = 1  // schema version
+			buf[20] = 0 // msg count = 0
+			binary.LittleEndian.PutUint16(buf[22:], 24)
+			return buf
+		}()},
+		{"bad schema version", func() []byte {
+			buf := make([]byte, 24)
+			buf[0] = 0x5A
+			buf[1] = 0x44
+			buf[2] = 99 // unsupported version
+			buf[20] = 1
+			binary.LittleEndian.PutUint16(buf[22:], 24)
+			return buf
+		}()},
+		{"frame length mismatch", func() []byte {
+			ts := uint64(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano())
+			hb := buildHeartbeat(1, ts)
+			frame := buildFrame(1, 1, ts, hb)
+			// Corrupt frame length to be larger than datagram.
+			binary.LittleEndian.PutUint16(frame[22:], uint16(len(frame)+100))
+			return frame
+		}()},
+		{"random bytes", []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x11, 0x22, 0x33,
+			0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB,
+			0xCC, 0xDD, 0xEE, 0xFF, 0x01, 0x02, 0x03, 0x04}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records, err := p.Parse(tt.data)
+			if err == nil {
+				t.Errorf("expected error for %s input, got %d records", tt.name, len(records))
+			}
+		})
+	}
+}
+
+func TestApplyExponent_ExtremeValues(t *testing.T) {
+	// Extreme exponents that would produce Inf should return 0.
+	v := applyExponent(math.MaxInt64, 127)
+	if v != 0 {
+		t.Errorf("expected 0 for overflow, got %f", v)
+	}
+
+	// Normal exponents should still work.
+	v = applyExponent(100, -2)
+	if math.Abs(v-1.0) > 0.001 {
+		t.Errorf("expected 1.0, got %f", v)
+	}
+
+	// Unsigned variant.
+	v = applyExponentUnsigned(math.MaxUint64, 127)
+	if v != 0 {
+		t.Errorf("expected 0 for unsigned overflow, got %f", v)
+	}
+}
+
+func TestApplyExponent(t *testing.T) {
+	tests := []struct {
+		raw    int64
+		exp    int8
+		expect float64
+	}{
+		{6743250, -2, 67432.50},
+		{100, 0, 100.0},
+		{5, 3, 5000.0},
+		{-100, -1, -10.0},
+	}
+	for _, tt := range tests {
+		got := applyExponent(tt.raw, tt.exp)
+		if math.Abs(got-tt.expect) > 0.001 {
+			t.Errorf("applyExponent(%d, %d) = %f, want %f", tt.raw, tt.exp, got, tt.expect)
+		}
+	}
+}
+
+func TestTrimNull(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"BTC-USDT\x00\x00\x00\x00\x00\x00\x00\x00", "BTC-USDT"},
+		{"SOL\x00\x00\x00\x00\x00", "SOL"},
+		{"ABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOP"},
+		{"\x00\x00\x00\x00", ""},
+	}
+	for _, tt := range tests {
+		got := trimNull(tt.input)
+		if got != tt.expect {
+			t.Errorf("trimNull(%q) = %q, want %q", tt.input, got, tt.expect)
+		}
+	}
+}

--- a/client/doublezerod/internal/edge/topofbook_wire.go
+++ b/client/doublezerod/internal/edge/topofbook_wire.go
@@ -1,0 +1,377 @@
+package edge
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Wire format for the DoubleZero Top-of-Book feed, v0.1.0.
+//
+// One UDP datagram carries one frame. A frame is a fixed 24-byte header
+// followed by a sequence of application messages. Every multi-byte
+// integer is little-endian. The layout is fixed-size (no varints, no
+// length-prefixed strings beyond fixed arrays), making a straight
+// positional decode sufficient.
+//
+// Message types:
+//
+//   0x01 heartbeat
+//   0x02 instrument definition (refdata)
+//   0x03 quote (marketdata)
+//   0x04 trade (marketdata)
+//   0x05 channel reset
+//   0x06 end of session
+//   0x07 manifest summary
+
+const (
+	frameHeaderBytes = 24
+
+	// Magic bytes at the start of every frame: "DZ".
+	frameMagic0 = 0x5A
+	frameMagic1 = 0x44
+)
+
+const (
+	msgHeartbeat            uint8 = 0x01
+	msgInstrumentDefinition uint8 = 0x02
+	msgQuote                uint8 = 0x03
+	msgTrade                uint8 = 0x04
+	msgChannelReset         uint8 = 0x05
+	msgEndOfSession         uint8 = 0x06
+	msgManifestSummary      uint8 = 0x07
+)
+
+// topOfBookFrame is one decoded UDP datagram.
+type topOfBookFrame struct {
+	Header   topOfBookHeader
+	Messages []topOfBookAppMessage
+}
+
+type topOfBookHeader struct {
+	Magic          [2]byte
+	SchemaVersion  uint8
+	ChannelID      uint8
+	SequenceNumber uint64
+	SendTimestamp  uint64 // nanoseconds since Unix epoch
+	MsgCount       uint8
+	Reserved       uint8
+	FrameLength    uint16
+}
+
+// topOfBookAppMessage is a single message inside a frame. Body is one
+// of the *topOfBook* body types below, selected by MsgType; unknown
+// message types leave Body nil so the parser can skip them.
+type topOfBookAppMessage struct {
+	MsgType   uint8
+	MsgLength uint8
+	Flags     uint16
+	Body      any
+}
+
+type topOfBookHeartbeat struct {
+	ChannelID uint8
+	Timestamp uint64
+}
+
+type topOfBookInstrumentDef struct {
+	InstrumentID  uint32
+	Symbol        string // fixed 16 bytes, null-padded ASCII
+	Leg1          string // fixed 8 bytes
+	Leg2          string // fixed 8 bytes
+	AssetClass    uint8
+	PriceExponent int8
+	QtyExponent   int8
+	MarketModel   uint8
+	TickSize      int64
+	LotSize       uint64
+	ContractValue uint64
+	Expiry        uint64
+	SettleType    uint8
+	PriceBound    uint8
+	ManifestSeq   uint16
+}
+
+type topOfBookQuote struct {
+	InstrumentID    uint32
+	SourceID        uint16
+	UpdateFlags     uint8
+	SourceTimestamp uint64
+	BidPrice        int64
+	BidQty          uint64
+	AskPrice        int64
+	AskQty          uint64
+	BidSourceCount  uint16
+	AskSourceCount  uint16
+}
+
+type topOfBookTrade struct {
+	InstrumentID     uint32
+	SourceID         uint16
+	AggressorSide    uint8
+	TradeFlags       uint8
+	SourceTimestamp  uint64
+	TradePrice       int64
+	TradeQty         uint64
+	TradeID          uint64
+	CumulativeVolume uint64
+}
+
+type topOfBookChannelReset struct {
+	Timestamp uint64
+}
+
+type topOfBookEndOfSession struct {
+	Timestamp uint64
+}
+
+type topOfBookManifestSummary struct {
+	ChannelID       uint8
+	ManifestSeq     uint16
+	InstrumentCount uint32
+	Timestamp       uint64
+}
+
+// wireReader is a trivial positional reader for fixed-layout
+// little-endian wire formats. Errors are sticky: once a read fails,
+// subsequent reads are no-ops and err stays set, so callers can do a
+// block of reads and check err once.
+type wireReader struct {
+	buf []byte
+	off int
+	err error
+}
+
+func (r *wireReader) need(n int) bool {
+	if r.err != nil {
+		return false
+	}
+	if r.off+n > len(r.buf) {
+		r.err = io.ErrUnexpectedEOF
+		return false
+	}
+	return true
+}
+
+func (r *wireReader) u8() uint8 {
+	if !r.need(1) {
+		return 0
+	}
+	v := r.buf[r.off]
+	r.off++
+	return v
+}
+
+func (r *wireReader) i8() int8 { return int8(r.u8()) }
+
+func (r *wireReader) u16() uint16 {
+	if !r.need(2) {
+		return 0
+	}
+	v := binary.LittleEndian.Uint16(r.buf[r.off:])
+	r.off += 2
+	return v
+}
+
+func (r *wireReader) u32() uint32 {
+	if !r.need(4) {
+		return 0
+	}
+	v := binary.LittleEndian.Uint32(r.buf[r.off:])
+	r.off += 4
+	return v
+}
+
+func (r *wireReader) u64() uint64 {
+	if !r.need(8) {
+		return 0
+	}
+	v := binary.LittleEndian.Uint64(r.buf[r.off:])
+	r.off += 8
+	return v
+}
+
+func (r *wireReader) i64() int64 { return int64(r.u64()) }
+
+func (r *wireReader) bytes(n int) []byte {
+	if !r.need(n) {
+		return nil
+	}
+	v := r.buf[r.off : r.off+n]
+	r.off += n
+	return v
+}
+
+func (r *wireReader) skip(n int) {
+	if r.need(n) {
+		r.off += n
+	}
+}
+
+// decodeTopOfBookFrame parses one UDP datagram into a topOfBookFrame.
+// Unknown message types are still counted and skipped so their bytes
+// are consumed; their Body field is left nil and callers should ignore
+// them.
+func decodeTopOfBookFrame(data []byte) (*topOfBookFrame, error) {
+	if len(data) < frameHeaderBytes {
+		return nil, fmt.Errorf("datagram too short: %d bytes (minimum %d)", len(data), frameHeaderBytes)
+	}
+
+	r := &wireReader{buf: data}
+
+	var f topOfBookFrame
+	f.Header.Magic[0] = r.u8()
+	f.Header.Magic[1] = r.u8()
+	if f.Header.Magic[0] != frameMagic0 || f.Header.Magic[1] != frameMagic1 {
+		return nil, fmt.Errorf("bad magic: 0x%02x 0x%02x (expected 0x5A 0x44)",
+			f.Header.Magic[0], f.Header.Magic[1])
+	}
+	f.Header.SchemaVersion = r.u8()
+	f.Header.ChannelID = r.u8()
+	f.Header.SequenceNumber = r.u64()
+	f.Header.SendTimestamp = r.u64()
+	f.Header.MsgCount = r.u8()
+	f.Header.Reserved = r.u8()
+	f.Header.FrameLength = r.u16()
+	if r.err != nil {
+		return nil, fmt.Errorf("decoding frame header: %w", r.err)
+	}
+
+	f.Messages = make([]topOfBookAppMessage, 0, f.Header.MsgCount)
+	for i := 0; i < int(f.Header.MsgCount); i++ {
+		var msg topOfBookAppMessage
+		msg.MsgType = r.u8()
+		msg.MsgLength = r.u8()
+		msg.Flags = r.u16()
+		if r.err != nil {
+			return nil, fmt.Errorf("decoding message %d header: %w", i, r.err)
+		}
+
+		if msg.MsgLength < 4 {
+			return nil, fmt.Errorf("message %d: msg_length %d too small (min 4)", i, msg.MsgLength)
+		}
+		bodyLen := int(msg.MsgLength) - 4
+		bodyBuf := r.bytes(bodyLen)
+		if r.err != nil {
+			return nil, fmt.Errorf("decoding message %d body (len=%d): %w", i, bodyLen, r.err)
+		}
+
+		body, err := decodeTopOfBookBody(msg.MsgType, bodyBuf)
+		if err != nil {
+			return nil, fmt.Errorf("decoding message %d (type=0x%02x): %w", i, msg.MsgType, err)
+		}
+		msg.Body = body
+		f.Messages = append(f.Messages, msg)
+	}
+
+	return &f, nil
+}
+
+// decodeTopOfBookBody dispatches on msg type to decode a message body.
+// Returns (nil, nil) for unknown types so the parser skips them.
+func decodeTopOfBookBody(msgType uint8, buf []byte) (any, error) {
+	br := &wireReader{buf: buf}
+
+	switch msgType {
+	case msgHeartbeat:
+		var b topOfBookHeartbeat
+		b.ChannelID = br.u8()
+		br.skip(3) // reserved
+		b.Timestamp = br.u64()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgInstrumentDefinition:
+		var b topOfBookInstrumentDef
+		b.InstrumentID = br.u32()
+		b.Symbol = string(br.bytes(16))
+		b.Leg1 = string(br.bytes(8))
+		b.Leg2 = string(br.bytes(8))
+		b.AssetClass = br.u8()
+		b.PriceExponent = br.i8()
+		b.QtyExponent = br.i8()
+		b.MarketModel = br.u8()
+		b.TickSize = br.i64()
+		b.LotSize = br.u64()
+		b.ContractValue = br.u64()
+		b.Expiry = br.u64()
+		b.SettleType = br.u8()
+		b.PriceBound = br.u8()
+		b.ManifestSeq = br.u16()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgQuote:
+		var b topOfBookQuote
+		b.InstrumentID = br.u32()
+		b.SourceID = br.u16()
+		b.UpdateFlags = br.u8()
+		br.skip(1) // reserved
+		b.SourceTimestamp = br.u64()
+		b.BidPrice = br.i64()
+		b.BidQty = br.u64()
+		b.AskPrice = br.i64()
+		b.AskQty = br.u64()
+		b.BidSourceCount = br.u16()
+		b.AskSourceCount = br.u16()
+		br.skip(4) // reserved
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgTrade:
+		var b topOfBookTrade
+		b.InstrumentID = br.u32()
+		b.SourceID = br.u16()
+		b.AggressorSide = br.u8()
+		b.TradeFlags = br.u8()
+		b.SourceTimestamp = br.u64()
+		b.TradePrice = br.i64()
+		b.TradeQty = br.u64()
+		b.TradeID = br.u64()
+		b.CumulativeVolume = br.u64()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgChannelReset:
+		var b topOfBookChannelReset
+		b.Timestamp = br.u64()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgEndOfSession:
+		var b topOfBookEndOfSession
+		b.Timestamp = br.u64()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	case msgManifestSummary:
+		var b topOfBookManifestSummary
+		b.ChannelID = br.u8()
+		br.skip(3) // reserved
+		b.ManifestSeq = br.u16()
+		br.skip(2) // reserved
+		b.InstrumentCount = br.u32()
+		b.Timestamp = br.u64()
+		if br.err != nil {
+			return nil, br.err
+		}
+		return &b, nil
+
+	default:
+		// Unknown message type — body bytes already consumed by the
+		// caller. Return a nil body so the parser skips it.
+		return nil, nil
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces the `edge` package with a pluggable `Parser` interface, a parser registry, and the first implementation: a decoder for the DoubleZero Top-of-Book feed v0.1.0 wire format.
- Parser is stateful: it learns instrument definitions from refdata messages and uses them to enrich marketdata (quote/trade) messages with symbol, price/qty exponents, and derived floats. Marketdata arriving before its definition is held in a bounded per-instrument buffer (most-recent-wins, capped at 1000 instruments) and flushed the moment the definition lands, so a cold-start reader still produces meaningful output at the first refdata cycle.
- Wire decoder is a hand-written positional reader over the fixed little-endian format using \`encoding/binary\` and a small sticky-error reader helper. No third-party deps, no code generation.
- Emits generic \`Record\` values; intentionally decoupled from output sinks, which land in the next PR.

## Part 1 of 4 — edge feed parser stack

1. **this PR** — edge: add Top-of-Book parser framework ← start here
2. edge: add JSON/CSV/Unix-socket output sinks
3. edge: add feed runner, manager, HTTP API, and CLI
4. edge: add integration tests, synthetic publisher, and devnet guide

Each PR compiles and tests standalone. Feature is off-by-default until PR 3 lands; early PRs are dormant code.

## Testing Verification
- Unit tests cover wire decode for each message type, bounded-buffer overwrite semantics, cap-reached drops, and refdata-triggered flush.
- Also exercised against real testnet Top-of-Book traffic on a QA node — processed 1M+ records end-to-end without buffer growth or parse errors.

## Size note
~1000 lines of production code, above doublezero's ~500-line guideline. The stack already splits the feature into 4 PRs; the parser itself doesn't subdivide further without creating non-functional intermediate states. Bulk of the diff is the wire decoder (~340 LOC, straight-line positional reads) and the parser state machine (~600 LOC), both of which benefit from being reviewed together.