### PR TITLE
edge: add JSON/CSV/Unix-socket output sinks

### DIFF
--- a/client/doublezerod/internal/edge/sink.go
+++ b/client/doublezerod/internal/edge/sink.go
@@ -1,0 +1,49 @@
+package edge
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OutputSink writes decoded records to a destination.
+type OutputSink interface {
+	// Write outputs one or more records.
+	Write(records []Record) error
+
+	// Close releases any resources held by the sink.
+	Close() error
+}
+
+// SinkConfig describes the desired output format and destination.
+type SinkConfig struct {
+	// Format is the output encoding: "json" or "csv".
+	Format string
+
+	// Path is the output destination. A file path for file output,
+	// or "unix:///path/to/sock" for a Unix domain socket.
+	Path string
+}
+
+// NewSink creates an OutputSink from the given configuration.
+//
+// Path formats:
+//   - "/path/to/file"          → file output
+//   - "unix:///path/to/sock"   → Unix domain socket (broadcast to all connected clients)
+func NewSink(cfg SinkConfig) (OutputSink, error) {
+	isSocket := strings.HasPrefix(cfg.Path, "unix://")
+
+	switch cfg.Format {
+	case "json":
+		if isSocket {
+			return NewSocketSink("json", strings.TrimPrefix(cfg.Path, "unix://"))
+		}
+		return NewJSONFileSink(cfg.Path)
+	case "csv":
+		if isSocket {
+			return NewSocketSink("csv", strings.TrimPrefix(cfg.Path, "unix://"))
+		}
+		return NewCSVFileSink(cfg.Path)
+	default:
+		return nil, fmt.Errorf("unknown output format: %q", cfg.Format)
+	}
+}

--- a/client/doublezerod/internal/edge/sink_csv.go
+++ b/client/doublezerod/internal/edge/sink_csv.go
@@ -1,0 +1,194 @@
+package edge
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// CSV column definitions for each supported record type.
+var (
+	quoteCSVHeader = []string{
+		"type", "ts", "channel_id", "seq", "instrument_id", "symbol",
+		"source_id", "bid_price", "bid_qty", "ask_price", "ask_qty",
+		"bid_source_count", "ask_source_count", "update_flags", "snapshot",
+	}
+	tradeCSVHeader = []string{
+		"type", "ts", "channel_id", "seq", "instrument_id", "symbol",
+		"source_id", "trade_price", "trade_qty", "aggressor_side",
+		"trade_id", "cumulative_volume", "snapshot",
+	}
+)
+
+// CSVFileSink writes quote and trade records as CSV to a file.
+// Each record type gets its own header row on first occurrence.
+type CSVFileSink struct {
+	mu            sync.Mutex
+	file          *os.File
+	w             *csv.Writer
+	wroteQuoteHdr bool
+	wroteTradeHdr bool
+}
+
+// NewCSVFileSink opens (or creates) the file at path for CSV output.
+func NewCSVFileSink(path string) (*CSVFileSink, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening output file: %w", err)
+	}
+	return &CSVFileSink{file: f, w: csv.NewWriter(f)}, nil
+}
+
+func (s *CSVFileSink) Write(records []Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range records {
+		r := &records[i]
+		switch r.Type {
+		case "quote":
+			if !s.wroteQuoteHdr {
+				if err := s.w.Write(quoteCSVHeader); err != nil {
+					return fmt.Errorf("writing quote header: %w", err)
+				}
+				s.wroteQuoteHdr = true
+			}
+			if err := s.w.Write(quoteToCSVRow(r)); err != nil {
+				return fmt.Errorf("writing quote row: %w", err)
+			}
+		case "trade":
+			if !s.wroteTradeHdr {
+				if err := s.w.Write(tradeCSVHeader); err != nil {
+					return fmt.Errorf("writing trade header: %w", err)
+				}
+				s.wroteTradeHdr = true
+			}
+			if err := s.w.Write(tradeToCSVRow(r)); err != nil {
+				return fmt.Errorf("writing trade row: %w", err)
+			}
+		default:
+			// CSV only outputs quotes and trades.
+			continue
+		}
+	}
+	s.w.Flush()
+	return s.w.Error()
+}
+
+func (s *CSVFileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.w.Flush()
+	return s.file.Close()
+}
+
+func quoteToCSVRow(r *Record) []string {
+	return []string{
+		r.Type,
+		r.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		strconv.FormatUint(uint64(r.ChannelID), 10),
+		strconv.FormatUint(r.SequenceNumber, 10),
+		strconv.FormatUint(uint64(r.InstrumentID), 10),
+		r.Symbol,
+		fmtFieldUint16(r.Fields, "source_id"),
+		fmtFieldFloat(r.Fields, "bid_price"),
+		fmtFieldFloat(r.Fields, "bid_qty"),
+		fmtFieldFloat(r.Fields, "ask_price"),
+		fmtFieldFloat(r.Fields, "ask_qty"),
+		fmtFieldUint16(r.Fields, "bid_source_count"),
+		fmtFieldUint16(r.Fields, "ask_source_count"),
+		fmtFieldUint8(r.Fields, "update_flags"),
+		fmtFieldBool(r.Fields, "snapshot"),
+	}
+}
+
+func tradeToCSVRow(r *Record) []string {
+	return []string{
+		r.Type,
+		r.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		strconv.FormatUint(uint64(r.ChannelID), 10),
+		strconv.FormatUint(r.SequenceNumber, 10),
+		strconv.FormatUint(uint64(r.InstrumentID), 10),
+		r.Symbol,
+		fmtFieldUint16(r.Fields, "source_id"),
+		fmtFieldFloat(r.Fields, "trade_price"),
+		fmtFieldFloat(r.Fields, "trade_qty"),
+		fmtFieldString(r.Fields, "aggressor_side"),
+		fmtFieldUint64(r.Fields, "trade_id"),
+		fmtFieldFloat(r.Fields, "cumulative_volume"),
+		fmtFieldBool(r.Fields, "snapshot"),
+	}
+}
+
+func fmtFieldFloat(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch f := v.(type) {
+	case float64:
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func fmtFieldUint8(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch n := v.(type) {
+	case uint8:
+		return strconv.FormatUint(uint64(n), 10)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func fmtFieldUint16(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch n := v.(type) {
+	case uint16:
+		return strconv.FormatUint(uint64(n), 10)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func fmtFieldUint64(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch n := v.(type) {
+	case uint64:
+		return strconv.FormatUint(n, 10)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func fmtFieldString(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprint(v)
+}
+
+func fmtFieldBool(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	if b, ok := v.(bool); ok {
+		return strconv.FormatBool(b)
+	}
+	return fmt.Sprint(v)
+}

--- a/client/doublezerod/internal/edge/sink_csv_test.go
+++ b/client/doublezerod/internal/edge/sink_csv_test.go
@@ -1,0 +1,187 @@
+package edge
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCSVFileSink_QuotesAndTrades(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.csv")
+
+	sink, err := NewCSVFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Type:           "quote",
+			Timestamp:      ts,
+			ChannelID:      1,
+			SequenceNumber: 100,
+			InstrumentID:   42,
+			Symbol:         "BTC-USDT",
+			Fields: map[string]any{
+				"source_id":        uint16(1),
+				"bid_price":        67432.5,
+				"bid_qty":          1.25,
+				"ask_price":        67433.0,
+				"ask_qty":          0.8,
+				"bid_source_count": uint16(5),
+				"ask_source_count": uint16(3),
+				"update_flags":     uint8(3),
+				"snapshot":         false,
+			},
+		},
+		{
+			Type:           "trade",
+			Timestamp:      ts,
+			ChannelID:      1,
+			SequenceNumber: 101,
+			InstrumentID:   42,
+			Symbol:         "BTC-USDT",
+			Fields: map[string]any{
+				"source_id":         uint16(1),
+				"trade_price":       67432.75,
+				"trade_qty":         0.5,
+				"aggressor_side":    "buy",
+				"trade_id":          uint64(12345),
+				"cumulative_volume": 100.0,
+				"snapshot":          false,
+			},
+		},
+	}
+
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("error writing records: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("error closing sink: %v", err)
+	}
+
+	// Read back and verify.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("error opening output: %v", err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	reader.FieldsPerRecord = -1 // quote and trade rows have different column counts
+	allRows, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("error reading CSV: %v", err)
+	}
+
+	// Expect: quote header, quote row, trade header, trade row = 4 rows.
+	if len(allRows) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(allRows))
+	}
+
+	// Quote header.
+	if allRows[0][0] != "type" {
+		t.Errorf("expected quote header first column 'type', got %q", allRows[0][0])
+	}
+	if len(allRows[0]) != len(quoteCSVHeader) {
+		t.Errorf("quote header has %d columns, expected %d", len(allRows[0]), len(quoteCSVHeader))
+	}
+
+	// Quote row.
+	if allRows[1][0] != "quote" {
+		t.Errorf("expected 'quote', got %q", allRows[1][0])
+	}
+	if allRows[1][5] != "BTC-USDT" {
+		t.Errorf("expected symbol BTC-USDT, got %q", allRows[1][5])
+	}
+	if allRows[1][7] != "67432.5" {
+		t.Errorf("expected bid_price 67432.5, got %q", allRows[1][7])
+	}
+
+	// Trade header.
+	if allRows[2][0] != "type" {
+		t.Errorf("expected trade header first column 'type', got %q", allRows[2][0])
+	}
+	if len(allRows[2]) != len(tradeCSVHeader) {
+		t.Errorf("trade header has %d columns, expected %d", len(allRows[2]), len(tradeCSVHeader))
+	}
+
+	// Trade row.
+	if allRows[3][0] != "trade" {
+		t.Errorf("expected 'trade', got %q", allRows[3][0])
+	}
+	if allRows[3][9] != "buy" {
+		t.Errorf("expected aggressor_side 'buy', got %q", allRows[3][9])
+	}
+}
+
+func TestCSVFileSink_SkipsNonQuoteTrade(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.csv")
+
+	sink, err := NewCSVFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Type: "heartbeat", Timestamp: ts, ChannelID: 1, SequenceNumber: 1},
+		{Type: "instrument_definition", Timestamp: ts, ChannelID: 1, SequenceNumber: 2},
+		{Type: "channel_reset", Timestamp: ts, ChannelID: 1, SequenceNumber: 3},
+	}
+
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("error writing records: %v", err)
+	}
+	sink.Close()
+
+	// File should be empty — no quote or trade records.
+	info, _ := os.Stat(path)
+	if info.Size() != 0 {
+		t.Errorf("expected empty file for non-quote/trade records, got %d bytes", info.Size())
+	}
+}
+
+func TestCSVFileSink_HeaderWrittenOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.csv")
+
+	sink, err := NewCSVFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	quote := Record{
+		Type: "quote", Timestamp: ts, ChannelID: 1, SequenceNumber: 100,
+		InstrumentID: 1, Symbol: "SOL-USDT",
+		Fields: map[string]any{
+			"source_id": uint16(1), "bid_price": 185.0, "bid_qty": 10.0,
+			"ask_price": 186.0, "ask_qty": 5.0, "bid_source_count": uint16(1),
+			"ask_source_count": uint16(1), "update_flags": uint8(3), "snapshot": false,
+		},
+	}
+
+	// Write two batches of quotes.
+	sink.Write([]Record{quote})
+	quote.SequenceNumber = 101
+	sink.Write([]Record{quote})
+	sink.Close()
+
+	f, _ := os.Open(path)
+	defer f.Close()
+	rows, _ := csv.NewReader(f).ReadAll()
+
+	// 1 header + 2 data rows = 3.
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows (1 header + 2 data), got %d", len(rows))
+	}
+	if rows[0][0] != "type" {
+		t.Errorf("expected header row first, got %q", rows[0][0])
+	}
+}

--- a/client/doublezerod/internal/edge/sink_json.go
+++ b/client/doublezerod/internal/edge/sink_json.go
@@ -1,0 +1,43 @@
+package edge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// JSONFileSink writes records as newline-delimited JSON (JSONL) to a file.
+type JSONFileSink struct {
+	mu   sync.Mutex
+	file *os.File
+	enc  *json.Encoder
+}
+
+// NewJSONFileSink opens (or creates) the file at path for JSONL output.
+func NewJSONFileSink(path string) (*JSONFileSink, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening output file: %w", err)
+	}
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+	return &JSONFileSink{file: f, enc: enc}, nil
+}
+
+func (s *JSONFileSink) Write(records []Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range records {
+		if err := s.enc.Encode(&records[i]); err != nil {
+			return fmt.Errorf("encoding record: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *JSONFileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.file.Close()
+}

--- a/client/doublezerod/internal/edge/sink_json_test.go
+++ b/client/doublezerod/internal/edge/sink_json_test.go
@@ -1,0 +1,121 @@
+package edge
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestJSONFileSink_Write(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.jsonl")
+
+	sink, err := NewJSONFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Type:           "quote",
+			Timestamp:      ts,
+			ChannelID:      1,
+			SequenceNumber: 100,
+			InstrumentID:   42,
+			Symbol:         "BTC-USDT",
+			Fields: map[string]any{
+				"bid_price": 67432.50,
+				"ask_price": 67433.00,
+			},
+		},
+		{
+			Type:           "trade",
+			Timestamp:      ts,
+			ChannelID:      1,
+			SequenceNumber: 101,
+			InstrumentID:   42,
+			Symbol:         "BTC-USDT",
+			Fields: map[string]any{
+				"trade_price":    67432.75,
+				"aggressor_side": "buy",
+			},
+		},
+	}
+
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("error writing records: %v", err)
+	}
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("error closing sink: %v", err)
+	}
+
+	// Read back and verify.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("error opening output file: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var decoded []Record
+	for scanner.Scan() {
+		var r Record
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			t.Fatalf("error decoding line: %v", err)
+		}
+		decoded = append(decoded, r)
+	}
+
+	if len(decoded) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(decoded))
+	}
+	if decoded[0].Type != "quote" {
+		t.Errorf("expected first record type quote, got %s", decoded[0].Type)
+	}
+	if decoded[0].Symbol != "BTC-USDT" {
+		t.Errorf("expected symbol BTC-USDT, got %s", decoded[0].Symbol)
+	}
+	if decoded[1].Type != "trade" {
+		t.Errorf("expected second record type trade, got %s", decoded[1].Type)
+	}
+}
+
+func TestJSONFileSink_Append(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.jsonl")
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	// Write first batch.
+	sink1, err := NewJSONFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+	sink1.Write([]Record{{Type: "heartbeat", Timestamp: ts, ChannelID: 1, SequenceNumber: 1}})
+	sink1.Close()
+
+	// Write second batch (should append).
+	sink2, err := NewJSONFileSink(path)
+	if err != nil {
+		t.Fatalf("error creating sink: %v", err)
+	}
+	sink2.Write([]Record{{Type: "heartbeat", Timestamp: ts, ChannelID: 1, SequenceNumber: 2}})
+	sink2.Close()
+
+	// Count lines.
+	f, _ := os.Open(path)
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected 2 lines after append, got %d", count)
+	}
+}

--- a/client/doublezerod/internal/edge/sink_socket.go
+++ b/client/doublezerod/internal/edge/sink_socket.go
@@ -1,0 +1,178 @@
+package edge
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+)
+
+// SocketSink listens on a Unix domain socket and writes records to all
+// connected clients. Each client gets its own encoder instance. Slow or
+// disconnected clients are dropped silently.
+type SocketSink struct {
+	format   string
+	sockPath string
+
+	mu       sync.Mutex
+	listener net.Listener
+	clients  map[net.Conn]recordWriter
+	closed   bool
+}
+
+// recordWriter writes records to a single connected client.
+type recordWriter interface {
+	writeRecords(records []Record) error
+}
+
+// NewSocketSink creates a Unix domain socket at sockPath and begins
+// accepting connections. format must be "json" or "csv".
+func NewSocketSink(format, sockPath string) (*SocketSink, error) {
+	// Remove any stale socket file.
+	os.Remove(sockPath) //nolint:errcheck
+
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("listening on unix socket %s: %w", sockPath, err)
+	}
+
+	if err := os.Chmod(sockPath, 0666); err != nil {
+		lis.Close()
+		return nil, fmt.Errorf("setting socket permissions: %w", err)
+	}
+
+	s := &SocketSink{
+		format:   format,
+		sockPath: sockPath,
+		listener: lis,
+		clients:  make(map[net.Conn]recordWriter),
+	}
+
+	go s.acceptLoop()
+	return s, nil
+}
+
+func (s *SocketSink) acceptLoop() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			s.mu.Lock()
+			closed := s.closed
+			s.mu.Unlock()
+			if closed {
+				return
+			}
+			slog.Warn("edge: socket accept error", "path", s.sockPath, "error", err)
+			continue
+		}
+
+		s.mu.Lock()
+		var w recordWriter
+		switch s.format {
+		case "json":
+			w = newJSONConnWriter(conn)
+		case "csv":
+			w = newCSVConnWriter(conn)
+		}
+		s.clients[conn] = w
+		s.mu.Unlock()
+
+		slog.Info("edge: socket client connected", "path", s.sockPath, "remote", conn.RemoteAddr())
+	}
+}
+
+func (s *SocketSink) Write(records []Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for conn, w := range s.clients {
+		if err := w.writeRecords(records); err != nil {
+			slog.Warn("edge: dropping socket client", "path", s.sockPath, "error", err)
+			conn.Close()
+			delete(s.clients, conn)
+		}
+	}
+	return nil
+}
+
+func (s *SocketSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+	for conn := range s.clients {
+		conn.Close()
+	}
+	s.clients = nil
+
+	err := s.listener.Close()
+	os.Remove(s.sockPath) //nolint:errcheck
+	return err
+}
+
+// jsonConnWriter writes JSONL to a single connection.
+type jsonConnWriter struct {
+	enc *json.Encoder
+}
+
+func newJSONConnWriter(w io.Writer) *jsonConnWriter {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return &jsonConnWriter{enc: enc}
+}
+
+func (j *jsonConnWriter) writeRecords(records []Record) error {
+	for i := range records {
+		if err := j.enc.Encode(&records[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// csvConnWriter writes CSV quote/trade rows to a single connection.
+type csvConnWriter struct {
+	w             *csv.Writer
+	wroteQuoteHdr bool
+	wroteTradeHdr bool
+}
+
+func newCSVConnWriter(w io.Writer) *csvConnWriter {
+	return &csvConnWriter{w: csv.NewWriter(w)}
+}
+
+func (c *csvConnWriter) writeRecords(records []Record) error {
+	for i := range records {
+		r := &records[i]
+		switch r.Type {
+		case "quote":
+			if !c.wroteQuoteHdr {
+				if err := c.w.Write(quoteCSVHeader); err != nil {
+					return err
+				}
+				c.wroteQuoteHdr = true
+			}
+			if err := c.w.Write(quoteToCSVRow(r)); err != nil {
+				return err
+			}
+		case "trade":
+			if !c.wroteTradeHdr {
+				if err := c.w.Write(tradeCSVHeader); err != nil {
+					return err
+				}
+				c.wroteTradeHdr = true
+			}
+			if err := c.w.Write(tradeToCSVRow(r)); err != nil {
+				return err
+			}
+		default:
+			continue
+		}
+	}
+	c.w.Flush()
+	return c.w.Error()
+}

--- a/client/doublezerod/internal/edge/sink_socket_test.go
+++ b/client/doublezerod/internal/edge/sink_socket_test.go
@@ -1,0 +1,165 @@
+package edge
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSocketSink_JSONBroadcast(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	sink, err := NewSocketSink("json", sockPath)
+	if err != nil {
+		t.Fatalf("error creating socket sink: %v", err)
+	}
+	defer sink.Close()
+
+	// Connect two clients.
+	conn1, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("error connecting client 1: %v", err)
+	}
+	defer conn1.Close()
+
+	conn2, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("error connecting client 2: %v", err)
+	}
+	defer conn2.Close()
+
+	// Give the accept loop time to register clients.
+	time.Sleep(50 * time.Millisecond)
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Type:           "quote",
+			Timestamp:      ts,
+			ChannelID:      1,
+			SequenceNumber: 100,
+			InstrumentID:   42,
+			Symbol:         "BTC-USDT",
+			Fields: map[string]any{
+				"bid_price": 67432.5,
+			},
+		},
+	}
+
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("error writing to socket sink: %v", err)
+	}
+
+	// Both clients should receive the same JSONL record.
+	for i, conn := range []net.Conn{conn1, conn2} {
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		scanner := bufio.NewScanner(conn)
+		if !scanner.Scan() {
+			t.Fatalf("client %d: no data received", i+1)
+		}
+		var r Record
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			t.Fatalf("client %d: error decoding JSON: %v", i+1, err)
+		}
+		if r.Symbol != "BTC-USDT" {
+			t.Errorf("client %d: expected symbol BTC-USDT, got %q", i+1, r.Symbol)
+		}
+	}
+}
+
+func TestSocketSink_CSVBroadcast(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	sink, err := NewSocketSink("csv", sockPath)
+	if err != nil {
+		t.Fatalf("error creating socket sink: %v", err)
+	}
+	defer sink.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Type: "quote", Timestamp: ts, ChannelID: 1, SequenceNumber: 100,
+			InstrumentID: 42, Symbol: "BTC-USDT",
+			Fields: map[string]any{
+				"source_id": uint16(1), "bid_price": 67432.5, "bid_qty": 1.25,
+				"ask_price": 67433.0, "ask_qty": 0.8, "bid_source_count": uint16(5),
+				"ask_source_count": uint16(3), "update_flags": uint8(3), "snapshot": false,
+			},
+		},
+	}
+
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("error writing: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	scanner := bufio.NewScanner(conn)
+
+	// First line should be the CSV header.
+	if !scanner.Scan() {
+		t.Fatal("no header received")
+	}
+	header := scanner.Text()
+	if header[:4] != "type" {
+		t.Errorf("expected CSV header starting with 'type', got %q", header[:4])
+	}
+
+	// Second line should be the data row.
+	if !scanner.Scan() {
+		t.Fatal("no data row received")
+	}
+	row := scanner.Text()
+	if row[:5] != "quote" {
+		t.Errorf("expected row starting with 'quote', got %q", row[:5])
+	}
+}
+
+func TestSocketSink_DropsDisconnectedClient(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	sink, err := NewSocketSink("json", sockPath)
+	if err != nil {
+		t.Fatalf("error creating socket sink: %v", err)
+	}
+	defer sink.Close()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("error connecting: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Close the client before writing.
+	conn.Close()
+
+	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Type: "heartbeat", Timestamp: ts, ChannelID: 1, SequenceNumber: 1},
+	}
+
+	// Write should succeed (disconnected client is dropped, not an error).
+	if err := sink.Write(records); err != nil {
+		t.Fatalf("expected no error after client disconnect, got: %v", err)
+	}
+
+	// Verify client was removed.
+	sink.mu.Lock()
+	count := len(sink.clients)
+	sink.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected 0 clients after disconnect, got %d", count)
+	}
+}


### PR DESCRIPTION
## Part 2 of 4 — edge feed parser stack

1. #3522 — edge: add Top-of-Book parser framework ← **start here**
2. **this PR** — edge: add JSON/CSV/Unix-socket output sinks
3. edge: add feed runner, manager, HTTP API, and CLI (coming)
4. edge: add integration tests, synthetic publisher, and devnet guide (coming)

Draft until #3522 lands. Reviewers welcome to read for context; I'll mark ready-for-review after rebasing onto main.

## Summary
- Introduces the \`OutputSink\` interface and three implementations: JSON-lines file, CSV file (with header row auto-inferred from the first record's shape), and Unix-socket broadcast with drop-on-slow-consumer semantics so a stuck reader can't backpressure the parser.
- \`NewSink\` factory keyed on format + path; paths beginning with \`unix://\` route to the socket sink, others to file sinks.
- CSV sink pivots the parser's flat \`Fields\` map onto a stable column set so heterogeneous record types (quotes, trades, instrument definitions, heartbeats) line up in one sheet.
- The parser still knows nothing about sinks — these are pure consumers of \`[]Record\` produced by the parser from #3522.

## Testing Verification
- Unit tests cover each sink: CSV header inference + column-pivot, JSON line format, socket broadcast to multiple connected clients, and slow-consumer drop behavior.