### PR TITLE
serviceability: add owner field to UpdateMulticastGroup instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - Smartcontract
   - Allow `SubscribeMulticastGroup` for users in `Pending` status so that `CreateSubscribeUser` can be followed by additional subscribe calls before the activator runs ([#3521](https://github.com/malbeclabs/doublezero/pull/3521))
+  - Add optional `owner` field to `UpdateMulticastGroup` instruction, allowing foundation members to reassign ownership of a multicast group ([#3527](https://github.com/malbeclabs/doublezero/pull/3527))
+- CLI
+  - Add `--owner` flag to `multicast group update`, accepting a pubkey or `me` ([#3527](https://github.com/malbeclabs/doublezero/pull/3527))
 
 ## [v0.17.0](https://github.com/malbeclabs/doublezero/compare/client/v0.16.0...client/v0.17.0) - 2026-04-10
 

--- a/smartcontract/cli/src/multicastgroup/update.rs
+++ b/smartcontract/cli/src/multicastgroup/update.rs
@@ -2,7 +2,9 @@ use crate::{
     doublezerocommand::CliCommand,
     poll_for_activation::poll_for_multicastgroup_activated,
     requirements::{CHECK_BALANCE, CHECK_ID_JSON},
-    validators::{validate_code, validate_parse_bandwidth, validate_pubkey_or_code},
+    validators::{
+        validate_code, validate_parse_bandwidth, validate_pubkey, validate_pubkey_or_code,
+    },
 };
 use clap::Args;
 use doublezero_sdk::commands::multicastgroup::{
@@ -30,6 +32,9 @@ pub struct UpdateMulticastGroupCliCommand {
     /// Updated subscriber count
     #[arg(long)]
     pub subscriber_count: Option<u32>,
+    /// Updated owner pubkey for the multicast group
+    #[arg(long, value_parser = validate_pubkey)]
+    pub owner: Option<String>,
     /// Wait for the multicast group to be activated
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -51,6 +56,13 @@ impl UpdateMulticastGroupCliCommand {
             max_bandwidth: self.max_bandwidth,
             publisher_count: self.publisher_count,
             subscriber_count: self.subscriber_count,
+            owner: self.owner.as_deref().map(|s| {
+                if s.eq_ignore_ascii_case("me") {
+                    client.get_payer()
+                } else {
+                    s.parse().unwrap()
+                }
+            }),
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -80,11 +92,35 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
+    const SIGNATURE_BYTES: [u8; 64] = [
+        120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222, 82,
+        64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240, 139, 130,
+        217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139, 100, 221, 20,
+        137, 4, 5,
+    ];
+
+    const EXPECTED_SIGNATURE_STR: &str = "Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n";
+
+    fn make_multicastgroup(pda_pubkey: Pubkey) -> MulticastGroup {
+        MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 255,
+            code: "test".to_string(),
+            tenant_pk: Pubkey::new_unique(),
+            multicast_ip: [10, 0, 0, 1].into(),
+            max_bandwidth: 1000000000,
+            status: MulticastGroupStatus::Activated,
+            owner: pda_pubkey,
+            publisher_count: 5,
+            subscriber_count: 10,
+        }
+    }
+
     #[test]
     fn test_cli_multicastgroup_update_bandwidth_parsing() {
         use clap::Parser;
 
-        // Define a test CLI structure to parse arguments
         #[derive(Parser, Debug)]
         struct TestCli {
             #[command(subcommand)]
@@ -96,14 +132,13 @@ mod tests {
             Update(UpdateMulticastGroupCliCommand),
         }
 
-        // Test various bandwidth formats
         let test_cases = vec![
             ("1Gbps", 1_000_000_000u64),
             ("100Mbps", 100_000_000u64),
             ("500Kbps", 500_000u64),
             ("1000bps", 1_000u64),
-            ("10gbps", 10_000_000_000u64), // lowercase
-            ("2.5Gbps", 2_500_000_000u64), // decimal
+            ("10gbps", 10_000_000_000u64),
+            ("2.5Gbps", 2_500_000_000u64),
         ];
 
         for (input, expected) in test_cases {
@@ -139,7 +174,6 @@ mod tests {
             }
         }
 
-        // Test invalid bandwidth formats
         let invalid_cases = vec!["invalid", "abc", "Gbps", ""];
 
         for input in invalid_cases {
@@ -162,30 +196,67 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_multicastgroup_update_owner_parsing() {
+        use clap::Parser;
+
+        #[derive(Parser, Debug)]
+        struct TestCli {
+            #[command(subcommand)]
+            command: TestCommand,
+        }
+
+        #[derive(clap::Subcommand, Debug)]
+        enum TestCommand {
+            Update(UpdateMulticastGroupCliCommand),
+        }
+
+        let valid_pubkey = Pubkey::new_unique().to_string();
+
+        let valid_cases = vec!["me", valid_pubkey.as_str()];
+        for input in valid_cases {
+            let args = vec![
+                "test",
+                "update",
+                "--pubkey",
+                "test-pubkey",
+                "--owner",
+                input,
+            ];
+            let result = TestCli::try_parse_from(args);
+            assert!(
+                result.is_ok(),
+                "Should have accepted owner '{}': {:?}",
+                input,
+                result.err()
+            );
+        }
+
+        let invalid_cases = vec!["not_a_pubkey", "invalid key!"];
+        for input in invalid_cases {
+            let args = vec![
+                "test",
+                "update",
+                "--pubkey",
+                "test-pubkey",
+                "--owner",
+                input,
+            ];
+            let result = TestCli::try_parse_from(args);
+            assert!(
+                result.is_err(),
+                "Should have rejected invalid owner '{}'",
+                input
+            );
+        }
+    }
+
+    #[test]
     fn test_cli_multicastgroup_update() {
         let mut client = create_test_client();
 
         let (pda_pubkey, _bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
-        let signature = Signature::from([
-            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
-            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
-            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
-            100, 221, 20, 137, 4, 5,
-        ]);
-
-        let multicastgroup = MulticastGroup {
-            account_type: AccountType::MulticastGroup,
-            index: 1,
-            bump_seed: 255,
-            code: "test".to_string(),
-            tenant_pk: Pubkey::new_unique(),
-            multicast_ip: [10, 0, 0, 1].into(),
-            max_bandwidth: 1000000000,
-            status: MulticastGroupStatus::Activated,
-            owner: pda_pubkey,
-            publisher_count: 5,
-            subscriber_count: 10,
-        };
+        let signature = Signature::from(SIGNATURE_BYTES);
+        let multicastgroup = make_multicastgroup(pda_pubkey);
 
         client
             .expect_check_requirements()
@@ -206,10 +277,10 @@ mod tests {
                 max_bandwidth: Some(1000000000),
                 publisher_count: Some(5),
                 subscriber_count: Some(10),
+                owner: None,
             }))
             .returning(move |_| Ok(signature));
 
-        /*****************************************************************************************************/
         let mut output = Vec::new();
         let res = UpdateMulticastGroupCliCommand {
             pubkey: pda_pubkey.to_string(),
@@ -218,13 +289,108 @@ mod tests {
             max_bandwidth: Some(1000000000),
             publisher_count: Some(5),
             subscriber_count: Some(10),
+            owner: None,
             wait: false,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());
-        let output_str = String::from_utf8(output).unwrap();
-        assert_eq!(
-            output_str,"Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
-        );
+        assert_eq!(String::from_utf8(output).unwrap(), EXPECTED_SIGNATURE_STR);
+    }
+
+    #[test]
+    fn test_cli_multicastgroup_update_with_explicit_owner() {
+        let mut client = create_test_client();
+
+        let (pda_pubkey, _bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
+        let explicit_owner = Pubkey::new_unique();
+        let signature = Signature::from(SIGNATURE_BYTES);
+        let multicastgroup = make_multicastgroup(pda_pubkey);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: pda_pubkey.to_string(),
+            }))
+            .returning(move |_| Ok((pda_pubkey, multicastgroup.clone())));
+        client
+            .expect_update_multicastgroup()
+            .with(predicate::eq(UpdateMulticastGroupCommand {
+                pubkey: pda_pubkey,
+                code: None,
+                multicast_ip: None,
+                max_bandwidth: None,
+                publisher_count: None,
+                subscriber_count: None,
+                owner: Some(explicit_owner),
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = UpdateMulticastGroupCliCommand {
+            pubkey: pda_pubkey.to_string(),
+            code: None,
+            multicast_ip: None,
+            max_bandwidth: None,
+            publisher_count: None,
+            subscriber_count: None,
+            owner: Some(explicit_owner.to_string()),
+            wait: false,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        assert_eq!(String::from_utf8(output).unwrap(), EXPECTED_SIGNATURE_STR);
+    }
+
+    #[test]
+    fn test_cli_multicastgroup_update_owner_me() {
+        let mut client = create_test_client();
+
+        let (pda_pubkey, _bump_seed) = get_multicastgroup_pda(&client.get_program_id(), 1);
+        // The payer configured in create_test_client()
+        let payer = Pubkey::from_str_const("DDddB7bhR9azxLAUEH7ZVtW168wRdreiDKhi4McDfKZt");
+        let signature = Signature::from(SIGNATURE_BYTES);
+        let multicastgroup = make_multicastgroup(pda_pubkey);
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: pda_pubkey.to_string(),
+            }))
+            .returning(move |_| Ok((pda_pubkey, multicastgroup.clone())));
+        client
+            .expect_update_multicastgroup()
+            .with(predicate::eq(UpdateMulticastGroupCommand {
+                pubkey: pda_pubkey,
+                code: None,
+                multicast_ip: None,
+                max_bandwidth: None,
+                publisher_count: None,
+                subscriber_count: None,
+                owner: Some(payer),
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = UpdateMulticastGroupCliCommand {
+            pubkey: pda_pubkey.to_string(),
+            code: None,
+            multicast_ip: None,
+            max_bandwidth: None,
+            publisher_count: None,
+            subscriber_count: None,
+            owner: Some("me".to_string()),
+            wait: false,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        assert_eq!(String::from_utf8(output).unwrap(), EXPECTED_SIGNATURE_STR);
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -994,6 +994,7 @@ mod tests {
                 publisher_count: None,
                 subscriber_count: None,
                 use_onchain_allocation: false,
+                owner: None,
             }),
             "UpdateMulticastGroup",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs
@@ -37,14 +37,15 @@ pub struct MulticastGroupUpdateArgs {
     /// Requires ResourceExtension account (MulticastGroupBlock).
     #[incremental(default = false)]
     pub use_onchain_allocation: bool,
+    pub owner: Option<Pubkey>,
 }
 
 impl fmt::Debug for MulticastGroupUpdateArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "code: {:?}, multicast_ip: {:?}, max_bandwidth: {:?}, publisher_count: {:?}, subscriber_count: {:?}, use_onchain_allocation: {}",
-            self.code, self.multicast_ip, self.max_bandwidth, self.publisher_count, self.subscriber_count, self.use_onchain_allocation
+            "code: {:?}, multicast_ip: {:?}, max_bandwidth: {:?}, publisher_count: {:?}, subscriber_count: {:?}, use_onchain_allocation: {}, owner: {:?}",
+            self.code, self.multicast_ip, self.max_bandwidth, self.publisher_count, self.subscriber_count, self.use_onchain_allocation, self.owner
         )
     }
 }
@@ -151,6 +152,9 @@ pub fn process_update_multicastgroup(
     }
     if let Some(ref subscriber_count) = value.subscriber_count {
         multicastgroup.subscriber_count = *subscriber_count;
+    }
+    if let Some(ref owner) = value.owner {
+        multicastgroup.owner = *owner;
     }
 
     try_acc_write(

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_onchain_allocation_test.rs
@@ -410,6 +410,7 @@ async fn test_update_multicastgroup_with_onchain_reallocation() {
             publisher_count: None,
             subscriber_count: None,
             use_onchain_allocation: true,
+            owner: None,
         }),
         vec![
             AccountMeta::new(mgroup_pubkey, false),
@@ -490,6 +491,7 @@ async fn test_update_multicastgroup_backward_compat() {
             publisher_count: None,
             subscriber_count: None,
             use_onchain_allocation: false,
+            owner: None,
         }),
         vec![
             AccountMeta::new(mgroup_pubkey, false),
@@ -557,6 +559,7 @@ async fn test_update_multicastgroup_feature_flag_disabled() {
             publisher_count: None,
             subscriber_count: None,
             use_onchain_allocation: true,
+            owner: None,
         }),
         vec![
             AccountMeta::new(mgroup_pubkey, false),

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_test.rs
@@ -164,6 +164,7 @@ async fn test_multicastgroup() {
     println!("✅ MulticastGroup reactivated");
     /*****************************************************************************************************************************************************/
     println!("4. Testing MulticastGroup update...");
+    let new_owner = Pubkey::new_unique();
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -177,6 +178,7 @@ async fn test_multicastgroup() {
             publisher_count: None,
             subscriber_count: None,
             use_onchain_allocation: false,
+            owner: Some(new_owner),
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
@@ -198,6 +200,7 @@ async fn test_multicastgroup() {
     assert_eq!(multicastgroup_la.publisher_count, 0);
     assert_eq!(multicastgroup_la.subscriber_count, 0);
     assert_eq!(multicastgroup_la.status, MulticastGroupStatus::Activated);
+    assert_eq!(multicastgroup_la.owner, new_owner);
 
     println!("✅ MulticastGroup updated");
     /*****************************************************************************************************************************************************/
@@ -238,7 +241,7 @@ async fn test_multicastgroup() {
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
-            AccountMeta::new(multicastgroup.owner, false),
+            AccountMeta::new(new_owner, false),
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,
@@ -324,6 +327,7 @@ async fn test_multicastgroup_deactivate_fails_when_counts_nonzero() {
             publisher_count: Some(1),
             subscriber_count: Some(1),
             use_onchain_allocation: false,
+            owner: None,
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
@@ -796,6 +800,7 @@ async fn test_delete_multicastgroup_fails_with_active_publishers_or_subscribers(
             publisher_count: Some(1),
             subscriber_count: None,
             use_onchain_allocation: false,
+            owner: None,
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
@@ -842,6 +847,7 @@ async fn test_delete_multicastgroup_fails_with_active_publishers_or_subscribers(
             publisher_count: Some(0),
             subscriber_count: Some(1),
             use_onchain_allocation: false,
+            owner: None,
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),
@@ -888,6 +894,7 @@ async fn test_delete_multicastgroup_fails_with_active_publishers_or_subscribers(
             publisher_count: Some(0),
             subscriber_count: Some(0),
             use_onchain_allocation: false,
+            owner: None,
         }),
         vec![
             AccountMeta::new(multicastgroup_pubkey, false),

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/update.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/update.rs
@@ -18,6 +18,7 @@ pub struct UpdateMulticastGroupCommand {
     pub max_bandwidth: Option<u64>,
     pub publisher_count: Option<u32>,
     pub subscriber_count: Option<u32>,
+    pub owner: Option<Pubkey>,
 }
 
 impl UpdateMulticastGroupCommand {
@@ -56,6 +57,7 @@ impl UpdateMulticastGroupCommand {
                 publisher_count: self.publisher_count,
                 subscriber_count: self.subscriber_count,
                 use_onchain_allocation,
+                owner: self.owner,
             }),
             accounts,
         )
@@ -99,6 +101,7 @@ mod tests {
                         publisher_count: Some(10),
                         subscriber_count: Some(100),
                         use_onchain_allocation: false,
+                        owner: None,
                     },
                 )),
                 predicate::eq(vec![
@@ -115,6 +118,7 @@ mod tests {
             max_bandwidth: Some(1000),
             publisher_count: Some(10),
             subscriber_count: Some(100),
+            owner: None,
         };
 
         let update_invalid_command = UpdateMulticastGroupCommand {
@@ -175,6 +179,7 @@ mod tests {
                         publisher_count: None,
                         subscriber_count: None,
                         use_onchain_allocation: true,
+                        owner: None,
                     },
                 )),
                 predicate::eq(vec![
@@ -192,6 +197,7 @@ mod tests {
             max_bandwidth: None,
             publisher_count: None,
             subscriber_count: None,
+            owner: None,
         }
         .execute(&client);
 


### PR DESCRIPTION
## Summary of Changes
- Adds an optional `owner` field to `MulticastGroupUpdateArgs`, allowing foundation members to reassign ownership of a multicast group after creation
- Adds `--owner` CLI flag to `doublezero multicast group update`, accepting a pubkey or `me` (resolves to the active keypair)
- New field is appended after `use_onchain_allocation` in the Borsh encoding, so older serialized instructions continue to deserialize correctly via `BorshDeserializeIncremental`

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     3 | +20 / -4     |  +16 |
| Scaffolding  |     1 | +1  / -0     |   +1 |
| Tests        |     4 | +200 / -30   | +170 |

Small core change, most of the diff is new and refactored unit tests.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/multicastgroup/update.rs` — adds `--owner` arg with `validate_pubkey` (accepts `me`), resolves `me` to the payer pubkey in `execute`; adds three new unit tests covering no owner, explicit pubkey, and `me` resolution
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/update.rs` — adds `owner: Option<Pubkey>` to `MulticastGroupUpdateArgs` and applies the update in the processor
- `smartcontract/sdk/rs/src/commands/multicastgroup/update.rs` — adds `owner: Option<Pubkey>` to `UpdateMulticastGroupCommand` and threads it through to the instruction args

</details>

## Testing Verification
- All existing multicast group integration tests pass (`test_multicastgroup`, `test_multicastgroup_deactivate_*`, `test_delete_multicastgroup_*`, `test_update_multicastgroup_*`)
- `test_multicastgroup` extended to set `owner: Some(new_owner)` in the update step and assert the new owner is persisted on-chain
- Three new CLI unit tests: `test_cli_multicastgroup_update_with_explicit_owner`, `test_cli_multicastgroup_update_owner_me`, and `test_cli_multicastgroup_update_owner_parsing`