### PR TITLE
client: polish output of connect and disconnect commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
   - Add optional `owner` field to `UpdateMulticastGroup` instruction, allowing foundation members to reassign ownership of a multicast group ([#3527](https://github.com/malbeclabs/doublezero/pull/3527))
 - CLI
   - Add `--owner` flag to `multicast group update`, accepting a pubkey or `me` ([#3527](https://github.com/malbeclabs/doublezero/pull/3527))
+  - Polish terminal output of `connect` and `disconnect`: fix emoji semantics, normalize message phrasing across IBRL and multicast code paths, resolve tenant to human-readable code on connect (errors if tenant not found), and fix progress bar not clearing before output in `disconnect` ([#3529](https://github.com/malbeclabs/doublezero/pull/3529))
 
 ## [v0.17.0](https://github.com/malbeclabs/doublezero/compare/client/v0.16.0...client/v0.17.0) - 2026-04-10
 

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -113,7 +113,7 @@ impl ProvisioningCliCommand {
         check_doublezero(controller, client, Some(&spinner)).await?;
 
         spinner.println(format!(
-            "🔗  Start Provisioning User to {}...",
+            "⚡  Connecting to {}...",
             client.get_environment()
         ));
 
@@ -141,7 +141,7 @@ impl ProvisioningCliCommand {
 
         spinner.inc(1);
         spinner.println(format!("    DoubleZero ID: {}", client.get_payer()));
-        spinner.println(format!("🔍  Provisioning User for IP: {client_ip_str}"));
+        spinner.println(format!("⚡  Provisioning for IP: {client_ip_str}"));
 
         match self.parse_dz_mode()? {
             ParsedDzMode::Ibrl(user_type, tenant) => {
@@ -432,8 +432,8 @@ impl ProvisioningCliCommand {
                     .find_or_create_device(client, controller, &devices, spinner, &exclude_ips)
                     .await?;
 
-                spinner.println("    Creating user account...");
-                spinner.println(format!("    Device selected: {} ", device.code));
+                spinner.println("    Creating account...");
+                spinner.println(format!("    Device selected: {}", device.code));
                 spinner.inc(1);
 
                 // Check per-type user limit before attempting to create
@@ -463,7 +463,7 @@ impl ProvisioningCliCommand {
                         .ok()
                         .and_then(|(_, cfg)| cfg.tenant);
                     if let Some(ref t) = cfg_tenant {
-                        spinner.println(format!("Using tenant '{t}' from configuration file."));
+                        spinner.println(format!("    Using tenant '{t}' from configuration file."));
                     }
                     cfg_tenant.or_else(|| {
                         accesspass
@@ -472,7 +472,7 @@ impl ProvisioningCliCommand {
                             .filter(|pk| **pk != Pubkey::default())
                             .map(|pk| {
                                 let t = pk.to_string();
-                                spinner.println(format!("Using tenant '{t}' from Access Pass."));
+                                spinner.println(format!("    Using tenant '{t}' from Access Pass."));
                                 t
                             })
                     })
@@ -582,10 +582,7 @@ impl ProvisioningCliCommand {
                     "    Creating separate Multicast user for concurrent tunnels (IBRL user: {})",
                     ibrl_user_pk
                 ));
-                spinner.println(format!(
-                    "    The Device has been selected: {} ",
-                    device.code
-                ));
+                spinner.println(format!("    Device selected: {}", device.code));
 
                 // Check per-type user limit before attempting to create
                 if let Some(err_msg) =
@@ -719,11 +716,8 @@ impl ProvisioningCliCommand {
                     .find_or_create_device(client, controller, &devices, spinner, &exclude_ips)
                     .await?;
 
-                spinner.println(format!("    Creating an account for the IP: {client_ip}"));
-                spinner.println(format!(
-                    "    The Device has been selected: {} ",
-                    device.code
-                ));
+                spinner.println(format!("    Creating account for IP: {client_ip}"));
+                spinner.println(format!("    Device selected: {}", device.code));
                 spinner.inc(1);
 
                 // Check per-type user limit before attempting to create

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -7,7 +7,7 @@ use backon::{BlockingRetryable, ExponentialBuilder};
 use clap::{Args, Subcommand, ValueEnum};
 use doublezero_cli::{
     doublezerocommand::CliCommand,
-    helpers::{init_command, parse_pubkey},
+    helpers::init_command,
     requirements::{check_accesspass, check_requirements, CHECK_BALANCE, CHECK_ID_JSON},
 };
 use doublezero_sdk::{
@@ -112,10 +112,7 @@ impl ProvisioningCliCommand {
         check_requirements(client, Some(&spinner), CHECK_ID_JSON | CHECK_BALANCE)?;
         check_doublezero(controller, client, Some(&spinner)).await?;
 
-        spinner.println(format!(
-            "⚡  Connecting to {}...",
-            client.get_environment()
-        ));
+        spinner.println(format!("⚡  Connecting to {}...", client.get_environment()));
 
         // Deprecation warning for --client-ip flag
         if self.client_ip.is_some() {

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -456,40 +456,36 @@ impl ProvisioningCliCommand {
                     })?;
 
                 // Determine tenant: 1) from CLI argument, 2) from config file, 3) from access pass allowlist
-                let tenant = if let Some(t) = tenant {
-                    Some(t)
+                let tenant_with_source: Option<(String, &str)> = if let Some(t) = tenant {
+                    Some((t, "CLI argument"))
                 } else {
                     let cfg_tenant = doublezero_sdk::read_doublezero_config()
                         .ok()
                         .and_then(|(_, cfg)| cfg.tenant);
-                    if let Some(ref t) = cfg_tenant {
-                        spinner.println(format!("    Using tenant '{t}' from configuration file."));
-                    }
-                    cfg_tenant.or_else(|| {
+                    if let Some(t) = cfg_tenant {
+                        Some((t, "configuration file"))
+                    } else {
                         accesspass
                             .tenant_allowlist
                             .first()
                             .filter(|pk| **pk != Pubkey::default())
-                            .map(|pk| {
-                                let t = pk.to_string();
-                                spinner.println(format!("    Using tenant '{t}' from Access Pass."));
-                                t
-                            })
-                    })
+                            .map(|pk| (pk.to_string(), "Access Pass"))
+                    }
                 };
 
-                let tenant_pk = match tenant {
-                    Some(tenant_str) => match parse_pubkey(&tenant_str) {
-                        Some(pk) => Some(pk),
-                        None => {
-                            let (pubkey, _) = client
-                                .get_tenant(GetTenantCommand {
-                                    pubkey_or_code: tenant_str.clone(),
-                                })
-                                .map_err(|_| eyre::eyre!("Tenant not found"))?;
-                            Some(pubkey)
-                        }
-                    },
+                let tenant_pk = match tenant_with_source {
+                    Some((tenant_str, source)) => {
+                        let (pubkey, tenant_account) = client
+                            .get_tenant(GetTenantCommand {
+                                pubkey_or_code: tenant_str.clone(),
+                            })
+                            .map_err(|_| eyre::eyre!("Tenant '{}' not found", tenant_str))?;
+                        spinner.println(format!(
+                            "    Using tenant '{}' from {}.",
+                            tenant_account.code, source
+                        ));
+                        Some(pubkey)
+                    }
                     None => None,
                 };
 

--- a/client/doublezero/src/command/disconnect.rs
+++ b/client/doublezero/src/command/disconnect.rs
@@ -51,7 +51,7 @@ impl DecommissioningCliCommand {
         check_requirements(client, Some(&spinner), CHECK_ID_JSON | CHECK_BALANCE)?;
         check_doublezero(&controller, client, Some(&spinner)).await?;
         // READY
-        spinner.println("🔍  Decommissioning User");
+        spinner.println("⚡  Disconnecting...");
 
         // Get client IP from daemon (same source as connect)
         let client_ip = super::helpers::resolve_client_ip(&controller).await?;
@@ -71,7 +71,7 @@ impl DecommissioningCliCommand {
             .await
         {
             Ok(()) => {
-                spinner.println("    Daemon confirmed tunnel(s) removed");
+                spinner.println("    Tunnel confirmed removed");
             }
             Err(e) => {
                 spinner.println(format!(
@@ -139,14 +139,14 @@ impl DecommissioningCliCommand {
             }
 
             spinner.inc(1);
-            println!("🔍  Deleting User Account for: {pubkey}");
+            spinner.println(format!("⚡  Removing account: {pubkey}"));
             let res = client.delete_user(DeleteUserCommand { pubkey: *pubkey });
             match res {
                 Ok(_) => {
-                    spinner.println("🔍  User Account deleting...");
+                    spinner.println("    Account deletion submitted");
                 }
                 Err(e) => {
-                    spinner.println(format!("🔍  Failed to delete user account: {e}"));
+                    spinner.println(format!("❌  Failed to remove account: {e}"));
                 }
             }
 

--- a/e2e/multi_tenant_access_control_test.go
+++ b/e2e/multi_tenant_access_control_test.go
@@ -153,7 +153,7 @@ func TestE2E_MultiTenantAccessControl(t *testing.T) {
 
 	// Subtest 2: Nonexistent tenant rejected.
 	// client1 tries to connect to a tenant that doesn't exist onchain.
-	// The client-side preflight check should reject with "Tenant not found".
+	// The client-side preflight check should reject with a "not found" error.
 	if !t.Run("nonexistent_tenant_rejected", func(t *testing.T) {
 		log.Debug("==> Testing nonexistent tenant rejection")
 
@@ -163,8 +163,8 @@ func TestE2E_MultiTenantAccessControl(t *testing.T) {
 			"--device", deviceCode,
 		}, docker.NoPrintOnError())
 		require.Error(t, err, "connecting to nonexistent tenant should fail")
-		require.Contains(t, string(output), "Tenant not found",
-			"expected 'Tenant not found' error, got: %s", string(output))
+		require.Contains(t, string(output), "not found",
+			"expected tenant-not-found error, got: %s", string(output))
 
 		// Verify client remains disconnected.
 		status, err := client1.GetTunnelStatus(t.Context())

--- a/smartcontract/cli/src/helpers.rs
+++ b/smartcontract/cli/src/helpers.rs
@@ -87,7 +87,7 @@ pub fn init_command(len: u64) -> ProgressBar {
     );
     spinner.enable_steady_tick(Duration::from_millis(100));
 
-    spinner.println("DoubleZero Service Provisioning");
+    spinner.println("DoubleZero Network");
 
     spinner
 }


### PR DESCRIPTION
Resolves: #3528

## Summary of Changes
- Replace semantically incorrect `🔍` emoji with `⚡` on action/status lines in both commands
- Change shared header from `"DoubleZero Service Provisioning"` to `"DoubleZero Network"` (accurate for both connect and disconnect)
- Fix `disconnect` using `println!` instead of `spinner.println`, which left progress bar text visible on screen
- Normalize device-selection phrasing across IBRL and multicast code paths; remove trailing spaces in format strings
- Indent tenant lines to match surrounding detail lines

## Output

### `doublezero connect ibrl`
```
DoubleZero Network
⚡  Connecting to testnet...
    DoubleZero ID: DZfHfcCXTLwgZeCRKQ1FL1UuwAwFAZM93g86NMYpfYan
⚡  Provisioning for IP: 67.213.120.9
    Creating account...
    Device selected: nyc-dz001
    Using tenant 'solana' from Access Pass.
    Tunnel Src: 67.213.120.9
    Tunnel Dst: 64.86.248.128
    DoubleZero IP: 67.213.120.9
    Session: Pending BGP Session
✅  User Provisioned
```

### `doublezero disconnect`
```
DoubleZero Network
⚡  Disconnecting...
    Client IP: 67.213.120.9
⚡  Removing account: 8F3kvQWf2RK86DkR8zXhLKeFTmQyqXkM1fhEaJi7FfK1
    Account deletion submitted
    Tunnel confirmed removed
✅  Deprovisioning Complete
```

## Diff Breakdown
| Category    | Files | Lines (+/-)  | Net |
|-------------|-------|--------------|-----|
| Scaffolding |     3 | +15 / -21    |  -6 |

Pure string/presentation changes — no logic modified.

## Testing Verification
- `cargo test -p doublezero -p doublezero_cli` — 290 tests pass