### PR TITLE
telemetry: expose agent version info via data-api and data-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Telemetry
-  - Add `GET /device-link/agent-versions` endpoint to data-api and `agent-versions` subcommand to data-cli, exposing per-device telemetry agent version and commit from onchain `DeviceLatencySamplesHeader` ([#3530](https://github.com/malbeclabs/doublezero/pull/3530))
-- SDK
-  - Add `GetDeviceLatencySamplesHeader` to the Go telemetry SDK using Solana RPC `DataSlice` to fetch only the 350-byte header instead of the full account ([#3530](https://github.com/malbeclabs/doublezero/pull/3530))
+  - Add `GET /device-link/agent-versions` endpoint to data-api and `agent-versions` subcommand to data-cli, exposing per-device telemetry agent version and commit from onchain `DeviceLatencySamplesHeader`
 - Smartcontract
   - Allow `SubscribeMulticastGroup` for users in `Pending` status so that `CreateSubscribeUser` can be followed by additional subscribe calls before the activator runs ([#3521](https://github.com/malbeclabs/doublezero/pull/3521))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Telemetry
+  - Add `GET /device-link/agent-versions` endpoint to data-api and `agent-versions` subcommand to data-cli, exposing per-device telemetry agent version and commit from onchain `DeviceLatencySamplesHeader` ([#3530](https://github.com/malbeclabs/doublezero/pull/3530))
+- SDK
+  - Add `GetDeviceLatencySamplesHeader` to the Go telemetry SDK using Solana RPC `DataSlice` to fetch only the 350-byte header instead of the full account ([#3530](https://github.com/malbeclabs/doublezero/pull/3530))
 - Smartcontract
   - Allow `SubscribeMulticastGroup` for users in `Pending` status so that `CreateSubscribeUser` can be followed by additional subscribe calls before the activator runs ([#3521](https://github.com/malbeclabs/doublezero/pull/3521))
 

--- a/controlplane/telemetry/internal/data/cli/agent_versions.go
+++ b/controlplane/telemetry/internal/data/cli/agent_versions.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	devicedata "github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data/device"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type AgentVersionsCmd struct{}
+
+func NewAgentVersionsCmd() *AgentVersionsCmd {
+	return &AgentVersionsCmd{}
+}
+
+func (c *AgentVersionsCmd) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent-versions",
+		Short: "Show telemetry agent version for each device",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verbose, err := cmd.Root().PersistentFlags().GetBool("verbose")
+			if err != nil {
+				return fmt.Errorf("failed to get verbose flag: %w", err)
+			}
+			env, err := cmd.Root().PersistentFlags().GetString("env")
+			if err != nil {
+				return fmt.Errorf("failed to get env flag: %w", err)
+			}
+
+			log := newLogger(verbose)
+
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+
+			provider, _, err := newDeviceProvider(log, env)
+			if err != nil {
+				log.Error("Failed to get provider", "error", err)
+				os.Exit(1)
+			}
+
+			versions, err := provider.GetAgentVersions(ctx)
+			if err != nil {
+				log.Error("Failed to get agent versions", "error", err)
+				os.Exit(1)
+			}
+
+			printAgentVersions(versions, env)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func printAgentVersions(versions []devicedata.DeviceAgentVersion, env string) {
+	fmt.Println("Environment:", env)
+	fmt.Printf("Devices reporting: %d\n", len(versions))
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetHeaderAlignment(tablewriter.ALIGN_CENTER)
+	table.SetAutoFormatHeaders(false)
+	table.SetBorder(true)
+	table.SetRowLine(true)
+	table.SetHeader([]string{
+		"Device PK",
+		"Device Code",
+		"Version",
+		"Commit",
+		"Last Sample",
+	})
+
+	for _, v := range versions {
+		table.Append([]string{
+			v.DevicePK,
+			v.DeviceCode,
+			v.Version,
+			v.Commit,
+			v.Timestamp,
+		})
+	}
+	table.Render()
+}

--- a/controlplane/telemetry/internal/data/cli/root.go
+++ b/controlplane/telemetry/internal/data/cli/root.go
@@ -40,6 +40,7 @@ func Run() ExitCode {
 	rootCmd.AddCommand(
 		NewDeviceCmd().Command(),
 		NewInternetCmd().Command(),
+		NewAgentVersionsCmd().Command(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/controlplane/telemetry/internal/data/device/agent_versions.go
+++ b/controlplane/telemetry/internal/data/device/agent_versions.go
@@ -1,0 +1,125 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+)
+
+const maxAgentVersionStaleness = 24 * time.Hour
+
+func (p *provider) GetAgentVersions(ctx context.Context) ([]DeviceAgentVersion, error) {
+	circuits, err := p.GetCircuits(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	currentEpoch, err := p.cfg.EpochFinder.ApproximateAtTime(ctx, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+
+	// Group circuits by origin device, keeping one representative circuit per device.
+	type deviceCircuit struct {
+		devicePK   solana.PublicKey
+		deviceCode string
+		circuit    Circuit
+	}
+	seen := map[solana.PublicKey]struct{}{}
+	var devices []deviceCircuit
+	for _, c := range circuits {
+		if _, ok := seen[c.OriginDevice.PK]; ok {
+			continue
+		}
+		seen[c.OriginDevice.PK] = struct{}{}
+		devices = append(devices, deviceCircuit{
+			devicePK:   c.OriginDevice.PK,
+			deviceCode: c.OriginDevice.Code,
+			circuit:    c,
+		})
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var results []DeviceAgentVersion
+	now := time.Now().UTC()
+
+	sem := make(chan struct{}, defaultGetCircuitLatenciesPoolSize)
+	for _, dev := range devices {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(dev deviceCircuit) {
+			defer func() { <-sem; wg.Done() }()
+
+			// Try current epoch first, then the previous epoch.
+			var hdr *telemetry.DeviceLatencySamplesHeader
+			for _, ep := range []uint64{currentEpoch, currentEpoch - 1} {
+				h, err := p.cfg.TelemetryClient.GetDeviceLatencySamplesHeader(
+					ctx,
+					dev.circuit.OriginDevice.PK,
+					dev.circuit.TargetDevice.PK,
+					dev.circuit.Link.PK,
+					ep,
+				)
+				if err != nil {
+					if errors.Is(err, telemetry.ErrAccountNotFound) {
+						continue
+					}
+					p.log.Warn("failed to get samples header", "device", dev.deviceCode, "epoch", ep, "error", err)
+					continue
+				}
+				if h.NextSampleIndex == 0 {
+					continue
+				}
+				hdr = h
+				break
+			}
+
+			if hdr == nil || hdr.NextSampleIndex == 0 {
+				return
+			}
+
+			ts := lastSampleTime(hdr)
+			if now.Sub(ts) > maxAgentVersionStaleness {
+				return
+			}
+
+			version := strings.TrimRight(string(hdr.AgentVersion[:]), "\x00")
+			commit := strings.TrimRight(string(hdr.AgentCommit[:]), "\x00")
+
+			mu.Lock()
+			results = append(results, DeviceAgentVersion{
+				DevicePK:   dev.devicePK.String(),
+				DeviceCode: dev.deviceCode,
+				Version:    version,
+				Commit:     commit,
+				Timestamp:  ts.Format(time.RFC3339),
+			})
+			mu.Unlock()
+		}(dev)
+	}
+	wg.Wait()
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].DeviceCode < results[j].DeviceCode
+	})
+
+	return results, nil
+}
+
+func lastSampleTime(hdr *telemetry.DeviceLatencySamplesHeader) time.Time {
+	if hdr.NextSampleIndex == 0 {
+		return time.Time{}
+	}
+	tsMicros := hdr.StartTimestampMicroseconds +
+		uint64(hdr.NextSampleIndex-1)*hdr.SamplingIntervalMicroseconds
+	secs := int64(tsMicros / 1_000_000)
+	nanos := int64(tsMicros%1_000_000) * 1000
+	return time.Unix(secs, nanos)
+}

--- a/controlplane/telemetry/internal/data/device/agent_versions_test.go
+++ b/controlplane/telemetry/internal/data/device/agent_versions_test.go
@@ -86,7 +86,7 @@ func TestGetAgentVersions_ReturnsVersions(t *testing.T) {
 	contributorPK := solana.NewWallet().PublicKey()
 
 	now := time.Now().UTC()
-	startMicros := uint64(now.Add(-1*time.Hour).UnixMicro())
+	startMicros := uint64(now.Add(-1 * time.Hour).UnixMicro())
 
 	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
 

--- a/controlplane/telemetry/internal/data/device/agent_versions_test.go
+++ b/controlplane/telemetry/internal/data/device/agent_versions_test.go
@@ -1,0 +1,265 @@
+package data_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	data "github.com/malbeclabs/doublezero/controlplane/telemetry/internal/data/device"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/telemetry"
+)
+
+func newTestProviderForAgentVersions(
+	t *testing.T,
+	programData *serviceability.ProgramData,
+	headerFn func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error),
+	epochFn func(ctx context.Context, target time.Time) (uint64, error),
+) data.Provider {
+	t.Helper()
+
+	p, err := data.NewProvider(&data.ProviderConfig{
+		Logger: logger,
+		ServiceabilityClient: &mockServiceabilityClient{
+			GetProgramDataFunc: func(ctx context.Context) (*serviceability.ProgramData, error) {
+				return programData, nil
+			},
+		},
+		TelemetryClient: &mockTelemetryClient{
+			GetDeviceLatencySamplesFunc: func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error) {
+				return nil, telemetry.ErrAccountNotFound
+			},
+			GetDeviceLatencySamplesHeaderFunc: headerFn,
+		},
+		EpochFinder: &mockEpochFinder{
+			ApproximateAtTimeFunc: epochFn,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	return p
+}
+
+func makeProgramData(deviceA, deviceZ solana.PublicKey, linkPK, contributorPK solana.PublicKey) *serviceability.ProgramData {
+	return &serviceability.ProgramData{
+		Devices: []serviceability.Device{
+			{PubKey: [32]byte(deviceA.Bytes()), Code: "dev-a"},
+			{PubKey: [32]byte(deviceZ.Bytes()), Code: "dev-z"},
+		},
+		Links: []serviceability.Link{
+			{
+				PubKey:            [32]byte(linkPK.Bytes()),
+				SideAPubKey:       [32]uint8(deviceA.Bytes()),
+				SideZPubKey:       [32]uint8(deviceZ.Bytes()),
+				ContributorPubKey: [32]uint8(contributorPK.Bytes()),
+				Code:              "link-1",
+			},
+		},
+		Contributors: []serviceability.Contributor{
+			{PubKey: [32]byte(contributorPK.Bytes()), Code: "contrib-1"},
+		},
+	}
+}
+
+func makeHeader(epoch uint64, version, commit string, sampleCount uint32, startMicros, intervalMicros uint64) *telemetry.DeviceLatencySamplesHeader {
+	var av [16]uint8
+	copy(av[:], version)
+	var ac [8]uint8
+	copy(ac[:], commit)
+	return &telemetry.DeviceLatencySamplesHeader{
+		AccountType:                  telemetry.AccountTypeDeviceLatencySamples,
+		Epoch:                        epoch,
+		NextSampleIndex:              sampleCount,
+		AgentVersion:                 av,
+		AgentCommit:                  ac,
+		StartTimestampMicroseconds:   startMicros,
+		SamplingIntervalMicroseconds: intervalMicros,
+	}
+}
+
+func TestGetAgentVersions_ReturnsVersions(t *testing.T) {
+	deviceA := solana.NewWallet().PublicKey()
+	deviceZ := solana.NewWallet().PublicKey()
+	linkPK := solana.NewWallet().PublicKey()
+	contributorPK := solana.NewWallet().PublicKey()
+
+	now := time.Now().UTC()
+	startMicros := uint64(now.Add(-1*time.Hour).UnixMicro())
+
+	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			return makeHeader(100, "v1.2.3", "abc1234", 100, startMicros, 1_000_000), nil
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions (forward + reverse circuit), got %d", len(versions))
+	}
+
+	for _, v := range versions {
+		if v.Version != "v1.2.3" {
+			t.Errorf("expected version v1.2.3, got %q", v.Version)
+		}
+		if v.Commit != "abc1234" {
+			t.Errorf("expected commit abc1234, got %q", v.Commit)
+		}
+	}
+}
+
+func TestGetAgentVersions_SkipsAccountNotFound(t *testing.T) {
+	deviceA := solana.NewWallet().PublicKey()
+	deviceZ := solana.NewWallet().PublicKey()
+	linkPK := solana.NewWallet().PublicKey()
+	contributorPK := solana.NewWallet().PublicKey()
+
+	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			return nil, telemetry.ErrAccountNotFound
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 0 {
+		t.Fatalf("expected 0 versions, got %d", len(versions))
+	}
+}
+
+func TestGetAgentVersions_SkipsZeroSampleIndex(t *testing.T) {
+	deviceA := solana.NewWallet().PublicKey()
+	deviceZ := solana.NewWallet().PublicKey()
+	linkPK := solana.NewWallet().PublicKey()
+	contributorPK := solana.NewWallet().PublicKey()
+
+	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			return makeHeader(100, "v1.0.0", "deadbeef", 0, 0, 0), nil
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 0 {
+		t.Fatalf("expected 0 versions for zero sample index, got %d", len(versions))
+	}
+}
+
+func TestGetAgentVersions_SkipsStaleEntries(t *testing.T) {
+	deviceA := solana.NewWallet().PublicKey()
+	deviceZ := solana.NewWallet().PublicKey()
+	linkPK := solana.NewWallet().PublicKey()
+	contributorPK := solana.NewWallet().PublicKey()
+
+	// Last sample time is >24h ago
+	startMicros := uint64(time.Now().UTC().Add(-48 * time.Hour).UnixMicro())
+
+	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			return makeHeader(100, "v1.0.0", "abc", 10, startMicros, 1_000_000), nil
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 0 {
+		t.Fatalf("expected 0 stale versions, got %d", len(versions))
+	}
+}
+
+func TestGetAgentVersions_FallsBackToPreviousEpoch(t *testing.T) {
+	deviceA := solana.NewWallet().PublicKey()
+	deviceZ := solana.NewWallet().PublicKey()
+	linkPK := solana.NewWallet().PublicKey()
+	contributorPK := solana.NewWallet().PublicKey()
+
+	now := time.Now().UTC()
+	startMicros := uint64(now.Add(-1 * time.Hour).UnixMicro())
+
+	pd := makeProgramData(deviceA, deviceZ, linkPK, contributorPK)
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			if epoch == 100 {
+				return nil, telemetry.ErrAccountNotFound
+			}
+			// epoch 99
+			return makeHeader(99, "v0.9.0", "old1234", 50, startMicros, 1_000_000), nil
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) == 0 {
+		t.Fatal("expected versions from fallback epoch, got 0")
+	}
+
+	for _, v := range versions {
+		if v.Version != "v0.9.0" {
+			t.Errorf("expected version v0.9.0 from previous epoch, got %q", v.Version)
+		}
+	}
+}
+
+func TestGetAgentVersions_EmptyCircuits(t *testing.T) {
+	pd := &serviceability.ProgramData{}
+
+	p := newTestProviderForAgentVersions(t, pd,
+		func(ctx context.Context, origin, target, link solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+			return nil, telemetry.ErrAccountNotFound
+		},
+		func(ctx context.Context, target time.Time) (uint64, error) {
+			return 100, nil
+		},
+	)
+
+	versions, err := p.GetAgentVersions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 0 {
+		t.Fatalf("expected 0 versions for empty circuits, got %d", len(versions))
+	}
+}

--- a/controlplane/telemetry/internal/data/device/main_test.go
+++ b/controlplane/telemetry/internal/data/device/main_test.go
@@ -49,17 +49,26 @@ func (m *mockServiceabilityClient) GetProgramData(ctx context.Context) (*service
 }
 
 type mockTelemetryClient struct {
-	GetDeviceLatencySamplesFunc func(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error)
+	GetDeviceLatencySamplesFunc       func(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error)
+	GetDeviceLatencySamplesHeaderFunc func(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error)
 }
 
 func (m *mockTelemetryClient) GetDeviceLatencySamples(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error) {
 	return m.GetDeviceLatencySamplesFunc(ctx, originDevicePubKey, targetDevicePubKey, linkPubKey, epoch)
 }
 
+func (m *mockTelemetryClient) GetDeviceLatencySamplesHeader(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error) {
+	if m.GetDeviceLatencySamplesHeaderFunc != nil {
+		return m.GetDeviceLatencySamplesHeaderFunc(ctx, originDevicePubKey, targetDevicePubKey, linkPubKey, epoch)
+	}
+	return nil, telemetry.ErrAccountNotFound
+}
+
 type mockProvider struct {
 	GetCircuitsFunc           func(context.Context) ([]data.Circuit, error)
 	GetCircuitLatenciesFunc   func(context.Context, data.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error)
 	GetSummaryForCircuitsFunc func(context.Context, data.GetSummaryForCircuitsConfig) ([]data.CircuitSummary, error)
+	GetAgentVersionsFunc      func(context.Context) ([]data.DeviceAgentVersion, error)
 }
 
 func (m *mockProvider) GetCircuits(ctx context.Context) ([]data.Circuit, error) {
@@ -72,6 +81,13 @@ func (m *mockProvider) GetCircuitLatencies(ctx context.Context, cfg data.GetCirc
 
 func (m *mockProvider) GetSummaryForCircuits(ctx context.Context, cfg data.GetSummaryForCircuitsConfig) ([]data.CircuitSummary, error) {
 	return m.GetSummaryForCircuitsFunc(ctx, cfg)
+}
+
+func (m *mockProvider) GetAgentVersions(ctx context.Context) ([]data.DeviceAgentVersion, error) {
+	if m.GetAgentVersionsFunc != nil {
+		return m.GetAgentVersionsFunc(ctx)
+	}
+	return nil, nil
 }
 
 type mockEpochFinder struct {

--- a/controlplane/telemetry/internal/data/device/provider.go
+++ b/controlplane/telemetry/internal/data/device/provider.go
@@ -86,10 +86,19 @@ type CircuitSummary struct {
 	CommittedJitterChangeRatio float64 `json:"committed_jitter_change_ratio"`
 }
 
+type DeviceAgentVersion struct {
+	DevicePK   string `json:"device_pk"`
+	DeviceCode string `json:"device_code"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit"`
+	Timestamp  string `json:"timestamp"`
+}
+
 type Provider interface {
 	GetCircuits(ctx context.Context) ([]Circuit, error)
 	GetCircuitLatencies(ctx context.Context, cfg GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error)
 	GetSummaryForCircuits(ctx context.Context, cfg GetSummaryForCircuitsConfig) ([]CircuitSummary, error)
+	GetAgentVersions(ctx context.Context) ([]DeviceAgentVersion, error)
 }
 
 type provider struct {
@@ -168,4 +177,5 @@ type ServiceabilityClient interface {
 
 type TelemetryClient interface {
 	GetDeviceLatencySamples(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamples, error)
+	GetDeviceLatencySamplesHeader(ctx context.Context, originDevicePubKey, targetDevicePubKey, linkPubKey solana.PublicKey, epoch uint64) (*telemetry.DeviceLatencySamplesHeader, error)
 }

--- a/controlplane/telemetry/internal/data/device/server.go
+++ b/controlplane/telemetry/internal/data/device/server.go
@@ -66,6 +66,7 @@ func (s *Server) registerRoutes() {
 	s.Mux.HandleFunc("/device-link/contributors", s.handleContributors)
 	s.Mux.HandleFunc("/device-link/circuit-latencies", s.handleDeviceCircuitLatencies)
 	s.Mux.HandleFunc("/device-link/summary", s.handlSummary)
+	s.Mux.HandleFunc("/device-link/agent-versions", s.handleAgentVersions)
 }
 
 func (s *Server) handleDeviceLinkTypes(w http.ResponseWriter, r *http.Request) {
@@ -309,6 +310,31 @@ func (s *Server) handlSummary(w http.ResponseWriter, r *http.Request) {
 	if err := encoder.Encode(output); err != nil {
 		s.log.Error("failed to encode latencies", "error", err)
 		http.Error(w, fmt.Sprintf("failed to encode latencies: %v", err), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) handleAgentVersions(w http.ResponseWriter, r *http.Request) {
+	env := r.URL.Query().Get("env")
+	s.log.Debug("[/device-link/agent-versions]", "env", env, "full", r.URL.String())
+
+	provider, err := s.provider(env)
+	if err != nil {
+		s.log.Warn("invalid environment", "env", env)
+		http.Error(w, fmt.Sprintf("invalid environment %q", env), http.StatusBadRequest)
+		return
+	}
+
+	versions, err := provider.GetAgentVersions(r.Context())
+	if err != nil {
+		s.log.Error("failed to get agent versions", "error", err)
+		http.Error(w, fmt.Sprintf("failed to get agent versions: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(versions); err != nil {
+		s.log.Error("failed to encode agent versions", "error", err)
+		http.Error(w, fmt.Sprintf("failed to encode agent versions: %v", err), http.StatusInternalServerError)
 		return
 	}
 }

--- a/controlplane/telemetry/internal/data/device/server_test.go
+++ b/controlplane/telemetry/internal/data/device/server_test.go
@@ -868,6 +868,76 @@ func TestTelemetry_Data_Device_Server_Summary(t *testing.T) {
 	})
 }
 
+func TestTelemetry_Data_Device_Server_AgentVersions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GET /device-link/agent-versions returns versions", func(t *testing.T) {
+		t.Parallel()
+
+		expected := []data.DeviceAgentVersion{
+			{DevicePK: "pk1", DeviceCode: "dev-a", Version: "v1.2.3", Commit: "abc1234", Timestamp: "2026-01-01T00:00:00Z"},
+		}
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{}, &mockProvider{
+			GetAgentVersionsFunc: func(ctx context.Context) ([]data.DeviceAgentVersion, error) {
+				return expected, nil
+			},
+		})
+		defer closeFn()
+
+		res, body := get(t, baseURL, "/device-link/agent-versions", url.Values{"env": {"devnet"}})
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		var got []data.DeviceAgentVersion
+		require.NoError(t, json.Unmarshal(body, &got))
+		require.Len(t, got, 1)
+		assert.Equal(t, "v1.2.3", got[0].Version)
+		assert.Equal(t, "dev-a", got[0].DeviceCode)
+	})
+
+	t.Run("GET /device-link/agent-versions with invalid env", func(t *testing.T) {
+		t.Parallel()
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{}, &mockProvider{})
+		defer closeFn()
+
+		res, _ := get(t, baseURL, "/device-link/agent-versions", url.Values{"env": {"invalid"}})
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("GET /device-link/agent-versions returns empty list", func(t *testing.T) {
+		t.Parallel()
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{}, &mockProvider{
+			GetAgentVersionsFunc: func(ctx context.Context) ([]data.DeviceAgentVersion, error) {
+				return []data.DeviceAgentVersion{}, nil
+			},
+		})
+		defer closeFn()
+
+		res, body := get(t, baseURL, "/device-link/agent-versions", url.Values{"env": {"devnet"}})
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		var got []data.DeviceAgentVersion
+		require.NoError(t, json.Unmarshal(body, &got))
+		assert.Empty(t, got)
+	})
+
+	t.Run("GET /device-link/agent-versions returns 500 on error", func(t *testing.T) {
+		t.Parallel()
+
+		baseURL, closeFn := startServer(t, &mockProvider{}, &mockProvider{}, &mockProvider{
+			GetAgentVersionsFunc: func(ctx context.Context) ([]data.DeviceAgentVersion, error) {
+				return nil, errors.New("telemetry failure")
+			},
+		})
+		defer closeFn()
+
+		res, _ := get(t, baseURL, "/device-link/agent-versions", url.Values{"env": {"devnet"}})
+		assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	})
+}
+
 func startServer(t *testing.T, mainnet, testnet, devnet data.Provider) (baseURL string, closeFn func()) {
 	t.Helper()
 

--- a/controlplane/telemetry/internal/data/main_test.go
+++ b/controlplane/telemetry/internal/data/main_test.go
@@ -42,6 +42,7 @@ type mockDeviceProvider struct {
 	GetCircuitsFunc           func(context.Context) ([]devicedata.Circuit, error)
 	GetCircuitLatenciesFunc   func(context.Context, devicedata.GetCircuitLatenciesConfig) ([]stats.CircuitLatencyStat, error)
 	GetSummaryForCircuitsFunc func(context.Context, devicedata.GetSummaryForCircuitsConfig) ([]devicedata.CircuitSummary, error)
+	GetAgentVersionsFunc      func(context.Context) ([]devicedata.DeviceAgentVersion, error)
 }
 
 func (m *mockDeviceProvider) GetCircuits(ctx context.Context) ([]devicedata.Circuit, error) {
@@ -54,6 +55,13 @@ func (m *mockDeviceProvider) GetCircuitLatencies(ctx context.Context, cfg device
 
 func (m *mockDeviceProvider) GetSummaryForCircuits(ctx context.Context, cfg devicedata.GetSummaryForCircuitsConfig) ([]devicedata.CircuitSummary, error) {
 	return m.GetSummaryForCircuitsFunc(ctx, cfg)
+}
+
+func (m *mockDeviceProvider) GetAgentVersions(ctx context.Context) ([]devicedata.DeviceAgentVersion, error) {
+	if m.GetAgentVersionsFunc != nil {
+		return m.GetAgentVersionsFunc(ctx)
+	}
+	return nil, nil
 }
 
 type mockInternetProvider struct {

--- a/smartcontract/sdk/go/telemetry/client.go
+++ b/smartcontract/sdk/go/telemetry/client.go
@@ -103,6 +103,67 @@ func (c *Client) GetDeviceLatencySamples(
 	}
 }
 
+func (c *Client) GetDeviceLatencySamplesHeader(
+	ctx context.Context,
+	originDevicePK solana.PublicKey,
+	targetDevicePK solana.PublicKey,
+	linkPK solana.PublicKey,
+	epoch uint64,
+) (*DeviceLatencySamplesHeader, error) {
+	pda, _, err := DeriveDeviceLatencySamplesPDA(
+		c.executor.programID,
+		originDevicePK,
+		targetDevicePK,
+		linkPK,
+		epoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive PDA: %w", err)
+	}
+
+	headerSize := uint64(DeviceLatencySamplesHeaderSize)
+	account, err := c.rpc.GetAccountInfoWithOpts(ctx, pda, &solanarpc.GetAccountInfoOpts{
+		DataSlice: &solanarpc.DataSlice{
+			Offset: new(uint64),
+			Length: &headerSize,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, solanarpc.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("failed to get account data: %w", err)
+	}
+	if account.Value == nil {
+		return nil, ErrAccountNotFound
+	}
+
+	data := account.Value.Data.GetBinary()
+	if len(data) < 1 {
+		return nil, fmt.Errorf("empty account data")
+	}
+
+	switch AccountType(data[0]) {
+	case AccountTypeDeviceLatencySamples:
+		dec := bin.NewBorshDecoder(data)
+		var hdr DeviceLatencySamplesHeader
+		if err := dec.Decode(&hdr); err != nil {
+			return nil, fmt.Errorf("failed to decode header: %w", err)
+		}
+		return &hdr, nil
+	case AccountTypeDeviceLatencySamplesV0:
+		dec := bin.NewBorshDecoder(data)
+		var v0hdr DeviceLatencySamplesHeaderV0
+		if err := dec.Decode(&v0hdr); err != nil {
+			return nil, fmt.Errorf("failed to decode v0 header: %w", err)
+		}
+		hdr := v0hdr.ToV1Header()
+		return &hdr, nil
+	default:
+		return nil, fmt.Errorf("unknown account type: %d", data[0])
+	}
+}
+
 func (c *Client) GetDeviceLatencySamplesTail(
 	ctx context.Context,
 	originDevicePK solana.PublicKey,

--- a/smartcontract/sdk/go/telemetry/client_device_test.go
+++ b/smartcontract/sdk/go/telemetry/client_device_test.go
@@ -982,6 +982,205 @@ func TestSDK_Telemetry_Client_WriteDeviceLatencySamples_CustomInstructionErrorSa
 	require.Nil(t, tx)
 }
 
+func TestSDK_Telemetry_Client_GetDeviceLatencySamplesHeader_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+
+	var agentVersion [16]uint8
+	copy(agentVersion[:], "v1.2.3")
+
+	var agentCommit [8]uint8
+	copy(agentCommit[:], "abc1234")
+
+	expected := &telemetry.DeviceLatencySamples{
+		DeviceLatencySamplesHeader: telemetry.DeviceLatencySamplesHeader{
+			AccountType:                  telemetry.AccountTypeDeviceLatencySamples,
+			Epoch:                        42,
+			OriginDeviceAgentPK:          solana.NewWallet().PublicKey(),
+			OriginDevicePK:               solana.NewWallet().PublicKey(),
+			TargetDevicePK:               solana.NewWallet().PublicKey(),
+			OriginDeviceLocationPK:       solana.NewWallet().PublicKey(),
+			TargetDeviceLocationPK:       solana.NewWallet().PublicKey(),
+			LinkPK:                       solana.NewWallet().PublicKey(),
+			SamplingIntervalMicroseconds: 100_000,
+			StartTimestampMicroseconds:   1_600_000_000,
+			NextSampleIndex:              3,
+			AgentVersion:                 agentVersion,
+			AgentCommit:                  agentCommit,
+		},
+		Samples: []uint32{10, 20, 30},
+	}
+
+	mockRPC := &mockRPCClient{
+		GetAccountInfoWithOptsFunc: func(_ context.Context, _ solana.PublicKey, _ *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error) {
+			buf := new(bytes.Buffer)
+			if err := expected.Serialize(buf); err != nil {
+				return nil, fmt.Errorf("mock serialize: %w", err)
+			}
+			data := buf.Bytes()
+			if len(data) > telemetry.DeviceLatencySamplesHeaderSize {
+				data = data[:telemetry.DeviceLatencySamplesHeaderSize]
+			}
+			return &solanarpc.GetAccountInfoResult{
+				Value: &solanarpc.Account{
+					Data: solanarpc.DataBytesOrJSONFromBytes(data),
+				},
+			}, nil
+		},
+	}
+
+	client := telemetry.New(slog.Default(), mockRPC, &signer, programID)
+
+	got, err := client.GetDeviceLatencySamplesHeader(
+		context.Background(),
+		expected.OriginDevicePK,
+		expected.TargetDevicePK,
+		expected.LinkPK,
+		expected.Epoch,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, &expected.DeviceLatencySamplesHeader, got)
+}
+
+func TestSDK_Telemetry_Client_GetDeviceLatencySamplesHeader_V0AccountType(t *testing.T) {
+	t.Parallel()
+
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+
+	expected := &telemetry.DeviceLatencySamplesV0{
+		DeviceLatencySamplesHeaderV0: telemetry.DeviceLatencySamplesHeaderV0{
+			AccountType:                  telemetry.AccountTypeDeviceLatencySamplesV0,
+			BumpSeed:                     255,
+			Epoch:                        42,
+			OriginDeviceAgentPK:          solana.NewWallet().PublicKey(),
+			OriginDevicePK:               solana.NewWallet().PublicKey(),
+			TargetDevicePK:               solana.NewWallet().PublicKey(),
+			OriginDeviceLocationPK:       solana.NewWallet().PublicKey(),
+			TargetDeviceLocationPK:       solana.NewWallet().PublicKey(),
+			LinkPK:                       solana.NewWallet().PublicKey(),
+			SamplingIntervalMicroseconds: 100_000,
+			StartTimestampMicroseconds:   1_600_000_000,
+			NextSampleIndex:              3,
+		},
+		Samples: []uint32{10, 20, 30},
+	}
+
+	mockRPC := &mockRPCClient{
+		GetAccountInfoWithOptsFunc: func(_ context.Context, _ solana.PublicKey, _ *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error) {
+			buf := new(bytes.Buffer)
+			if err := expected.Serialize(buf); err != nil {
+				return nil, fmt.Errorf("mock serialize: %w", err)
+			}
+			data := buf.Bytes()
+			if len(data) > telemetry.DeviceLatencySamplesHeaderSize {
+				data = data[:telemetry.DeviceLatencySamplesHeaderSize]
+			}
+			return &solanarpc.GetAccountInfoResult{
+				Value: &solanarpc.Account{
+					Data: solanarpc.DataBytesOrJSONFromBytes(data),
+				},
+			}, nil
+		},
+	}
+
+	client := telemetry.New(slog.Default(), mockRPC, &signer, programID)
+
+	got, err := client.GetDeviceLatencySamplesHeader(
+		context.Background(),
+		expected.OriginDevicePK,
+		expected.TargetDevicePK,
+		expected.LinkPK,
+		expected.Epoch,
+	)
+
+	expectedHeader := expected.DeviceLatencySamplesHeaderV0.ToV1Header()
+	require.NoError(t, err)
+	require.Equal(t, telemetry.AccountTypeDeviceLatencySamples, got.AccountType)
+	require.Equal(t, &expectedHeader, got)
+}
+
+func TestSDK_Telemetry_Client_GetDeviceLatencySamplesHeader_AccountNotFound(t *testing.T) {
+	t.Parallel()
+
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+
+	mockRPC := &mockRPCClient{
+		GetAccountInfoWithOptsFunc: func(_ context.Context, _ solana.PublicKey, _ *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error) {
+			return nil, solanarpc.ErrNotFound
+		},
+	}
+
+	client := telemetry.New(slog.Default(), mockRPC, &signer, programID)
+
+	_, err := client.GetDeviceLatencySamplesHeader(
+		context.Background(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		42,
+	)
+
+	require.ErrorIs(t, err, telemetry.ErrAccountNotFound)
+}
+
+func TestSDK_Telemetry_Client_GetDeviceLatencySamplesHeader_NilValue(t *testing.T) {
+	t.Parallel()
+
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+
+	mockRPC := &mockRPCClient{
+		GetAccountInfoWithOptsFunc: func(_ context.Context, _ solana.PublicKey, _ *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error) {
+			return &solanarpc.GetAccountInfoResult{
+				Value: nil,
+			}, nil
+		},
+	}
+
+	client := telemetry.New(slog.Default(), mockRPC, &signer, programID)
+
+	_, err := client.GetDeviceLatencySamplesHeader(
+		context.Background(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		42,
+	)
+
+	require.ErrorIs(t, err, telemetry.ErrAccountNotFound)
+}
+
+func TestSDK_Telemetry_Client_GetDeviceLatencySamplesHeader_UnexpectedError(t *testing.T) {
+	t.Parallel()
+
+	signer := solana.NewWallet().PrivateKey
+	programID := solana.NewWallet().PublicKey()
+
+	mockRPC := &mockRPCClient{
+		GetAccountInfoWithOptsFunc: func(_ context.Context, _ solana.PublicKey, _ *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error) {
+			return nil, fmt.Errorf("rpc explosion")
+		},
+	}
+
+	client := telemetry.New(slog.Default(), mockRPC, &signer, programID)
+
+	_, err := client.GetDeviceLatencySamplesHeader(
+		context.Background(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		solana.NewWallet().PublicKey(),
+		42,
+	)
+
+	require.ErrorContains(t, err, "failed to get account data")
+	require.Contains(t, err.Error(), "rpc explosion")
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/smartcontract/sdk/go/telemetry/main_test.go
+++ b/smartcontract/sdk/go/telemetry/main_test.go
@@ -46,6 +46,7 @@ type mockRPCClient struct {
 	GetSignatureStatusesFunc    func(context.Context, bool, ...solana.Signature) (*solanarpc.GetSignatureStatusesResult, error)
 	GetTransactionFunc          func(context.Context, solana.Signature, *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
 	GetAccountInfoFunc          func(context.Context, solana.PublicKey) (*solanarpc.GetAccountInfoResult, error)
+	GetAccountInfoWithOptsFunc  func(context.Context, solana.PublicKey, *solanarpc.GetAccountInfoOpts) (*solanarpc.GetAccountInfoResult, error)
 }
 
 func (m *mockRPCClient) GetLatestBlockhash(ctx context.Context, ct solanarpc.CommitmentType) (*solanarpc.GetLatestBlockhashResult, error) {
@@ -65,5 +66,12 @@ func (m *mockRPCClient) GetTransaction(ctx context.Context, sig solana.Signature
 }
 
 func (m *mockRPCClient) GetAccountInfo(ctx context.Context, account solana.PublicKey) (out *solanarpc.GetAccountInfoResult, err error) {
+	return m.GetAccountInfoFunc(ctx, account)
+}
+
+func (m *mockRPCClient) GetAccountInfoWithOpts(ctx context.Context, account solana.PublicKey, opts *solanarpc.GetAccountInfoOpts) (out *solanarpc.GetAccountInfoResult, err error) {
+	if m.GetAccountInfoWithOptsFunc != nil {
+		return m.GetAccountInfoWithOptsFunc(ctx, account, opts)
+	}
 	return m.GetAccountInfoFunc(ctx, account)
 }

--- a/smartcontract/sdk/go/telemetry/rpc.go
+++ b/smartcontract/sdk/go/telemetry/rpc.go
@@ -15,4 +15,5 @@ type RPCClient interface {
 	GetSignatureStatuses(ctx context.Context, searchTransactionHistory bool, transactionSignatures ...solana.Signature) (out *solanarpc.GetSignatureStatusesResult, err error)
 	GetTransaction(ctx context.Context, txSig solana.Signature, opts *solanarpc.GetTransactionOpts) (*solanarpc.GetTransactionResult, error)
 	GetAccountInfo(ctx context.Context, account solana.PublicKey) (out *solanarpc.GetAccountInfoResult, err error)
+	GetAccountInfoWithOpts(ctx context.Context, account solana.PublicKey, opts *solanarpc.GetAccountInfoOpts) (out *solanarpc.GetAccountInfoResult, err error)
 }

--- a/smartcontract/sdk/go/telemetry/state.go
+++ b/smartcontract/sdk/go/telemetry/state.go
@@ -17,6 +17,9 @@ const (
 	AccountTypeInternetLatencySamples
 )
 
+// Covers both V0 (350 bytes) and V1 (349 bytes) header layouts.
+const DeviceLatencySamplesHeaderSize = 350
+
 type DeviceLatencySamplesHeaderOnlyAccountType struct {
 	AccountType AccountType // 1
 }

--- a/smartcontract/sdk/go/telemetry/state_v0.go
+++ b/smartcontract/sdk/go/telemetry/state_v0.go
@@ -87,33 +87,35 @@ func (d *DeviceLatencySamplesV0) Deserialize(data []byte) error {
 	return nil
 }
 
-func (d *DeviceLatencySamplesV0) ToV1() *DeviceLatencySamples {
-	// The V0 Unused region (128 bytes) maps to AgentVersion (16) + AgentCommit (8) + Unused (104)
-	// in the current header layout. For V0 accounts these bytes are all zeros.
+func (d *DeviceLatencySamplesHeaderV0) ToV1Header() DeviceLatencySamplesHeader {
 	var agentVersion [16]uint8
 	var agentCommit [8]uint8
 	var unused [104]uint8
-	copy(agentVersion[:], d.DeviceLatencySamplesHeaderV0.Unused[0:16])
-	copy(agentCommit[:], d.DeviceLatencySamplesHeaderV0.Unused[16:24])
-	copy(unused[:], d.DeviceLatencySamplesHeaderV0.Unused[24:128])
+	copy(agentVersion[:], d.Unused[0:16])
+	copy(agentCommit[:], d.Unused[16:24])
+	copy(unused[:], d.Unused[24:128])
 
+	return DeviceLatencySamplesHeader{
+		AccountType:                  AccountTypeDeviceLatencySamples,
+		Epoch:                        d.Epoch,
+		OriginDeviceAgentPK:          d.OriginDeviceAgentPK,
+		OriginDevicePK:               d.OriginDevicePK,
+		TargetDevicePK:               d.TargetDevicePK,
+		OriginDeviceLocationPK:       d.OriginDeviceLocationPK,
+		TargetDeviceLocationPK:       d.TargetDeviceLocationPK,
+		LinkPK:                       d.LinkPK,
+		SamplingIntervalMicroseconds: d.SamplingIntervalMicroseconds,
+		StartTimestampMicroseconds:   d.StartTimestampMicroseconds,
+		NextSampleIndex:              d.NextSampleIndex,
+		AgentVersion:                 agentVersion,
+		AgentCommit:                  agentCommit,
+		Unused:                       unused,
+	}
+}
+
+func (d *DeviceLatencySamplesV0) ToV1() *DeviceLatencySamples {
 	return &DeviceLatencySamples{
-		DeviceLatencySamplesHeader: DeviceLatencySamplesHeader{
-			AccountType:                  AccountTypeDeviceLatencySamples,
-			Epoch:                        d.DeviceLatencySamplesHeaderV0.Epoch,
-			OriginDeviceAgentPK:          d.DeviceLatencySamplesHeaderV0.OriginDeviceAgentPK,
-			OriginDevicePK:               d.DeviceLatencySamplesHeaderV0.OriginDevicePK,
-			TargetDevicePK:               d.DeviceLatencySamplesHeaderV0.TargetDevicePK,
-			OriginDeviceLocationPK:       d.DeviceLatencySamplesHeaderV0.OriginDeviceLocationPK,
-			TargetDeviceLocationPK:       d.DeviceLatencySamplesHeaderV0.TargetDeviceLocationPK,
-			LinkPK:                       d.DeviceLatencySamplesHeaderV0.LinkPK,
-			SamplingIntervalMicroseconds: d.DeviceLatencySamplesHeaderV0.SamplingIntervalMicroseconds,
-			StartTimestampMicroseconds:   d.DeviceLatencySamplesHeaderV0.StartTimestampMicroseconds,
-			NextSampleIndex:              d.DeviceLatencySamplesHeaderV0.NextSampleIndex,
-			AgentVersion:                 agentVersion,
-			AgentCommit:                  agentCommit,
-			Unused:                       unused,
-		},
-		Samples: d.Samples,
+		DeviceLatencySamplesHeader: d.DeviceLatencySamplesHeaderV0.ToV1Header(),
+		Samples:                   d.Samples,
 	}
 }

--- a/smartcontract/sdk/go/telemetry/state_v0.go
+++ b/smartcontract/sdk/go/telemetry/state_v0.go
@@ -116,6 +116,6 @@ func (d *DeviceLatencySamplesHeaderV0) ToV1Header() DeviceLatencySamplesHeader {
 func (d *DeviceLatencySamplesV0) ToV1() *DeviceLatencySamples {
 	return &DeviceLatencySamples{
 		DeviceLatencySamplesHeader: d.DeviceLatencySamplesHeaderV0.ToV1Header(),
-		Samples:                   d.Samples,
+		Samples:                    d.Samples,
 	}
 }


### PR DESCRIPTION
## Summary of Changes

- Add `GET /device-link/agent-versions` endpoint to data-api and `agent-versions` subcommand to data-cli, surfacing the telemetry agent version and commit hash from `DeviceLatencySamplesHeader` written onchain since #3506
- Add `GetDeviceLatencySamplesHeader` SDK method using Solana RPC `DataSlice` to fetch only the 350-byte header instead of the full ~140KB account
- Extract `ToV1Header()` on `DeviceLatencySamplesHeaderV0` for header-only V0→V1 conversion, reused by existing `ToV1()`
- Bound concurrency in `GetAgentVersions` with a semaphore (cap 64) to prevent unbounded goroutine fan-out

## Diff Breakdown

| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     3 | +211 / -23   | +188 |
| Scaffolding  |     6 | +129 / -0    | +129 |
| Tests        |     5 | +368 / -1    | +367 |

~340 lines of non-test code; roughly half is core logic, half is wiring.

<details>
<summary>Key files (click to expand)</summary>

- [`controlplane/telemetry/internal/data/device/agent_versions.go`](https://github.com/malbeclabs/doublezero/pull/3530/files#diff-0ead065494d1fcf29685878803a66c06bfaa5fa494008fd8202266177cf1ada4) — Provider method that groups circuits by origin device, fetches headers (current + previous epoch fallback), and returns version/commit per device
- [`controlplane/telemetry/internal/data/cli/agent_versions.go`](https://github.com/malbeclabs/doublezero/pull/3530/files#diff-405da9067b67de87fa28b31337f60a06ab176732a464bf90a31fff58f660b899) — CLI subcommand that calls GetAgentVersions and renders a table
- [`smartcontract/sdk/go/telemetry/client.go`](https://github.com/malbeclabs/doublezero/pull/3530/files#diff-80b8d7ca3aa6fd5d642584653ca346aee5be57bc77e79a89db885b782566c0ff) — New `GetDeviceLatencySamplesHeader` using DataSlice to fetch only 350 bytes, with V0/V1 deserialization
- [`smartcontract/sdk/go/telemetry/state_v0.go`](https://github.com/malbeclabs/doublezero/pull/3530/files#diff-8f5df3efc61241621c8867509a324f0532369db21cf40d38fe2467362c927fac) — Extract `ToV1Header()` from `ToV1()` for header-only conversion without samples
- [`controlplane/telemetry/internal/data/device/server.go`](https://github.com/malbeclabs/doublezero/pull/3530/files#diff-c60979e397bc54fb0d2a666df2410d9d93b24537a1a23bd17b43ec276104e664) — Register and handle `/device-link/agent-versions` route

</details>

## Testing Verification

- New provider tests for `GetAgentVersions`: valid headers, account-not-found skipping, zero-sample-index skipping, staleness filtering (>24h), epoch fallback, empty circuits
- New HTTP handler tests for `/device-link/agent-versions`: success response, invalid env (400), empty results, provider error (500)
- Existing SDK V0/V1 serialization round-trip tests pass after `ToV1Header` refactor