### PR TITLE
devcontainer: add optional worktrees mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
             "version": "1.90.0"
         },
     },
+    "initializeCommand": "mkdir -p \"${DZ_WORKTREES_DIR:-/tmp/worktrees}\"",
     "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/doublezero/target && rustup component add --toolchain nightly rustfmt",
     "postStartCommand": "sudo chmod 666 /var/run/docker.sock && sudo chown -R vscode:vscode /home/vscode/.docker && sudo chown -R vscode:vscode /workspaces/doublezero/target",
     "customizations": {
@@ -56,9 +57,14 @@
     },
     "remoteUser": "vscode",
     "updateRemoteUserUID": true,
+    // Optional: set DZ_WORKTREES_DIR on the host to expose a worktrees directory
+    // (e.g. export DZ_WORKTREES_DIR="$HOME/projects/worktrees") at /workspaces/worktrees
+    // inside the container. Defaults to /tmp/worktrees when unset (created by
+    // initializeCommand above); harmless no-op for devs who don't use it.
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-        "source=devcontainer-target,target=/workspaces/doublezero/target,type=volume"
+        "source=devcontainer-target,target=/workspaces/doublezero/target,type=volume",
+        "source=${localEnv:DZ_WORKTREES_DIR:/tmp/worktrees},target=/workspaces/worktrees,type=bind"
     ],
     "capAdd": [
         "NET_ADMIN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
   - Reduce default probing interval to 5m from 30s since DZDs don't generally move.
 - Dependencies
   - Bump vulnerable packages across Rust, Go, and Python to address Dependabot security alerts (14 packages fixed)
+- DevContainer
+  - Add optional `DZ_WORKTREES_DIR` mount exposing a host worktrees directory at `/workspaces/worktrees` inside the container; useful when `docker exec`-ing into the persistent dev container to work on git worktrees outside the repo. Defaults to `/tmp/worktrees` (empty, harmless) when unset
 
 ## [v0.17.0](https://github.com/malbeclabs/doublezero/compare/client/v0.16.0...client/v0.17.0) - 2026-04-10
 


### PR DESCRIPTION
## Summary

- Adds an optional `DZ_WORKTREES_DIR` host env var that mounts a worktrees directory at `/workspaces/worktrees` inside the dev container, so `docker exec` workflows can reach git worktrees stored outside the main repo checkout
- Defaults to `/tmp/worktrees` (created by `initializeCommand`) when the env var is unset — harmless empty mount for devs who don't opt in
- Works with VS Code launched from Dock/Spotlight; VS Code's `resolveShellEnv` picks up the env var from shell rc

## Motivation

The persistent dev container (`dz-dev-workspace-vsc`) is used via `docker exec` for Linux builds. Worktrees kept in a global location (e.g. `~/projects/worktrees/`) are not visible inside the container without a mount, so switching between worktrees required constant rebuilds or host-side tooling.

## Opt-in

Add one line to your shell rc:

```sh
export DZ_WORKTREES_DIR="$HOME/projects/worktrees"  # or wherever you keep worktrees
```

Then rebuild the dev container. Your worktrees appear at `/workspaces/worktrees/` inside the container, mirroring the host layout.

## Testing Verification

- Rebuilt the dev container with `DZ_WORKTREES_DIR` set; confirmed mount source resolves to `$HOME/projects/worktrees` via `docker inspect`
- Verified inside the container that `/workspaces/worktrees/` shows host worktrees content
- Verified the unset path: without the env var, mount source resolves to `/tmp/worktrees`, created by `initializeCommand`
- Confirmed VS Code launched from Dock/Spotlight inherits the env var via `resolveShellEnv`