### PR TITLE
qa: use CommitmentFinalized for USDC balance check

### DIFF
--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -197,7 +197,7 @@ func (c *Client) GetUSDCBalance(ctx context.Context) (uint64, error) {
 	}
 
 	solanaClient := rpc.New(c.SolanaRPCURL)
-	result, err := solanaClient.GetTokenAccountBalance(ctx, ata, rpc.CommitmentConfirmed)
+	result, err := solanaClient.GetTokenAccountBalance(ctx, ata, rpc.CommitmentFinalized)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get token account balance for ATA %s on host %s: %w", ata, c.Host, err)
 	}


### PR DESCRIPTION
## Summary of Changes
- Change `GetTokenAccountBalance` commitment level from `CommitmentConfirmed` to `CommitmentFinalized` when checking USDC balances in the QA settlement test

## Testing Verification
- Fixes flaky `TestQA_MulticastSettlement/validate_balance_after_pay` failure seen in https://github.com/malbeclabs/infra/actions/runs/24531910905/job/71717025418, where the balance was read immediately after a transaction was confirmed but before it was finalized, causing the debit to not yet be visible