### PR TITLE
e2e/qa: wait for multicast status specifically in settlement test

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -361,6 +361,39 @@ func (c *Client) WaitForStatusUp(ctx context.Context) error {
 	return nil
 }
 
+// WaitForUnicastStatusUp polls until a Unicast (IBRL) status entry exists and
+// its session is up. Prefer this over WaitForStatusUp in multi-tunnel contexts
+// where other tunnel types may already be present.
+func (c *Client) WaitForUnicastStatusUp(ctx context.Context) error {
+	return c.waitForUserTypeStatusUp(ctx, "IBRL", FindIBRLStatus)
+}
+
+// WaitForMulticastStatusUp polls until a Multicast status entry exists and
+// its session is up. Prefer this over WaitForStatusUp in multi-tunnel contexts
+// where other tunnel types may already be present.
+func (c *Client) WaitForMulticastStatusUp(ctx context.Context) error {
+	return c.waitForUserTypeStatusUp(ctx, "Multicast", FindMulticastStatus)
+}
+
+// waitForUserTypeStatusUp polls until find returns a non-nil status whose
+// session is up. userType is used only for log context.
+func (c *Client) waitForUserTypeStatusUp(ctx context.Context, userType string, find func([]*pb.Status) *pb.Status) error {
+	c.log.Debug("Waiting for status to be up", "host", c.Host, "userType", userType)
+	err := poll.Until(ctx, func() (bool, error) {
+		resp, err := c.grpcClient.GetStatus(ctx, &emptypb.Empty{})
+		if err != nil {
+			return false, err
+		}
+		s := find(resp.Status)
+		return s != nil && IsStatusUp(s.SessionStatus), nil
+	}, waitForStatusUpTimeout, waitInterval)
+	if err != nil {
+		return fmt.Errorf("failed to wait for %s status to be up on host %s: %w", userType, c.Host, err)
+	}
+	c.log.Debug("Confirmed status is up", "host", c.Host, "userType", userType)
+	return nil
+}
+
 // WaitForAllStatusesUp polls until all tunnel statuses are up and at least
 // minExpected statuses exist. Sets doubleZeroIP from the IBRL status preferentially.
 func (c *Client) WaitForAllStatusesUp(ctx context.Context, minExpected int) error {

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -183,8 +183,8 @@ func TestQA_MulticastSettlement(t *testing.T) {
 	}
 
 	if !t.Run("validate_tunnel_up", func(t *testing.T) {
-		err := client.WaitForStatusUp(ctx)
-		require.NoError(t, err, "tunnel did not come up after seat payment")
+		err := client.WaitForMulticastStatusUp(ctx)
+		require.NoError(t, err, "multicast tunnel did not come up after seat payment")
 	}) {
 		return
 	}


### PR DESCRIPTION
## Summary
- Fix `TestQA_MulticastSettlement/validate_device_assignment` failing with *"no multicast status found after seat payment"* ([run 24580260777](https://github.com/malbeclabs/infra/actions/runs/24580260777/job/71878368149)). On QA hosts with a pre-existing IBRL tunnel, the previous `WaitForStatusUp` returned in ~137ms because it only checks that every currently-listed status is up — it has no notion of *which* tunnel. The Multicast service hadn't been provisioned yet (Solana finalize + activator + 10s reconciler tick + BGP establish), so the subsequent `FindMulticastStatus` assertion saw only the IBRL entry and failed.
- Add `WaitForUnicastStatusUp` and `WaitForMulticastStatusUp` helpers that poll for a specific user-type entry to exist *and* have its session up.
- Switch `validate_tunnel_up` in the settlement test to `WaitForMulticastStatusUp`. Other 13 `WaitForStatusUp` callers are intentionally left untouched — they'll be audited in a follow-up.

## Testing Verification
- New helper polls up to 90s, which covers Solana finalize + activator approval + one reconciler tick (10s default) + BGP establish — the full async pipeline between `FeedSeatPay` returning and the daemon's `Status()` including a Multicast entry.
- Asserted against log evidence: post-failure diagnostics showed the status list contained only `userType=IBRL currentDevice=dz100a-lax1-tsw doubleZeroIP=206.189.166.187`, matching the "up" IP the old helper logged — confirming the Multicast entry was absent, not just not-up.