### PR TITLE
shreds-e2e: shard tests across 4 runners

### DIFF
--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -78,10 +78,20 @@ jobs:
           echo "$tests"
 
           # Pinned heavy tests: each gets its own shard slot to keep the two
-          # biggest rocks (MultiUserInstantAllocation ~396s, DeviceScale ~345s)
-          # off the same runner. Update this list if a new test exceeds ~5min.
-          pinned_1="TestE2E_MultiUserInstantAllocation"
+          # biggest rocks off the same runner. Update this list if a new test
+          # exceeds ~5min, or if a pinned test is renamed/removed upstream
+          # (the validation below will fail fast in that case).
+          pinned_1="TestE2E_MultiUserInstantAllocationAndWithdrawal"
           pinned_2="TestE2E_DeviceScale"
+
+          # Fail fast if a pinned test no longer exists in the shreds repo —
+          # otherwise its shard would silently run zero tests.
+          for pin in "$pinned_1" "$pinned_2"; do
+            if ! echo "$tests" | grep -qxF "$pin"; then
+              echo "::error::Pinned test '$pin' not found in doublezero-shreds. Update the pin list in this workflow."
+              exit 1
+            fi
+          done
 
           # Remaining tests round-robin across shards 3 and 4.
           remaining=$(echo "$tests" | grep -vE "^(${pinned_1}|${pinned_2})$")

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -121,8 +121,8 @@ jobs:
           echo "Matrix: $matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
-  e2e:
-    name: e2e (shard ${{ matrix.shard }})
+  shard-e2e:
+    name: shard-e2e (shard ${{ matrix.shard }})
     needs: setup
     strategy:
       fail-fast: false

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     outputs:
       shreds-sha: ${{ steps.checkout-shreds.outputs.commit }}
+      matrix: ${{ steps.shard.outputs.matrix }}
     steps:
       - name: Checkout doublezero-shreds
         id: checkout-shreds
@@ -62,11 +63,63 @@ jobs:
           docker push ${{ env.SHRED_IMAGE_REPO }}/activator:${{ env.SHRED_IMAGE_TAG }}
           docker push ${{ env.SHRED_IMAGE_REPO }}/oracle:${{ env.SHRED_IMAGE_TAG }}
           docker push ${{ env.SHRED_IMAGE_REPO }}/client:${{ env.SHRED_IMAGE_TAG }}
+      - name: Discover tests and distribute across shards
+        id: shard
+        working-directory: e2e/
+        run: |
+          # Find all TestE2E_* functions in files with the e2e build tag.
+          tests=$(grep -rl '^//go:build e2e$' *_test.go \
+            | xargs grep -h '^func TestE2E_' \
+            | sed 's/func \(TestE2E_[a-zA-Z0-9_]*\).*/\1/' \
+            | sort)
+
+          count=$(echo "$tests" | wc -l)
+          echo "Discovered $count tests"
+          echo "$tests"
+
+          # Pinned heavy tests: each gets its own shard slot to keep the two
+          # biggest rocks (MultiUserInstantAllocation ~396s, DeviceScale ~345s)
+          # off the same runner. Update this list if a new test exceeds ~5min.
+          pinned_1="TestE2E_MultiUserInstantAllocation"
+          pinned_2="TestE2E_DeviceScale"
+
+          # Remaining tests round-robin across shards 3 and 4.
+          remaining=$(echo "$tests" | grep -vE "^(${pinned_1}|${pinned_2})$")
+
+          ROUND_ROBIN_SHARDS=2
+          declare -a shards
+          for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do shards[$i]=""; done
+          i=0
+          while IFS= read -r test; do
+            idx=$((i % ROUND_ROBIN_SHARDS))
+            if [ -n "${shards[$idx]}" ]; then
+              shards[$idx]="${shards[$idx]}|${test}"
+            else
+              shards[$idx]="$test"
+            fi
+            i=$((i + 1))
+          done <<< "$remaining"
+
+          # Build JSON matrix: shards 1-2 are pinned, shards 3-4 are round-robin.
+          matrix="[{\"shard\":1,\"run\":\"^(${pinned_1})$\"}"
+          matrix="${matrix},{\"shard\":2,\"run\":\"^(${pinned_2})$\"}"
+          for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do
+            matrix="${matrix},{\"shard\":$((i + 3)),\"run\":\"^(${shards[$i]})$\"}"
+          done
+          matrix="${matrix}]"
+
+          echo "Matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   e2e:
+    name: e2e (shard ${{ matrix.shard }})
     needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: doublezero-k8s-ci
-    timeout-minutes: 20
+    timeout-minutes: 15
     permissions:
       packages: read
       contents: read
@@ -117,4 +170,4 @@ jobs:
       - name: Run e2e tests
         env:
           SHRED_E2E_NO_BUILD: "1"
-        run: go test -tags=e2e -timeout=20m -v -count=1 .
+        run: go test -tags=e2e -timeout=12m -count=1 -run '${{ matrix.run }}' -v .


### PR DESCRIPTION
## Summary of Changes
* Shard the `shreds-e2e` workflow across 4 parallel runners
* `setup` job discovers all `TestE2E_*` functions in the checked-out shreds repo, pins the two heaviest tests (`TestE2E_MultiUserInstantAllocation` ~396s, `TestE2E_DeviceScale` ~345s) to their own shards, and round-robin distributes the remaining 19 tests across shards 3-4. Matrix is emitted as JSON on the job's outputs.
* `e2e` job becomes a matrix job consuming that output, named `e2e (shard N)`, with `timeout-minutes: 15` and `go test -timeout=12m -run '${{ matrix.run }}'`.
* Reduces wall-clock time of the in-repo shreds e2e run from ~15 min (one monolithic job) to parity with the shreds repo's own CI.

## Testing Verification
* Ran the shard-discovery bash block locally against the current `malbeclabs/doublezero-shreds` checkout — produced a 4-entry matrix covering all 21 discovered tests with every test appearing in exactly one shard's regex.
* Parsed the workflow YAML with a yaml loader; confirmed the `e2e` job's `strategy.matrix.include` resolves from `needs.setup.outputs.matrix`.
* Actual parallel shard behavior will be verified on the PR's first CI run — expect 4 jobs named `e2e (shard 1)` through `e2e (shard 4)` running concurrently.