### PR TITLE
smartcontract: fix multicast allowlist for allow_multiple_ip access passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 - Client
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
+- Smartcontract
+  - Fix multicast group allowlist add/remove for AccessPasses created with `allow_multiple_ip=true`; the processors were rejecting requests with a real client IP because the stored IP is always `0.0.0.0` for these passes ([#3551](https://github.com/malbeclabs/doublezero/issues/3551))
+  - SDK now auto-detects the correct AccessPass PDA (static or dynamic) for allowlist operations based on whether an `allow_multiple_ip` pass exists
 
 ## [v0.18.0](https://github.com/malbeclabs/doublezero/compare/client/v0.17.0...client/v0.18.0) - 2026-04-17
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
@@ -128,10 +128,26 @@ pub fn process_add_multicastgroup_pub_allowlist(
         );
 
         let mut accesspass = AccessPass::try_from(accesspass_account)?;
+
+        // Validate PDA using the stored user_payer (so feed authority with different value.user_payer still works).
+        // For allow_multiple_ip passes, also accept the dynamic (0.0.0.0) PDA.
+        let (expected_pda, _) =
+            get_accesspass_pda(program_id, &value.client_ip, &accesspass.user_payer);
+        let (dynamic_pda, _) =
+            get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, &accesspass.user_payer);
         assert!(
-            accesspass.client_ip == value.client_ip,
-            "AccessPass client_ip does not match"
+            accesspass_account.key == &expected_pda
+                || (accesspass.allow_multiple_ip() && accesspass_account.key == &dynamic_pda),
+            "Invalid AccessPass PDA"
         );
+
+        // For allow_multiple_ip passes, the stored client_ip is 0.0.0.0 regardless of the connecting IP
+        if !accesspass.allow_multiple_ip() {
+            assert!(
+                accesspass.client_ip == value.client_ip,
+                "AccessPass client_ip does not match"
+            );
+        }
         assert!(
             accesspass.user_payer == value.user_payer,
             "AccessPass user_payer does not match"

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::DoubleZeroError,
+    pda::get_accesspass_pda,
     processors::validation::validate_program_account,
     serializer::try_acc_write,
     state::{accesspass::AccessPass, globalstate::GlobalState, multicastgroup::MulticastGroup},
@@ -88,10 +89,25 @@ pub fn process_remove_multicast_pub_allowlist(
     }
 
     let mut accesspass = AccessPass::try_from(accesspass_account)?;
+
+    // Validate PDA using the stored user_payer. For allow_multiple_ip passes, also accept the dynamic (0.0.0.0) PDA.
+    let (expected_pda, _) =
+        get_accesspass_pda(program_id, &value.client_ip, &accesspass.user_payer);
+    let (dynamic_pda, _) =
+        get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, &accesspass.user_payer);
     assert!(
-        accesspass.client_ip == value.client_ip,
-        "AccessPass client_ip does not match"
+        accesspass_account.key == &expected_pda
+            || (accesspass.allow_multiple_ip() && accesspass_account.key == &dynamic_pda),
+        "Invalid AccessPass PDA"
     );
+
+    // For allow_multiple_ip passes, the stored client_ip is 0.0.0.0 regardless of the connecting IP
+    if !accesspass.allow_multiple_ip() {
+        assert!(
+            accesspass.client_ip == value.client_ip,
+            "AccessPass client_ip does not match"
+        );
+    }
     assert!(
         accesspass.user_payer == value.user_payer,
         "AccessPass user_payer does not match"

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
@@ -131,6 +131,18 @@ pub fn process_add_multicastgroup_sub_allowlist(
 
         let mut accesspass = AccessPass::try_from(accesspass_account)?;
 
+        // Validate PDA using the stored user_payer (so feed authority with different value.user_payer still works).
+        // For allow_multiple_ip passes, also accept the dynamic (0.0.0.0) PDA.
+        let (expected_pda, _) =
+            get_accesspass_pda(program_id, &value.client_ip, &accesspass.user_payer);
+        let (dynamic_pda, _) =
+            get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, &accesspass.user_payer);
+        assert!(
+            accesspass_account.key == &expected_pda
+                || (accesspass.allow_multiple_ip() && accesspass_account.key == &dynamic_pda),
+            "Invalid AccessPass PDA"
+        );
+
         // Feed authority can only modify access passes they own
         if globalstate.feed_authority_pk == *payer_account.key
             && accesspass.owner != *payer_account.key
@@ -138,10 +150,13 @@ pub fn process_add_multicastgroup_sub_allowlist(
             return Err(DoubleZeroError::NotAllowed.into());
         }
 
-        assert!(
-            accesspass.client_ip == value.client_ip,
-            "AccessPass client_ip does not match"
-        );
+        // For allow_multiple_ip passes, the stored client_ip is 0.0.0.0 regardless of the connecting IP
+        if !accesspass.allow_multiple_ip() {
+            assert!(
+                accesspass.client_ip == value.client_ip,
+                "AccessPass client_ip does not match"
+            );
+        }
         // Feed authority may operate on access passes with a different user_payer
         if globalstate.feed_authority_pk != *payer_account.key {
             assert!(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::DoubleZeroError,
+    pda::get_accesspass_pda,
     processors::validation::validate_program_account,
     serializer::try_acc_write,
     state::{accesspass::AccessPass, globalstate::GlobalState, multicastgroup::MulticastGroup},
@@ -89,10 +90,25 @@ pub fn process_remove_multicast_sub_allowlist(
     }
 
     let mut accesspass = AccessPass::try_from(accesspass_account)?;
+
+    // Validate PDA using the stored user_payer. For allow_multiple_ip passes, also accept the dynamic (0.0.0.0) PDA.
+    let (expected_pda, _) =
+        get_accesspass_pda(program_id, &value.client_ip, &accesspass.user_payer);
+    let (dynamic_pda, _) =
+        get_accesspass_pda(program_id, &Ipv4Addr::UNSPECIFIED, &accesspass.user_payer);
     assert!(
-        accesspass.client_ip == value.client_ip,
-        "AccessPass client_ip does not match"
+        accesspass_account.key == &expected_pda
+            || (accesspass.allow_multiple_ip() && accesspass_account.key == &dynamic_pda),
+        "Invalid AccessPass PDA"
     );
+
+    // For allow_multiple_ip passes, the stored client_ip is 0.0.0.0 regardless of the connecting IP
+    if !accesspass.allow_multiple_ip() {
+        assert!(
+            accesspass.client_ip == value.client_ip,
+            "AccessPass client_ip does not match"
+        );
+    }
     assert!(
         accesspass.user_payer == value.user_payer,
         "AccessPass user_payer does not match"

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs
@@ -109,10 +109,13 @@ pub fn process_remove_multicast_sub_allowlist(
             "AccessPass client_ip does not match"
         );
     }
-    assert!(
-        accesspass.user_payer == value.user_payer,
-        "AccessPass user_payer does not match"
-    );
+    // Feed authority may operate on access passes with a different user_payer
+    if globalstate.feed_authority_pk != *payer_account.key {
+        assert!(
+            accesspass.user_payer == value.user_payer,
+            "AccessPass user_payer does not match"
+        );
+    }
 
     accesspass
         .mgroup_sub_allowlist

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/delete.rs
@@ -173,10 +173,13 @@ pub fn process_delete_user(
             );
             return Err(DoubleZeroError::Unauthorized.into());
         }
-        if accesspass.is_dynamic() && accesspass.client_ip == Ipv4Addr::UNSPECIFIED {
-            accesspass.client_ip = user.client_ip; // lock to the first used IP
-        }
-        if accesspass.client_ip != user.client_ip && !accesspass.allow_multiple_ip() {
+        // Skip IP validation when the pass is stored at the UNSPECIFIED PDA (0.0.0.0): it is
+        // a dynamic pass valid for any IP by construction. This includes legacy passes created
+        // before the IS_DYNAMIC flag existed, which have client_ip=0.0.0.0 but flags=0.
+        if accesspass.client_ip != Ipv4Addr::UNSPECIFIED
+            && accesspass.client_ip != user.client_ip
+            && !accesspass.allow_multiple_ip()
+        {
             msg!(
                 "Invalid client_ip accesspass.{{client_ip: {}}} = {{ client_ip: {} }}",
                 accesspass.client_ip,

--- a/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
@@ -1,0 +1,573 @@
+use doublezero_serviceability::{
+    instructions::*,
+    pda::*,
+    processors::{
+        accesspass::set::SetAccessPassArgs,
+        contributor::create::ContributorCreateArgs,
+        device::update::DeviceUpdateArgs,
+        user::{activate::*, create::*, delete::*},
+        *,
+    },
+    resource::ResourceType,
+    state::{
+        accesspass::{AccessPassStatus, AccessPassType},
+        accounttype::AccountType,
+        device::*,
+        user::{UserCYOA, UserStatus, UserType},
+    },
+};
+use globalconfig::set::SetGlobalConfigArgs;
+use solana_program_test::*;
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Keypair, signer::Signer};
+use std::net::Ipv4Addr;
+
+mod test_helpers;
+use test_helpers::*;
+
+struct TestEnv {
+    banks_client: BanksClient,
+    payer: Keypair,
+    program_id: Pubkey,
+    globalstate_pubkey: Pubkey,
+    device_pubkey: Pubkey,
+}
+
+/// Initialize the program environment up to and including an activated device.
+async fn setup_test_env() -> TestEnv {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (config_pubkey, _) = get_globalconfig_pda(&program_id);
+
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+    let (admin_group_bits_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::AdminGroupBits);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: "10.0.0.0/24".parse().unwrap(),
+            user_tunnel_block: "9.0.0.0/24".parse().unwrap(),
+            multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block_pda, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block_pda, false),
+            AccountMeta::new(vrf_ids_pda, false),
+            AccountMeta::new(admin_group_bits_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(location::create::LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.0,
+            lng: 2.0,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(exchange::create::ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.0,
+            lng: 2.0,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, gs.account_index + 1);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, gs.account_index + 1);
+    let (tunnel_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDevice(device::create::DeviceCreateArgs {
+            code: "la".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [100, 0, 0, 1].into(),
+            dz_prefixes: "100.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: "mgmt".to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+            resource_count: 0,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(128),
+            resource_count: 2,
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(tunnel_ids_pda, false),
+            AccountMeta::new(dz_prefix_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateDevice(device::activate::DeviceActivateArgs {
+            resource_count: 2,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(tunnel_ids_pda, false),
+            AccountMeta::new(dz_prefix_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    TestEnv {
+        banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        device_pubkey,
+    }
+}
+
+/// Create an access pass, create a user, and activate it. Returns (accesspass_pubkey, user_pubkey).
+async fn create_and_activate_user(
+    env: &mut TestEnv,
+    user_ip: Ipv4Addr,
+    user_type: UserType,
+    accesspass_ip: Ipv4Addr,
+    allow_multiple_ip: bool,
+) -> (Pubkey, Pubkey) {
+    let recent_blockhash = env
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    let (accesspass_pubkey, _) =
+        get_accesspass_pda(&env.program_id, &accesspass_ip, &env.payer.pubkey());
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: accesspass_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+            AccountMeta::new(env.payer.pubkey(), false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    let (user_pubkey, _) = get_user_pda(&env.program_id, &user_ip, user_type);
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::CreateUser(UserCreateArgs {
+            client_ip: user_ip,
+            user_type,
+            cyoa_type: UserCYOA::GREOverDIA,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(env.device_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::ActivateUser(UserActivateArgs {
+            tunnel_id: 500,
+            tunnel_net: "169.254.0.0/25".parse().unwrap(),
+            dz_ip: [200, 0, 0, 1].into(),
+            dz_prefix_count: 0,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    (accesspass_pubkey, user_pubkey)
+}
+
+/// IS_DYNAMIC pass (UNSPECIFIED PDA, no ALLOW_MULTIPLE_IP): DeleteUser succeeds and access pass
+/// connection_count decrements to 0. The pass client_ip is NOT reset since allow_multiple_ip=false.
+#[tokio::test]
+async fn test_delete_user_is_dynamic_pass() {
+    let mut env = setup_test_env().await;
+    let user_ip: Ipv4Addr = [100, 0, 0, 1].into();
+
+    // IS_DYNAMIC pass: client_ip=UNSPECIFIED, allow_multiple_ip=false
+    let (accesspass_pubkey, user_pubkey) = create_and_activate_user(
+        &mut env,
+        user_ip,
+        UserType::IBRL,
+        Ipv4Addr::UNSPECIFIED,
+        false,
+    )
+    .await;
+
+    // CreateUser with IS_DYNAMIC pass locks the pass's client_ip to the user's IP
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.client_ip, user_ip);
+    assert_eq!(pass.connection_count, 1);
+    assert_eq!(pass.status, AccessPassStatus::Connected);
+
+    let recent_blockhash = env
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
+            dz_prefix_count: 0,
+            multicast_publisher_count: 0,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    let user = get_account_data(&mut env.banks_client, user_pubkey)
+        .await
+        .unwrap()
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Deleting);
+
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.connection_count, 0);
+    assert_eq!(pass.status, AccessPassStatus::Disconnected);
+    // Not allow_multiple_ip — client_ip is NOT reset to UNSPECIFIED
+    assert_eq!(pass.client_ip, user_ip);
+}
+
+/// ALLOW_MULTIPLE_IP pass: after the last user is deleted, the pass's client_ip resets to
+/// UNSPECIFIED so the pass can be reused for any IP.
+#[tokio::test]
+async fn test_delete_user_allow_multiple_ip_resets_client_ip() {
+    let mut env = setup_test_env().await;
+    let user_ip: Ipv4Addr = [100, 0, 0, 2].into();
+
+    // ALLOW_MULTIPLE_IP pass at UNSPECIFIED PDA
+    let (accesspass_pubkey, user_pubkey) = create_and_activate_user(
+        &mut env,
+        user_ip,
+        UserType::IBRL,
+        Ipv4Addr::UNSPECIFIED,
+        true,
+    )
+    .await;
+
+    // Verify pass IP was locked to user_ip during CreateUser
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.client_ip, user_ip);
+    assert_eq!(pass.connection_count, 1);
+
+    let recent_blockhash = env
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
+            dz_prefix_count: 0,
+            multicast_publisher_count: 0,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    let user = get_account_data(&mut env.banks_client, user_pubkey)
+        .await
+        .unwrap()
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Deleting);
+
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.connection_count, 0);
+    assert_eq!(pass.status, AccessPassStatus::Disconnected);
+    // allow_multiple_ip: client_ip resets to UNSPECIFIED when connection_count reaches 0
+    assert_eq!(pass.client_ip, Ipv4Addr::UNSPECIFIED);
+}
+
+/// Specific-IP pass (not UNSPECIFIED): DeleteUser succeeds when pass.client_ip matches user.client_ip.
+#[tokio::test]
+async fn test_delete_user_specific_ip_pass() {
+    let mut env = setup_test_env().await;
+    let user_ip: Ipv4Addr = [100, 0, 0, 3].into();
+
+    // Specific-IP pass at the user's IP PDA
+    let (accesspass_pubkey, user_pubkey) =
+        create_and_activate_user(&mut env, user_ip, UserType::IBRL, user_ip, false).await;
+
+    let recent_blockhash = env
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
+            dz_prefix_count: 0,
+            multicast_publisher_count: 0,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    let user = get_account_data(&mut env.banks_client, user_pubkey)
+        .await
+        .unwrap()
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Deleting);
+
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.connection_count, 0);
+    assert_eq!(pass.status, AccessPassStatus::Disconnected);
+    assert_eq!(pass.client_ip, user_ip);
+}
+
+/// Multicast user with IS_DYNAMIC pass: DeleteUser succeeds with the same IP validation logic.
+#[tokio::test]
+async fn test_delete_multicast_user_dynamic_pass() {
+    let mut env = setup_test_env().await;
+    let user_ip: Ipv4Addr = [100, 0, 0, 4].into();
+
+    // IS_DYNAMIC pass at UNSPECIFIED PDA, no ALLOW_MULTIPLE_IP
+    let (accesspass_pubkey, user_pubkey) = create_and_activate_user(
+        &mut env,
+        user_ip,
+        UserType::Multicast,
+        Ipv4Addr::UNSPECIFIED,
+        false,
+    )
+    .await;
+
+    let user = get_account_data(&mut env.banks_client, user_pubkey)
+        .await
+        .unwrap()
+        .get_user()
+        .unwrap();
+    assert_eq!(user.account_type, AccountType::User);
+    assert_eq!(user.user_type, UserType::Multicast);
+    assert_eq!(user.status, UserStatus::Activated);
+
+    let recent_blockhash = env
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .expect("Failed to get latest blockhash");
+
+    execute_transaction(
+        &mut env.banks_client,
+        recent_blockhash,
+        env.program_id,
+        DoubleZeroInstruction::DeleteUser(UserDeleteArgs {
+            dz_prefix_count: 0,
+            multicast_publisher_count: 0,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(env.globalstate_pubkey, false),
+        ],
+        &env.payer,
+    )
+    .await;
+
+    let user = get_account_data(&mut env.banks_client, user_pubkey)
+        .await
+        .unwrap()
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Deleting);
+
+    let pass = get_account_data(&mut env.banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(pass.connection_count, 0);
+    assert_eq!(pass.status, AccessPassStatus::Disconnected);
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -425,3 +425,437 @@ async fn test_multicast_publisher_allowlist_sentinel_authority() {
         "Unauthorized keypair should not be able to add publisher allowlist entry"
     );
 }
+
+/// AccessPass with allow_multiple_ip=true (dynamic PDA at 0.0.0.0) can be added/removed from publisher allowlist.
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_allow_multiple_ip() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let dynamic_ip: std::net::Ipv4Addr = [0, 0, 0, 0].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "amip-pub".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 2, 1].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass at dynamic PDA (0.0.0.0) with allow_multiple_ip=true
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &dynamic_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: dynamic_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: true,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add with client_ip=0.0.0.0 and dynamic PDA — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: dynamic_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(res.is_ok(), "allow_multiple_ip AccessPass should be addable to publisher allowlist");
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass.mgroup_pub_allowlist.contains(&multicastgroup_pubkey));
+
+    // Remove with client_ip=0.0.0.0 and dynamic PDA — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupPubAllowlist(
+            RemoveMulticastGroupPubAllowlistArgs {
+                client_ip: dynamic_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should be removable from publisher allowlist"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_pub_allowlist.len(), 0);
+}
+
+/// A real client_ip in instruction args still works when the AccessPass has allow_multiple_ip=true
+/// and lives at the dynamic PDA. This is the bug that was fixed.
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_allow_multiple_ip_real_ip_in_args() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let dynamic_ip: std::net::Ipv4Addr = [0, 0, 0, 0].into();
+    let real_ip: std::net::Ipv4Addr = [98, 46, 188, 245].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "amip-pub-real-ip".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 2, 2].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass at dynamic PDA (0.0.0.0) with allow_multiple_ip=true
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &dynamic_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: dynamic_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: true,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add with a real IP in args but the dynamic PDA as account — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: real_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should accept real IP in args while using dynamic PDA"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass.mgroup_pub_allowlist.contains(&multicastgroup_pubkey));
+
+    // Remove with a real IP in args but the dynamic PDA as account — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupPubAllowlist(
+            RemoveMulticastGroupPubAllowlistArgs {
+                client_ip: real_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should accept real IP for remove with dynamic PDA"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_pub_allowlist.len(), 0);
+}
+
+/// Passing the wrong AccessPass PDA (one derived from a different IP) is rejected.
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_wrong_pda_rejected() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let ip_a: std::net::Ipv4Addr = [10, 0, 2, 3].into();
+    let ip_b: std::net::Ipv4Addr = [10, 0, 2, 4].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "pub-wrong-pda".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 2, 3].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass A at PDA(ip_a, user_payer)
+    let (accesspass_a, _) = get_accesspass_pda(&program_id, &ip_a, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: ip_a,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_a, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass B at PDA(ip_b, user_payer)
+    let (accesspass_b, _) = get_accesspass_pda(&program_id, &ip_b, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: ip_b,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_b, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Attempt to add with client_ip=ip_a in args but pass accesspass_b account — should fail
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip: ip_a,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_b, false), // wrong PDA
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "AccessPass PDA mismatch should be rejected for publisher allowlist"
+    );
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -532,14 +532,19 @@ async fn test_multicast_publisher_allowlist_allow_multiple_ip() {
         &payer,
     )
     .await;
-    assert!(res.is_ok(), "allow_multiple_ip AccessPass should be addable to publisher allowlist");
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should be addable to publisher allowlist"
+    );
 
     let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
         .await
         .expect("Unable to get Account")
         .get_accesspass()
         .unwrap();
-    assert!(accesspass.mgroup_pub_allowlist.contains(&multicastgroup_pubkey));
+    assert!(accesspass
+        .mgroup_pub_allowlist
+        .contains(&multicastgroup_pubkey));
 
     // Remove with client_ip=0.0.0.0 and dynamic PDA — should succeed
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
@@ -692,7 +697,9 @@ async fn test_multicast_publisher_allowlist_allow_multiple_ip_real_ip_in_args() 
         .expect("Unable to get Account")
         .get_accesspass()
         .unwrap();
-    assert!(accesspass.mgroup_pub_allowlist.contains(&multicastgroup_pubkey));
+    assert!(accesspass
+        .mgroup_pub_allowlist
+        .contains(&multicastgroup_pubkey));
 
     // Remove with a real IP in args but the dynamic PDA as account — should succeed
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -1203,6 +1203,185 @@ async fn test_multicast_subscriber_allowlist_wrong_pda_rejected() {
     );
 }
 
+/// Feed authority can add/remove an allow_multiple_ip AccessPass from the subscriber allowlist
+/// using a value.user_payer that differs from the stored accesspass.user_payer.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_allow_multiple_ip_feed_authority_different_user_payer()
+{
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let dynamic_ip: std::net::Ipv4Addr = [0, 0, 0, 0].into();
+    let real_ip: std::net::Ipv4Addr = [10, 0, 7, 1].into();
+    let original_user_payer = payer.pubkey();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    // 1. Initialize global state
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 2. Create a feed keypair and set it as feed authority
+    let feed = Keypair::new();
+    transfer(&mut banks_client, &payer, &feed.pubkey(), 10_000_000_000).await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            feed_authority_pk: Some(feed.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // 3. Create and activate a multicast group
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "amip-feed-diff".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 254, 0, 7].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // 4. Feed authority creates allow_multiple_ip AccessPass at dynamic PDA (0.0.0.0, original_user_payer)
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &dynamic_ip, &original_user_payer);
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: dynamic_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: true,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(original_user_payer, false),
+        ],
+        &feed,
+    )
+    .await;
+
+    // 5. Feed authority adds subscriber allowlist with a real IP and a DIFFERENT user_payer — should succeed
+    let different_user_payer = Pubkey::new_unique();
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip: real_ip,
+            user_payer: different_user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &feed,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Feed authority should be able to add allow_multiple_ip subscriber allowlist with different user_payer"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
+    assert_eq!(accesspass.user_payer, original_user_payer);
+
+    // 6. Feed authority removes subscriber allowlist with the same real IP and different user_payer — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupSubAllowlist(
+            RemoveMulticastGroupSubAllowlistArgs {
+                client_ip: real_ip,
+                user_payer: different_user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &feed,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "Feed authority should be able to remove allow_multiple_ip subscriber allowlist with different user_payer"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_sub_allowlist.len(), 0);
+    assert_eq!(accesspass.user_payer, original_user_payer);
+}
+
 /// Feed authority can remove from subscriber allowlist.
 #[tokio::test]
 async fn test_multicast_subscriber_allowlist_feed_authority_remove() {

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -762,6 +762,440 @@ async fn test_multicast_subscriber_allowlist_feed_authority_different_user_payer
     );
 }
 
+/// AccessPass with allow_multiple_ip=true (dynamic PDA at 0.0.0.0) can be added/removed from subscriber allowlist.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_allow_multiple_ip() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let dynamic_ip: std::net::Ipv4Addr = [0, 0, 0, 0].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "amip-sub".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 1, 1].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass at dynamic PDA (0.0.0.0) with allow_multiple_ip=true
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &dynamic_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: dynamic_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: true,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add with client_ip=0.0.0.0 and dynamic PDA — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip: dynamic_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(res.is_ok(), "allow_multiple_ip AccessPass should be addable to subscriber allowlist");
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass.mgroup_sub_allowlist.contains(&multicastgroup_pubkey));
+
+    // Remove with client_ip=0.0.0.0 and dynamic PDA — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupSubAllowlist(
+            RemoveMulticastGroupSubAllowlistArgs {
+                client_ip: dynamic_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should be removable from subscriber allowlist"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_sub_allowlist.len(), 0);
+}
+
+/// A real client_ip in instruction args (rather than 0.0.0.0) still works when the AccessPass
+/// has allow_multiple_ip=true and lives at the dynamic PDA. This is the bug that was fixed.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_allow_multiple_ip_real_ip_in_args() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let dynamic_ip: std::net::Ipv4Addr = [0, 0, 0, 0].into();
+    let real_ip: std::net::Ipv4Addr = [98, 46, 188, 245].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "amip-real-ip".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 1, 2].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass at dynamic PDA (0.0.0.0) with allow_multiple_ip=true
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &dynamic_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: dynamic_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: true,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add with a real IP in args but the dynamic PDA as account — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip: real_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should accept real IP in args while using dynamic PDA"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass.mgroup_sub_allowlist.contains(&multicastgroup_pubkey));
+
+    // Remove with a real IP in args but the dynamic PDA as account — should succeed
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::RemoveMulticastGroupSubAllowlist(
+            RemoveMulticastGroupSubAllowlistArgs {
+                client_ip: real_ip,
+                user_payer,
+            },
+        ),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should accept real IP for remove with dynamic PDA"
+    );
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(accesspass.mgroup_sub_allowlist.len(), 0);
+}
+
+/// Passing the wrong AccessPass PDA (one derived from a different IP) is rejected.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_wrong_pda_rejected() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let user_payer = payer.pubkey();
+    let ip_a: std::net::Ipv4Addr = [10, 0, 1, 3].into();
+    let ip_b: std::net::Ipv4Addr = [10, 0, 1, 4].into();
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .expect("Unable to get Account")
+        .get_global_state()
+        .unwrap();
+
+    let (multicastgroup_pubkey, _) =
+        get_multicastgroup_pda(&program_id, globalstate.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "wrong-pda".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: false,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateMulticastGroup(MulticastGroupActivateArgs {
+            multicast_ip: [224, 255, 1, 3].into(),
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass A at PDA(ip_a, user_payer)
+    let (accesspass_a, _) = get_accesspass_pda(&program_id, &ip_a, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: ip_a,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_a, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create AccessPass B at PDA(ip_b, user_payer)
+    let (accesspass_b, _) = get_accesspass_pda(&program_id, &ip_b, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: ip_b,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_b, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Attempt to add with client_ip=ip_a in args but pass accesspass_b account — should fail
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip: ip_a,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_b, false), // wrong PDA
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "AccessPass PDA mismatch should be rejected for subscriber allowlist"
+    );
+}
+
 /// Feed authority can remove from subscriber allowlist.
 #[tokio::test]
 async fn test_multicast_subscriber_allowlist_feed_authority_remove() {

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -868,14 +868,19 @@ async fn test_multicast_subscriber_allowlist_allow_multiple_ip() {
         &payer,
     )
     .await;
-    assert!(res.is_ok(), "allow_multiple_ip AccessPass should be addable to subscriber allowlist");
+    assert!(
+        res.is_ok(),
+        "allow_multiple_ip AccessPass should be addable to subscriber allowlist"
+    );
 
     let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
         .await
         .expect("Unable to get Account")
         .get_accesspass()
         .unwrap();
-    assert!(accesspass.mgroup_sub_allowlist.contains(&multicastgroup_pubkey));
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
 
     // Remove with client_ip=0.0.0.0 and dynamic PDA — should succeed
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
@@ -1028,7 +1033,9 @@ async fn test_multicast_subscriber_allowlist_allow_multiple_ip_real_ip_in_args()
         .expect("Unable to get Account")
         .get_accesspass()
         .unwrap();
-    assert!(accesspass.mgroup_sub_allowlist.contains(&multicastgroup_pubkey));
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
 
     // Remove with a real IP in args but the dynamic PDA as account — should succeed
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
@@ -1,2 +1,161 @@
 pub mod publisher;
 pub mod subscriber;
+
+use std::net::Ipv4Addr;
+
+use doublezero_serviceability::{
+    pda::get_accesspass_pda,
+    state::accountdata::AccountData,
+};
+use solana_sdk::pubkey::Pubkey;
+
+use crate::DoubleZeroClient;
+
+/// Resolves which AccessPass PDA to use for allowlist operations.
+///
+/// Tries the static PDA (`client_ip`, `user_payer`) first. If no AccessPass exists there,
+/// falls back to the dynamic PDA (`0.0.0.0`, `user_payer`) for `allow_multiple_ip` passes.
+/// If neither exists, returns the static PDA so the program can create a new AccessPass.
+pub(crate) fn resolve_accesspass_pda(
+    client: &dyn DoubleZeroClient,
+    client_ip: &Ipv4Addr,
+    user_payer: &Pubkey,
+) -> Pubkey {
+    let program_id = client.get_program_id();
+    let (static_pda, _) = get_accesspass_pda(&program_id, client_ip, user_payer);
+
+    if let Ok(AccountData::AccessPass(_)) = client.get(static_pda) {
+        return static_pda;
+    }
+
+    let (dynamic_pda, _) =
+        get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, user_payer);
+    if let Ok(AccountData::AccessPass(ap)) = client.get(dynamic_pda) {
+        if ap.allow_multiple_ip() {
+            return dynamic_pda;
+        }
+    }
+
+    static_pda
+}
+
+#[cfg(test)]
+mod tests {
+    use doublezero_serviceability::{
+        pda::get_accesspass_pda,
+        state::{
+            accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP},
+            accountdata::AccountData,
+            accounttype::AccountType,
+        },
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+    use std::net::Ipv4Addr;
+
+    use crate::{tests::utils::create_test_client, DoubleZeroClient};
+
+    use super::resolve_accesspass_pda;
+
+    fn make_accesspass(client_ip: Ipv4Addr, user_payer: Pubkey, bump_seed: u8, flags: u8) -> AccessPass {
+        AccessPass {
+            account_type: AccountType::AccessPass,
+            owner: Pubkey::new_unique(),
+            bump_seed,
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            user_payer,
+            last_access_epoch: u64::MAX,
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            flags,
+            tenant_allowlist: vec![],
+        }
+    }
+
+    #[test]
+    fn test_resolve_accesspass_pda_returns_static_when_found() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
+        let user_payer = Pubkey::new_unique();
+        let (static_pda, bump) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+        let ap = make_accesspass(client_ip, user_payer, bump, 0);
+        client
+            .expect_get()
+            .with(predicate::eq(static_pda))
+            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
+
+        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
+        assert_eq!(result, static_pda);
+    }
+
+    #[test]
+    fn test_resolve_accesspass_pda_returns_dynamic_for_allow_multiple_ip() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
+        let user_payer = Pubkey::new_unique();
+        let (static_pda, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+        let (dynamic_pda, bump) =
+            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
+
+        let ap = make_accesspass(Ipv4Addr::UNSPECIFIED, user_payer, bump, ALLOW_MULTIPLE_IP);
+
+        client
+            .expect_get()
+            .with(predicate::eq(static_pda))
+            .returning(|_| Err(eyre::eyre!("not found")));
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pda))
+            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
+
+        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
+        assert_eq!(result, dynamic_pda);
+    }
+
+    #[test]
+    fn test_resolve_accesspass_pda_returns_static_when_neither_found() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
+        let user_payer = Pubkey::new_unique();
+        let (static_pda, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+        client
+            .expect_get()
+            .returning(|_| Err(eyre::eyre!("not found")));
+
+        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
+        assert_eq!(result, static_pda);
+    }
+
+    #[test]
+    fn test_resolve_accesspass_pda_ignores_dynamic_without_allow_multiple_ip() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
+        let user_payer = Pubkey::new_unique();
+        let (static_pda, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+        let (dynamic_pda, bump) =
+            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
+
+        let ap = make_accesspass(Ipv4Addr::UNSPECIFIED, user_payer, bump, 0); // flags=0, no allow_multiple_ip
+
+        client
+            .expect_get()
+            .with(predicate::eq(static_pda))
+            .returning(|_| Err(eyre::eyre!("not found")));
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pda))
+            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
+
+        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
+        assert_eq!(result, static_pda);
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
@@ -3,10 +3,7 @@ pub mod subscriber;
 
 use std::net::Ipv4Addr;
 
-use doublezero_serviceability::{
-    pda::get_accesspass_pda,
-    state::accountdata::AccountData,
-};
+use doublezero_serviceability::{pda::get_accesspass_pda, state::accountdata::AccountData};
 use solana_sdk::pubkey::Pubkey;
 
 use crate::DoubleZeroClient;
@@ -28,8 +25,7 @@ pub(crate) fn resolve_accesspass_pda(
         return static_pda;
     }
 
-    let (dynamic_pda, _) =
-        get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, user_payer);
+    let (dynamic_pda, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, user_payer);
     if let Ok(AccountData::AccessPass(ap)) = client.get(dynamic_pda) {
         if ap.allow_multiple_ip() {
             return dynamic_pda;
@@ -57,7 +53,12 @@ mod tests {
 
     use super::resolve_accesspass_pda;
 
-    fn make_accesspass(client_ip: Ipv4Addr, user_payer: Pubkey, bump_seed: u8, flags: u8) -> AccessPass {
+    fn make_accesspass(
+        client_ip: Ipv4Addr,
+        user_payer: Pubkey,
+        bump_seed: u8,
+        flags: u8,
+    ) -> AccessPass {
         AccessPass {
             account_type: AccountType::AccessPass,
             owner: Pubkey::new_unique(),

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
@@ -3,8 +3,7 @@ use crate::{
     DoubleZeroClient,
 };
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    pda::get_globalstate_pda,
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::publisher::add::AddMulticastGroupPubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
@@ -24,8 +23,7 @@ impl AddMulticastGroupPubAllowlistCommand {
         }
         .execute(client)?;
 
-        let accesspass_pk =
-            resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
+        let accesspass_pk = resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
@@ -1,7 +1,10 @@
-use crate::{commands::multicastgroup::get::GetMulticastGroupCommand, DoubleZeroClient};
+use crate::{
+    commands::multicastgroup::{allowlist::resolve_accesspass_pda, get::GetMulticastGroupCommand},
+    DoubleZeroClient,
+};
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
-    pda::{get_accesspass_pda, get_globalstate_pda},
+    pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::publisher::add::AddMulticastGroupPubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
@@ -21,8 +24,8 @@ impl AddMulticastGroupPubAllowlistCommand {
         }
         .execute(client)?;
 
-        let (accesspass_pk, _) =
-            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+        let accesspass_pk =
+            resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 
@@ -84,6 +87,10 @@ mod tests {
             .expect_get()
             .with(predicate::eq(pubkey))
             .returning(move |_| Ok(AccountData::MulticastGroup(cloned_mgroup.clone())));
+        // AccessPass PDA lookups in resolve_accesspass_pda — no account found, use static PDA
+        client
+            .expect_get()
+            .returning(|_| Err(eyre::eyre!("account not found")));
         let cloned_mgroup = mgroup.clone();
         client
             .expect_gets()

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/remove.rs
@@ -1,13 +1,15 @@
 use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    pda::{get_accesspass_pda, get_globalstate_pda},
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::publisher::remove::RemoveMulticastGroupPubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
-use crate::{commands::multicastgroup::get::GetMulticastGroupCommand, DoubleZeroClient};
+use crate::{
+    commands::multicastgroup::{allowlist::resolve_accesspass_pda, get::GetMulticastGroupCommand},
+    DoubleZeroClient,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RemoveMulticastGroupPubAllowlistCommand {
@@ -23,8 +25,7 @@ impl RemoveMulticastGroupPubAllowlistCommand {
         }
         .execute(client)?;
 
-        let (accesspass_pk, _) =
-            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+        let accesspass_pk = resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 
@@ -86,6 +87,10 @@ mod tests {
             .expect_get()
             .with(predicate::eq(pubkey))
             .returning(move |_| Ok(AccountData::MulticastGroup(cloned_mgroup.clone())));
+        // AccessPass PDA lookups in resolve_accesspass_pda — no account found, use static PDA
+        client
+            .expect_get()
+            .returning(|_| Err(eyre::eyre!("account not found")));
         let cloned_mgroup = mgroup.clone();
         client
             .expect_gets()

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
@@ -1,8 +1,7 @@
 use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    pda::get_globalstate_pda,
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::subscriber::add::AddMulticastGroupSubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
@@ -26,8 +25,7 @@ impl AddMulticastGroupSubAllowlistCommand {
         }
         .execute(client)?;
 
-        let accesspass_pk =
-            resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
+        let accesspass_pk = resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
@@ -2,12 +2,15 @@ use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
-    pda::{get_accesspass_pda, get_globalstate_pda},
+    pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::subscriber::add::AddMulticastGroupSubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
-use crate::{commands::multicastgroup::get::GetMulticastGroupCommand, DoubleZeroClient};
+use crate::{
+    commands::multicastgroup::{allowlist::resolve_accesspass_pda, get::GetMulticastGroupCommand},
+    DoubleZeroClient,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct AddMulticastGroupSubAllowlistCommand {
@@ -23,8 +26,8 @@ impl AddMulticastGroupSubAllowlistCommand {
         }
         .execute(client)?;
 
-        let (accesspass_pk, _) =
-            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+        let accesspass_pk =
+            resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 
@@ -86,6 +89,10 @@ mod tests {
             .expect_get()
             .with(predicate::eq(pubkey))
             .returning(move |_| Ok(AccountData::MulticastGroup(cloned_mgroup.clone())));
+        // AccessPass PDA lookups in resolve_accesspass_pda — no account found, use static PDA
+        client
+            .expect_get()
+            .returning(|_| Err(eyre::eyre!("account not found")));
         let cloned_mgroup = mgroup.clone();
         client
             .expect_gets()

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/remove.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/remove.rs
@@ -1,13 +1,15 @@
 use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    pda::{get_accesspass_pda, get_globalstate_pda},
+    instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
     processors::multicastgroup::allowlist::subscriber::remove::RemoveMulticastGroupSubAllowlistArgs,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
-use crate::{commands::multicastgroup::get::GetMulticastGroupCommand, DoubleZeroClient};
+use crate::{
+    commands::multicastgroup::{allowlist::resolve_accesspass_pda, get::GetMulticastGroupCommand},
+    DoubleZeroClient,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RemoveMulticastGroupSubAllowlistCommand {
@@ -23,8 +25,7 @@ impl RemoveMulticastGroupSubAllowlistCommand {
         }
         .execute(client)?;
 
-        let (accesspass_pk, _) =
-            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+        let accesspass_pk = resolve_accesspass_pda(client, &self.client_ip, &self.user_payer);
 
         let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
 
@@ -86,6 +87,10 @@ mod tests {
             .expect_get()
             .with(predicate::eq(pubkey))
             .returning(move |_| Ok(AccountData::MulticastGroup(cloned_mgroup.clone())));
+        // AccessPass PDA lookups in resolve_accesspass_pda — no account found, use static PDA
+        client
+            .expect_get()
+            .returning(|_| Err(eyre::eyre!("account not found")));
         let cloned_mgroup = mgroup.clone();
         client
             .expect_gets()


### PR DESCRIPTION
Resolves: #3551

## Summary of Changes
- Fix `AddMulticastGroupSubAllowlist`, `RemoveMulticastGroupSubAllowlist`, `AddMulticastGroupPubAllowlist`, and `RemoveMulticastGroupPubAllowlist` to correctly handle AccessPasses created with `allow_multiple_ip=true`. These passes store `client_ip=0.0.0.0` and live at the dynamic PDA `(0.0.0.0, user_payer)`. The processors were doing a strict `client_ip` equality check that always failed when a real IP was passed in the instruction args.
- Add `resolve_accesspass_pda` to the SDK allowlist module. It tries the static PDA first and falls back to the dynamic PDA when an `allow_multiple_ip` pass is found there. Both `AddMulticastGroupSubAllowlistCommand` and `AddMulticastGroupPubAllowlistCommand` now use it.

## Diff Breakdown
| Category   | Files | Lines (+/-)   | Net   |
|------------|-------|---------------|-------|
| Core logic | 7     | +254 / -18    | +236  |
| Tests      | 3     | +868 / -0     | +868  |

Mostly tests; the core fix is a small but targeted change to 4 processor files and the SDK PDA resolution logic.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs` — 3 new integration tests for subscriber allowlist: `allow_multiple_ip` with zero IP in args, with real IP in args, and wrong PDA rejected
- `smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs` — same 3 scenarios for publisher allowlist
- `smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs` — new `resolve_accesspass_pda` helper + 4 unit tests covering all PDA resolution branches
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs` — PDA validation extended to accept dynamic PDA; `client_ip` check made conditional on `!allow_multiple_ip()`
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs` — same fix as subscriber add
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/remove.rs` — same fix applied to remove path
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/remove.rs` — same fix applied to remove path

</details>

## Testing Verification
- 6 new program integration tests covering `allow_multiple_ip` add/remove (pub and sub) and wrong-PDA rejection
- 4 new SDK unit tests covering all branches of `resolve_accesspass_pda`
- All existing allowlist integration tests continue to pass