### PR TITLE
sentinel: accept multiple --client-filter values in multicast publisher worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - Smartcontract
   - Fix multicast group allowlist add/remove for AccessPasses created with `allow_multiple_ip=true`; the processors were rejecting requests with a real client IP because the stored IP is always `0.0.0.0` for these passes ([#3551](https://github.com/malbeclabs/doublezero/issues/3551))
   - SDK now auto-detects the correct AccessPass PDA (static or dynamic) for allowlist operations based on whether an `allow_multiple_ip` pass exists
+- Sentinel
+  - Make the multicast publisher worker's `--client-filter` flag repeatable so multiple validator client names can be matched in one run (OR semantics), matching the admin CLI behavior
 
 ## [v0.18.0](https://github.com/malbeclabs/doublezero/compare/client/v0.17.0...client/v0.18.0) - 2026-04-17
 

--- a/crates/sentinel/src/main.rs
+++ b/crates/sentinel/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
         poll_interval_secs = args.poll_interval,
         pubkey = %keypair.pubkey(),
         groups = ?multicast_group_pubkeys,
-        client_filter = ?args.client_filter,
+        client_filters = ?args.client_filters,
         "DoubleZero Sentinel starting"
     );
 
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
         keypair,
         serviceability_id,
         multicast_group_pubkeys,
-        args.client_filter,
+        args.client_filters,
         args.validator_metadata_url,
         args.poll_interval,
     );

--- a/crates/sentinel/src/multicast_publisher.rs
+++ b/crates/sentinel/src/multicast_publisher.rs
@@ -62,7 +62,7 @@ pub struct MulticastPublisherSentinel<D: MulticastDzLedgerClient, V: ValidatorLi
     validator_list_reader: V,
     metadata_api_url: Option<String>,
     multicast_group_pubkeys: Vec<Pubkey>,
-    client_filter: Option<String>,
+    client_filters: Vec<String>,
     poll_interval: Duration,
 }
 
@@ -71,7 +71,7 @@ impl<D: MulticastDzLedgerClient, V: ValidatorListReader> MulticastPublisherSenti
         dz_client: D,
         validator_list_reader: V,
         multicast_group_pubkeys: Vec<Pubkey>,
-        client_filter: Option<String>,
+        client_filters: Vec<String>,
         metadata_api_url: Option<String>,
         poll_interval_secs: u64,
     ) -> Self {
@@ -80,7 +80,7 @@ impl<D: MulticastDzLedgerClient, V: ValidatorListReader> MulticastPublisherSenti
             validator_list_reader,
             metadata_api_url,
             multicast_group_pubkeys,
-            client_filter,
+            client_filters,
             poll_interval: Duration::from_secs(poll_interval_secs),
         }
     }
@@ -125,10 +125,10 @@ impl<D: MulticastDzLedgerClient, V: ValidatorListReader> MulticastPublisherSenti
             return Ok(());
         }
 
-        // If client_filter is set, enrich validators with software_client from the
+        // If client_filters is set, enrich validators with software_client from the
         // metadata API so we can filter. This must succeed — returning unfiltered
         // data when filtering was requested is not acceptable.
-        if self.client_filter.is_some() {
+        if !self.client_filters.is_empty() {
             let needs_enrichment = validators.values().any(|v| v.software_client.is_empty());
             if needs_enrichment {
                 let metadata_url = self.metadata_api_url.as_deref().ok_or_else(|| {
@@ -183,12 +183,13 @@ impl<D: MulticastDzLedgerClient, V: ValidatorListReader> MulticastPublisherSenti
                     {
                         return false;
                     }
-                    if let Some(ref filter) = self.client_filter {
+                    if !self.client_filters.is_empty() {
                         if let Some(v) = validators.get(&u.client_ip) {
-                            return v
-                                .software_client
-                                .to_lowercase()
-                                .contains(&filter.to_lowercase());
+                            let name = v.software_client.to_lowercase();
+                            return self
+                                .client_filters
+                                .iter()
+                                .any(|f| name.contains(&f.to_lowercase()));
                         }
                     }
                     true
@@ -521,7 +522,7 @@ impl MulticastPublisherSentinel<RpcMulticastDzLedgerClient, SolanaRpcValidatorLi
         payer: Arc<Keypair>,
         serviceability_id: Pubkey,
         multicast_group_pubkeys: Vec<Pubkey>,
-        client_filter: Option<String>,
+        client_filters: Vec<String>,
         validator_metadata_url: Option<String>,
         poll_interval_secs: u64,
     ) -> Self {
@@ -529,7 +530,7 @@ impl MulticastPublisherSentinel<RpcMulticastDzLedgerClient, SolanaRpcValidatorLi
             RpcMulticastDzLedgerClient::new(dz_rpc_url, payer, serviceability_id),
             SolanaRpcValidatorListReader::new(solana_rpc_url),
             multicast_group_pubkeys,
-            client_filter,
+            client_filters,
             validator_metadata_url,
             poll_interval_secs,
         )
@@ -586,9 +587,9 @@ mod tests {
         dz: MockMulticastDzLedgerClient,
         api: MockValidatorListReader,
         groups: Vec<Pubkey>,
-        client_filter: Option<String>,
+        client_filters: Vec<String>,
     ) -> MulticastPublisherSentinel<MockMulticastDzLedgerClient, MockValidatorListReader> {
-        MulticastPublisherSentinel::with_clients(dz, api, groups, client_filter, None, 300)
+        MulticastPublisherSentinel::with_clients(dz, api, groups, client_filters, None, 300)
     }
 
     fn make_sentinel(
@@ -596,7 +597,7 @@ mod tests {
         api: MockValidatorListReader,
         groups: Vec<Pubkey>,
     ) -> MulticastPublisherSentinel<MockMulticastDzLedgerClient, MockValidatorListReader> {
-        make_sentinel_with_filter(dz, api, groups, None)
+        make_sentinel_with_filter(dz, api, groups, vec![])
     }
 
     #[tokio::test]
@@ -887,8 +888,74 @@ mod tests {
             .times(1)
             .returning(|_, _| Ok(()));
 
-        let sentinel = make_sentinel_with_filter(dz, api, vec![group], Some("JitoLabs".into()));
+        let sentinel = make_sentinel_with_filter(dz, api, vec![group], vec!["JitoLabs".into()]);
         sentinel.poll_cycle().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiple_client_filters_match_any() {
+        let group = Pubkey::new_unique();
+        let ip_jito = [10, 0, 0, 1];
+        let ip_agave = [10, 0, 0, 2];
+        let ip_frank = [10, 0, 0, 3];
+
+        let mut api = MockValidatorListReader::new();
+        let mut validators = HashMap::new();
+        validators.insert(
+            Ipv4Addr::from(ip_jito),
+            ValidatorStake {
+                activated_stake: 300,
+                software_client: "JitoLabs".into(),
+            },
+        );
+        validators.insert(
+            Ipv4Addr::from(ip_agave),
+            ValidatorStake {
+                activated_stake: 200,
+                software_client: "Agave".into(),
+            },
+        );
+        validators.insert(
+            Ipv4Addr::from(ip_frank),
+            ValidatorStake {
+                activated_stake: 100,
+                software_client: "Frankendancer".into(),
+            },
+        );
+        api.expect_fetch_validators()
+            .returning(move || Ok(validators.clone()));
+
+        let mut dz = MockMulticastDzLedgerClient::new();
+        dz.expect_fetch_all_dz_users().returning(move || {
+            Ok(vec![
+                make_ibrl_user(ip_jito, Pubkey::new_unique()),
+                make_ibrl_user(ip_agave, Pubkey::new_unique()),
+                make_ibrl_user(ip_frank, Pubkey::new_unique()),
+            ])
+        });
+
+        // Both JitoLabs and Frankendancer should be created; Agave skipped.
+        let created_ips = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let created_ips_clone = created_ips.clone();
+        dz.expect_create_multicast_publisher()
+            .times(2)
+            .returning(move |_, u| {
+                created_ips_clone.lock().unwrap().insert(u.client_ip);
+                Ok(())
+            });
+
+        let sentinel = make_sentinel_with_filter(
+            dz,
+            api,
+            vec![group],
+            vec!["jito".into(), "Frankendancer".into()],
+        );
+        sentinel.poll_cycle().await.unwrap();
+
+        let ips = created_ips.lock().unwrap();
+        assert!(ips.contains(&Ipv4Addr::from(ip_jito)));
+        assert!(ips.contains(&Ipv4Addr::from(ip_frank)));
+        assert!(!ips.contains(&Ipv4Addr::from(ip_agave)));
     }
 
     #[tokio::test]
@@ -917,7 +984,7 @@ mod tests {
             dz,
             api,
             vec![group],
-            Some("JitoLabs".into()),
+            vec!["JitoLabs".into()],
             None,
             300,
         );

--- a/crates/sentinel/src/settings.rs
+++ b/crates/sentinel/src/settings.rs
@@ -40,9 +40,10 @@ pub struct AppArgs {
     pub multicast_group_pubkeys: String,
 
     /// Only create publishers for validators matching this client name (e.g. "JitoLabs").
+    /// Repeatable; a validator matches if its software client contains any of the given names.
     /// Requires --validator-metadata-url for software client enrichment.
-    #[arg(long)]
-    pub client_filter: Option<String>,
+    #[arg(long = "client-filter", value_name = "NAME")]
+    pub client_filters: Vec<String>,
 
     /// Solana RPC URL for validator listing (get_vote_accounts + get_cluster_nodes).
     #[arg(long)]
@@ -112,7 +113,7 @@ mod tests {
             log: "info".into(),
             metrics_addr: "127.0.0.1:2112".into(),
             multicast_group_pubkeys: pubkeys.into(),
-            client_filter: None,
+            client_filters: vec![],
             solana_rpc: "http://localhost:8899".into(),
             validator_metadata_url: None,
             poll_interval: 300,


### PR DESCRIPTION
## Summary of Changes
- Make the sentinel multicast publisher worker's `--client-filter` flag repeatable, so multiple validator client names can be matched in a single run
- Match semantics already used by the admin CLI (`controlplane/doublezero-admin`): a validator matches if its software client substring-contains **any** of the given filter names (case-insensitive OR)
- Changes `client_filter: Option<String>` → `client_filters: Vec<String>`; flag name `--client-filter` is unchanged, so existing single-value invocations continue to work

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +19 / -9    | +10  |
| Scaffolding  |     1 | +2 / -2     |   0  |
| Tests        |     1 | +69 / -11   | +58  |
| Docs         |     1 | +2 / -0     |  +2  |
| **Total**    |     4 | +92 / -22   | +70  |

Small change — the bulk of additions is a new test covering the multi-filter OR semantics.

<details>
<summary>Key files (click to expand)</summary>

- `crates/sentinel/src/multicast_publisher.rs` — filter predicate now OR-matches against `Vec<String>`; constructor signatures updated; new `multiple_client_filters_match_any` test
- `crates/sentinel/src/settings.rs` — `--client-filter` declared as `Vec<String>` (repeatable)
- `crates/sentinel/src/main.rs` — wiring update for the renamed field

</details>

## Testing Verification
- All 46 sentinel crate unit tests pass, including the new `multiple_client_filters_match_any` test that verifies OR semantics and case-insensitive matching across multiple filter values
- Existing single-filter test `client_filter_only_creates_for_matching_validators` still passes, confirming backward compatibility of the `--client-filter foo` form