### PR TITLE
e2e/qa: fix withdraw accounting invariant for free-seat override

### DIFF
--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ secrets.MALBEC_INFRA_RO }}
       - uses: actions/setup-go@v5
         with:
-          go-version-file: e2e/go.mod
+          go-version-file: go.mod
           cache: true
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -145,7 +145,7 @@ jobs:
           token: ${{ secrets.MALBEC_INFRA_RO }}
       - uses: actions/setup-go@v5
         with:
-          go-version-file: e2e/go.mod
+          go-version-file: go.mod
           cache: true
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -258,6 +258,7 @@ func TestQA_MulticastSettlement(t *testing.T) {
 			"balance", balanceAfterWithdraw,
 			"before_pay", balanceBeforePay,
 			"after_pay", balanceAfterPay,
+			"paid_amount", parsedAmount,
 			"effective_price", effectivePrice,
 			"refund", refund,
 			"retained", retained,
@@ -266,11 +267,13 @@ func TestQA_MulticastSettlement(t *testing.T) {
 
 		// Accounting invariant: regardless of prorating, the sum of what was
 		// refunded to the wallet and what the program retained must equal the
-		// effective price debited at pay time.
-		require.Equal(t, effectivePrice, refund+retained,
-			"refund + retained must equal the effective price paid")
+		// amount debited at pay time. This uses parsedAmount rather than
+		// effectivePrice because a seat with a zero price override is still
+		// charged parsedAmount at pay and fully refunded on withdraw.
+		require.Equal(t, parsedAmount, refund+retained,
+			"refund + retained must equal the amount paid")
 
-		if !proratingEnabled {
+		if !proratingEnabled || effectivePrice == 0 {
 			return
 		}
 
@@ -280,12 +283,12 @@ func TestQA_MulticastSettlement(t *testing.T) {
 		// that distinguish a real partial refund from a regression:
 		//   - refund > 0 (prorating actually happened)
 		//   - retained > 0 (the seat was not free for the used portion)
-		//   - refund < effective_price (refund is a strict partial)
+		//   - retained < effective_price (kept less than a full epoch)
 		require.Greater(t, refund, uint64(0),
 			"prorating: refund should be strictly greater than zero")
 		require.Greater(t, retained, uint64(0),
 			"prorating: retained should be strictly greater than zero")
-		require.Less(t, refund, effectivePrice,
-			"prorating: refund should be strictly less than the effective price")
+		require.Less(t, retained, effectivePrice,
+			"prorating: retained should be strictly less than the effective price")
 	})
 }


### PR DESCRIPTION
## Summary

- Mainnet QA run [malbeclabs/infra/actions/runs/24744408505](https://github.com/malbeclabs/infra/actions/runs/24744408505) failed in `TestQA_MulticastSettlement/validate_balance_after_withdraw` because the selected seat had a zero USDC price override (`effective_price = 0`) while the client still paid `parsedAmount = 30_000_000` at pay time and got it all back on withdraw. The accounting invariant `refund + retained == effective_price` evaluated to `30_000_000 == 0` and failed.
- Tie the money-conservation invariant to `parsedAmount` (what was actually debited) instead of `effectivePrice`. Holds regardless of prorating or zero-override seats.
- Skip the prorating partial-refund invariants when `effectivePrice == 0` (nothing meaningful to assert about a free seat under prorating).
- Fix the partial-refund assertion direction: the test was checking `refund < effective_price`, which is the wrong way around. The correct invariant is `retained < effective_price` — the program kept less than a full epoch because the client left early.

## Testing Verification

- Reproduced the failing invariant against the observed mainnet telemetry (`paid=30_000_000, refund=30_000_000, retained=0, effective_price=0`) and confirmed the new invariant `parsedAmount == refund + retained` holds (30M == 30M + 0).
- On the testnet path (prorating on, effective_price > 0), the partial-refund invariants still exercise: `refund > 0`, `retained > 0`, `retained < effective_price`.