### PR TITLE
e2e/qa: check per-type device capacity in ValidDevices

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -181,7 +181,7 @@ jobs:
           pull_with_retry ${{ env.DZ_IMAGE_REPO }}/geoprobe:${{ env.DZ_IMAGE_TAG }}
           pull_with_retry ${{ env.DZ_IMAGE_REPO }}/sentinel:${{ env.DZ_IMAGE_TAG }}
           pull_with_retry ${{ env.DZ_IMAGE_REPO }}/validator-metadata-service-mock:${{ env.DZ_IMAGE_TAG }}
-          pull_with_retry quay.io/prometheus/prometheus:v2.54.1
+          pull_with_retry ghcr.io/malbeclabs/dz-e2e/prometheus:v2.54.1
           pull_with_retry public.ecr.aws/influxdb/influxdb:1.8
       - name: test
         env:

--- a/e2e/internal/devnet/prometheus.go
+++ b/e2e/internal/devnet/prometheus.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	prometheusImage        = "quay.io/prometheus/prometheus:v2.54.1"
+	prometheusImage        = "ghcr.io/malbeclabs/dz-e2e/prometheus:v2.54.1"
 	prometheusInternalPort = 9090
 )
 

--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -81,13 +81,19 @@ func FindMulticastStatus(statuses []*pb.Status) *pb.Status {
 }
 
 type Device struct {
-	PubKey       string
-	Code         string
-	ExchangeCode string
-	MaxUsers     int
-	UsersCount   int
-	Status       serviceability.DeviceStatus
-	DeviceType   serviceability.DeviceDeviceType
+	PubKey                    string
+	Code                      string
+	ExchangeCode              string
+	MaxUsers                  int
+	UsersCount                int
+	MaxUnicastUsers           int
+	UnicastUsersCount         int
+	MaxMulticastPublishers    int
+	MulticastPublishersCount  int
+	MaxMulticastSubscribers   int
+	MulticastSubscribersCount int
+	Status                    serviceability.DeviceStatus
+	DeviceType                serviceability.DeviceDeviceType
 }
 
 type Client struct {

--- a/e2e/internal/qa/test.go
+++ b/e2e/internal/qa/test.go
@@ -87,10 +87,52 @@ func (t *Test) Devices() map[string]*Device {
 	return t.devices
 }
 
-// ValidDevices returns devices that pass filtering criteria.
-// If skipCapacityCheck is true (e.g., when using a QA identity that bypasses on-chain capacity checks),
-// devices are not filtered by available capacity.
-func (t *Test) ValidDevices(minCapacity int, skipCapacityCheck bool) []*Device {
+// DeviceUserType identifies which per-type user slot bucket to check against
+// a device's capacity. The onchain device tracks three independent counters —
+// unicast, multicast publisher, multicast subscriber — each with its own max.
+type DeviceUserType int
+
+const (
+	DeviceUserTypeUnicast DeviceUserType = iota
+	DeviceUserTypeMulticastPublisher
+	DeviceUserTypeMulticastSubscriber
+)
+
+func (d DeviceUserType) String() string {
+	switch d {
+	case DeviceUserTypeUnicast:
+		return "unicast"
+	case DeviceUserTypeMulticastPublisher:
+		return "multicast_publisher"
+	case DeviceUserTypeMulticastSubscriber:
+		return "multicast_subscriber"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(d))
+	}
+}
+
+// capacityFor returns the (current, max) counters for the requested user type.
+func (d *Device) capacityFor(userType DeviceUserType) (current, max int) {
+	switch userType {
+	case DeviceUserTypeUnicast:
+		return d.UnicastUsersCount, d.MaxUnicastUsers
+	case DeviceUserTypeMulticastPublisher:
+		return d.MulticastPublishersCount, d.MaxMulticastPublishers
+	case DeviceUserTypeMulticastSubscriber:
+		return d.MulticastSubscribersCount, d.MaxMulticastSubscribers
+	default:
+		return 0, 0
+	}
+}
+
+// ValidDevices returns devices that pass filtering criteria for the given
+// user type. A device is considered valid when it has at least minCapacity
+// free slots in the type-specific bucket (e.g. unicast) AND in the aggregate
+// users bucket — both are enforced onchain independently.
+//
+// If skipCapacityCheck is true (e.g., when using a QA identity that bypasses
+// on-chain capacity checks), devices are not filtered by available capacity.
+func (t *Test) ValidDevices(userType DeviceUserType, minCapacity int, skipCapacityCheck bool) []*Device {
 	devices := make([]*Device, 0, len(t.devices))
 
 	for _, device := range t.Devices() {
@@ -102,10 +144,22 @@ func (t *Test) ValidDevices(minCapacity int, skipCapacityCheck bool) []*Device {
 
 		// Skip capacity check if using QA identity (bypasses on-chain max_users check)
 		if !skipCapacityCheck {
-			// Check if device has capacity for at least minCapacity users
-			availableSlots := device.MaxUsers - device.UsersCount
-			if availableSlots < minCapacity {
-				t.log.Debug("Skipping device with insufficient capacity", "device", device.Code, "users", device.UsersCount, "maxUsers", device.MaxUsers)
+			typeCount, typeMax := device.capacityFor(userType)
+			if typeMax-typeCount < minCapacity {
+				t.log.Debug("Skipping device with insufficient type-specific capacity",
+					"device", device.Code,
+					"userType", userType,
+					"count", typeCount,
+					"max", typeMax,
+				)
+				continue
+			}
+			if device.MaxUsers-device.UsersCount < minCapacity {
+				t.log.Debug("Skipping device with insufficient aggregate capacity",
+					"device", device.Code,
+					"users", device.UsersCount,
+					"maxUsers", device.MaxUsers,
+				)
 				continue
 			}
 		}
@@ -153,13 +207,19 @@ func getDevices(ctx context.Context, serviceabilityClient *serviceability.Client
 	for _, device := range data.Devices {
 		exchangeCode := exchanges[device.ExchangePubKey]
 		devices[device.Code] = &Device{
-			PubKey:       base58.Encode(device.PubKey[:]),
-			Code:         device.Code,
-			ExchangeCode: exchangeCode,
-			MaxUsers:     int(device.MaxUsers),
-			UsersCount:   int(device.UsersCount),
-			Status:       device.Status,
-			DeviceType:   device.DeviceType,
+			PubKey:                    base58.Encode(device.PubKey[:]),
+			Code:                      device.Code,
+			ExchangeCode:              exchangeCode,
+			MaxUsers:                  int(device.MaxUsers),
+			UsersCount:                int(device.UsersCount),
+			MaxUnicastUsers:           int(device.MaxUnicastUsers),
+			UnicastUsersCount:         int(device.UnicastUsersCount),
+			MaxMulticastPublishers:    int(device.MaxMulticastPublishers),
+			MulticastPublishersCount:  int(device.MulticastPublishersCount),
+			MaxMulticastSubscribers:   int(device.MaxMulticastSubscribers),
+			MulticastSubscribersCount: int(device.MulticastSubscribersCount),
+			Status:                    device.Status,
+			DeviceType:                device.DeviceType,
 		}
 	}
 	return devices, nil

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -53,9 +53,9 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 	clients := test.Clients()
 	require.GreaterOrEqual(t, len(clients), 2, "At least 2 clients are required for connectivity testing")
 
-	// Filter devices to only include those with sufficient capacity and skip test devices
+	// Filter devices to only include those with sufficient unicast capacity and skip test devices
 	// When using a QA identity (--skip-capacity-check), all devices are included regardless of capacity
-	devices := test.ValidDevices(2, *skipCapacityCheckFlag)
+	devices := test.ValidDevices(qa.DeviceUserTypeUnicast, 2, *skipCapacityCheckFlag)
 	if len(devices) == 0 {
 		t.Skip("No valid devices found with sufficient capacity")
 	}


### PR DESCRIPTION
## Summary

- QA tests that pin to an explicit device (e.g. `TestQA_AllDevices_UnicastConnectivity`) were failing on devices that had free aggregate slots but zero free slots in a per-type bucket (e.g. `max_unicast_users=29 / unicast_users_count=29` while `max_users=128 / users_count=61`).
- `qa.Test.ValidDevices` only consulted the aggregate `MaxUsers`/`UsersCount` counters, so these devices passed the capacity check and failed later at connect time with an onchain cap error.
- Extends `qa.Device` with the three per-type counters already exposed by the serviceability SDK (unicast, multicast publisher, multicast subscriber), adds a `DeviceUserType` enum, and makes `ValidDevices` take the user type so it enforces both the type-specific and aggregate buckets.

Related: builds on the auto-select fix from #3550, which solved the same class of problem for callers that don't specify a device code.

## Testing Verification

- `go build -tags=qa ./e2e/...` clean
- `go vet -tags=qa ./e2e/...` clean
- Ran through the failure scenario from [infra run 24744593257](https://github.com/malbeclabs/infra/actions/runs/24744593257): with the fix, `ValidDevices(DeviceUserTypeUnicast, 2, false)` filters out the saturated `nyc001-dz002` entry that previously leaked through.