### PR TITLE
ci: add infra_branch input to devnet daily release workflow

### DIFF
--- a/.github/workflows/release.daily.yml
+++ b/.github/workflows/release.daily.yml
@@ -9,6 +9,10 @@ on:
       playbook:
         required: true
         type: string
+      infra_branch:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -54,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "malbeclabs/infra"
+          ref: ${{ inputs.infra_branch || '' }}
           path: infra
           token: ${{ secrets.GA_ANSIBLE_REPO_RO }}
       - name: Create ansible vault password file

--- a/.github/workflows/release.devnet.all.daily.yml
+++ b/.github/workflows/release.devnet.all.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.all.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
   schedule:
     - cron: '0 14 * * 1-5'  # Every weekday at 10AM ET/9AM CT
 
@@ -43,6 +49,7 @@ jobs:
     with:
       component: ${{ matrix.component }}
       playbook: ${{ matrix.playbook }}
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add optional `infra_branch` input to the `release.devnet.all.daily` workflow, allowing users to specify which branch of `malbeclabs/infra` to use for ansible playbooks
- Defaults to the infra repo's default branch when not specified, preserving existing behavior
- The input is passed through to the reusable `release.daily.yml` workflow and used as the `ref` in the infra repo checkout step

## Testing Verification

- When `infra_branch` is left empty (or on scheduled runs), the workflow checks out the infra repo's default branch — same as before
- When `infra_branch` is specified via workflow_dispatch, the infra repo is checked out at that branch