### PR TITLE
smartcontract: fix flaky test_device_interfaces blockhash reuse

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
@@ -233,7 +233,7 @@ async fn execute_transaction_tester(
 #[allow(dead_code)]
 pub async fn try_execute_transaction(
     banks_client: &mut BanksClient,
-    recent_blockhash: solana_program::hash::Hash,
+    _recent_blockhash: solana_program::hash::Hash,
     program_id: Pubkey,
     instruction: DoubleZeroInstruction,
     accounts: Vec<AccountMeta>,
@@ -241,6 +241,11 @@ pub async fn try_execute_transaction(
 ) -> Result<(), BanksClientError> {
     print!("➡️  Transaction {instruction:?} ");
 
+    // Wait for a new blockhash so retries of an identical message don't hit Solana's
+    // signature status cache (same signature + same blockhash → cached Ok). This also
+    // avoids the stale-blockhash panic in banks-server when a single hash is reused
+    // across a long sequence of transactions.
+    let recent_blockhash = wait_for_new_blockhash(banks_client).await;
     let mut transaction = create_transaction(program_id, &instruction, &accounts, payer);
     transaction.try_sign(&[&payer], recent_blockhash).unwrap();
     banks_client.process_transaction(transaction).await?;
@@ -347,7 +352,7 @@ pub async fn execute_transaction_with_extra_accounts(
 #[allow(dead_code)]
 pub async fn try_execute_transaction_with_extra_accounts(
     banks_client: &mut BanksClient,
-    recent_blockhash: solana_program::hash::Hash,
+    _recent_blockhash: solana_program::hash::Hash,
     program_id: Pubkey,
     instruction: DoubleZeroInstruction,
     accounts: Vec<AccountMeta>,
@@ -356,6 +361,8 @@ pub async fn try_execute_transaction_with_extra_accounts(
 ) -> Result<(), BanksClientError> {
     print!("➡️  Transaction {instruction:?} ");
 
+    // See comment in `try_execute_transaction` for why we wait for a new blockhash.
+    let recent_blockhash = wait_for_new_blockhash(banks_client).await;
     let mut transaction = create_transaction_with_extra_accounts(
         program_id,
         &instruction,


### PR DESCRIPTION
## Summary

- `test_device_interfaces` intermittently panics in `banks-server`'s blockhash-age math because the `try_execute_transaction` helpers were signing with the stale `recent_blockhash` captured at the start of `init_test`, which ages out across the ~50-transaction flow.
- A naive fix — fetch the latest blockhash inside the helpers — uncovered a second flake: when the test asserts that retrying an identical message fails (e.g., reject an already-rejected interface), both calls produce the same signature, and if they happen to share the same latest blockhash, Solana's signature status cache returns the first call's `Ok`, tripping `unwrap_err() on an Ok value`.
- Use `wait_for_new_blockhash` in the `try_*` helpers so each retry gets a blockhash distinct from the current latest. This resolves both the stale-hash panic and the dedup false-positive.

Only `try_execute_transaction` and `try_execute_transaction_with_extra_accounts` were still using the passed-in stale hash; every other helper already fetches a fresh blockhash internally.

## Testing Verification

- 50/50 green on a tight burn-in of `cargo test -p doublezero-serviceability --test interface_test test_device_interfaces` (previously flaked within ~15 runs).
- Full `cargo test -p doublezero-serviceability` suite green.