### PR TITLE
feat(collector): fallback to any probe if anchor gone (#3569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
 - Client
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
+- Collector
+  - fallback to any probe if anchor probes aren't available
 - Smartcontract
   - Fix multicast group allowlist add/remove for AccessPasses created with `allow_multiple_ip=true`; the processors were rejecting requests with a real client IP because the stored IP is always `0.0.0.0` for these passes ([#3551](https://github.com/malbeclabs/doublezero/issues/3551))
   - SDK now auto-detects the correct AccessPass PDA (static or dynamic) for allowlist operations based on whether an `allow_multiple_ip` pass exists

--- a/controlplane/internet-latency-collector/internal/ripeatlas/client.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client.go
@@ -130,9 +130,9 @@ func (c *Client) setCommonHeaders(req *http.Request, contentType string) {
 }
 
 func (c *Client) fetchProbesWithErrorHandling(ctx context.Context, lat, lng float64, entityName string) ([]Probe, error) {
-	probes, err := c.GetProbesInRadius(ctx, lat, lng, int(collector.MaxDistanceKM))
+	probes, err := c.GetProbesInRadius(ctx, lat, lng, int(collector.MaxDistanceKM), true)
 	if err != nil {
-		c.log.Warn("Failed to get probes for location",
+		c.log.Warn("Failed to get anchor probes for location",
 			slog.String("entity_name", entityName),
 			slog.Float64("latitude", lat),
 			slog.Float64("longitude", lng),
@@ -140,7 +140,26 @@ func (c *Client) fetchProbesWithErrorHandling(ctx context.Context, lat, lng floa
 		return []Probe{}, nil
 	}
 
-	return filterValidProbes(probes), nil
+	valid := filterValidProbes(probes)
+
+	// Fall back to any Connected probe in radius when no anchors are available.
+	// A single-anchor location otherwise goes dark the moment that anchor becomes unresponsive.
+	if len(valid) == 0 {
+		c.log.Warn("No anchor probes found, falling back to non-anchor Connected probes",
+			slog.String("entity_name", entityName),
+			slog.Float64("latitude", lat),
+			slog.Float64("longitude", lng))
+		probes, err = c.GetProbesInRadius(ctx, lat, lng, int(collector.MaxDistanceKM), false)
+		if err != nil {
+			c.log.Warn("Failed to get fallback probes for location",
+				slog.String("entity_name", entityName),
+				slog.String("error", err.Error()))
+			return []Probe{}, nil
+		}
+		valid = filterValidProbes(probes)
+	}
+
+	return valid, nil
 }
 
 func (c *Client) makeRequest(ctx context.Context, endpoint string) (*http.Response, error) {
@@ -166,9 +185,12 @@ func (c *Client) makeRequest(ctx context.Context, endpoint string) (*http.Respon
 	return resp, nil
 }
 
-func (c *Client) GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int) ([]Probe, error) {
+func (c *Client) GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error) {
 	radiusParam := fmt.Sprintf("%.6f,%.6f:%d", latitude, longitude, radiusKm)
-	endpoint := "/probes/?radius=" + radiusParam + "&status_name=Connected&is_anchor=true"
+	endpoint := "/probes/?radius=" + radiusParam + "&status_name=Connected"
+	if anchorsOnly {
+		endpoint += "&is_anchor=true"
+	}
 
 	allProbes := []Probe{}
 

--- a/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
@@ -233,7 +233,7 @@ func TestInternetLatency_RIPEAtlas_GetProbesInRadius(t *testing.T) {
 				log:        log,
 			}
 
-			probes, err := client.GetProbesInRadius(t.Context(), tt.lat, tt.lng, tt.radius)
+			probes, err := client.GetProbesInRadius(t.Context(), tt.lat, tt.lng, tt.radius, true)
 
 			if tt.wantErr {
 				require.Error(t, err, "GetProbesInRadius() should return error")
@@ -291,7 +291,7 @@ func TestInternetLatency_RIPEAtlas_GetProbesInRadius_Pagination(t *testing.T) {
 		},
 	}
 
-	probes, err := client.GetProbesInRadius(t.Context(), 40.7128, -74.0060, 10)
+	probes, err := client.GetProbesInRadius(t.Context(), 40.7128, -74.0060, 10, true)
 
 	require.NoError(t, err, "GetProbesInRadius() failed")
 
@@ -685,6 +685,97 @@ func TestInternetLatency_RIPEAtlas_FetchProbesWithErrorHandling(t *testing.T) {
 			require.Len(t, probes, tt.wantLen, "Unexpected number of probes")
 		})
 	}
+}
+
+// TestInternetLatency_RIPEAtlas_FetchProbesWithErrorHandling_AnchorFallback verifies that
+// when the anchor-only query returns no probes, the fallback query (without is_anchor=true)
+// runs and its results are returned. This protects locations that have no RIPE Atlas anchors
+// nearby (or whose sole anchor is unresponsive).
+func TestInternetLatency_RIPEAtlas_FetchProbesWithErrorHandling_AnchorFallback(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var anchorCalls, fallbackCalls int
+	client := &Client{
+		log:     log,
+		BaseURL: "https://atlas.ripe.net/api/v2",
+		HTTPClient: &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				var results []Probe
+				if strings.Contains(req.URL.RawQuery, "is_anchor=true") {
+					anchorCalls++
+					results = []Probe{} // no anchors in radius
+				} else {
+					fallbackCalls++
+					results = []Probe{
+						{ID: 1012231, Address: "1.1.1.1", Latitude: 40.7, Longitude: -74.0,
+							Status: struct {
+								ID    int    `json:"id"`
+								Name  string `json:"name"`
+								Since string `json:"since"`
+							}{Name: "Connected"}},
+					}
+				}
+				body, _ := json.Marshal(ProbesResponse{Count: len(results), Results: results})
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}, nil
+			},
+		},
+	}
+
+	probes, err := client.fetchProbesWithErrorHandling(t.Context(), 40.7128, -74.0060, "slc")
+	require.NoError(t, err)
+	require.Equal(t, 1, anchorCalls, "should have issued anchor-only query first")
+	require.Equal(t, 1, fallbackCalls, "should have fallen back when anchors were empty")
+	require.Len(t, probes, 1, "should have returned the fallback probe")
+	require.Equal(t, 1012231, probes[0].ID)
+}
+
+// TestInternetLatency_RIPEAtlas_FetchProbesWithErrorHandling_AnchorsFoundNoFallback verifies
+// that when the anchor-only query returns probes, no fallback request is issued.
+func TestInternetLatency_RIPEAtlas_FetchProbesWithErrorHandling_AnchorsFoundNoFallback(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var anchorCalls, fallbackCalls int
+	client := &Client{
+		log:     log,
+		BaseURL: "https://atlas.ripe.net/api/v2",
+		HTTPClient: &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				var results []Probe
+				if strings.Contains(req.URL.RawQuery, "is_anchor=true") {
+					anchorCalls++
+					results = []Probe{
+						{ID: 7549, Address: "2.2.2.2", Latitude: 40.7, Longitude: -111.9,
+							Status: struct {
+								ID    int    `json:"id"`
+								Name  string `json:"name"`
+								Since string `json:"since"`
+							}{Name: "Connected"}},
+					}
+				} else {
+					fallbackCalls++
+				}
+				body, _ := json.Marshal(ProbesResponse{Count: len(results), Results: results})
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}, nil
+			},
+		},
+	}
+
+	probes, err := client.fetchProbesWithErrorHandling(t.Context(), 40.7128, -74.0060, "slc")
+	require.NoError(t, err)
+	require.Equal(t, 1, anchorCalls, "should have issued anchor-only query")
+	require.Equal(t, 0, fallbackCalls, "should NOT have fallen back when anchors were present")
+	require.Len(t, probes, 1)
+	require.Equal(t, 7549, probes[0].ID)
 }
 
 func TestInternetLatency_RIPEAtlas_GetProbesForLocations(t *testing.T) {

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -23,7 +23,7 @@ const (
 // CallDelay is defined in client.go to avoid duplication
 
 type clientInterface interface {
-	GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int) ([]Probe, error)
+	GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error)
 	GetProbesForLocations(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error)
 	CreateMeasurement(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error)
 	GetAllMeasurements(ctx context.Context, env string) ([]Measurement, error)

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
@@ -21,7 +21,7 @@ import (
 
 // MockClient implements a mock of RipeAtlasClient for testing
 type MockClient struct {
-	GetProbesInRadiusFunc                func(ctx context.Context, latitude, longitude float64, radiusKm int) ([]Probe, error)
+	GetProbesInRadiusFunc                func(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error)
 	GetProbesForLocationsFunc            func(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error)
 	CreateMeasurementFunc                func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error)
 	GetAllMeasurementsFunc               func(ctx context.Context, env string) ([]Measurement, error)
@@ -31,9 +31,9 @@ type MockClient struct {
 	GetCreditBalanceFunc                 func(ctx context.Context) (float64, error)
 }
 
-func (m *MockClient) GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int) ([]Probe, error) {
+func (m *MockClient) GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error) {
 	if m.GetProbesInRadiusFunc != nil {
-		return m.GetProbesInRadiusFunc(ctx, latitude, longitude, radiusKm)
+		return m.GetProbesInRadiusFunc(ctx, latitude, longitude, radiusKm, anchorsOnly)
 	}
 	return []Probe{}, nil
 }


### PR DESCRIPTION
## Summary of Changes
Probes were failing for [SLC](https://malbeclabs.slack.com/archives/C0804H5R7JP/p1776898815572579) so this PR enables fallback logic to non-anchor probes in the even the probes are not available.

### Identifying Probe Issue
1. Alert fired - query showed slc ripeatlas samples stopped at 19:47 UTC
2. Logs revealed the collector's measurement-rotation cycle deleted the slc measurement and didn't recreate it
3. The "No responsive probes found for location: slc" log + the is_anchor=true filter in client.go explained why; probe 7549 was slc's only anchor within 60 km
 
To resolve: anchor-preferred with non-anchor fallback, pushed on bgm/ripe-atlas-anchor-fallback.

Closes https://github.com/malbeclabs/doublezero/issues/3569

## Testing Verification
* Updated existing tests
