### PR TITLE
fix(collector): fall back to non-anchor probes when all anchors are unresponsive

### DIFF
--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -713,10 +713,22 @@ func (c *Collector) configureMeasurements(ctx context.Context, locationMatches [
 		}
 	}
 
-	// Step 2: Generate the list of measurements we want, skipping unresponsive probes
+	// Step 2: Augment locations where all known probes are unresponsive with non-anchor
+	// fallback probes, then generate the list of measurements we want.
+	//
+	// fetchProbesWithErrorHandling already falls back to non-anchor probes when the
+	// RIPE Atlas API returns no anchors at all. But that covers only the "no anchors in
+	// area" case. Here we handle a different failure mode: RIPE Atlas still reports the
+	// anchor as "Connected" (so fetchProbesWithErrorHandling sees it and returns it), but
+	// the probe has stopped responding to our measurements and was marked unresponsive in
+	// the local measurement state. Without this pass, generateWantedMeasurements would log
+	// "No responsive probes found for location" and skip the location entirely.
+	locationMatches = c.fetchFallbackProbesForUnresponsiveLocations(ctx, locationMatches, measurementState)
+
+	// Step 3: Generate the list of measurements we want, skipping unresponsive probes
 	wantedMeasurements := c.generateWantedMeasurements(locationMatches, probesPerLocation, measurementState)
 
-	// Step 2: Get all existing measurements
+	// Step 4: Get all existing measurements
 	existingMeasurements, err := c.client.GetAllMeasurements(ctx, c.env)
 	if err != nil {
 		c.log.Warn("Failed to get existing measurements", slog.String("error", err.Error()))
@@ -1211,6 +1223,56 @@ func (c *Collector) configureMeasurements(ctx context.Context, locationMatches [
 		slog.String("source", "api_estimates_with_fallback"))
 
 	return nil
+}
+
+// fetchFallbackProbesForUnresponsiveLocations returns a copy of locationMatches where
+// locations that have probes but all are marked unresponsive in measurementState are
+// augmented with non-anchor Connected probes fetched from the RIPE Atlas API.
+//
+// This prevents a location from going dark when its anchor probe stops responding while
+// RIPE Atlas still reports it as "Connected" — a lag that means fetchProbesWithErrorHandling
+// always sees the anchor and never triggers its own fallback.
+func (c *Collector) fetchFallbackProbesForUnresponsiveLocations(ctx context.Context, locationMatches []LocationProbeMatch, measurementState *MeasurementState) []LocationProbeMatch {
+	result := make([]LocationProbeMatch, len(locationMatches))
+	copy(result, locationMatches)
+
+	for i, match := range result {
+		if len(match.NearbyProbes) == 0 {
+			continue
+		}
+		if len(filterResponsiveProbes(match.NearbyProbes, measurementState)) > 0 {
+			continue // at least one probe is still responsive — no fallback needed
+		}
+
+		// All known probes for this location are unresponsive. Fetch non-anchor
+		// Connected probes as a fallback.
+		c.log.Info("All known probes unresponsive for location, fetching non-anchor fallback probes",
+			slog.String("location", match.LocationCode))
+
+		probes, err := c.client.GetProbesInRadius(ctx, match.Latitude, match.Longitude, int(collector.MaxDistanceKM), false)
+		if err != nil {
+			c.log.Warn("Failed to fetch non-anchor fallback probes for location",
+				slog.String("location", match.LocationCode),
+				slog.String("error", err.Error()))
+			continue
+		}
+
+		fallbackProbes := filterValidProbes(probes)
+		if len(fallbackProbes) > 0 {
+			c.log.Info("Using non-anchor fallback probes for location",
+				slog.String("location", match.LocationCode),
+				slog.Int("count", len(fallbackProbes)))
+			result[i].NearbyProbes = fallbackProbes
+			result[i].ProbeCount = len(fallbackProbes)
+		} else {
+			c.log.Warn("No non-anchor fallback probes found for location",
+				slog.String("location", match.LocationCode))
+		}
+
+		time.Sleep(CallDelay)
+	}
+
+	return result
 }
 
 func (c *Collector) generateWantedMeasurements(locationMatches []LocationProbeMatch, probesPerLocation int, measurementState *MeasurementState) []MeasurementSpec {

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
@@ -944,6 +944,103 @@ func TestInternetLatency_RIPEAtlas_RunRipeAtlasMeasurementCreation(t *testing.T)
 	t.Fatalf("Unexpected error: %v", err)
 }
 
+// TestInternetLatency_RIPEAtlas_FetchFallbackProbes_TriggeredWhenAllUnresponsive verifies that
+// when all known probes for a location are in the unresponsive list, a non-anchor fallback
+// query is issued and those probes replace the unresponsive ones.
+func TestInternetLatency_RIPEAtlas_FetchFallbackProbes_TriggeredWhenAllUnresponsive(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	const anchorProbeID = 7549
+	const fallbackProbeID = 99999
+
+	var nonAnchorCalls int
+	mockClient := &MockClient{
+		GetProbesInRadiusFunc: func(_ context.Context, _, _ float64, _ int, anchorsOnly bool) ([]Probe, error) {
+			if anchorsOnly {
+				return []Probe{}, nil // should not be called in this path
+			}
+			nonAnchorCalls++
+			return []Probe{
+				{ID: fallbackProbeID, Address: "1.2.3.4", Latitude: 40.76, Longitude: -111.89},
+			}, nil
+		},
+	}
+
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	measurementState := NewMeasurementState(stateFile)
+	measurementState.AddUnresponsiveProbe(anchorProbeID)
+
+	locationMatches := []LocationProbeMatch{
+		{
+			LocationMatch: collector.LocationMatch{
+				LocationCode: "slc",
+				Latitude:     40.7608,
+				Longitude:    -111.8910,
+			},
+			NearbyProbes: []Probe{
+				{ID: anchorProbeID, Address: "8.8.8.8", Latitude: 40.76, Longitude: -111.89},
+			},
+			ProbeCount: 1,
+		},
+	}
+
+	c := &Collector{client: mockClient, log: log}
+	result := c.fetchFallbackProbesForUnresponsiveLocations(t.Context(), locationMatches, measurementState)
+
+	require.Len(t, result, 1)
+	require.Equal(t, 1, nonAnchorCalls, "should have fetched non-anchor fallback probes")
+	require.Len(t, result[0].NearbyProbes, 1)
+	require.Equal(t, fallbackProbeID, result[0].NearbyProbes[0].ID, "should use the fallback probe")
+}
+
+// TestInternetLatency_RIPEAtlas_FetchFallbackProbes_NoFallbackWhenResponsive verifies that
+// when at least one probe for a location is still responsive, no non-anchor fallback query
+// is issued and the original probes are left unchanged.
+func TestInternetLatency_RIPEAtlas_FetchFallbackProbes_NoFallbackWhenResponsive(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	const anchorProbeID = 7549
+
+	var nonAnchorCalls int
+	mockClient := &MockClient{
+		GetProbesInRadiusFunc: func(_ context.Context, _, _ float64, _ int, anchorsOnly bool) ([]Probe, error) {
+			if !anchorsOnly {
+				nonAnchorCalls++
+			}
+			return []Probe{}, nil
+		},
+	}
+
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	measurementState := NewMeasurementState(stateFile) // anchor probe is NOT unresponsive
+
+	locationMatches := []LocationProbeMatch{
+		{
+			LocationMatch: collector.LocationMatch{
+				LocationCode: "slc",
+				Latitude:     40.7608,
+				Longitude:    -111.8910,
+			},
+			NearbyProbes: []Probe{
+				{ID: anchorProbeID, Address: "8.8.8.8", Latitude: 40.76, Longitude: -111.89},
+			},
+			ProbeCount: 1,
+		},
+	}
+
+	c := &Collector{client: mockClient, log: log}
+	result := c.fetchFallbackProbesForUnresponsiveLocations(t.Context(), locationMatches, measurementState)
+
+	require.Len(t, result, 1)
+	require.Equal(t, 0, nonAnchorCalls, "should NOT have fetched non-anchor probes when anchor is responsive")
+	require.Len(t, result[0].NearbyProbes, 1)
+	require.Equal(t, anchorProbeID, result[0].NearbyProbes[0].ID, "original anchor probe should be preserved")
+}
+
 func TestInternetLatency_RIPEAtlas_ConfigureMeasurements_CreateNew(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fixes the "No responsive probes found for location: slc" error where a location goes dark even though non-anchor probes are available
- Adds `fetchFallbackProbesForUnresponsiveLocations` in `configureMeasurements`, called before `generateWantedMeasurements`, which detects locations where all known probes are unresponsive and fetches non-anchor Connected probes as a replacement

## Context

PR #3570 added a fallback in `fetchProbesWithErrorHandling` that retries without `is_anchor=true` when the RIPE Atlas API returns zero anchors. That handles the "no anchors in area" case but misses the more common failure mode: RIPE Atlas still reports the anchor as `Connected` (so the API returns it), but the probe has stopped responding to our measurements and was marked unresponsive in the local measurement state. When `generateWantedMeasurements` runs `filterResponsiveProbes`, the anchor is excluded and the location is skipped with no fallback.

## Test plan

- [x] Two new unit tests: fallback triggered when all probes unresponsive, no fallback when at least one is responsive
- [x] Full `ripeatlas` package tests pass
- [ ] Deploy snapshot to devnet and verify SLC measurements are created using non-anchor probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)