### PR TITLE
feat(cli): allow unsubscribe without disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - CLI
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
   - Fix `doublezero resource verify` to report missing `TunnelIds` resource extensions for all devices, including those without any users; previously the discrepancy was suppressed when a device had no users, hiding unallocated extensions
+  - Add `multicast subscribe`, `multicast unsubscribe`, `multicast publish`, and `multicast unpublish` CLI commands so users can modify their multicast role set on a connected session without running `disconnect`. `unpublish` warns when the removal would drop the user's last publisher role (legacy-allocation environments may briefly reprovision in that case).
 - Client
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
 - Collector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
   - Fix `doublezero resource verify` to report missing `TunnelIds` resource extensions for all devices, including those without any users; previously the discrepancy was suppressed when a device had no users, hiding unallocated extensions
   - Extend `doublezero resource verify` to detect orphaned `ResourceExtension` accounts whose PDA does not correspond to any currently-expected resource type (global singleton or per-device extension for a live device/prefix); `--fix` closes them via the existing y/N confirmation flow
+  - Add `multicast subscribe`, `multicast unsubscribe`, `multicast publish`, and `multicast unpublish` CLI commands so users can modify their multicast role set on a connected session without running `disconnect`. `unpublish` warns when the removal would drop the user's last publisher role (legacy-allocation environments may briefly reprovision in that case).
 - Client
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
 - Collector

--- a/client/doublezero/src/cli/multicast.rs
+++ b/client/doublezero/src/cli/multicast.rs
@@ -13,4 +13,44 @@ pub enum MulticastCommands {
     /// Manage multicast groups
     #[clap()]
     Group(MulticastGroupCliCommand),
+    /// Subscribe to one or more multicast groups (user must already be connected)
+    #[clap()]
+    Subscribe(MulticastSubscribeCliCommand),
+    /// Unsubscribe from one or more multicast groups
+    #[clap()]
+    Unsubscribe(MulticastUnsubscribeCliCommand),
+    /// Publish to one or more multicast groups (user must already be connected)
+    #[clap()]
+    Publish(MulticastPublishCliCommand),
+    /// Stop publishing to one or more multicast groups
+    #[clap()]
+    Unpublish(MulticastUnpublishCliCommand),
+}
+
+#[derive(Args, Debug)]
+pub struct MulticastSubscribeCliCommand {
+    /// Multicast group code(s) to subscribe to
+    #[arg(num_args = 1..)]
+    pub groups: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct MulticastUnsubscribeCliCommand {
+    /// Multicast group code(s) to unsubscribe from
+    #[arg(num_args = 1..)]
+    pub groups: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct MulticastPublishCliCommand {
+    /// Multicast group code(s) to publish to
+    #[arg(num_args = 1..)]
+    pub groups: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct MulticastUnpublishCliCommand {
+    /// Multicast group code(s) to stop publishing to
+    #[arg(num_args = 1..)]
+    pub groups: Vec<String>,
 }

--- a/client/doublezero/src/command/mod.rs
+++ b/client/doublezero/src/command/mod.rs
@@ -4,6 +4,7 @@ pub mod disconnect;
 pub mod enable;
 pub mod helpers;
 pub mod latency;
+pub mod multicast;
 pub mod routes;
 pub mod status;
 pub mod util;

--- a/client/doublezero/src/command/multicast.rs
+++ b/client/doublezero/src/command/multicast.rs
@@ -60,11 +60,11 @@ impl MulticastUnsubscribeCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
-        self.execute_inner(client, client_ip).await
+        self.execute_inner(client, client_ip)
     }
 
     /// Testable core: takes an already-resolved client_ip.
-    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+    fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
         let spinner = init_command(2);
         spinner.println(format!("⚡  Unsubscribing (client_ip: {client_ip})..."));
 
@@ -82,30 +82,49 @@ impl MulticastUnsubscribeCliCommand {
             spinner.println(warn_idle_tunnel());
         }
 
+        let mut failures: Vec<String> = Vec::new();
         for (code, group_pk) in groups {
             if !user.subscribers.contains(&group_pk) {
                 spinner.println(format!("    not subscribed to {code} — skipping"));
                 continue;
             }
             let carry_pub = user.publishers.contains(&group_pk);
-            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+            match client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                 user_pk,
                 group_pk,
                 client_ip,
                 publisher: carry_pub,
                 subscriber: false,
-            })?;
-            spinner.println(format!("    unsubscribed from {code}"));
+            }) {
+                Ok(_) => spinner.println(format!("    unsubscribed from {code}")),
+                Err(e) => {
+                    spinner.println(format!("    ❌ failed to unsubscribe from {code}: {e}"));
+                    failures.push(code);
+                }
+            }
         }
 
         finish_update(&spinner);
-        Ok(())
+        report_failures("unsubscribe", &failures)
     }
 }
 
 fn finish_update(spinner: &ProgressBar) {
     spinner.println("✅  Updated. Routes will adjust shortly.");
     spinner.finish_and_clear();
+}
+
+/// If any per-group calls failed, surface a non-zero exit by returning an error
+/// listing the affected codes. Per-group failures are already printed inline.
+fn report_failures(op: &str, failures: &[String]) -> eyre::Result<()> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+    Err(eyre::eyre!(
+        "{op} failed for {} group(s): {}",
+        failures.len(),
+        failures.join(", ")
+    ))
 }
 
 /// Returns true when removing `to_remove` publisher roles from `user` would leave
@@ -157,10 +176,10 @@ impl MulticastUnpublishCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
-        self.execute_inner(client, client_ip).await
+        self.execute_inner(client, client_ip)
     }
 
-    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+    fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
         let spinner = init_command(2);
         spinner.println(format!("⚡  Unpublishing (client_ip: {client_ip})..."));
 
@@ -187,24 +206,30 @@ impl MulticastUnpublishCliCommand {
             spinner.println(warn_idle_tunnel());
         }
 
+        let mut failures: Vec<String> = Vec::new();
         for (code, group_pk) in groups {
             if !user.publishers.contains(&group_pk) {
                 spinner.println(format!("    not publishing to {code} — skipping"));
                 continue;
             }
             let carry_sub = user.subscribers.contains(&group_pk);
-            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+            match client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                 user_pk,
                 group_pk,
                 client_ip,
                 publisher: false,
                 subscriber: carry_sub,
-            })?;
-            spinner.println(format!("    unpublished from {code}"));
+            }) {
+                Ok(_) => spinner.println(format!("    unpublished from {code}")),
+                Err(e) => {
+                    spinner.println(format!("    ❌ failed to unpublish from {code}: {e}"));
+                    failures.push(code);
+                }
+            }
         }
 
         finish_update(&spinner);
-        Ok(())
+        report_failures("unpublish", &failures)
     }
 }
 
@@ -212,10 +237,10 @@ impl MulticastSubscribeCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
-        self.execute_inner(client, client_ip).await
+        self.execute_inner(client, client_ip)
     }
 
-    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+    fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
         let spinner = init_command(2);
         spinner.println(format!("⚡  Subscribing (client_ip: {client_ip})..."));
 
@@ -223,24 +248,30 @@ impl MulticastSubscribeCliCommand {
         let groups = resolve_groups(client, &self.groups)?;
         spinner.inc(1);
 
+        let mut failures: Vec<String> = Vec::new();
         for (code, group_pk) in groups {
             if user.subscribers.contains(&group_pk) {
                 spinner.println(format!("    already subscribed to {code} — skipping"));
                 continue;
             }
             let carry_pub = user.publishers.contains(&group_pk);
-            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+            match client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                 user_pk,
                 group_pk,
                 client_ip,
                 publisher: carry_pub,
                 subscriber: true,
-            })?;
-            spinner.println(format!("    subscribed to {code}"));
+            }) {
+                Ok(_) => spinner.println(format!("    subscribed to {code}")),
+                Err(e) => {
+                    spinner.println(format!("    ❌ failed to subscribe to {code}: {e}"));
+                    failures.push(code);
+                }
+            }
         }
 
         finish_update(&spinner);
-        Ok(())
+        report_failures("subscribe", &failures)
     }
 }
 
@@ -248,10 +279,10 @@ impl MulticastPublishCliCommand {
     pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
         let controller = ServiceControllerImpl::new(None);
         let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
-        self.execute_inner(client, client_ip).await
+        self.execute_inner(client, client_ip)
     }
 
-    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+    fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
         let spinner = init_command(2);
         spinner.println(format!("⚡  Publishing (client_ip: {client_ip})..."));
 
@@ -259,24 +290,30 @@ impl MulticastPublishCliCommand {
         let groups = resolve_groups(client, &self.groups)?;
         spinner.inc(1);
 
+        let mut failures: Vec<String> = Vec::new();
         for (code, group_pk) in groups {
             if user.publishers.contains(&group_pk) {
                 spinner.println(format!("    already publishing to {code} — skipping"));
                 continue;
             }
             let carry_sub = user.subscribers.contains(&group_pk);
-            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+            match client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                 user_pk,
                 group_pk,
                 client_ip,
                 publisher: true,
                 subscriber: carry_sub,
-            })?;
-            spinner.println(format!("    publishing to {code}"));
+            }) {
+                Ok(_) => spinner.println(format!("    publishing to {code}")),
+                Err(e) => {
+                    spinner.println(format!("    ❌ failed to publish to {code}: {e}"));
+                    failures.push(code);
+                }
+            }
         }
 
         finish_update(&spinner);
-        Ok(())
+        report_failures("publish", &failures)
     }
 }
 
@@ -431,8 +468,8 @@ mod tests {
         u
     }
 
-    #[tokio::test]
-    async fn unsubscribe_removes_subscriber_role_and_preserves_publisher_role() {
+    #[test]
+    fn unsubscribe_removes_subscriber_role_and_preserves_publisher_role() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -467,11 +504,11 @@ mod tests {
         let cmd = MulticastUnsubscribeCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn unsubscribe_skips_group_user_is_not_subscribed_to() {
+    #[test]
+    fn unsubscribe_skips_group_user_is_not_subscribed_to() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -495,11 +532,11 @@ mod tests {
         let cmd = MulticastUnsubscribeCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn unsubscribe_errors_when_user_missing() {
+    #[test]
+    fn unsubscribe_errors_when_user_missing() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let mut client = create_test_client();
         client.expect_list_user().returning(|_| Ok(HashMap::new()));
@@ -507,12 +544,12 @@ mod tests {
         let cmd = MulticastUnsubscribeCliCommand {
             groups: vec!["g".into()],
         };
-        let err = cmd.execute_inner(&client, ip).await.unwrap_err();
+        let err = cmd.execute_inner(&client, ip).unwrap_err();
         assert!(err.to_string().contains("No active multicast user"));
     }
 
-    #[tokio::test]
-    async fn unsubscribe_errors_on_unknown_group_before_any_onchain_call() {
+    #[test]
+    fn unsubscribe_errors_on_unknown_group_before_any_onchain_call() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let user_pk = Pubkey::new_unique();
         let mut client = create_test_client();
@@ -532,16 +569,61 @@ mod tests {
         let cmd = MulticastUnsubscribeCliCommand {
             groups: vec!["unknown".into()],
         };
-        let err = cmd.execute_inner(&client, ip).await.unwrap_err();
+        let err = cmd.execute_inner(&client, ip).unwrap_err();
         assert!(err
             .to_string()
             .contains("Multicast group not found: unknown"));
     }
 
+    #[test]
+    fn unsubscribe_continues_after_per_group_failure_and_aggregates_error() {
+        // g1's onchain call fails; g2's must still be attempted, and the
+        // command must return an aggregated error naming g1.
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g1 = Pubkey::new_unique();
+        let g2 = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![], vec![g1, g2]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g1, make_group("g1"));
+        groups.insert(g2, make_group("g2"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| cmd.group_pk == g1)
+            .once()
+            .returning(|_| Err(eyre::eyre!("simulated chain failure")));
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| cmd.group_pk == g2)
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastUnsubscribeCliCommand {
+            groups: vec!["g1".into(), "g2".into()],
+        };
+        let err = cmd.execute_inner(&client, ip).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unsubscribe failed"), "got: {msg}");
+        assert!(msg.contains("g1"), "got: {msg}");
+        assert!(!msg.contains("g2"), "g2 should have succeeded; got: {msg}");
+    }
+
     // --- MulticastUnpublishCliCommand tests ---
 
-    #[tokio::test]
-    async fn unpublish_removes_publisher_role_and_preserves_subscriber_role() {
+    #[test]
+    fn unpublish_removes_publisher_role_and_preserves_subscriber_role() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g1 = Pubkey::new_unique();
         let g2 = Pubkey::new_unique();
@@ -574,11 +656,11 @@ mod tests {
         let cmd = MulticastUnpublishCliCommand {
             groups: vec!["g1".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn unpublish_skips_group_user_is_not_publishing_to() {
+    #[test]
+    fn unpublish_skips_group_user_is_not_publishing_to() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -602,11 +684,11 @@ mod tests {
         let cmd = MulticastUnpublishCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn unpublish_last_publisher_still_issues_onchain_call() {
+    #[test]
+    fn unpublish_last_publisher_still_issues_onchain_call() {
         // The CLI prints a warning but does not block.
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
@@ -634,11 +716,11 @@ mod tests {
         let cmd = MulticastUnpublishCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn unpublish_of_nonlast_publisher_does_not_claim_last() {
+    #[test]
+    fn unpublish_of_nonlast_publisher_does_not_claim_last() {
         // would_empty_publishers logic: user has two, remove one — NOT last.
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g1 = Pubkey::new_unique();
@@ -697,8 +779,8 @@ mod tests {
 
     // --- MulticastSubscribeCliCommand tests ---
 
-    #[tokio::test]
-    async fn subscribe_adds_subscriber_role_and_preserves_publisher_role() {
+    #[test]
+    fn subscribe_adds_subscriber_role_and_preserves_publisher_role() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -729,11 +811,11 @@ mod tests {
         let cmd = MulticastSubscribeCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn subscribe_skips_already_subscribed_group() {
+    #[test]
+    fn subscribe_skips_already_subscribed_group() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -757,13 +839,13 @@ mod tests {
         let cmd = MulticastSubscribeCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
     // --- MulticastPublishCliCommand tests ---
 
-    #[tokio::test]
-    async fn publish_adds_publisher_role_and_preserves_subscriber_role() {
+    #[test]
+    fn publish_adds_publisher_role_and_preserves_subscriber_role() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -794,11 +876,11 @@ mod tests {
         let cmd = MulticastPublishCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 
-    #[tokio::test]
-    async fn publish_skips_already_published_group() {
+    #[test]
+    fn publish_skips_already_published_group() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let g_pk = Pubkey::new_unique();
         let user_pk = Pubkey::new_unique();
@@ -822,6 +904,6 @@ mod tests {
         let cmd = MulticastPublishCliCommand {
             groups: vec!["g".into()],
         };
-        cmd.execute_inner(&client, ip).await.unwrap();
+        cmd.execute_inner(&client, ip).unwrap();
     }
 }

--- a/client/doublezero/src/command/multicast.rs
+++ b/client/doublezero/src/command/multicast.rs
@@ -1,0 +1,827 @@
+use std::net::Ipv4Addr;
+
+use doublezero_cli::{doublezerocommand::CliCommand, helpers::init_command};
+use doublezero_sdk::{
+    commands::{
+        multicastgroup::{
+            list::ListMulticastGroupCommand, subscribe::UpdateMulticastGroupRolesCommand,
+        },
+        user::list::ListUserCommand,
+    },
+    User, UserType,
+};
+use indicatif::ProgressBar;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::{
+    cli::multicast::{
+        MulticastPublishCliCommand, MulticastSubscribeCliCommand, MulticastUnpublishCliCommand,
+        MulticastUnsubscribeCliCommand,
+    },
+    servicecontroller::ServiceControllerImpl,
+};
+
+/// Resolve a list of multicast group codes to their on-chain pubkeys.
+/// Errors on any unknown code, with no onchain writes.
+pub(super) fn resolve_groups(
+    client: &dyn CliCommand,
+    codes: &[String],
+) -> eyre::Result<Vec<(String, Pubkey)>> {
+    let mcast_groups = client.list_multicastgroup(ListMulticastGroupCommand)?;
+    let mut out = Vec::with_capacity(codes.len());
+    for code in codes {
+        let (pk, _) = mcast_groups
+            .iter()
+            .find(|(_, g)| g.code == *code)
+            .ok_or_else(|| eyre::eyre!("Multicast group not found: {code}"))?;
+        out.push((code.clone(), *pk));
+    }
+    Ok(out)
+}
+
+/// Load the Multicast user for the given client_ip. Errors if none exists.
+pub(super) fn load_multicast_user(
+    client: &dyn CliCommand,
+    client_ip: Ipv4Addr,
+) -> eyre::Result<(Pubkey, User)> {
+    let users = client.list_user(ListUserCommand)?;
+    users
+        .into_iter()
+        .find(|(_, u)| u.client_ip == client_ip && u.user_type == UserType::Multicast)
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "No active multicast user for {client_ip}. \
+                 Run 'doublezero connect Multicast --publish/--subscribe <group>' first."
+            )
+        })
+}
+
+impl MulticastUnsubscribeCliCommand {
+    pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
+        let controller = ServiceControllerImpl::new(None);
+        let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
+        self.execute_inner(client, client_ip).await
+    }
+
+    /// Testable core: takes an already-resolved client_ip.
+    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+        let spinner = init_command(2);
+        spinner.println(format!("⚡  Unsubscribing (client_ip: {client_ip})..."));
+
+        let (user_pk, user) = load_multicast_user(client, client_ip)?;
+        let groups = resolve_groups(client, &self.groups)?;
+        spinner.inc(1);
+
+        let effective_removals: Vec<Pubkey> = groups
+            .iter()
+            .map(|(_, pk)| *pk)
+            .filter(|pk| user.subscribers.contains(pk))
+            .collect();
+
+        if would_empty_all_roles(&user, &[], &effective_removals) {
+            spinner.println(warn_idle_tunnel());
+        }
+
+        for (code, group_pk) in groups {
+            if !user.subscribers.contains(&group_pk) {
+                spinner.println(format!("    not subscribed to {code} — skipping"));
+                continue;
+            }
+            let carry_pub = user.publishers.contains(&group_pk);
+            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+                user_pk,
+                group_pk,
+                client_ip,
+                publisher: carry_pub,
+                subscriber: false,
+            })?;
+            spinner.println(format!("    unsubscribed from {code}"));
+        }
+
+        finish_update(&spinner);
+        Ok(())
+    }
+}
+
+fn finish_update(spinner: &ProgressBar) {
+    spinner.println("✅  Updated. Routes will adjust shortly.");
+    spinner.finish_and_clear();
+}
+
+/// Returns true when removing `to_remove` publisher roles from `user` would leave
+/// `user.publishers` empty (and the user currently has at least one publisher role).
+pub(super) fn would_empty_publishers(user: &User, to_remove: &[Pubkey]) -> bool {
+    if user.publishers.is_empty() {
+        return false;
+    }
+    let remaining = user
+        .publishers
+        .iter()
+        .filter(|p| !to_remove.contains(p))
+        .count();
+    remaining == 0
+}
+
+/// Returns true when applying the given publisher + subscriber removals would
+/// leave the user with zero multicast roles (i.e. an idle tunnel). Returns
+/// false when the call is a complete no-op (nothing to remove) so an already-
+/// empty user doesn't produce a spurious warning.
+pub(super) fn would_empty_all_roles(
+    user: &User,
+    remove_pubs: &[Pubkey],
+    remove_subs: &[Pubkey],
+) -> bool {
+    if remove_pubs.is_empty() && remove_subs.is_empty() {
+        return false;
+    }
+    let remaining_pubs = user
+        .publishers
+        .iter()
+        .filter(|p| !remove_pubs.contains(p))
+        .count();
+    let remaining_subs = user
+        .subscribers
+        .iter()
+        .filter(|s| !remove_subs.contains(s))
+        .count();
+    remaining_pubs == 0 && remaining_subs == 0
+}
+
+fn warn_idle_tunnel() -> &'static str {
+    "⚠️  This leaves your multicast user with no publisher or subscriber roles. \
+     The tunnel will remain provisioned but idle — run 'doublezero disconnect' \
+     if you want to fully tear it down."
+}
+
+impl MulticastUnpublishCliCommand {
+    pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
+        let controller = ServiceControllerImpl::new(None);
+        let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
+        self.execute_inner(client, client_ip).await
+    }
+
+    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+        let spinner = init_command(2);
+        spinner.println(format!("⚡  Unpublishing (client_ip: {client_ip})..."));
+
+        let (user_pk, user) = load_multicast_user(client, client_ip)?;
+        let groups = resolve_groups(client, &self.groups)?;
+        spinner.inc(1);
+
+        // Figure out which of the requested groups the user is actually publishing to.
+        let effective_removals: Vec<Pubkey> = groups
+            .iter()
+            .map(|(_, pk)| *pk)
+            .filter(|pk| user.publishers.contains(pk))
+            .collect();
+
+        if would_empty_publishers(&user, &effective_removals) {
+            spinner.println(
+                "⚠️  This removes your last publisher role. In legacy-allocation \
+                 environments the service may briefly reprovision while the network \
+                 reallocates.",
+            );
+        }
+
+        if would_empty_all_roles(&user, &effective_removals, &[]) {
+            spinner.println(warn_idle_tunnel());
+        }
+
+        for (code, group_pk) in groups {
+            if !user.publishers.contains(&group_pk) {
+                spinner.println(format!("    not publishing to {code} — skipping"));
+                continue;
+            }
+            let carry_sub = user.subscribers.contains(&group_pk);
+            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+                user_pk,
+                group_pk,
+                client_ip,
+                publisher: false,
+                subscriber: carry_sub,
+            })?;
+            spinner.println(format!("    unpublished from {code}"));
+        }
+
+        finish_update(&spinner);
+        Ok(())
+    }
+}
+
+impl MulticastSubscribeCliCommand {
+    pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
+        let controller = ServiceControllerImpl::new(None);
+        let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
+        self.execute_inner(client, client_ip).await
+    }
+
+    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+        let spinner = init_command(2);
+        spinner.println(format!("⚡  Subscribing (client_ip: {client_ip})..."));
+
+        let (user_pk, user) = load_multicast_user(client, client_ip)?;
+        let groups = resolve_groups(client, &self.groups)?;
+        spinner.inc(1);
+
+        for (code, group_pk) in groups {
+            if user.subscribers.contains(&group_pk) {
+                spinner.println(format!("    already subscribed to {code} — skipping"));
+                continue;
+            }
+            let carry_pub = user.publishers.contains(&group_pk);
+            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+                user_pk,
+                group_pk,
+                client_ip,
+                publisher: carry_pub,
+                subscriber: true,
+            })?;
+            spinner.println(format!("    subscribed to {code}"));
+        }
+
+        finish_update(&spinner);
+        Ok(())
+    }
+}
+
+impl MulticastPublishCliCommand {
+    pub async fn execute(self, client: &dyn CliCommand) -> eyre::Result<()> {
+        let controller = ServiceControllerImpl::new(None);
+        let client_ip = crate::command::helpers::resolve_client_ip(&controller).await?;
+        self.execute_inner(client, client_ip).await
+    }
+
+    async fn execute_inner(self, client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<()> {
+        let spinner = init_command(2);
+        spinner.println(format!("⚡  Publishing (client_ip: {client_ip})..."));
+
+        let (user_pk, user) = load_multicast_user(client, client_ip)?;
+        let groups = resolve_groups(client, &self.groups)?;
+        spinner.inc(1);
+
+        for (code, group_pk) in groups {
+            if user.publishers.contains(&group_pk) {
+                spinner.println(format!("    already publishing to {code} — skipping"));
+                continue;
+            }
+            let carry_sub = user.subscribers.contains(&group_pk);
+            client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
+                user_pk,
+                group_pk,
+                client_ip,
+                publisher: true,
+                subscriber: carry_sub,
+            })?;
+            spinner.println(format!("    publishing to {code}"));
+        }
+
+        finish_update(&spinner);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::multicast::{
+        MulticastPublishCliCommand, MulticastSubscribeCliCommand, MulticastUnpublishCliCommand,
+        MulticastUnsubscribeCliCommand,
+    };
+    use doublezero_cli::tests::utils::create_test_client;
+    use doublezero_sdk::{
+        commands::multicastgroup::subscribe::UpdateMulticastGroupRolesCommand, AccountType,
+        MulticastGroup, MulticastGroupStatus, User, UserCYOA, UserStatus,
+    };
+    use std::collections::HashMap;
+
+    fn make_user(client_ip: Ipv4Addr, user_type: UserType) -> User {
+        User {
+            account_type: AccountType::User,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            bump_seed: 0,
+            user_type,
+            tenant_pk: Pubkey::default(),
+            device_pk: Pubkey::default(),
+            cyoa_type: UserCYOA::None,
+            client_ip,
+            dz_ip: Ipv4Addr::UNSPECIFIED,
+            tunnel_id: 0,
+            tunnel_net: Default::default(),
+            status: UserStatus::Activated,
+            publishers: vec![],
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+        }
+    }
+
+    fn make_group(code: &str) -> MulticastGroup {
+        MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::default(),
+            index: 0,
+            bump_seed: 0,
+            tenant_pk: Pubkey::default(),
+            multicast_ip: Ipv4Addr::UNSPECIFIED,
+            max_bandwidth: 0,
+            status: MulticastGroupStatus::Activated,
+            code: code.to_string(),
+            publisher_count: 0,
+            subscriber_count: 0,
+        }
+    }
+
+    #[test]
+    fn resolve_groups_returns_pubkeys_in_order() {
+        let mut client = create_test_client();
+        let g1_pk = Pubkey::new_unique();
+        let g2_pk = Pubkey::new_unique();
+        let mut groups = HashMap::new();
+        groups.insert(g1_pk, make_group("g1"));
+        groups.insert(g2_pk, make_group("g2"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        let out = resolve_groups(&client, &["g2".into(), "g1".into()]).unwrap();
+        assert_eq!(out, vec![("g2".into(), g2_pk), ("g1".into(), g1_pk)]);
+    }
+
+    #[test]
+    fn resolve_groups_errors_on_unknown_code() {
+        let mut client = create_test_client();
+        let g1_pk = Pubkey::new_unique();
+        let mut groups = HashMap::new();
+        groups.insert(g1_pk, make_group("g1"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        let err = resolve_groups(&client, &["nope".into()]).unwrap_err();
+        assert!(
+            err.to_string().contains("Multicast group not found: nope"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_multicast_user_finds_user_for_client_ip() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let mut client = create_test_client();
+        let user_pk = Pubkey::new_unique();
+        let user = make_user(ip, UserType::Multicast);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user.clone());
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let (pk, loaded) = load_multicast_user(&client, ip).unwrap();
+        assert_eq!(pk, user_pk);
+        assert_eq!(loaded.client_ip, ip);
+        assert_eq!(loaded.user_type, UserType::Multicast);
+    }
+
+    #[test]
+    fn load_multicast_user_errors_when_only_ibrl_user_exists() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let mut client = create_test_client();
+        let mut users = HashMap::new();
+        users.insert(Pubkey::new_unique(), make_user(ip, UserType::IBRL));
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let err = load_multicast_user(&client, ip).unwrap_err();
+        assert!(
+            err.to_string().contains("No active multicast user"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_multicast_user_errors_when_no_user_for_this_ip() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let other_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let mut client = create_test_client();
+        let mut users = HashMap::new();
+        users.insert(
+            Pubkey::new_unique(),
+            make_user(other_ip, UserType::Multicast),
+        );
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let err = load_multicast_user(&client, ip).unwrap_err();
+        assert!(err.to_string().contains("No active multicast user"));
+    }
+
+    // --- MulticastUnsubscribeCliCommand tests ---
+
+    fn user_with_roles(ip: Ipv4Addr, publishers: Vec<Pubkey>, subscribers: Vec<Pubkey>) -> User {
+        let mut u = make_user(ip, UserType::Multicast);
+        u.publishers = publishers;
+        u.subscribers = subscribers;
+        u
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_removes_subscriber_role_and_preserves_publisher_role() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        // User is BOTH publisher and subscriber of g — unsubscribe must keep publisher=true.
+        let user = user_with_roles(ip, vec![g_pk], vec![g_pk]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| {
+                cmd.user_pk == user_pk
+                    && cmd.group_pk == g_pk
+                    && cmd.client_ip == ip
+                    && cmd.publisher
+                    && !cmd.subscriber
+            })
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastUnsubscribeCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_skips_group_user_is_not_subscribed_to() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client.expect_update_multicastgroup_roles().never();
+
+        let cmd = MulticastUnsubscribeCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_errors_when_user_missing() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let mut client = create_test_client();
+        client.expect_list_user().returning(|_| Ok(HashMap::new()));
+
+        let cmd = MulticastUnsubscribeCliCommand {
+            groups: vec!["g".into()],
+        };
+        let err = cmd.execute_inner(&client, ip).await.unwrap_err();
+        assert!(err.to_string().contains("No active multicast user"));
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_errors_on_unknown_group_before_any_onchain_call() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let user_pk = Pubkey::new_unique();
+        let mut client = create_test_client();
+
+        let user = user_with_roles(ip, vec![], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        client
+            .expect_list_multicastgroup()
+            .returning(|_| Ok(HashMap::new()));
+        client.expect_update_multicastgroup_roles().never();
+
+        let cmd = MulticastUnsubscribeCliCommand {
+            groups: vec!["unknown".into()],
+        };
+        let err = cmd.execute_inner(&client, ip).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Multicast group not found: unknown"));
+    }
+
+    // --- MulticastUnpublishCliCommand tests ---
+
+    #[tokio::test]
+    async fn unpublish_removes_publisher_role_and_preserves_subscriber_role() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g1 = Pubkey::new_unique();
+        let g2 = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        // Publisher of g1 & g2, subscriber of g1. Unpublish g1 must keep subscriber=true.
+        let user = user_with_roles(ip, vec![g1, g2], vec![g1]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g1, make_group("g1"));
+        groups.insert(g2, make_group("g2"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| {
+                cmd.user_pk == user_pk && cmd.group_pk == g1 && !cmd.publisher && cmd.subscriber
+            })
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastUnpublishCliCommand {
+            groups: vec!["g1".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unpublish_skips_group_user_is_not_publishing_to() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client.expect_update_multicastgroup_roles().never();
+
+        let cmd = MulticastUnpublishCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unpublish_last_publisher_still_issues_onchain_call() {
+        // The CLI prints a warning but does not block.
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![g_pk], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastUnpublishCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unpublish_of_nonlast_publisher_does_not_claim_last() {
+        // would_empty_publishers logic: user has two, remove one — NOT last.
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g1 = Pubkey::new_unique();
+        let g2 = Pubkey::new_unique();
+
+        let user = user_with_roles(ip, vec![g1, g2], vec![]);
+        let would_empty = super::would_empty_publishers(&user, &[g1]);
+        assert!(!would_empty);
+
+        let would_empty_all = super::would_empty_publishers(&user, &[g1, g2]);
+        assert!(would_empty_all);
+    }
+
+    #[test]
+    fn would_empty_all_roles_detects_idle_tunnel_cases() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g = Pubkey::new_unique();
+
+        // Only subscriber role; removing it empties everything.
+        let sub_only = user_with_roles(ip, vec![], vec![g]);
+        assert!(super::would_empty_all_roles(&sub_only, &[], &[g]));
+
+        // Only publisher role; removing it empties everything.
+        let pub_only = user_with_roles(ip, vec![g], vec![]);
+        assert!(super::would_empty_all_roles(&pub_only, &[g], &[]));
+    }
+
+    #[test]
+    fn would_empty_all_roles_false_when_any_role_remains() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g1 = Pubkey::new_unique();
+        let g2 = Pubkey::new_unique();
+
+        // Two subs; removing one leaves the other.
+        let two_subs = user_with_roles(ip, vec![], vec![g1, g2]);
+        assert!(!super::would_empty_all_roles(&two_subs, &[], &[g1]));
+
+        // Pub + sub; removing only the sub leaves the pub.
+        let both = user_with_roles(ip, vec![g1], vec![g2]);
+        assert!(!super::would_empty_all_roles(&both, &[], &[g2]));
+    }
+
+    #[test]
+    fn would_empty_all_roles_false_on_no_op() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g = Pubkey::new_unique();
+
+        // Nothing to remove on either side → no-op, don't warn.
+        let user = user_with_roles(ip, vec![g], vec![]);
+        assert!(!super::would_empty_all_roles(&user, &[], &[]));
+
+        // Already-empty user + no removals → don't warn.
+        let empty = user_with_roles(ip, vec![], vec![]);
+        assert!(!super::would_empty_all_roles(&empty, &[], &[]));
+    }
+
+    // --- MulticastSubscribeCliCommand tests ---
+
+    #[tokio::test]
+    async fn subscribe_adds_subscriber_role_and_preserves_publisher_role() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        // User is already a publisher of g — subscribing must keep publisher=true.
+        let user = user_with_roles(ip, vec![g_pk], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| {
+                cmd.user_pk == user_pk && cmd.group_pk == g_pk && cmd.publisher && cmd.subscriber
+            })
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastSubscribeCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn subscribe_skips_already_subscribed_group() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![], vec![g_pk]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client.expect_update_multicastgroup_roles().never();
+
+        let cmd = MulticastSubscribeCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    // --- MulticastPublishCliCommand tests ---
+
+    #[tokio::test]
+    async fn publish_adds_publisher_role_and_preserves_subscriber_role() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        // User is already a subscriber of g — publishing must keep subscriber=true.
+        let user = user_with_roles(ip, vec![], vec![g_pk]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client
+            .expect_update_multicastgroup_roles()
+            .withf(move |cmd: &UpdateMulticastGroupRolesCommand| {
+                cmd.user_pk == user_pk && cmd.group_pk == g_pk && cmd.publisher && cmd.subscriber
+            })
+            .once()
+            .returning(|_| Ok(solana_sdk::signature::Signature::default()));
+
+        let cmd = MulticastPublishCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_skips_already_published_group() {
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let g_pk = Pubkey::new_unique();
+        let user_pk = Pubkey::new_unique();
+
+        let mut client = create_test_client();
+        let user = user_with_roles(ip, vec![g_pk], vec![]);
+        let mut users = HashMap::new();
+        users.insert(user_pk, user);
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+
+        let mut groups = HashMap::new();
+        groups.insert(g_pk, make_group("g"));
+        client
+            .expect_list_multicastgroup()
+            .returning(move |_| Ok(groups.clone()));
+
+        client.expect_update_multicastgroup_roles().never();
+
+        let cmd = MulticastPublishCliCommand {
+            groups: vec!["g".into()],
+        };
+        cmd.execute_inner(&client, ip).await.unwrap();
+    }
+}

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -310,6 +310,10 @@ async fn main() -> eyre::Result<()> {
                     args.execute(&client, &mut handle)
                 }
             },
+            cli::multicast::MulticastCommands::Subscribe(args) => args.execute(&client).await,
+            cli::multicast::MulticastCommands::Unsubscribe(args) => args.execute(&client).await,
+            cli::multicast::MulticastCommands::Publish(args) => args.execute(&client).await,
+            cli::multicast::MulticastCommands::Unpublish(args) => args.execute(&client).await,
         },
 
         Command::Resource(command) => match command.command {

--- a/client/doublezerod/internal/latency/singlesocket.go
+++ b/client/doublezerod/internal/latency/singlesocket.go
@@ -3,6 +3,7 @@ package latency
 import (
 	"context"
 	"log/slog"
+	"math"
 	"net"
 	"sync/atomic"
 	"time"
@@ -27,6 +28,17 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 		return nil
 	}
 
+	// ICMP Echo ID is a 16-bit field; we use it to identify the target index
+	// when matching replies, so we can't support more targets than that.
+	if len(targets) > math.MaxUint16 {
+		slog.Error("latency: too many targets for single-socket ICMP probe", "count", len(targets), "max", math.MaxUint16)
+		results := make([]LatencyResult, len(targets))
+		for i, t := range targets {
+			results[i] = LatencyResult{Device: t.Device, InterfaceName: t.InterfaceName, IP: t.IP, Reachable: false}
+		}
+		return results
+	}
+
 	conn, err := icmp.ListenPacket("ip4:icmp", "")
 	if err != nil {
 		slog.Error("latency: failed to open ICMP socket", "error", err)
@@ -41,13 +53,6 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 	states := make([]probeState, len(targets))
 	for i, t := range targets {
 		states[i].target = t
-	}
-
-	// Build a lookup from destination IP to list of target indices (multiple
-	// targets can share an IP in theory, but typically they don't).
-	ipToIndices := make(map[string][]int, len(targets))
-	for i, t := range targets {
-		ipToIndices[t.IP.String()] = append(ipToIndices[t.IP.String()], i)
 	}
 
 	payload := make([]byte, pingPayload)
@@ -89,19 +94,31 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 				continue
 			}
 
-			peerIP := peer.String()
-			indices, ok := ipToIndices[peerIP]
-			if !ok {
+			// The echo ID carries the target index from the send side; verify
+			// the peer IP matches to guard against kernel ID mangling or
+			// stray replies from another process's pings.
+			idx := echo.ID
+			if idx < 0 || idx >= len(states) {
+				continue
+			}
+			peerAddr, ok := peer.(*net.IPAddr)
+			if !ok || !states[idx].target.IP.Equal(peerAddr.IP) {
 				continue
 			}
 
-			for _, idx := range indices {
-				if !states[idx].rtts[seq].got {
-					states[idx].rtts[seq].got = true
-					states[idx].rtts[seq].rtt = receiveTime.Sub(states[idx].rtts[seq].sent)
-					totalReceived.Add(1)
-				}
+			if states[idx].rtts[seq].got {
+				continue
 			}
+			sentNanos := states[idx].rtts[seq].sent.Load()
+			if sentNanos == 0 {
+				// Reply observed before the send time was recorded. Shouldn't
+				// happen since the sender records sent before calling WriteTo,
+				// but guard so we never compute a garbage RTT.
+				continue
+			}
+			states[idx].rtts[seq].got = true
+			states[idx].rtts[seq].rtt = receiveTime.Sub(time.Unix(0, sentNanos))
+			totalReceived.Add(1)
 		}
 	}()
 
@@ -122,7 +139,9 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 				slog.Error("latency: failed to marshal ICMP message", "target", t.IP, "error", err)
 				continue
 			}
-			states[i].rtts[seq].sent = time.Now()
+			// Record send time atomically so the reader goroutine observes it
+			// with proper memory synchronization.
+			states[i].rtts[seq].sent.Store(time.Now().UnixNano())
 			_, err = conn.WriteTo(b, &net.IPAddr{IP: t.IP})
 			if err != nil {
 				slog.Error("latency: failed to send ICMP echo", "target", t.IP, "error", err)
@@ -147,7 +166,7 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 }
 
 type rttEntry struct {
-	sent time.Time
+	sent atomic.Int64 // UnixNano of send time; 0 means not yet sent
 	rtt  time.Duration
 	got  bool
 }
@@ -159,12 +178,14 @@ type probeState struct {
 
 func buildResults(states []probeState) []LatencyResult {
 	results := make([]LatencyResult, len(states))
-	for i, s := range states {
+	for i := range states {
+		s := &states[i]
 		var received int
 		var total, minRtt, maxRtt time.Duration
 		minRtt = time.Hour // sentinel
 
-		for _, r := range s.rtts {
+		for j := range s.rtts {
+			r := &s.rtts[j]
 			if r.got {
 				received++
 				total += r.rtt

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -558,6 +558,50 @@ func (dn *TestDevnet) AddMulticastSubscriberGroupSkipAccessPass(t *testing.T, cl
 	dn.log.Debug("--> Multicast subscriber groups added incrementally")
 }
 
+// SubscribeMulticastGroup adds subscriber role(s) to an already-connected multicast user.
+func (dn *TestDevnet) SubscribeMulticastGroup(t *testing.T, client *devnet.Client, multicastGroupCodes ...string) {
+	dn.log.Debug("==> Subscribing to multicast groups", "clientIP", client.CYOANetworkIP, "groups", multicastGroupCodes)
+
+	groupArgs := strings.Join(multicastGroupCodes, " ")
+	_, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero multicast subscribe " + groupArgs})
+	require.NoError(t, err, "failed to subscribe to multicast groups")
+
+	dn.log.Debug("--> Subscribed to multicast groups")
+}
+
+// UnsubscribeMulticastGroup removes subscriber role(s) from an already-connected multicast user.
+func (dn *TestDevnet) UnsubscribeMulticastGroup(t *testing.T, client *devnet.Client, multicastGroupCodes ...string) {
+	dn.log.Debug("==> Unsubscribing from multicast groups", "clientIP", client.CYOANetworkIP, "groups", multicastGroupCodes)
+
+	groupArgs := strings.Join(multicastGroupCodes, " ")
+	_, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero multicast unsubscribe " + groupArgs})
+	require.NoError(t, err, "failed to unsubscribe from multicast groups")
+
+	dn.log.Debug("--> Unsubscribed from multicast groups")
+}
+
+// PublishMulticastGroup adds publisher role(s) to an already-connected multicast user.
+func (dn *TestDevnet) PublishMulticastGroup(t *testing.T, client *devnet.Client, multicastGroupCodes ...string) {
+	dn.log.Debug("==> Publishing to multicast groups", "clientIP", client.CYOANetworkIP, "groups", multicastGroupCodes)
+
+	groupArgs := strings.Join(multicastGroupCodes, " ")
+	_, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero multicast publish " + groupArgs})
+	require.NoError(t, err, "failed to publish to multicast groups")
+
+	dn.log.Debug("--> Published to multicast groups")
+}
+
+// UnpublishMulticastGroup removes publisher role(s) from an already-connected multicast user.
+func (dn *TestDevnet) UnpublishMulticastGroup(t *testing.T, client *devnet.Client, multicastGroupCodes ...string) {
+	dn.log.Debug("==> Unpublishing from multicast groups", "clientIP", client.CYOANetworkIP, "groups", multicastGroupCodes)
+
+	groupArgs := strings.Join(multicastGroupCodes, " ")
+	_, err := client.Exec(t.Context(), []string{"bash", "-c", "doublezero multicast unpublish " + groupArgs})
+	require.NoError(t, err, "failed to unpublish from multicast groups")
+
+	dn.log.Debug("--> Unpublished from multicast groups")
+}
+
 func (dn *TestDevnet) DisconnectMulticastSubscriber(t *testing.T, client *devnet.Client) {
 	dn.log.Debug("==> Disconnecting multicast subscriber", "clientIP", client.CYOANetworkIP)
 

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -225,6 +225,87 @@ func TestE2E_Multicast(t *testing.T) {
 		return
 	}
 
+	if !t.Run("modify_roles", func(t *testing.T) {
+		// doublezero user list renders multicast memberships in a column named `groups`
+		// with each entry prefixed "P:<code>" (publisher) or "S:<code>" (subscriber).
+		// See smartcontract/cli/src/user/list.rs::format_multicast_group_names.
+
+		subscriberRow := func() map[string]string {
+			out, err := dn.Manager.Exec(t.Context(), []string{"doublezero", "user", "list"})
+			if err != nil {
+				return nil
+			}
+			for _, row := range fixtures.ParseCLITable(out) {
+				if row["user_type"] == "Multicast" && row["client_ip"] == subscriberClient.CYOANetworkIP {
+					return row
+				}
+			}
+			return nil
+		}
+		publisherRow := func() map[string]string {
+			out, err := dn.Manager.Exec(t.Context(), []string{"doublezero", "user", "list"})
+			if err != nil {
+				return nil
+			}
+			for _, row := range fixtures.ParseCLITable(out) {
+				if row["user_type"] == "Multicast" && row["client_ip"] == publisherClient.CYOANetworkIP {
+					return row
+				}
+			}
+			return nil
+		}
+
+		// Unsubscribe the subscriber from mg01 (keeps it subscribed to mg02).
+		tdn.UnsubscribeMulticastGroup(t, subscriberClient, "mg01")
+
+		require.Eventually(t, func() bool {
+			row := subscriberRow()
+			if row == nil {
+				return false
+			}
+			groups := row["groups"]
+			return !strings.Contains(groups, "S:mg01") && strings.Contains(groups, "S:mg02")
+		}, 60*time.Second, 2*time.Second, "subscriber should be unsubscribed from mg01 but still subscribed to mg02")
+
+		// Unpublish the publisher from mg01 (keeps it publishing to mg02).
+		tdn.UnpublishMulticastGroup(t, publisherClient, "mg01")
+
+		require.Eventually(t, func() bool {
+			row := publisherRow()
+			if row == nil {
+				return false
+			}
+			groups := row["groups"]
+			return !strings.Contains(groups, "P:mg01") && strings.Contains(groups, "P:mg02")
+		}, 60*time.Second, 2*time.Second, "publisher should be unpublished from mg01 but still publishing to mg02")
+
+		// Tunnels should still be up — key assertion: no disconnect required.
+		err := publisherClient.WaitForTunnelUp(t.Context(), 30*time.Second)
+		require.NoError(t, err, "publisher tunnel should remain up after unpublish")
+		err = subscriberClient.WaitForTunnelUp(t.Context(), 30*time.Second)
+		require.NoError(t, err, "subscriber tunnel should remain up after unsubscribe")
+
+		// Restore pre-test state so the disconnect sub-test exercises the same two-group
+		// teardown it did before.
+		tdn.SubscribeMulticastGroup(t, subscriberClient, "mg01")
+		tdn.PublishMulticastGroup(t, publisherClient, "mg01")
+
+		require.Eventually(t, func() bool {
+			pub := publisherRow()
+			sub := subscriberRow()
+			if pub == nil || sub == nil {
+				return false
+			}
+			return strings.Contains(pub["groups"], "P:mg01") &&
+				strings.Contains(pub["groups"], "P:mg02") &&
+				strings.Contains(sub["groups"], "S:mg01") &&
+				strings.Contains(sub["groups"], "S:mg02")
+		}, 60*time.Second, 2*time.Second, "roles should be restored for both clients")
+	}) {
+		t.Fail()
+		return
+	}
+
 	if !t.Run("disconnect", func(t *testing.T) {
 		tdn.DisconnectMulticastPublisher(t, publisherClient)
 		tdn.DisconnectMulticastSubscriber(t, subscriberClient)


### PR DESCRIPTION
## Summary of Changes
This PR adds the ability for a user to unsubscribe or no longer publish without the need for a disconnect. This is only for connections managed by the user, ie not the oracle. There's a warning if a user tries to unpublish or unsubscribe from their only remaining group.

Closes https://github.com/malbeclabs/doublezero/issues/3575

## Testing Verification
* Updated e2e test
* Resolved a flaky single socket issue
* rust rests
