### PR TITLE
controller: write config agent version info to ClickHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
 - Collector
   - fallback to any probe if anchor probes aren't available
+- Device Controller
+  - store config agent version info in clickhouse
 - Smartcontract
   - Fix multicast group allowlist add/remove for AccessPasses created with `allow_multiple_ip=true`; the processors were rejecting requests with a real client IP because the stored IP is always `0.0.0.0` for these passes ([#3551](https://github.com/malbeclabs/doublezero/issues/3551))
   - SDK now auto-detects the correct AccessPass PDA (static or dynamic) for allowlist operations based on whether an `allow_multiple_ip` pass exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
   - EdgeSeat multicast connect is metro-gated: a device whose exchange is not covered by any of the pass's feeds is rejected with `MetroMismatch`, and the matching feed's per-feed cap is enforced. (#3955)
 - SDK
   - Go, TypeScript, and Python deserialization for the `Feed` account and the `EdgeSeat` `FeedSeat` payload. (#3956)
+- Controller
+  - Track the latest config agent version per device in a new `controller_agent_versions` ClickHouse table, updated on GetConfig polls. (#3578)
 
 ### Changes
 
@@ -393,8 +395,6 @@ All notable changes to this project will be documented in this file.
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
 - Collector
   - fallback to any probe if anchor probes aren't available
-- Device Controller
-  - store config agent version info in clickhouse
 - Smartcontract
   - Fix `BackfillTopology` account ordering: payer and system_program are now correctly placed after the variable-length device list, not before it
   - Fix `BackfillTopology` SID collision: flex-algo node segment indices are now guaranteed not to duplicate any existing base `node_segment_idx` value on the device

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,8 @@ All notable changes to this project will be documented in this file.
   - Filter devices by type-specific capacity during auto-selection so clients are not provisioned onto devices that have reached their unicast, multicast publisher, or multicast subscriber limits
 - Collector
   - fallback to any probe if anchor probes aren't available
+- Device Controller
+  - store config agent version info in clickhouse
 - Smartcontract
   - Fix `BackfillTopology` account ordering: payer and system_program are now correctly placed after the variable-length device list, not before it
   - Fix `BackfillTopology` SID collision: flex-algo node segment indices are now guaranteed not to duplicate any existing base `node_segment_idx` value on the device

--- a/controlplane/controller/README.md
+++ b/controlplane/controller/README.md
@@ -26,11 +26,14 @@ CREATE USER controller_devnet IDENTIFIED BY 'your_password';
 
 -- Grant permissions
 GRANT SELECT, INSERT, CREATE TABLE, SHOW COLUMNS ON devnet.controller_grpc_getconfig_success TO controller_devnet;
+GRANT SELECT, INSERT, CREATE TABLE, SHOW COLUMNS ON devnet.controller_agent_versions TO controller_devnet;
 ```
 
-The controller will automatically create the `controller_grpc_getconfig_success` table on startup and batch-insert GetConfig events every 10 seconds.
+The controller automatically creates both tables on startup and batch-inserts every 10 seconds.
 
-#### Table Schema
+#### Table Schemas
+
+**GetConfig events** — one row per successful GetConfig poll:
 
 ```sql
 CREATE TABLE devnet.controller_grpc_getconfig_success (
@@ -39,4 +42,20 @@ CREATE TABLE devnet.controller_grpc_getconfig_success (
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (timestamp, device_pubkey)
+```
+
+**Agent versions** — latest agent and controller version per device. Uses `ReplacingMergeTree` so ClickHouse merges rows down to one per device; query with `FINAL` for deduplicated results:
+
+```sql
+CREATE TABLE devnet.controller_agent_versions (
+    device_pubkey LowCardinality(String),
+    updated_at DateTime64(3),
+    agent_version LowCardinality(String) DEFAULT '',
+    agent_commit LowCardinality(String) DEFAULT '',
+    agent_date LowCardinality(String) DEFAULT '',
+    controller_version LowCardinality(String) DEFAULT '',
+    controller_commit LowCardinality(String) DEFAULT '',
+    controller_date LowCardinality(String) DEFAULT ''
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY device_pubkey
 ```

--- a/controlplane/controller/README.md
+++ b/controlplane/controller/README.md
@@ -109,6 +109,8 @@ GRANT SELECT, INSERT, CREATE TABLE, SHOW COLUMNS ON devnet.controller_agent_vers
 
 The controller automatically creates both tables on startup and batch-inserts every 10 seconds.
 
+Apply the grants **before** deploying a controller version that adds a table: table creation degrades per-table, so a failing `CREATE TABLE` (e.g. a missing grant) disables writes to that table until restart while the other table keeps working. Failures are logged at `ERROR`.
+
 #### Table Schemas
 
 **GetConfig events** — one row per successful GetConfig poll:
@@ -137,3 +139,8 @@ CREATE TABLE devnet.controller_agent_versions (
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY device_pubkey
 ```
+
+Caveats for consumers of this table:
+
+- Rows are **last-reported values, agent-asserted over an unauthenticated endpoint** with latest-write-wins semantics — treat them as informational, not verified fleet state.
+- Blank version reports are skipped, so a device whose agent never reports version fields gets no row (indistinguishable from never having polled), and a downgrade to a non-reporting agent leaves the old row in place. Check `updated_at` freshness or join against `controller_grpc_getconfig_success` for liveness.

--- a/controlplane/controller/README.md
+++ b/controlplane/controller/README.md
@@ -104,11 +104,14 @@ CREATE USER controller_devnet IDENTIFIED BY 'your_password';
 
 -- Grant permissions
 GRANT SELECT, INSERT, CREATE TABLE, SHOW COLUMNS ON devnet.controller_grpc_getconfig_success TO controller_devnet;
+GRANT SELECT, INSERT, CREATE TABLE, SHOW COLUMNS ON devnet.controller_agent_versions TO controller_devnet;
 ```
 
-The controller will automatically create the `controller_grpc_getconfig_success` table on startup and batch-insert GetConfig events every 10 seconds.
+The controller automatically creates both tables on startup and batch-inserts every 10 seconds.
 
-#### Table Schema
+#### Table Schemas
+
+**GetConfig events** — one row per successful GetConfig poll:
 
 ```sql
 CREATE TABLE devnet.controller_grpc_getconfig_success (
@@ -117,4 +120,20 @@ CREATE TABLE devnet.controller_grpc_getconfig_success (
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (timestamp, device_pubkey)
+```
+
+**Agent versions** — latest agent and controller version per device. Uses `ReplacingMergeTree` so ClickHouse merges rows down to one per device; query with `FINAL` for deduplicated results:
+
+```sql
+CREATE TABLE devnet.controller_agent_versions (
+    device_pubkey LowCardinality(String),
+    updated_at DateTime64(3),
+    agent_version LowCardinality(String) DEFAULT '',
+    agent_commit LowCardinality(String) DEFAULT '',
+    agent_date LowCardinality(String) DEFAULT '',
+    controller_version LowCardinality(String) DEFAULT '',
+    controller_commit LowCardinality(String) DEFAULT '',
+    controller_date LowCardinality(String) DEFAULT ''
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY device_pubkey
 ```

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -238,7 +238,7 @@ func (c *ControllerCommand) Run() error {
 		}
 		chPass := os.Getenv("CLICKHOUSE_PASS")
 		chTLSDisabled := os.Getenv("CLICKHOUSE_TLS_DISABLED") == "true"
-		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled)
+		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled, version, commit, date)
 		if err != nil {
 			log.Warn("clickhouse connection failed, continuing without clickhouse", "addr", chAddr, "error", err)
 		} else {

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -257,7 +257,7 @@ func (c *ControllerCommand) Run() error {
 		}
 		chPass := os.Getenv("CLICKHOUSE_PASS")
 		chTLSDisabled := os.Getenv("CLICKHOUSE_TLS_DISABLED") == "true"
-		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled)
+		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled, version, commit, date)
 		if err != nil {
 			log.Warn("clickhouse connection failed, continuing without clickhouse", "addr", chAddr, "error", err)
 		} else {

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -257,7 +257,7 @@ func (c *ControllerCommand) Run() error {
 		}
 		chPass := os.Getenv("CLICKHOUSE_PASS")
 		chTLSDisabled := os.Getenv("CLICKHOUSE_TLS_DISABLED") == "true"
-		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled, version, commit, date)
+		cw, err := controller.NewClickhouseWriter(log, chAddr, chDB, chUser, chPass, chTLSDisabled, controller.Build{Version: version, Commit: commit, Date: date})
 		if err != nil {
 			log.Warn("clickhouse connection failed, continuing without clickhouse", "addr", chAddr, "error", err)
 		} else {

--- a/controlplane/controller/internal/controller/clickhouse.go
+++ b/controlplane/controller/internal/controller/clickhouse.go
@@ -17,13 +17,30 @@ type getConfigEvent struct {
 	DevicePubkey string
 }
 
+type versionEvent struct {
+	DevicePubkey      string
+	UpdatedAt         time.Time
+	AgentVersion      string
+	AgentCommit       string
+	AgentDate         string
+	ControllerVersion string
+	ControllerCommit  string
+	ControllerDate    string
+}
+
 type ClickhouseWriter struct {
 	conn              clickhouse.Conn
 	log               *slog.Logger
 	db                string
 	mu                sync.Mutex
 	events            []getConfigEvent
+	versions          []versionEvent
 	consecutiveErrors int
+
+	// Controller build info, stamped on every version event.
+	controllerVersion string
+	controllerCommit  string
+	controllerDate    string
 }
 
 // consecutiveErrorThreshold is the number of consecutive flush failures
@@ -53,7 +70,7 @@ func buildClickhouseOptions(addr, db, user, pass string, disableTLS bool) *click
 	return opts
 }
 
-func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableTLS bool) (*ClickhouseWriter, error) {
+func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableTLS bool, controllerVersion, controllerCommit, controllerDate string) (*ClickhouseWriter, error) {
 	chOpts := buildClickhouseOptions(addr, db, user, pass, disableTLS)
 	conn, err := clickhouse.Open(chOpts)
 	if err != nil {
@@ -63,13 +80,16 @@ func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableT
 		return nil, fmt.Errorf("error pinging clickhouse: %w", err)
 	}
 	return &ClickhouseWriter{
-		conn: conn,
-		log:  log,
-		db:   db,
+		conn:              conn,
+		log:               log,
+		db:                db,
+		controllerVersion: controllerVersion,
+		controllerCommit:  controllerCommit,
+		controllerDate:    controllerDate,
 	}, nil
 }
 
-func (cw *ClickhouseWriter) CreateTable(ctx context.Context) error {
+func (cw *ClickhouseWriter) CreateTables(ctx context.Context) error {
 	err := cw.conn.Exec(ctx, fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS "%s".controller_grpc_getconfig_success (
 			timestamp DateTime64(3),
@@ -79,14 +99,41 @@ func (cw *ClickhouseWriter) CreateTable(ctx context.Context) error {
 		ORDER BY (timestamp, device_pubkey)
 	`, cw.db))
 	if err != nil {
-		return fmt.Errorf("error creating table: %w", err)
+		return fmt.Errorf("error creating getconfig table: %w", err)
 	}
+
+	err = cw.conn.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS "%s".controller_agent_versions (
+			device_pubkey LowCardinality(String),
+			updated_at DateTime64(3),
+			agent_version LowCardinality(String) DEFAULT '',
+			agent_commit LowCardinality(String) DEFAULT '',
+			agent_date LowCardinality(String) DEFAULT '',
+			controller_version LowCardinality(String) DEFAULT '',
+			controller_commit LowCardinality(String) DEFAULT '',
+			controller_date LowCardinality(String) DEFAULT ''
+		) ENGINE = ReplacingMergeTree(updated_at)
+		ORDER BY device_pubkey
+	`, cw.db))
+	if err != nil {
+		return fmt.Errorf("error creating agent_versions table: %w", err)
+	}
+
 	return nil
 }
 
 func (cw *ClickhouseWriter) Record(event getConfigEvent) {
 	cw.mu.Lock()
 	cw.events = append(cw.events, event)
+	cw.mu.Unlock()
+}
+
+func (cw *ClickhouseWriter) RecordVersion(event versionEvent) {
+	event.ControllerVersion = cw.controllerVersion
+	event.ControllerCommit = cw.controllerCommit
+	event.ControllerDate = cw.controllerDate
+	cw.mu.Lock()
+	cw.versions = append(cw.versions, event)
 	cw.mu.Unlock()
 }
 
@@ -106,14 +153,21 @@ func (cw *ClickhouseWriter) Run(ctx context.Context) {
 
 func (cw *ClickhouseWriter) flush(ctx context.Context) {
 	cw.mu.Lock()
-	if len(cw.events) == 0 {
-		cw.mu.Unlock()
-		return
-	}
 	events := cw.events
 	cw.events = nil
+	versions := cw.versions
+	cw.versions = nil
 	cw.mu.Unlock()
 
+	if len(events) > 0 {
+		cw.flushEvents(ctx, events)
+	}
+	if len(versions) > 0 {
+		cw.flushVersions(ctx, versions)
+	}
+}
+
+func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigEvent) {
 	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
 		`INSERT INTO "%s".controller_grpc_getconfig_success (timestamp, device_pubkey)`, cw.db,
 	))
@@ -137,6 +191,31 @@ func (cw *ClickhouseWriter) flush(ctx context.Context) {
 	}
 	cw.consecutiveErrors = 0
 	cw.log.Debug("flushed getconfig events to clickhouse", "count", len(events))
+}
+
+func (cw *ClickhouseWriter) flushVersions(ctx context.Context, versions []versionEvent) {
+	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
+		`INSERT INTO "%s".controller_agent_versions (device_pubkey, updated_at, agent_version, agent_commit, agent_date, controller_version, controller_commit, controller_date)`, cw.db,
+	))
+	if err != nil {
+		cw.recordFlushError("error preparing clickhouse versions batch", err)
+		return
+	}
+	for _, v := range versions {
+		if err := batch.Append(v.DevicePubkey, v.UpdatedAt, v.AgentVersion, v.AgentCommit, v.AgentDate, v.ControllerVersion, v.ControllerCommit, v.ControllerDate); err != nil {
+			cw.logFlushError("error appending to clickhouse versions batch", err)
+		}
+	}
+	if err := batch.Send(); err != nil {
+		_ = batch.Close()
+		cw.recordFlushError("error sending clickhouse versions batch", err)
+		return
+	}
+	if err := batch.Close(); err != nil {
+		cw.recordFlushError("error closing clickhouse versions batch", err)
+		return
+	}
+	cw.log.Debug("flushed version events to clickhouse", "count", len(versions))
 }
 
 // recordFlushError increments the consecutive error counter and logs at the

--- a/controlplane/controller/internal/controller/clickhouse.go
+++ b/controlplane/controller/internal/controller/clickhouse.go
@@ -17,35 +17,56 @@ type getConfigEvent struct {
 	DevicePubkey string
 }
 
+// agentVersionReport is the caller-supplied part of a version row. The
+// controller build info columns are stamped by RecordVersion.
+type agentVersionReport struct {
+	DevicePubkey string
+	UpdatedAt    time.Time
+	AgentVersion string
+	AgentCommit  string
+	AgentDate    string
+}
+
 type versionEvent struct {
-	DevicePubkey      string
-	UpdatedAt         time.Time
-	AgentVersion      string
-	AgentCommit       string
-	AgentDate         string
+	agentVersionReport
 	ControllerVersion string
 	ControllerCommit  string
 	ControllerDate    string
 }
 
+// Build identifies a controller build; it is stamped on every version row.
+type Build struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 type ClickhouseWriter struct {
-	conn              clickhouse.Conn
-	log               *slog.Logger
-	db                string
+	conn  clickhouse.Conn
+	log   *slog.Logger
+	db    string
+	build Build
+
+	// mu guards the buffers, the per-table enabled flags, and
+	// consecutiveErrors: one writer may be shared by two Controller instances
+	// (plaintext + TLS listeners), each running its own flush loop.
 	mu                sync.Mutex
 	events            []getConfigEvent
 	versions          []versionEvent
+	eventsEnabled     bool
+	versionsEnabled   bool
 	consecutiveErrors int
-
-	// Controller build info, stamped on every version event.
-	controllerVersion string
-	controllerCommit  string
-	controllerDate    string
 }
 
 // consecutiveErrorThreshold is the number of consecutive flush failures
 // before escalating from WARN to ERROR level logging.
 const consecutiveErrorThreshold = 3
+
+// maxAgentFieldLen caps agent-reported version strings. They come verbatim
+// from an unauthenticated request and land in LowCardinality(String) columns,
+// so unbounded values would bloat the in-memory buffer and the column
+// dictionary.
+const maxAgentFieldLen = 128
 
 // buildClickhouseOptions constructs clickhouse.Options for the HTTP protocol.
 // When disableTLS is false (default), TLS is enabled (HTTPS).
@@ -70,7 +91,7 @@ func buildClickhouseOptions(addr, db, user, pass string, disableTLS bool) *click
 	return opts
 }
 
-func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableTLS bool, controllerVersion, controllerCommit, controllerDate string) (*ClickhouseWriter, error) {
+func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableTLS bool, build Build) (*ClickhouseWriter, error) {
 	chOpts := buildClickhouseOptions(addr, db, user, pass, disableTLS)
 	conn, err := clickhouse.Open(chOpts)
 	if err != nil {
@@ -80,17 +101,19 @@ func NewClickhouseWriter(log *slog.Logger, addr, db, user, pass string, disableT
 		return nil, fmt.Errorf("error pinging clickhouse: %w", err)
 	}
 	return &ClickhouseWriter{
-		conn:              conn,
-		log:               log,
-		db:                db,
-		controllerVersion: controllerVersion,
-		controllerCommit:  controllerCommit,
-		controllerDate:    controllerDate,
+		conn:  conn,
+		log:   log,
+		db:    db,
+		build: build,
 	}, nil
 }
 
+// CreateTables creates the tables the writer needs and enables writes
+// per-table, so a single failing CREATE (e.g. a missing per-table GRANT on an
+// upgraded deployment) disables only that table's writes instead of the whole
+// writer. An error is returned only when no table is usable.
 func (cw *ClickhouseWriter) CreateTables(ctx context.Context) error {
-	err := cw.conn.Exec(ctx, fmt.Sprintf(`
+	eventsErr := cw.conn.Exec(ctx, fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS "%s".controller_grpc_getconfig_success (
 			timestamp DateTime64(3),
 			device_pubkey LowCardinality(String)
@@ -98,11 +121,11 @@ func (cw *ClickhouseWriter) CreateTables(ctx context.Context) error {
 		PARTITION BY toYYYYMM(timestamp)
 		ORDER BY (timestamp, device_pubkey)
 	`, cw.db))
-	if err != nil {
-		return fmt.Errorf("error creating getconfig table: %w", err)
+	if eventsErr != nil {
+		cw.log.Error("error creating getconfig table, disabling getconfig event writes", "error", eventsErr)
 	}
 
-	err = cw.conn.Exec(ctx, fmt.Sprintf(`
+	versionsErr := cw.conn.Exec(ctx, fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS "%s".controller_agent_versions (
 			device_pubkey LowCardinality(String),
 			updated_at DateTime64(3),
@@ -115,32 +138,58 @@ func (cw *ClickhouseWriter) CreateTables(ctx context.Context) error {
 		) ENGINE = ReplacingMergeTree(updated_at)
 		ORDER BY device_pubkey
 	`, cw.db))
-	if err != nil {
-		return fmt.Errorf("error creating agent_versions table: %w", err)
+	if versionsErr != nil {
+		cw.log.Error("error creating agent_versions table, disabling version writes", "error", versionsErr)
 	}
 
+	cw.mu.Lock()
+	cw.eventsEnabled = eventsErr == nil
+	cw.versionsEnabled = versionsErr == nil
+	cw.mu.Unlock()
+
+	if eventsErr != nil && versionsErr != nil {
+		return fmt.Errorf("error creating tables: %w; %w", eventsErr, versionsErr)
+	}
 	return nil
 }
 
 func (cw *ClickhouseWriter) Record(event getConfigEvent) {
 	cw.mu.Lock()
+	defer cw.mu.Unlock()
+	if !cw.eventsEnabled {
+		return
+	}
 	cw.events = append(cw.events, event)
-	cw.mu.Unlock()
 }
 
-func (cw *ClickhouseWriter) RecordVersion(event versionEvent) {
+func (cw *ClickhouseWriter) RecordVersion(report agentVersionReport) {
 	// A blank report (e.g. an old or restarting agent) must not overwrite the
 	// last known good version row, since ReplacingMergeTree keeps the row with
 	// the newest updated_at.
-	if event.AgentVersion == "" && event.AgentCommit == "" && event.AgentDate == "" {
+	if report.AgentVersion == "" && report.AgentCommit == "" && report.AgentDate == "" {
 		return
 	}
-	event.ControllerVersion = cw.controllerVersion
-	event.ControllerCommit = cw.controllerCommit
-	event.ControllerDate = cw.controllerDate
+	report.AgentVersion = truncateAgentField(report.AgentVersion)
+	report.AgentCommit = truncateAgentField(report.AgentCommit)
+	report.AgentDate = truncateAgentField(report.AgentDate)
 	cw.mu.Lock()
-	cw.versions = append(cw.versions, event)
-	cw.mu.Unlock()
+	defer cw.mu.Unlock()
+	if !cw.versionsEnabled {
+		return
+	}
+	cw.versions = append(cw.versions, versionEvent{
+		agentVersionReport: report,
+		ControllerVersion:  cw.build.Version,
+		ControllerCommit:   cw.build.Commit,
+		ControllerDate:     cw.build.Date,
+	})
+}
+
+func truncateAgentField(s string) string {
+	if len(s) > maxAgentFieldLen {
+		return s[:maxAgentFieldLen]
+	}
+	return s
 }
 
 func (cw *ClickhouseWriter) Run(ctx context.Context) {
@@ -175,9 +224,15 @@ func (cw *ClickhouseWriter) flush(ctx context.Context) {
 	if len(versions) > 0 {
 		ok = cw.flushVersions(ctx, versions) && ok
 	}
+	// The counter advances at most once per flush pass so that
+	// consecutiveErrorThreshold counts failed ticks, not failed sub-flushes.
+	cw.mu.Lock()
 	if ok {
 		cw.consecutiveErrors = 0
+	} else {
+		cw.consecutiveErrors++
 	}
+	cw.mu.Unlock()
 }
 
 func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigEvent) bool {
@@ -185,21 +240,25 @@ func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigE
 		`INSERT INTO "%s".controller_grpc_getconfig_success (timestamp, device_pubkey)`, cw.db,
 	))
 	if err != nil {
-		cw.recordFlushError("error preparing clickhouse batch", err)
+		cw.logFlushError("error preparing clickhouse batch", err)
 		return false
 	}
 	for _, e := range events {
 		if err := batch.Append(e.Timestamp, e.DevicePubkey); err != nil {
+			// An Append error is systematic (wrong arity or types), so don't
+			// send a partial batch.
+			_ = batch.Close()
 			cw.logFlushError("error appending to clickhouse batch", err)
+			return false
 		}
 	}
 	if err := batch.Send(); err != nil {
 		_ = batch.Close()
-		cw.recordFlushError("error sending clickhouse batch", err)
+		cw.logFlushError("error sending clickhouse batch", err)
 		return false
 	}
 	if err := batch.Close(); err != nil {
-		cw.recordFlushError("error closing clickhouse batch", err)
+		cw.logFlushError("error closing clickhouse batch", err)
 		return false
 	}
 	cw.log.Debug("flushed getconfig events to clickhouse", "count", len(events))
@@ -207,42 +266,54 @@ func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigE
 }
 
 func (cw *ClickhouseWriter) flushVersions(ctx context.Context, versions []versionEvent) bool {
+	// Agents poll faster than the flush interval, so a tick usually buffers
+	// several rows per device; only the newest per device would survive the
+	// ReplacingMergeTree anyway, so skip inserting the rest.
+	newest := make(map[string]versionEvent, len(versions))
+	for _, v := range versions {
+		if cur, seen := newest[v.DevicePubkey]; !seen || v.UpdatedAt.After(cur.UpdatedAt) {
+			newest[v.DevicePubkey] = v
+		}
+	}
+
 	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
 		`INSERT INTO "%s".controller_agent_versions (device_pubkey, updated_at, agent_version, agent_commit, agent_date, controller_version, controller_commit, controller_date)`, cw.db,
 	))
 	if err != nil {
-		cw.recordFlushError("error preparing clickhouse versions batch", err)
+		cw.logFlushError("error preparing clickhouse versions batch", err)
 		return false
 	}
-	for _, v := range versions {
+	for _, v := range newest {
 		if err := batch.Append(v.DevicePubkey, v.UpdatedAt, v.AgentVersion, v.AgentCommit, v.AgentDate, v.ControllerVersion, v.ControllerCommit, v.ControllerDate); err != nil {
+			// An Append error is systematic (wrong arity or types), so don't
+			// send a partial batch.
+			_ = batch.Close()
 			cw.logFlushError("error appending to clickhouse versions batch", err)
+			return false
 		}
 	}
 	if err := batch.Send(); err != nil {
 		_ = batch.Close()
-		cw.recordFlushError("error sending clickhouse versions batch", err)
+		cw.logFlushError("error sending clickhouse versions batch", err)
 		return false
 	}
 	if err := batch.Close(); err != nil {
-		cw.recordFlushError("error closing clickhouse versions batch", err)
+		cw.logFlushError("error closing clickhouse versions batch", err)
 		return false
 	}
-	cw.log.Debug("flushed version events to clickhouse", "count", len(versions))
+	cw.log.Debug("flushed version events to clickhouse", "count", len(newest))
 	return true
 }
 
-// recordFlushError increments the consecutive error counter and logs at the
-// appropriate level. Transient errors are logged as WARN; persistent errors
-// (exceeding consecutiveErrorThreshold) are logged as ERROR.
-func (cw *ClickhouseWriter) recordFlushError(msg string, err error) {
-	cw.consecutiveErrors++
-	cw.logFlushError(msg, err)
-}
-
+// logFlushError logs a flush error at WARN, escalating to ERROR when the
+// failure being logged belongs to at least the consecutiveErrorThreshold-th
+// consecutive failed flush. The counter itself advances in flush().
 func (cw *ClickhouseWriter) logFlushError(msg string, err error) {
-	if cw.consecutiveErrors >= consecutiveErrorThreshold {
-		cw.log.Error(msg, "error", err, "consecutive_errors", cw.consecutiveErrors)
+	cw.mu.Lock()
+	failures := cw.consecutiveErrors + 1 // include the flush currently failing
+	cw.mu.Unlock()
+	if failures >= consecutiveErrorThreshold {
+		cw.log.Error(msg, "error", err, "consecutive_errors", failures)
 	} else {
 		cw.log.Warn(msg, "error", err)
 	}

--- a/controlplane/controller/internal/controller/clickhouse.go
+++ b/controlplane/controller/internal/controller/clickhouse.go
@@ -129,6 +129,12 @@ func (cw *ClickhouseWriter) Record(event getConfigEvent) {
 }
 
 func (cw *ClickhouseWriter) RecordVersion(event versionEvent) {
+	// A blank report (e.g. an old or restarting agent) must not overwrite the
+	// last known good version row, since ReplacingMergeTree keeps the row with
+	// the newest updated_at.
+	if event.AgentVersion == "" && event.AgentCommit == "" && event.AgentDate == "" {
+		return
+	}
 	event.ControllerVersion = cw.controllerVersion
 	event.ControllerCommit = cw.controllerCommit
 	event.ControllerDate = cw.controllerDate
@@ -159,21 +165,28 @@ func (cw *ClickhouseWriter) flush(ctx context.Context) {
 	cw.versions = nil
 	cw.mu.Unlock()
 
+	if len(events) == 0 && len(versions) == 0 {
+		return
+	}
+	ok := true
 	if len(events) > 0 {
-		cw.flushEvents(ctx, events)
+		ok = cw.flushEvents(ctx, events) && ok
 	}
 	if len(versions) > 0 {
-		cw.flushVersions(ctx, versions)
+		ok = cw.flushVersions(ctx, versions) && ok
+	}
+	if ok {
+		cw.consecutiveErrors = 0
 	}
 }
 
-func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigEvent) {
+func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigEvent) bool {
 	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
 		`INSERT INTO "%s".controller_grpc_getconfig_success (timestamp, device_pubkey)`, cw.db,
 	))
 	if err != nil {
 		cw.recordFlushError("error preparing clickhouse batch", err)
-		return
+		return false
 	}
 	for _, e := range events {
 		if err := batch.Append(e.Timestamp, e.DevicePubkey); err != nil {
@@ -183,23 +196,23 @@ func (cw *ClickhouseWriter) flushEvents(ctx context.Context, events []getConfigE
 	if err := batch.Send(); err != nil {
 		_ = batch.Close()
 		cw.recordFlushError("error sending clickhouse batch", err)
-		return
+		return false
 	}
 	if err := batch.Close(); err != nil {
 		cw.recordFlushError("error closing clickhouse batch", err)
-		return
+		return false
 	}
-	cw.consecutiveErrors = 0
 	cw.log.Debug("flushed getconfig events to clickhouse", "count", len(events))
+	return true
 }
 
-func (cw *ClickhouseWriter) flushVersions(ctx context.Context, versions []versionEvent) {
+func (cw *ClickhouseWriter) flushVersions(ctx context.Context, versions []versionEvent) bool {
 	batch, err := cw.conn.PrepareBatch(ctx, fmt.Sprintf(
 		`INSERT INTO "%s".controller_agent_versions (device_pubkey, updated_at, agent_version, agent_commit, agent_date, controller_version, controller_commit, controller_date)`, cw.db,
 	))
 	if err != nil {
 		cw.recordFlushError("error preparing clickhouse versions batch", err)
-		return
+		return false
 	}
 	for _, v := range versions {
 		if err := batch.Append(v.DevicePubkey, v.UpdatedAt, v.AgentVersion, v.AgentCommit, v.AgentDate, v.ControllerVersion, v.ControllerCommit, v.ControllerDate); err != nil {
@@ -209,13 +222,14 @@ func (cw *ClickhouseWriter) flushVersions(ctx context.Context, versions []versio
 	if err := batch.Send(); err != nil {
 		_ = batch.Close()
 		cw.recordFlushError("error sending clickhouse versions batch", err)
-		return
+		return false
 	}
 	if err := batch.Close(); err != nil {
 		cw.recordFlushError("error closing clickhouse versions batch", err)
-		return
+		return false
 	}
 	cw.log.Debug("flushed version events to clickhouse", "count", len(versions))
+	return true
 }
 
 // recordFlushError increments the consecutive error counter and logs at the

--- a/controlplane/controller/internal/controller/clickhouse_test.go
+++ b/controlplane/controller/internal/controller/clickhouse_test.go
@@ -67,6 +67,34 @@ func TestClickhouseWriterLogEscalation(t *testing.T) {
 	}
 }
 
+func TestRecordVersion(t *testing.T) {
+	cw := &ClickhouseWriter{
+		controllerVersion: "v1.2.3",
+		controllerCommit:  "abc123",
+		controllerDate:    "2026-01-01",
+	}
+
+	// A blank agent report must not be recorded: ReplacingMergeTree keeps the
+	// row with the newest updated_at, so it would overwrite the last known
+	// good version row.
+	cw.RecordVersion(versionEvent{DevicePubkey: "dev1"})
+	if len(cw.versions) != 0 {
+		t.Fatalf("blank agent report was recorded, want skipped")
+	}
+
+	cw.RecordVersion(versionEvent{DevicePubkey: "dev1", AgentVersion: "v0.9.0"})
+	if len(cw.versions) != 1 {
+		t.Fatalf("expected 1 recorded version event, got %d", len(cw.versions))
+	}
+	got := cw.versions[0]
+	if got.ControllerVersion != "v1.2.3" || got.ControllerCommit != "abc123" || got.ControllerDate != "2026-01-01" {
+		t.Errorf("controller build info not stamped: %+v", got)
+	}
+	if got.AgentVersion != "v0.9.0" {
+		t.Errorf("AgentVersion = %q, want %q", got.AgentVersion, "v0.9.0")
+	}
+}
+
 func TestBuildClickhouseOptions(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/controlplane/controller/internal/controller/clickhouse_test.go
+++ b/controlplane/controller/internal/controller/clickhouse_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 // logEntry captures a single log call for test assertions.
@@ -28,61 +31,271 @@ func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
 func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
 func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
 
-func TestClickhouseWriterLogEscalation(t *testing.T) {
+// fakeBatch implements driver.Batch for the methods the writer uses; the
+// embedded nil interface panics on anything else.
+type fakeBatch struct {
+	driver.Batch
+	rows      [][]any
+	appendErr error
+	sendErr   error
+	sent      bool
+}
+
+func (b *fakeBatch) Append(v ...any) error {
+	if b.appendErr != nil {
+		return b.appendErr
+	}
+	b.rows = append(b.rows, v)
+	return nil
+}
+func (b *fakeBatch) Send() error {
+	if b.sendErr != nil {
+		return b.sendErr
+	}
+	b.sent = true
+	return nil
+}
+func (b *fakeBatch) Close() error { return nil }
+
+// fakeConn implements driver.Conn for the methods the writer uses.
+type fakeConn struct {
+	driver.Conn
+	prepared   []string
+	batches    []*fakeBatch
+	prepareErr error
+	appendErr  error
+	sendErr    error
+	execErrOn  string // substring of a query whose Exec should fail
+	execErr    error
+}
+
+func (c *fakeConn) PrepareBatch(_ context.Context, query string, _ ...driver.PrepareBatchOption) (driver.Batch, error) {
+	c.prepared = append(c.prepared, query)
+	if c.prepareErr != nil {
+		return nil, c.prepareErr
+	}
+	b := &fakeBatch{appendErr: c.appendErr, sendErr: c.sendErr}
+	c.batches = append(c.batches, b)
+	return b, nil
+}
+
+func (c *fakeConn) Exec(_ context.Context, query string, _ ...any) error {
+	if c.execErrOn != "" && strings.Contains(query, c.execErrOn) {
+		return c.execErr
+	}
+	return nil
+}
+
+func newTestWriter(conn clickhouse.Conn) (*ClickhouseWriter, *capturingHandler) {
 	h := &capturingHandler{}
-	logger := slog.New(h)
-	cw := &ClickhouseWriter{log: logger}
+	return &ClickhouseWriter{
+		conn:            conn,
+		log:             slog.New(h),
+		db:              "testdb",
+		build:           Build{Version: "v1.2.3", Commit: "abc123", Date: "2026-01-01"},
+		eventsEnabled:   true,
+		versionsEnabled: true,
+	}, h
+}
 
-	testErr := errors.New("connection reset")
+func TestFlushSuccessResetsCounterAndPreservesColumnOrder(t *testing.T) {
+	conn := &fakeConn{}
+	cw, _ := newTestWriter(conn)
+	cw.consecutiveErrors = 2
 
-	// First few errors should be WARN
-	for range consecutiveErrorThreshold {
-		cw.recordFlushError("error sending clickhouse batch", testErr)
+	ts := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cw.Record(getConfigEvent{Timestamp: ts, DevicePubkey: "dev1"})
+	cw.RecordVersion(agentVersionReport{
+		DevicePubkey: "dev1",
+		UpdatedAt:    ts,
+		AgentVersion: "v0.9.0",
+		AgentCommit:  "deadbeef",
+		AgentDate:    "2026-07-01",
+	})
+	cw.flush(context.Background())
+
+	if cw.consecutiveErrors != 0 {
+		t.Errorf("consecutiveErrors = %d after successful flush, want 0", cw.consecutiveErrors)
+	}
+	if len(conn.batches) != 2 {
+		t.Fatalf("prepared %d batches, want 2", len(conn.batches))
 	}
 
-	// Verify first errors are WARN, last one crosses threshold and is ERROR
-	for i, entry := range h.entries {
-		if i < consecutiveErrorThreshold-1 {
-			if entry.Level != slog.LevelWarn {
-				t.Errorf("entry[%d]: got level %v, want WARN", i, entry.Level)
-			}
-		} else {
-			if entry.Level != slog.LevelError {
-				t.Errorf("entry[%d]: got level %v, want ERROR", i, entry.Level)
-			}
+	// Version row values must line up with the INSERT column list.
+	wantColumns := `(device_pubkey, updated_at, agent_version, agent_commit, agent_date, controller_version, controller_commit, controller_date)`
+	if !strings.Contains(conn.prepared[1], wantColumns) {
+		t.Fatalf("versions INSERT = %q, want column list %q", conn.prepared[1], wantColumns)
+	}
+	rows := conn.batches[1].rows
+	if len(rows) != 1 {
+		t.Fatalf("versions batch has %d rows, want 1", len(rows))
+	}
+	want := []any{"dev1", ts, "v0.9.0", "deadbeef", "2026-07-01", "v1.2.3", "abc123", "2026-01-01"}
+	if len(rows[0]) != len(want) {
+		t.Fatalf("versions row has %d values, want %d", len(rows[0]), len(want))
+	}
+	for i, v := range want {
+		if rows[0][i] != v {
+			t.Errorf("versions row[%d] = %v, want %v", i, rows[0][i], v)
+		}
+	}
+}
+
+func TestFlushNoopTickDoesNotResetCounter(t *testing.T) {
+	conn := &fakeConn{}
+	cw, _ := newTestWriter(conn)
+	cw.consecutiveErrors = 2
+
+	cw.flush(context.Background())
+
+	if cw.consecutiveErrors != 2 {
+		t.Errorf("consecutiveErrors = %d after no-op tick, want 2", cw.consecutiveErrors)
+	}
+	if len(conn.prepared) != 0 {
+		t.Errorf("no-op tick prepared %d batches, want 0", len(conn.prepared))
+	}
+}
+
+func TestFlushFailureIncrementsCounterOncePerTick(t *testing.T) {
+	conn := &fakeConn{sendErr: errors.New("connection reset")}
+	cw, h := newTestWriter(conn)
+
+	record := func() {
+		cw.Record(getConfigEvent{Timestamp: time.Time{}, DevicePubkey: "dev1"})
+		cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", AgentVersion: "v0.9.0"})
+	}
+
+	// Both sub-flushes fail each tick, but the counter must advance once per
+	// tick so the WARN→ERROR threshold counts failed ticks.
+	for tick := 1; tick <= consecutiveErrorThreshold; tick++ {
+		record()
+		cw.flush(context.Background())
+		if cw.consecutiveErrors != tick {
+			t.Fatalf("tick %d: consecutiveErrors = %d, want %d", tick, cw.consecutiveErrors, tick)
 		}
 	}
 
-	// Reset counter (simulating a successful flush)
-	cw.consecutiveErrors = 0
-	h.entries = nil
-
-	// Next error after reset should be WARN again
-	cw.recordFlushError("error sending clickhouse batch", testErr)
-	if len(h.entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(h.entries))
+	var warns, errs int
+	for _, e := range h.entries {
+		switch e.Level {
+		case slog.LevelWarn:
+			warns++
+		case slog.LevelError:
+			errs++
+		}
 	}
-	if h.entries[0].Level != slog.LevelWarn {
-		t.Errorf("after reset: got level %v, want WARN", h.entries[0].Level)
+	// Two failing sub-flushes per tick: WARN for the first threshold-1 ticks,
+	// ERROR from the threshold-th tick on.
+	if wantWarns := 2 * (consecutiveErrorThreshold - 1); warns != wantWarns {
+		t.Errorf("got %d WARN entries, want %d", warns, wantWarns)
+	}
+	if errs != 2 {
+		t.Errorf("got %d ERROR entries, want 2", errs)
+	}
+
+	// A successful flush resets the counter and de-escalates back to WARN.
+	conn.sendErr = nil
+	record()
+	cw.flush(context.Background())
+	if cw.consecutiveErrors != 0 {
+		t.Fatalf("consecutiveErrors = %d after successful flush, want 0", cw.consecutiveErrors)
+	}
+	h.entries = nil
+	conn.sendErr = errors.New("connection reset")
+	record()
+	cw.flush(context.Background())
+	for _, e := range h.entries {
+		if e.Level != slog.LevelWarn {
+			t.Errorf("after reset: got level %v, want WARN", e.Level)
+		}
+	}
+}
+
+func TestFlushAbortsBatchOnAppendError(t *testing.T) {
+	conn := &fakeConn{appendErr: errors.New("wrong column count")}
+	cw, _ := newTestWriter(conn)
+
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", AgentVersion: "v0.9.0"})
+	cw.flush(context.Background())
+
+	if cw.consecutiveErrors != 1 {
+		t.Errorf("consecutiveErrors = %d after append error, want 1", cw.consecutiveErrors)
+	}
+	if len(conn.batches) != 1 {
+		t.Fatalf("prepared %d batches, want 1", len(conn.batches))
+	}
+	if conn.batches[0].sent {
+		t.Error("partial batch was sent after append error, want aborted")
+	}
+}
+
+func TestFlushVersionsDeduplicatesPerDevice(t *testing.T) {
+	conn := &fakeConn{}
+	cw, _ := newTestWriter(conn)
+
+	older := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(5 * time.Second)
+	// Insert newest first to prove dedup picks by UpdatedAt, not order.
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", UpdatedAt: newer, AgentVersion: "v0.9.1"})
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", UpdatedAt: older, AgentVersion: "v0.9.0"})
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev2", UpdatedAt: older, AgentVersion: "v0.9.0"})
+	cw.flush(context.Background())
+
+	rows := conn.batches[0].rows
+	if len(rows) != 2 {
+		t.Fatalf("versions batch has %d rows, want 2 (one per device)", len(rows))
+	}
+	for _, row := range rows {
+		if row[0] == "dev1" && row[2] != "v0.9.1" {
+			t.Errorf("dev1 row kept version %v, want newest v0.9.1", row[2])
+		}
+	}
+}
+
+func TestCreateTablesDegradesPerTable(t *testing.T) {
+	conn := &fakeConn{execErrOn: "controller_agent_versions", execErr: errors.New("ACCESS_DENIED")}
+	cw, h := newTestWriter(conn)
+
+	if err := cw.CreateTables(context.Background()); err != nil {
+		t.Fatalf("CreateTables returned %v, want nil when one table is usable", err)
+	}
+	if !cw.eventsEnabled || cw.versionsEnabled {
+		t.Errorf("enabled flags = (events=%v, versions=%v), want (true, false)", cw.eventsEnabled, cw.versionsEnabled)
+	}
+	if len(h.entries) != 1 || h.entries[0].Level != slog.LevelError {
+		t.Errorf("expected one ERROR log for the failed table, got %+v", h.entries)
+	}
+
+	// The disabled stream must not buffer; the enabled one must.
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", AgentVersion: "v0.9.0"})
+	cw.Record(getConfigEvent{DevicePubkey: "dev1"})
+	if len(cw.versions) != 0 || len(cw.events) != 1 {
+		t.Errorf("buffers = (events=%d, versions=%d), want (1, 0)", len(cw.events), len(cw.versions))
+	}
+
+	// Both tables failing disables everything and surfaces an error.
+	conn.execErrOn = "CREATE TABLE"
+	if err := cw.CreateTables(context.Background()); err == nil {
+		t.Error("CreateTables returned nil, want error when no table is usable")
+	}
+	if cw.eventsEnabled || cw.versionsEnabled {
+		t.Error("expected both streams disabled when no table is usable")
 	}
 }
 
 func TestRecordVersion(t *testing.T) {
-	cw := &ClickhouseWriter{
-		controllerVersion: "v1.2.3",
-		controllerCommit:  "abc123",
-		controllerDate:    "2026-01-01",
-	}
+	cw, _ := newTestWriter(&fakeConn{})
 
 	// A blank agent report must not be recorded: ReplacingMergeTree keeps the
 	// row with the newest updated_at, so it would overwrite the last known
 	// good version row.
-	cw.RecordVersion(versionEvent{DevicePubkey: "dev1"})
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1"})
 	if len(cw.versions) != 0 {
 		t.Fatalf("blank agent report was recorded, want skipped")
 	}
 
-	cw.RecordVersion(versionEvent{DevicePubkey: "dev1", AgentVersion: "v0.9.0"})
+	long := strings.Repeat("x", maxAgentFieldLen+50)
+	cw.RecordVersion(agentVersionReport{DevicePubkey: "dev1", AgentVersion: "v0.9.0", AgentCommit: long})
 	if len(cw.versions) != 1 {
 		t.Fatalf("expected 1 recorded version event, got %d", len(cw.versions))
 	}
@@ -92,6 +305,9 @@ func TestRecordVersion(t *testing.T) {
 	}
 	if got.AgentVersion != "v0.9.0" {
 		t.Errorf("AgentVersion = %q, want %q", got.AgentVersion, "v0.9.0")
+	}
+	if len(got.AgentCommit) != maxAgentFieldLen {
+		t.Errorf("AgentCommit length = %d, want truncated to %d", len(got.AgentCommit), maxAgentFieldLen)
 	}
 }
 

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -584,8 +584,8 @@ func (c *Controller) Run(ctx context.Context) error {
 	}()
 
 	if c.clickhouse != nil {
-		if err := c.clickhouse.CreateTable(ctx); err != nil {
-			c.log.Warn("error creating clickhouse table, continuing without clickhouse", "error", err)
+		if err := c.clickhouse.CreateTables(ctx); err != nil {
+			c.log.Warn("error creating clickhouse tables, continuing without clickhouse", "error", err)
 			c.clickhouse = nil
 		} else {
 			go c.clickhouse.Run(ctx)
@@ -823,6 +823,13 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		c.clickhouse.Record(getConfigEvent{
 			Timestamp:    reqStart,
 			DevicePubkey: req.GetPubkey(),
+		})
+		c.clickhouse.RecordVersion(versionEvent{
+			DevicePubkey: req.GetPubkey(),
+			UpdatedAt:    reqStart,
+			AgentVersion: agentVersion,
+			AgentCommit:  agentCommit,
+			AgentDate:    agentDate,
 		})
 	}
 	return resp, nil

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -739,8 +739,8 @@ func (c *Controller) Run(ctx context.Context) error {
 	}()
 
 	if c.clickhouse != nil {
-		if err := c.clickhouse.CreateTable(ctx); err != nil {
-			c.log.Warn("error creating clickhouse table, continuing without clickhouse", "error", err)
+		if err := c.clickhouse.CreateTables(ctx); err != nil {
+			c.log.Warn("error creating clickhouse tables, continuing without clickhouse", "error", err)
 			c.clickhouse = nil
 		} else {
 			go c.clickhouse.Run(ctx)
@@ -1039,6 +1039,13 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 		c.clickhouse.Record(getConfigEvent{
 			Timestamp:    reqStart,
 			DevicePubkey: req.GetPubkey(),
+		})
+		c.clickhouse.RecordVersion(versionEvent{
+			DevicePubkey: req.GetPubkey(),
+			UpdatedAt:    reqStart,
+			AgentVersion: agentVersion,
+			AgentCommit:  agentCommit,
+			AgentDate:    agentDate,
 		})
 	}
 	return resp, nil

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -1040,7 +1040,7 @@ func (c *Controller) GetConfig(ctx context.Context, req *pb.ConfigRequest) (*pb.
 			Timestamp:    reqStart,
 			DevicePubkey: req.GetPubkey(),
 		})
-		c.clickhouse.RecordVersion(versionEvent{
+		c.clickhouse.RecordVersion(agentVersionReport{
 			DevicePubkey: req.GetPubkey(),
 			UpdatedAt:    reqStart,
 			AgentVersion: agentVersion,


### PR DESCRIPTION
## Summary of Changes
- Add a `controller_agent_versions` ClickHouse table using `ReplacingMergeTree(updated_at)` keyed by `device_pubkey` to track the latest agent and controller version per device
- The controller writes on every GetConfig poll; ClickHouse merges rows down to one per device. Lake queries with `FINAL` for deduplicated results
- Keep `controller_grpc_getconfig_success` lean (`timestamp` + `device_pubkey` only) — separates event tracking from version state
- Companion: malbeclabs/lake#534 adds `controller_agent_versions` to Lake's external remote table proxies
- Allows malbeclabs/lake to display device config agent version info
- Schema is still simple so not adding goose migrations at this point

## Diff Breakdown
| Category     | Files | Lines (+/-)   | Net  |
|--------------|-------|---------------|------|
| Core logic   |     2 | +98 / -12     |  +86 |
| Scaffolding  |     1 | +1 / -1       |   +0 |
| Docs         |     1 | +21 / -2      |  +19 |
| **Total**    |     4 | +120 / -15    | +105 |

Small feature — mostly core logic (ClickHouse writer + flush), with minimal scaffolding.

## Testing Verification
- `go build ./controlplane/controller/...` — builds clean
- `go test ./controlplane/controller/...` — all existing tests pass
- `go vet ./controlplane/controller/...` — no issues