### PR TITLE
cli: add --tunnel_endpoint flag to user update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - CLI
   - Add `cyoa_ips` field to `doublezero device get` and `doublezero device list` output, showing the IP networks of interfaces with `user_tunnel_endpoint` enabled
+  - Add `--tunnel_endpoint` flag to `user update` command so operators can set the tunnel endpoint IP of an existing user
   - Extend `doublezero resource verify` to check `MulticastPublisherBlock` against multicast publisher users' `dz_ip` allocations; legacy `dz_ip`s that fall outside the block's range are ignored so pre-existing users allocated before this extension existed do not produce false discrepancies
   - Fix `doublezero resource verify` to report missing `TunnelIds` resource extensions for all devices, including those without any users; previously the discrepancy was suppressed when a device had no users, hiding unallocated extensions
   - Extend `doublezero resource verify` to detect orphaned `ResourceExtension` accounts whose PDA does not correspond to any currently-expected resource type (global singleton or per-device extension for a live device/prefix); `--fix` closes them via the existing y/N confirmation flow

--- a/smartcontract/cli/src/user/update.rs
+++ b/smartcontract/cli/src/user/update.rs
@@ -26,6 +26,9 @@ pub struct UpdateUserCliCommand {
     /// New Validator Pubkey
     #[arg(long, value_parser = validate_pubkey)]
     pub validator_pubkey: Option<String>,
+    /// New Tunnel Endpoint IP address
+    #[arg(long)]
+    pub tunnel_endpoint: Option<Ipv4Addr>,
 }
 
 impl UpdateUserCliCommand {
@@ -46,7 +49,7 @@ impl UpdateUserCliCommand {
                 .map(|s| Pubkey::from_str(&s))
                 .transpose()?,
             tenant_pk: None,
-            tunnel_endpoint: None,
+            tunnel_endpoint: self.tunnel_endpoint,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -132,7 +135,7 @@ mod tests {
                 tunnel_net: Some("10.2.2.3/24".parse().unwrap()),
                 validator_pubkey: None,
                 tenant_pk: None,
-                tunnel_endpoint: None,
+                tunnel_endpoint: Some([1, 2, 3, 4].into()),
             }))
             .returning(move |_| Ok(signature));
 
@@ -144,6 +147,7 @@ mod tests {
             tunnel_id: Some(1),
             tunnel_net: Some("10.2.2.3/24".parse().unwrap()),
             validator_pubkey: None,
+            tunnel_endpoint: Some([1, 2, 3, 4].into()),
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());


### PR DESCRIPTION
## Summary of Changes
- Expose `tunnel_endpoint` as a CLI argument in `user update` so operators can set or update the tunnel endpoint IP of an existing user
- Previously the field was hardcoded to `None`, making it impossible to set via the admin CLI

## Testing Verification
- `cargo test -p doublezero_cli user::update` passes — updated test exercises the new field end-to-end through the mock CLI command
- `make rust-lint` passes cleanly