### PR TITLE
telemetry/geoprobe: accept ICMP targets with zero LocationOffsetPort

### DIFF
--- a/controlplane/telemetry/internal/geoprobe/target_discovery.go
+++ b/controlplane/telemetry/internal/geoprobe/target_discovery.go
@@ -268,12 +268,19 @@ func targetToProbeAddress(t *geolocation.GeolocationTarget) ProbeAddress {
 }
 
 // icmpTargetToProbeAddress converts an OutboundIcmp GeolocationTarget to a ProbeAddress.
+// ICMP itself uses no port; LocationOffsetPort only matters if offsets are delivered back
+// to the target. Treat 0 as "use the default geoprobe UDP port" so 0:0 targets — common
+// when paired with a ResultDestination override — pass validation.
 func icmpTargetToProbeAddress(t *geolocation.GeolocationTarget) ProbeAddress {
 	host := fmt.Sprintf("%d.%d.%d.%d",
 		t.IPAddress[0], t.IPAddress[1], t.IPAddress[2], t.IPAddress[3])
+	port := t.LocationOffsetPort
+	if port == 0 {
+		port = telemetryconfig.DefaultGeoprobeUDPPort
+	}
 	return ProbeAddress{
 		Host:      host,
-		Port:      t.LocationOffsetPort,
+		Port:      port,
 		TWAMPPort: 0,
 	}
 }

--- a/controlplane/telemetry/internal/geoprobe/target_discovery_test.go
+++ b/controlplane/telemetry/internal/geoprobe/target_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
+	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 	geolocation "github.com/malbeclabs/doublezero/sdk/geolocation/go"
 )
 
@@ -606,6 +607,35 @@ func TestTargetDiscovery_MixedOutboundAndIcmp(t *testing.T) {
 	}
 	if len(keys) != 0 {
 		t.Errorf("expected 0 keys, got %d", len(keys))
+	}
+}
+
+func TestTargetDiscovery_OutboundIcmpZeroPortDefaulted(t *testing.T) {
+	probePK := testProbePubkey()
+	client := &mockGeolocationUserClient{
+		users: []geolocation.KeyedGeolocationUser{
+			makeUserWithResultDest(
+				geolocation.GeolocationUserStatusActivated,
+				geolocation.GeolocationPaymentStatusPaid,
+				"user1",
+				[]geolocation.GeolocationTarget{
+					outboundIcmpTarget([4]uint8{44, 0, 0, 1}, 0, probePK),
+				},
+				"results.example.com:9000",
+			),
+		},
+	}
+
+	td := newTestTargetDiscovery(client)
+	_, icmpTargets, _, _, _, err := td.discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(icmpTargets) != 1 {
+		t.Fatalf("expected 1 ICMP target (zero port should default, not be rejected), got %d", len(icmpTargets))
+	}
+	if icmpTargets[0].Port != telemetryconfig.DefaultGeoprobeUDPPort {
+		t.Errorf("expected Port=%d (default), got %d", telemetryconfig.DefaultGeoprobeUDPPort, icmpTargets[0].Port)
 	}
 }
 


### PR DESCRIPTION
## Summary of Changes
- ICMP targets onchain that set `LocationOffsetPort=0` were being rejected by `target_discovery` with `port cannot be zero`, even though ICMP doesn't use ports and the offset is typically delivered to the user's `ResultDestination` override. Now `icmpTargetToProbeAddress` substitutes `DefaultGeoprobeUDPPort` (8923) when the onchain port is 0, so 0:0 ICMP targets pass validation and get registered with the pinger.
- Validation, scope check, and downstream delivery semantics for non-zero ports are unchanged.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net |
|------------|-------|-------------|-----|
| Core logic |     1 | +8 / -1     | +7  |
| Tests      |     1 | +30 / -0    | +30 |

Tiny fix; one-line behavior change in the ICMP target conversion plus a regression test.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/internal/geoprobe/target_discovery.go` — `icmpTargetToProbeAddress` defaults `Port` to `DefaultGeoprobeUDPPort` when the onchain `LocationOffsetPort` is 0.
- `controlplane/telemetry/internal/geoprobe/target_discovery_test.go` — adds `TestTargetDiscovery_OutboundIcmpZeroPortDefaulted` covering an ICMP target with port 0 paired with a `ResultDestination`.

</details>

## Testing Verification
- New test `TestTargetDiscovery_OutboundIcmpZeroPortDefaulted` fails on main (target rejected) and passes with the fix.
- Existing `TestProbeAddress_Validate*` and `TestTargetDiscovery_OutboundIcmp*` tests still pass — non-zero-port behavior unchanged.
- Verified against the original log line on yto-mn-gp1 (`addr=137.220.55.224:0:0 error="port cannot be zero"`) — that target shape is now accepted.
