### PR TITLE
geolocation: refactor write paths to in-place targets cursor

### DIFF
--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/add_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/add_target.rs
@@ -3,9 +3,8 @@ use crate::{
     serializer::try_acc_write,
     state::{
         geo_probe::GeoProbe,
-        geolocation_user::{
-            GeoLocationTargetType, GeolocationTarget, GeolocationUser, MAX_TARGETS,
-        },
+        geolocation_user::{GeoLocationTargetType, GeolocationTarget, MAX_TARGETS},
+        geolocation_user_view::GeolocationUserView,
     },
     validation::validate_public_ip,
 };
@@ -62,16 +61,16 @@ pub fn process_add_target(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut user = GeolocationUser::try_from(user_account)?;
+    let mut view = GeolocationUserView::try_from_account(user_account)?;
 
-    if user.owner != *payer_account.key {
+    if view.owner != *payer_account.key {
         msg!("Signer is not the account owner");
         return Err(GeolocationError::Unauthorized.into());
     }
 
     let mut probe = GeoProbe::try_from(probe_account)?;
 
-    if user.targets.len() >= MAX_TARGETS {
+    if (view.targets_count as usize) >= MAX_TARGETS {
         msg!("Cannot add target: already at maximum of {}", MAX_TARGETS);
         return Err(GeolocationError::MaxTargetsReached.into());
     }
@@ -90,29 +89,34 @@ pub fn process_add_target(
         }
     }
 
-    let duplicate = user.targets.iter().any(|t| {
-        t.target_type == args.target_type
-            && t.geoprobe_pk == geoprobe_pk
-            && t.ip_address == args.ip_address
-            && t.target_pk == args.target_pk
-    });
-    if duplicate {
-        msg!("Target already exists");
-        return Err(GeolocationError::TargetAlreadyExists.into());
+    // Duplicate check: scan the targets section without materializing it.
+    {
+        let data = user_account.try_borrow_data()?;
+        let cursor = view.cursor(&data)?;
+        let duplicate = cursor.find_match(|t| {
+            t.target_type == args.target_type
+                && t.geoprobe_pk == geoprobe_pk
+                && t.ip_address == args.ip_address
+                && t.target_pk == args.target_pk
+        })?;
+        if duplicate.is_some() {
+            msg!("Target already exists");
+            return Err(GeolocationError::TargetAlreadyExists.into());
+        }
     }
 
-    user.targets.push(GeolocationTarget {
+    let new_target = GeolocationTarget {
         target_type: args.target_type,
         ip_address: args.ip_address,
         location_offset_port: args.location_offset_port,
         target_pk: args.target_pk,
         geoprobe_pk,
-    });
+    };
+    view.append_target(user_account, payer_account, accounts, &new_target)?;
 
     probe.reference_count = probe.reference_count.saturating_add(1);
     probe.target_update_count = probe.target_update_count.wrapping_add(1);
 
-    try_acc_write(&user, user_account, payer_account, accounts)?;
     try_acc_write(&probe, probe_account, payer_account, accounts)?;
 
     Ok(())

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/delete.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/delete.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::GeolocationError, processors::check_foundation_allowlist, serializer::try_acc_close,
-    state::geolocation_user::GeolocationUser,
+    state::geolocation_user_view::GeolocationUserView,
 };
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
@@ -35,9 +35,9 @@ pub fn process_delete_geolocation_user(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let user = GeolocationUser::try_from(user_account)?;
+    let view = GeolocationUserView::try_from_account(user_account)?;
 
-    if user.owner != *payer_account.key {
+    if view.owner != *payer_account.key {
         check_foundation_allowlist(
             program_config_account,
             serviceability_globalstate_account,
@@ -46,10 +46,10 @@ pub fn process_delete_geolocation_user(
         )?;
     }
 
-    if !user.targets.is_empty() {
+    if view.targets_count != 0 {
         msg!(
             "Cannot delete GeolocationUser with {} remaining targets",
-            user.targets.len()
+            view.targets_count
         );
         return Err(GeolocationError::TargetsNotEmpty.into());
     }

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
@@ -4,7 +4,8 @@ use crate::{
     serializer::try_acc_write,
     state::{
         geo_probe::GeoProbe,
-        geolocation_user::{GeoLocationTargetType, GeolocationUser},
+        geolocation_user::GeoLocationTargetType,
+        geolocation_user_view::GeolocationUserView,
     },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -61,9 +62,9 @@ pub fn process_remove_target(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut user = GeolocationUser::try_from(user_account)?;
+    let mut view = GeolocationUserView::try_from_account(user_account)?;
 
-    if user.owner != *payer_account.key {
+    if view.owner != *payer_account.key {
         check_foundation_allowlist(
             program_config_account,
             serviceability_globalstate_account,
@@ -73,30 +74,29 @@ pub fn process_remove_target(
     }
 
     let mut probe = GeoProbe::try_from(probe_account)?;
-
     let geoprobe_pk = *probe_account.key;
 
-    let index = user
-        .targets
-        .iter()
-        .position(|t| {
-            t.target_type == args.target_type
-                && t.geoprobe_pk == geoprobe_pk
-                && match args.target_type {
-                    GeoLocationTargetType::Outbound | GeoLocationTargetType::OutboundIcmp => {
-                        t.ip_address == args.ip_address
+    let index = {
+        let data = user_account.try_borrow_data()?;
+        let cursor = view.cursor(&data)?;
+        cursor
+            .find_match(|t| {
+                t.target_type == args.target_type
+                    && t.geoprobe_pk == geoprobe_pk
+                    && match args.target_type {
+                        GeoLocationTargetType::Outbound | GeoLocationTargetType::OutboundIcmp => {
+                            t.ip_address == args.ip_address
+                        }
+                        GeoLocationTargetType::Inbound => t.target_pk == args.target_pk,
                     }
-                    GeoLocationTargetType::Inbound => t.target_pk == args.target_pk,
-                }
-        })
-        .ok_or(GeolocationError::TargetNotFound)?;
+            })?
+            .ok_or(GeolocationError::TargetNotFound)?
+    };
 
-    user.targets.swap_remove(index);
+    view.swap_remove_target(user_account, payer_account, accounts, index)?;
 
     probe.reference_count = probe.reference_count.saturating_sub(1);
     probe.target_update_count = probe.target_update_count.wrapping_add(1);
-
-    try_acc_write(&user, user_account, payer_account, accounts)?;
     try_acc_write(&probe, probe_account, payer_account, accounts)?;
 
     Ok(())

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs
@@ -3,8 +3,7 @@ use crate::{
     processors::check_foundation_allowlist,
     serializer::try_acc_write,
     state::{
-        geo_probe::GeoProbe,
-        geolocation_user::GeoLocationTargetType,
+        geo_probe::GeoProbe, geolocation_user::GeoLocationTargetType,
         geolocation_user_view::GeolocationUserView,
     },
 };

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
@@ -119,10 +119,10 @@ pub fn process_set_result_destination(
         args.destination.clone()
     };
 
-    // Phase 0: pre-flight each provided probe account (owner / writable /
-    // dedup), and assemble a small sorted Vec<Pubkey> of provided keys that
-    // we can binary-search per target during the cursor scan. Bounded by
-    // the tx accounts list size (~30), so heap usage stays small.
+    // Pre-flight each provided probe account (owner / writable / dedup) and
+    // assemble a small sorted Vec<Pubkey> we can binary-search per target
+    // during the cursor scan. Bounded by the tx accounts list size (~30),
+    // so heap usage stays small.
     let mut provided: Vec<Pubkey> = Vec::with_capacity(probe_accounts.len());
     for probe_account in probe_accounts {
         if probe_account.owner != program_id {
@@ -143,12 +143,11 @@ pub fn process_set_result_destination(
         }
     }
 
-    // Phase 1: build a sorted set of unique probes referenced by the
-    // targets, via a cursor scan. We only need to know whether
-    // |unique-from-targets| equals |provided|, so we cap the set at
-    // |provided| + 1: anything beyond that is already a count mismatch.
-    // Heap bound: (provided.len() + 1) * 32 bytes (≤ ~1 KB at realistic
-    // tx-size limits).
+    // Build a sorted set of unique probes referenced by the targets via a
+    // cursor scan. We only need to know whether |unique-from-targets|
+    // equals |provided|, so we cap the set at |provided| + 1: anything
+    // beyond that is already a count mismatch. Heap bound:
+    // (provided.len() + 1) * 32 bytes (≤ ~1 KB at realistic tx-size limits).
     let unique_cap = provided.len().saturating_add(1);
     let mut unique_from_targets: Vec<Pubkey> = Vec::with_capacity(unique_cap);
     {
@@ -169,7 +168,7 @@ pub fn process_set_result_destination(
         }
     }
 
-    // Phase 2: cardinality check.
+    // Cardinality check.
     if provided.len() != unique_from_targets.len() {
         msg!(
             "Expected {} probe accounts, got {}",
@@ -179,7 +178,7 @@ pub fn process_set_result_destination(
         return Err(GeolocationError::ProbeAccountCountMismatch.into());
     }
 
-    // Phase 3: membership — every provided probe must appear among the
+    // Membership: every provided probe must appear among the
     // unique-from-targets set. (Cardinalities are equal, so this also
     // implies the reverse direction.)
     for p in &provided {

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::GeolocationError,
     serializer::try_acc_write,
-    state::{geo_probe::GeoProbe, geolocation_user::GeolocationUser},
+    state::{geo_probe::GeoProbe, geolocation_user_view::GeolocationUserView},
     validation::validate_public_ip,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -9,7 +9,7 @@ use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
     pubkey::Pubkey,
 };
-use std::{collections::HashSet, net::Ipv4Addr};
+use std::net::Ipv4Addr;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
 pub struct SetResultDestinationArgs {
@@ -105,37 +105,25 @@ pub fn process_set_result_destination(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut user = GeolocationUser::try_from(user_account)?;
+    let mut view = GeolocationUserView::try_from_account(user_account)?;
 
-    if user.owner != *payer_account.key {
+    if view.owner != *payer_account.key {
         msg!("Signer is not the account owner");
         return Err(GeolocationError::Unauthorized.into());
     }
 
-    if args.destination.is_empty() {
-        user.result_destination = String::new();
+    let new_destination = if args.destination.is_empty() {
+        String::new()
     } else {
         validate_destination(&args.destination)?;
-        user.result_destination = args.destination.clone();
-    }
+        args.destination.clone()
+    };
 
-    // Collect unique probe pubkeys from the user's targets.
-    let mut unique_probes: HashSet<Pubkey> = HashSet::new();
-    for target in &user.targets {
-        if !unique_probes.contains(&target.geoprobe_pk) {
-            unique_probes.insert(target.geoprobe_pk);
-        }
-    }
-
-    if probe_accounts.len() != unique_probes.len() {
-        msg!(
-            "Expected {} probe accounts, got {}",
-            unique_probes.len(),
-            probe_accounts.len()
-        );
-        return Err(GeolocationError::ProbeAccountCountMismatch.into());
-    }
-
+    // Phase 0: pre-flight each provided probe account (owner / writable /
+    // dedup), and assemble a small sorted Vec<Pubkey> of provided keys that
+    // we can binary-search per target during the cursor scan. Bounded by
+    // the tx accounts list size (~30), so heap usage stays small.
+    let mut provided: Vec<Pubkey> = Vec::with_capacity(probe_accounts.len());
     for probe_account in probe_accounts {
         if probe_account.owner != program_id {
             msg!("Invalid GeoProbe account owner");
@@ -145,16 +133,63 @@ pub fn process_set_result_destination(
             msg!("GeoProbe account must be writable");
             return Err(ProgramError::InvalidAccountData);
         }
-        if !unique_probes.contains(probe_account.key) {
-            msg!(
-                "Probe account {} not referenced by user targets",
-                probe_account.key
-            );
+        let key = *probe_account.key;
+        match provided.binary_search(&key) {
+            Ok(_) => {
+                msg!("Duplicate probe account: {}", key);
+                return Err(ProgramError::InvalidAccountData);
+            }
+            Err(insert_at) => provided.insert(insert_at, key),
+        }
+    }
+
+    // Phase 1: build a sorted set of unique probes referenced by the
+    // targets, via a cursor scan. We only need to know whether
+    // |unique-from-targets| equals |provided|, so we cap the set at
+    // |provided| + 1: anything beyond that is already a count mismatch.
+    // Heap bound: (provided.len() + 1) * 32 bytes (≤ ~1 KB at realistic
+    // tx-size limits).
+    let unique_cap = provided.len().saturating_add(1);
+    let mut unique_from_targets: Vec<Pubkey> = Vec::with_capacity(unique_cap);
+    {
+        let data = user_account.try_borrow_data()?;
+        let cursor = view.cursor(&data)?;
+        for entry in cursor.iter() {
+            let target = entry?;
+            if let Err(insert_at) = unique_from_targets.binary_search(&target.geoprobe_pk) {
+                if unique_from_targets.len() >= unique_cap {
+                    msg!(
+                        "Targets reference more than {} unique probes",
+                        provided.len()
+                    );
+                    return Err(GeolocationError::ProbeAccountCountMismatch.into());
+                }
+                unique_from_targets.insert(insert_at, target.geoprobe_pk);
+            }
+        }
+    }
+
+    // Phase 2: cardinality check.
+    if provided.len() != unique_from_targets.len() {
+        msg!(
+            "Expected {} probe accounts, got {}",
+            unique_from_targets.len(),
+            provided.len()
+        );
+        return Err(GeolocationError::ProbeAccountCountMismatch.into());
+    }
+
+    // Phase 3: membership — every provided probe must appear among the
+    // unique-from-targets set. (Cardinalities are equal, so this also
+    // implies the reverse direction.)
+    for p in &provided {
+        if unique_from_targets.binary_search(p).is_err() {
+            msg!("Probe account {} not referenced by user targets", p);
             return Err(ProgramError::InvalidAccountData);
         }
     }
 
-    try_acc_write(&user, user_account, payer_account, accounts)?;
+    view.write_result_destination(user_account, payer_account, accounts, new_destination)?;
 
     for probe_account in probe_accounts {
         let mut probe = GeoProbe::try_from(probe_account)?;

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::GeolocationError, serializer::try_acc_write, state::geolocation_user::GeolocationUser,
+    error::GeolocationError, state::geolocation_user_view::GeolocationUserView,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
@@ -44,18 +44,18 @@ pub fn process_update_geolocation_user(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut user = GeolocationUser::try_from(user_account)?;
+    let mut view = GeolocationUserView::try_from_account(user_account)?;
 
-    if user.owner != *payer_account.key {
+    if view.owner != *payer_account.key {
         msg!("Signer is not the account owner");
         return Err(GeolocationError::Unauthorized.into());
     }
 
     if let Some(token_account) = args.token_account {
-        user.token_account = token_account;
+        view.token_account = token_account;
     }
 
-    try_acc_write(&user, user_account, payer_account, accounts)?;
+    view.write_prefix(user_account)?;
 
     Ok(())
 }

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update.rs
@@ -1,6 +1,4 @@
-use crate::{
-    error::GeolocationError, state::geolocation_user_view::GeolocationUserView,
-};
+use crate::{error::GeolocationError, state::geolocation_user_view::GeolocationUserView};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},

--- a/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update_payment_status.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update_payment_status.rs
@@ -1,7 +1,9 @@
 use crate::{
     processors::check_foundation_allowlist,
-    serializer::try_acc_write,
-    state::geolocation_user::{GeolocationPaymentStatus, GeolocationUser},
+    state::{
+        geolocation_user::{GeolocationBillingConfig, GeolocationPaymentStatus},
+        geolocation_user_view::GeolocationUserView,
+    },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
@@ -51,19 +53,19 @@ pub fn process_update_payment_status(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut user = GeolocationUser::try_from(user_account)?;
+    let mut view = GeolocationUserView::try_from_account(user_account)?;
 
-    user.payment_status = args.payment_status;
+    view.payment_status = args.payment_status;
 
     if let Some(epoch) = args.last_deduction_dz_epoch {
-        match &mut user.billing {
-            crate::state::geolocation_user::GeolocationBillingConfig::FlatPerEpoch(config) => {
+        match &mut view.billing {
+            GeolocationBillingConfig::FlatPerEpoch(config) => {
                 config.last_deduction_dz_epoch = epoch;
             }
         }
     }
 
-    try_acc_write(&user, user_account, payer_account, accounts)?;
+    view.write_prefix(user_account)?;
 
     Ok(())
 }

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -1,15 +1,17 @@
 //! Heap-friendly read of a `GeolocationUser` account.
 //!
 //! `GeolocationUser::try_from` borsh-deserializes `targets: Vec<GeolocationTarget>`
-//! onto the BPF heap, which OOMs at N≈250 (#3591). This view reads the same
-//! wire format but **skips** past the targets bytes — their length is fully
+//! onto the BPF heap, which OOMs at N≈250. This view reads the same wire
+//! format but **skips** past the targets bytes — their length is fully
 //! determined by the preceding `u32` count, so we can record the offset and
 //! continue parsing `result_destination` without materializing any per-target
 //! data. Heap usage is bounded by `code` + `result_destination` lengths,
 //! independent of N.
 //!
-//! Use `cursor()` to scan the targets section. Use `with_cursor()` for the
-//! common borrow + scan + drop pattern.
+//! Use [`GeolocationUserView::cursor`] over a borrowed `&data` slice to scan
+//! the targets section. Mutating operations (`append_target`,
+//! `swap_remove_target`, `write_prefix`, `write_result_destination`) take
+//! `&AccountInfo` and handle the resize + memmove bookkeeping in place.
 
 use crate::state::{
     accounttype::AccountType,
@@ -71,8 +73,8 @@ impl GeolocationUserView {
             .map_err(|_| ProgramError::InvalidAccountData)?;
         let status = GeolocationUserStatus::deserialize_reader(&mut reader)
             .map_err(|_| ProgramError::InvalidAccountData)?;
-        let targets_count = u32::deserialize_reader(&mut reader)
-            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let targets_count =
+            u32::deserialize_reader(&mut reader).map_err(|_| ProgramError::InvalidAccountData)?;
 
         // Position right after the targets length prefix.
         let targets_offset = data.len() - reader.len();
@@ -90,8 +92,7 @@ impl GeolocationUserView {
         let result_destination = if reader.is_empty() {
             String::new()
         } else {
-            String::deserialize_reader(&mut reader)
-                .map_err(|_| ProgramError::InvalidAccountData)?
+            String::deserialize_reader(&mut reader).map_err(|_| ProgramError::InvalidAccountData)?
         };
 
         Ok(Self {

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -198,6 +198,42 @@ impl GeolocationUserView {
         Ok(())
     }
 
+    /// Replace the trailing `result_destination` with `new_dest`. Resizes the
+    /// account to fit, then writes the new length prefix and chars directly
+    /// at the post-targets offset. Updates `self.result_destination` to
+    /// match. The targets section is left untouched.
+    pub fn write_result_destination(
+        &mut self,
+        account: &AccountInfo,
+        payer: &AccountInfo,
+        accounts: &[AccountInfo],
+        new_dest: String,
+    ) -> ProgramResult {
+        let trailing_offset = self
+            .targets_offset
+            .checked_add((self.targets_count as usize) * STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        let new_trailing_size = 4usize
+            .checked_add(new_dest.len())
+            .ok_or(ProgramError::InvalidAccountData)?;
+        let new_account_len = trailing_offset
+            .checked_add(new_trailing_size)
+            .ok_or(ProgramError::InvalidAccountData)?;
+
+        resize_account_if_needed(account, payer, accounts, new_account_len)?;
+
+        {
+            let mut data = account.try_borrow_mut_data()?;
+            let len_le = (new_dest.len() as u32).to_le_bytes();
+            data[trailing_offset..trailing_offset + 4].copy_from_slice(&len_le);
+            data[trailing_offset + 4..trailing_offset + 4 + new_dest.len()]
+                .copy_from_slice(new_dest.as_bytes());
+        }
+
+        self.result_destination = new_dest;
+        Ok(())
+    }
+
     /// Remove the target at `index` via swap-remove. Shifts trailing bytes
     /// (`result_destination`) left, patches `targets_count`, and shrinks the
     /// account by `STRIDE`.

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -17,7 +17,7 @@ use crate::state::{
         GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationTarget,
         GeolocationUserStatus,
     },
-    targets_cursor::{append_target_bytes, TargetsCursor, STRIDE},
+    targets_cursor::{append_target_bytes, swap_remove_target_bytes, TargetsCursor, STRIDE},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use doublezero_program_common::resize_account::resize_account_if_needed;
@@ -157,6 +157,31 @@ impl GeolocationUserView {
             let mut data = account.try_borrow_mut_data()?;
             append_target_bytes(&mut data, self.targets_offset, self.targets_count, &buf)?
         };
+
+        self.targets_count = new_count;
+        Ok(())
+    }
+
+    /// Remove the target at `index` via swap-remove. Shifts trailing bytes
+    /// (`result_destination`) left, patches `targets_count`, and shrinks the
+    /// account by `STRIDE`.
+    pub fn swap_remove_target(
+        &mut self,
+        account: &AccountInfo,
+        payer: &AccountInfo,
+        accounts: &[AccountInfo],
+        index: u32,
+    ) -> ProgramResult {
+        let new_count = {
+            let mut data = account.try_borrow_mut_data()?;
+            swap_remove_target_bytes(&mut data, self.targets_offset, self.targets_count, index)?
+        };
+
+        let new_len = account
+            .data_len()
+            .checked_sub(STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        resize_account_if_needed(account, payer, accounts, new_len)?;
 
         self.targets_count = new_count;
         Ok(())

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -162,6 +162,42 @@ impl GeolocationUserView {
         Ok(())
     }
 
+    /// Re-serialize the view's prefix (everything before `targets_count`) at
+    /// offset `0` of the account. Used by metadata-only updates to avoid
+    /// rewriting the targets section or `result_destination`.
+    ///
+    /// **Invariant:** the serialized prefix size must equal
+    /// `self.targets_offset - 4`. Today's processors only modify fixed-size
+    /// fields (`token_account`, `payment_status`, `billing`), so the size
+    /// is preserved. If a future processor allows changing the variable-
+    /// length `code` field, it must memmove the targets and trailing bytes
+    /// instead.
+    pub fn write_prefix(&self, account: &AccountInfo) -> ProgramResult {
+        let prefix_size = self
+            .targets_offset
+            .checked_sub(4)
+            .ok_or(ProgramError::InvalidAccountData)?;
+
+        let mut data = account.try_borrow_mut_data()?;
+        let mut writer: &mut [u8] = &mut data[..prefix_size];
+        let err = |_| ProgramError::InvalidAccountData;
+        self.account_type.serialize(&mut writer).map_err(err)?;
+        self.owner.serialize(&mut writer).map_err(err)?;
+        self.code.serialize(&mut writer).map_err(err)?;
+        self.token_account.serialize(&mut writer).map_err(err)?;
+        self.payment_status.serialize(&mut writer).map_err(err)?;
+        self.billing.serialize(&mut writer).map_err(err)?;
+        self.status.serialize(&mut writer).map_err(err)?;
+        if !writer.is_empty() {
+            msg!(
+                "prefix size mismatch: {} bytes left unwritten",
+                writer.len()
+            );
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(())
+    }
+
     /// Remove the target at `index` via swap-remove. Shifts trailing bytes
     /// (`result_destination`) left, patches `targets_count`, and shrinks the
     /// account by `STRIDE`.

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -13,12 +13,17 @@
 
 use crate::state::{
     accounttype::AccountType,
-    geolocation_user::{GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUserStatus},
-    targets_cursor::{TargetsCursor, STRIDE},
+    geolocation_user::{
+        GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationTarget,
+        GeolocationUserStatus,
+    },
+    targets_cursor::{append_target_bytes, TargetsCursor, STRIDE},
 };
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+use doublezero_program_common::resize_account::resize_account_if_needed;
 use solana_program::{
-    account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+    pubkey::Pubkey,
 };
 
 /// Parsed `GeolocationUser` metadata + a byte offset to the targets section.
@@ -119,6 +124,42 @@ impl GeolocationUserView {
             return Err(ProgramError::InvalidAccountData);
         }
         TargetsCursor::new(&data[self.targets_offset..end], self.targets_count)
+    }
+
+    /// Append `target` to the account's targets section. Resizes the account
+    /// by `+STRIDE`, shifts trailing bytes (`result_destination`) forward, and
+    /// patches `targets_count` in place. The view's `targets_count` is updated
+    /// to match.
+    ///
+    /// Caller is responsible for the duplicate check and `MAX_TARGETS` bound.
+    pub fn append_target(
+        &mut self,
+        account: &AccountInfo,
+        payer: &AccountInfo,
+        accounts: &[AccountInfo],
+        target: &GeolocationTarget,
+    ) -> ProgramResult {
+        let mut buf = [0u8; STRIDE];
+        {
+            let mut out: &mut [u8] = &mut buf;
+            target
+                .serialize(&mut out)
+                .map_err(|_| ProgramError::InvalidAccountData)?;
+        }
+
+        let new_len = account
+            .data_len()
+            .checked_add(STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        resize_account_if_needed(account, payer, accounts, new_len)?;
+
+        let new_count = {
+            let mut data = account.try_borrow_mut_data()?;
+            append_target_bytes(&mut data, self.targets_offset, self.targets_count, &buf)?
+        };
+
+        self.targets_count = new_count;
+        Ok(())
     }
 }
 

--- a/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs
@@ -1,0 +1,245 @@
+//! Heap-friendly read of a `GeolocationUser` account.
+//!
+//! `GeolocationUser::try_from` borsh-deserializes `targets: Vec<GeolocationTarget>`
+//! onto the BPF heap, which OOMs at N≈250 (#3591). This view reads the same
+//! wire format but **skips** past the targets bytes — their length is fully
+//! determined by the preceding `u32` count, so we can record the offset and
+//! continue parsing `result_destination` without materializing any per-target
+//! data. Heap usage is bounded by `code` + `result_destination` lengths,
+//! independent of N.
+//!
+//! Use `cursor()` to scan the targets section. Use `with_cursor()` for the
+//! common borrow + scan + drop pattern.
+
+use crate::state::{
+    accounttype::AccountType,
+    geolocation_user::{GeolocationBillingConfig, GeolocationPaymentStatus, GeolocationUserStatus},
+    targets_cursor::{TargetsCursor, STRIDE},
+};
+use borsh::BorshDeserialize;
+use solana_program::{
+    account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey,
+};
+
+/// Parsed `GeolocationUser` metadata + a byte offset to the targets section.
+/// All owned; the targets payload itself is left in the account buffer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeolocationUserView {
+    pub account_type: AccountType,
+    pub owner: Pubkey,
+    pub code: String,
+    pub token_account: Pubkey,
+    pub payment_status: GeolocationPaymentStatus,
+    pub billing: GeolocationBillingConfig,
+    pub status: GeolocationUserStatus,
+
+    /// Number of targets in the targets section.
+    pub targets_count: u32,
+    /// Byte offset (within the account data) at which the first target begins,
+    /// i.e. immediately after the `u32` length prefix.
+    pub targets_offset: usize,
+
+    pub result_destination: String,
+}
+
+impl GeolocationUserView {
+    /// Parse the metadata. The targets section is *not* deserialized.
+    pub fn try_from_slice(data: &[u8]) -> Result<Self, ProgramError> {
+        let mut reader = data;
+
+        let account_type = AccountType::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        if account_type != AccountType::GeolocationUser {
+            msg!("Invalid account type: {}", account_type);
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let owner = Pubkey::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let code = String::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let token_account = Pubkey::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let payment_status = GeolocationPaymentStatus::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let billing = GeolocationBillingConfig::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let status = GeolocationUserStatus::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let targets_count = u32::deserialize_reader(&mut reader)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+
+        // Position right after the targets length prefix.
+        let targets_offset = data.len() - reader.len();
+
+        let targets_bytes = (targets_count as usize)
+            .checked_mul(STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if reader.len() < targets_bytes {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        reader = &reader[targets_bytes..];
+
+        // `result_destination` is BDI-style trailing-grace: empty if the
+        // account predates the field being added.
+        let result_destination = if reader.is_empty() {
+            String::new()
+        } else {
+            String::deserialize_reader(&mut reader)
+                .map_err(|_| ProgramError::InvalidAccountData)?
+        };
+
+        Ok(Self {
+            account_type,
+            owner,
+            code,
+            token_account,
+            payment_status,
+            billing,
+            status,
+            targets_count,
+            targets_offset,
+            result_destination,
+        })
+    }
+
+    /// Borrow the account data and parse a view from it.
+    pub fn try_from_account(account: &AccountInfo) -> Result<Self, ProgramError> {
+        let data = account.try_borrow_data()?;
+        Self::try_from_slice(&data)
+    }
+
+    /// Build a `TargetsCursor` over the targets section of `data`.
+    pub fn cursor<'a>(&self, data: &'a [u8]) -> Result<TargetsCursor<'a>, ProgramError> {
+        let end = self
+            .targets_offset
+            .checked_add((self.targets_count as usize) * STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if data.len() < end {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        TargetsCursor::new(&data[self.targets_offset..end], self.targets_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::geolocation_user::{
+        FlatPerEpochConfig, GeoLocationTargetType, GeolocationTarget, GeolocationUser,
+    };
+    use std::net::Ipv4Addr;
+
+    fn sample_target(seed: u32) -> GeolocationTarget {
+        let octets = seed.to_be_bytes();
+        GeolocationTarget {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(10, octets[1], octets[2], octets[3]),
+            location_offset_port: 8000,
+            target_pk: Pubkey::default(),
+            geoprobe_pk: Pubkey::new_from_array([seed as u8; 32]),
+        }
+    }
+
+    fn sample_user(targets: Vec<GeolocationTarget>, result_destination: &str) -> GeolocationUser {
+        GeolocationUser {
+            account_type: AccountType::GeolocationUser,
+            owner: Pubkey::new_unique(),
+            code: "geo-user-01".to_string(),
+            token_account: Pubkey::new_unique(),
+            payment_status: GeolocationPaymentStatus::Paid,
+            billing: GeolocationBillingConfig::FlatPerEpoch(FlatPerEpochConfig {
+                rate: 1000,
+                last_deduction_dz_epoch: 42,
+            }),
+            status: GeolocationUserStatus::Activated,
+            targets,
+            result_destination: result_destination.to_string(),
+        }
+    }
+
+    fn assert_view_matches(view: &GeolocationUserView, user: &GeolocationUser) {
+        assert_eq!(view.account_type, user.account_type);
+        assert_eq!(view.owner, user.owner);
+        assert_eq!(view.code, user.code);
+        assert_eq!(view.token_account, user.token_account);
+        assert_eq!(view.payment_status, user.payment_status);
+        assert_eq!(view.billing, user.billing);
+        assert_eq!(view.status, user.status);
+        assert_eq!(view.targets_count, user.targets.len() as u32);
+        assert_eq!(view.result_destination, user.result_destination);
+    }
+
+    #[test]
+    fn parses_user_with_zero_targets() {
+        let user = sample_user(vec![], "host:1234");
+        let bytes = borsh::to_vec(&user).unwrap();
+        let view = GeolocationUserView::try_from_slice(&bytes).unwrap();
+        assert_view_matches(&view, &user);
+        assert_eq!(view.targets_count, 0);
+    }
+
+    #[test]
+    fn parses_user_with_many_targets_without_materializing_them() {
+        let targets: Vec<_> = (0..1000).map(sample_target).collect();
+        let user = sample_user(targets.clone(), "");
+        let bytes = borsh::to_vec(&user).unwrap();
+        let view = GeolocationUserView::try_from_slice(&bytes).unwrap();
+        assert_view_matches(&view, &user);
+
+        // The cursor should hand back exactly what we serialized.
+        let cursor = view.cursor(&bytes).unwrap();
+        for (i, original) in targets.iter().enumerate() {
+            assert_eq!(&cursor.get(i as u32).unwrap(), original);
+        }
+    }
+
+    #[test]
+    fn targets_offset_is_correct() {
+        let target = sample_target(7);
+        let user = sample_user(vec![target.clone()], "");
+        let bytes = borsh::to_vec(&user).unwrap();
+        let view = GeolocationUserView::try_from_slice(&bytes).unwrap();
+
+        // The bytes at `targets_offset` should round-trip through borsh as
+        // the same target.
+        let slice = &bytes[view.targets_offset..view.targets_offset + STRIDE];
+        let decoded: GeolocationTarget = borsh::from_slice(slice).unwrap();
+        assert_eq!(decoded, target);
+    }
+
+    #[test]
+    fn rejects_wrong_account_type() {
+        let mut bytes = borsh::to_vec(&sample_user(vec![], "")).unwrap();
+        bytes[0] = AccountType::GeoProbe as u8;
+        assert_eq!(
+            GeolocationUserView::try_from_slice(&bytes).unwrap_err(),
+            ProgramError::InvalidAccountData
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_targets_section() {
+        let user = sample_user((0..3).map(sample_target).collect(), "");
+        let mut bytes = borsh::to_vec(&user).unwrap();
+        // Drop a byte from inside the targets section.
+        bytes.truncate(bytes.len() - STRIDE - 5);
+        assert_eq!(
+            GeolocationUserView::try_from_slice(&bytes).unwrap_err(),
+            ProgramError::InvalidAccountData
+        );
+    }
+
+    #[test]
+    fn handles_missing_result_destination_field() {
+        // Simulate an old account written before result_destination existed:
+        // borsh-serialize the user, then strip the trailing 4-byte empty
+        // String prefix.
+        let user = sample_user(vec![sample_target(1)], "");
+        let mut bytes = borsh::to_vec(&user).unwrap();
+        bytes.truncate(bytes.len() - 4);
+        let view = GeolocationUserView::try_from_slice(&bytes).unwrap();
+        assert_eq!(view.targets_count, 1);
+        assert_eq!(view.result_destination, "");
+    }
+}

--- a/smartcontract/programs/doublezero-geolocation/src/state/mod.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/mod.rs
@@ -2,3 +2,4 @@ pub mod accounttype;
 pub mod geo_probe;
 pub mod geolocation_user;
 pub mod program_config;
+pub mod targets_cursor;

--- a/smartcontract/programs/doublezero-geolocation/src/state/mod.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/mod.rs
@@ -1,5 +1,6 @@
 pub mod accounttype;
 pub mod geo_probe;
 pub mod geolocation_user;
+pub mod geolocation_user_view;
 pub mod program_config;
 pub mod targets_cursor;

--- a/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
@@ -79,6 +79,50 @@ impl<'a> TargetsCursor<'a> {
     }
 }
 
+/// Remove the target at `index` via swap-remove: copies the bytes of the
+/// last target over the slot at `index`, then shifts trailing bytes (e.g.
+/// `result_destination`) left by `STRIDE`. Patches the `u32` count at
+/// `targets_offset - 4`. Returns the new count.
+///
+/// Caller must subsequently resize the account by `-STRIDE` to drop the
+/// stale trailing bytes left at the end of the buffer.
+pub fn swap_remove_target_bytes(
+    data: &mut [u8],
+    targets_offset: usize,
+    targets_count: u32,
+    index: u32,
+) -> Result<u32, ProgramError> {
+    if index >= targets_count {
+        return Err(ProgramError::InvalidArgument);
+    }
+    let count_offset = targets_offset
+        .checked_sub(4)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let new_count = targets_count - 1;
+    let removed_offset = targets_offset + (index as usize) * STRIDE;
+    let last_offset = targets_offset + (new_count as usize) * STRIDE;
+
+    // 1. If we're removing a non-last entry, copy the last target's bytes
+    // into the removed slot. (For index == new_count the slot is already at
+    // the boundary; no swap needed.)
+    if index != new_count {
+        data.copy_within(last_offset..last_offset + STRIDE, removed_offset);
+    }
+
+    // 2. Shift trailing bytes left by STRIDE so they sit immediately after
+    // the (now smaller) targets section.
+    let trailing_src = last_offset + STRIDE;
+    let trailing_len = data.len().saturating_sub(trailing_src);
+    if trailing_len > 0 {
+        data.copy_within(trailing_src..trailing_src + trailing_len, last_offset);
+    }
+
+    // 3. Patch the count prefix.
+    data[count_offset..count_offset + 4].copy_from_slice(&new_count.to_le_bytes());
+
+    Ok(new_count)
+}
+
 /// Insert `target_bytes` at the end of the targets section in `data`, shifting
 /// any trailing bytes (e.g. `result_destination`) by `+STRIDE`. The buffer
 /// must already be sized to the post-append length (i.e. caller has resized
@@ -322,6 +366,141 @@ mod tests {
             // Trailing bytes intact.
             let trailing_offset = targets_offset + new_count as usize * STRIDE;
             assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+        }
+    }
+
+    #[test]
+    fn swap_remove_bytes_last_index_no_swap() {
+        let existing: Vec<_> = (0..3).map(sample_target).collect();
+        let trailing = b"\x05\x00\x00\x00hello";
+        let (mut data, targets_offset) = synthetic_buffer(&existing, trailing);
+
+        let new_count =
+            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 2)
+                .unwrap();
+        assert_eq!(new_count, 2);
+
+        let cursor = TargetsCursor::new(
+            &data[targets_offset..targets_offset + new_count as usize * STRIDE],
+            new_count,
+        )
+        .unwrap();
+        assert_eq!(cursor.get(0).unwrap(), existing[0]);
+        assert_eq!(cursor.get(1).unwrap(), existing[1]);
+
+        // Trailing bytes should now sit immediately after the truncated
+        // targets section — i.e. at `targets_offset + 2 * STRIDE`.
+        let trailing_offset = targets_offset + 2 * STRIDE;
+        assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+    }
+
+    #[test]
+    fn swap_remove_bytes_middle_index_swaps_last_in() {
+        let existing: Vec<_> = (0..5).map(sample_target).collect();
+        let (mut data, targets_offset) = synthetic_buffer(&existing, &[]);
+
+        let new_count =
+            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 1)
+                .unwrap();
+        assert_eq!(new_count, 4);
+
+        let cursor = TargetsCursor::new(
+            &data[targets_offset..targets_offset + new_count as usize * STRIDE],
+            new_count,
+        )
+        .unwrap();
+        // index 0 unchanged
+        assert_eq!(cursor.get(0).unwrap(), existing[0]);
+        // index 1 now holds what used to be the last entry (existing[4])
+        assert_eq!(cursor.get(1).unwrap(), existing[4]);
+        // index 2,3 unchanged
+        assert_eq!(cursor.get(2).unwrap(), existing[2]);
+        assert_eq!(cursor.get(3).unwrap(), existing[3]);
+    }
+
+    #[test]
+    fn swap_remove_bytes_out_of_range_errors() {
+        let existing = vec![sample_target(0)];
+        let (mut data, targets_offset) = synthetic_buffer(&existing, &[]);
+        assert_eq!(
+            swap_remove_target_bytes(&mut data, targets_offset, 1, 1).unwrap_err(),
+            ProgramError::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn append_and_swap_remove_oracle() {
+        // Drive the byte helpers through an interleaved sequence of appends
+        // and removes; mirror the same sequence on a Vec<GeolocationTarget>;
+        // after each step assert the cursor view matches the oracle.
+        let trailing = b"\x05\x00\x00\x00hello";
+        let mut oracle: Vec<GeolocationTarget> = Vec::new();
+        let (mut data, targets_offset) = synthetic_buffer(&oracle, trailing);
+
+        // Operations: A=append, R=remove. Indices interpreted against the
+        // oracle's current length, with `% len()`.
+        let ops = [
+            ("A", 0),
+            ("A", 1),
+            ("A", 2),
+            ("A", 3),
+            ("A", 4),
+            ("R", 1), // remove middle
+            ("R", 2),
+            ("A", 99),
+            ("R", 0), // remove first
+            ("A", 100),
+            ("A", 101),
+            ("R", 4), // remove last (oracle len after last A is 5)
+        ];
+
+        for (op, key) in ops {
+            match op {
+                "A" => {
+                    let new = sample_target(2000 + key);
+                    data.resize(data.len() + STRIDE, 0);
+                    let new_count = append_target_bytes(
+                        &mut data,
+                        targets_offset,
+                        oracle.len() as u32,
+                        &target_bytes(&new),
+                    )
+                    .unwrap();
+                    oracle.push(new);
+                    assert_eq!(new_count, oracle.len() as u32);
+                }
+                "R" => {
+                    let idx = (key as usize) % oracle.len();
+                    let new_count = swap_remove_target_bytes(
+                        &mut data,
+                        targets_offset,
+                        oracle.len() as u32,
+                        idx as u32,
+                    )
+                    .unwrap();
+                    oracle.swap_remove(idx);
+                    let new_size = data.len() - STRIDE;
+                    data.truncate(new_size);
+                    assert_eq!(new_count, oracle.len() as u32);
+                }
+                _ => unreachable!(),
+            }
+
+            // After every op, cursor view must match the oracle exactly.
+            let cursor = TargetsCursor::new(
+                &data[targets_offset..targets_offset + oracle.len() * STRIDE],
+                oracle.len() as u32,
+            )
+            .unwrap();
+            for (i, expected) in oracle.iter().enumerate() {
+                assert_eq!(&cursor.get(i as u32).unwrap(), expected);
+            }
+            // Trailing bytes must always sit at the end, intact.
+            let trailing_off = targets_offset + oracle.len() * STRIDE;
+            assert_eq!(
+                &data[trailing_off..trailing_off + trailing.len()],
+                trailing
+            );
         }
     }
 }

--- a/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
@@ -4,7 +4,6 @@
 //! Per-call heap usage is bounded by a single `GeolocationTarget` (71 bytes)
 //! regardless of `N`. This avoids the OOM that hits the default 32 KiB BPF
 //! heap when borsh-deserializing a `Vec<GeolocationTarget>` past N≈250.
-//! See https://github.com/malbeclabs/doublezero/issues/3591.
 
 use crate::state::geolocation_user::GeolocationTarget;
 use solana_program::program_error::ProgramError;
@@ -228,10 +227,7 @@ mod tests {
     #[test]
     fn get_out_of_range_errors() {
         let cursor = TargetsCursor::new(&[], 0).unwrap();
-        assert_eq!(
-            cursor.get(0).unwrap_err(),
-            ProgramError::InvalidArgument
-        );
+        assert_eq!(cursor.get(0).unwrap_err(), ProgramError::InvalidArgument);
     }
 
     #[test]
@@ -283,13 +279,8 @@ mod tests {
         // Caller must resize first.
         data.resize(data.len() + STRIDE, 0);
 
-        let new_count = append_target_bytes(
-            &mut data,
-            targets_offset,
-            0,
-            &target_bytes(&new_target),
-        )
-        .unwrap();
+        let new_count =
+            append_target_bytes(&mut data, targets_offset, 0, &target_bytes(&new_target)).unwrap();
 
         assert_eq!(new_count, 1);
         // Verify the count prefix updated.
@@ -330,7 +321,10 @@ mod tests {
         assert_eq!(cursor.get(existing.len() as u32).unwrap(), new_target);
         // Trailing bytes intact at the new offset.
         let trailing_offset = targets_offset + new_count as usize * STRIDE;
-        assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+        assert_eq!(
+            &data[trailing_offset..trailing_offset + trailing.len()],
+            trailing
+        );
     }
 
     #[test]
@@ -365,7 +359,10 @@ mod tests {
             }
             // Trailing bytes intact.
             let trailing_offset = targets_offset + new_count as usize * STRIDE;
-            assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+            assert_eq!(
+                &data[trailing_offset..trailing_offset + trailing.len()],
+                trailing
+            );
         }
     }
 
@@ -376,8 +373,7 @@ mod tests {
         let (mut data, targets_offset) = synthetic_buffer(&existing, trailing);
 
         let new_count =
-            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 2)
-                .unwrap();
+            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 2).unwrap();
         assert_eq!(new_count, 2);
 
         let cursor = TargetsCursor::new(
@@ -391,7 +387,10 @@ mod tests {
         // Trailing bytes should now sit immediately after the truncated
         // targets section — i.e. at `targets_offset + 2 * STRIDE`.
         let trailing_offset = targets_offset + 2 * STRIDE;
-        assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+        assert_eq!(
+            &data[trailing_offset..trailing_offset + trailing.len()],
+            trailing
+        );
     }
 
     #[test]
@@ -400,8 +399,7 @@ mod tests {
         let (mut data, targets_offset) = synthetic_buffer(&existing, &[]);
 
         let new_count =
-            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 1)
-                .unwrap();
+            swap_remove_target_bytes(&mut data, targets_offset, existing.len() as u32, 1).unwrap();
         assert_eq!(new_count, 4);
 
         let cursor = TargetsCursor::new(
@@ -497,10 +495,7 @@ mod tests {
             }
             // Trailing bytes must always sit at the end, intact.
             let trailing_off = targets_offset + oracle.len() * STRIDE;
-            assert_eq!(
-                &data[trailing_off..trailing_off + trailing.len()],
-                trailing
-            );
+            assert_eq!(&data[trailing_off..trailing_off + trailing.len()], trailing);
         }
     }
 }

--- a/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
@@ -1,0 +1,177 @@
+//! Read-only cursor over the packed `GeolocationTarget` bytes inside a
+//! `GeolocationUser` account.
+//!
+//! Per-call heap usage is bounded by a single `GeolocationTarget` (71 bytes)
+//! regardless of `N`. This avoids the OOM that hits the default 32 KiB BPF
+//! heap when borsh-deserializing a `Vec<GeolocationTarget>` past N≈250.
+//! See https://github.com/malbeclabs/doublezero/issues/3591.
+
+use crate::state::geolocation_user::GeolocationTarget;
+use solana_program::program_error::ProgramError;
+
+/// Wire size of one `GeolocationTarget` (1 + 4 + 2 + 32 + 32). Pinned by the
+/// `stride_matches_wire_format` test.
+pub const STRIDE: usize = 71;
+
+/// Borrowed view over the targets payload of a `GeolocationUser` account.
+/// Construct with [`TargetsCursor::new`] from the slice that *follows* the
+/// `u32` length prefix.
+#[derive(Debug)]
+pub struct TargetsCursor<'a> {
+    bytes: &'a [u8],
+    count: u32,
+}
+
+impl<'a> TargetsCursor<'a> {
+    /// Build a cursor over `bytes`, whose first `count * STRIDE` bytes hold
+    /// `count` packed targets. Trailing bytes (e.g. `result_destination`) are
+    /// ignored. Returns `InvalidAccountData` if `bytes` is too short.
+    pub fn new(bytes: &'a [u8], count: u32) -> Result<Self, ProgramError> {
+        let needed = (count as usize)
+            .checked_mul(STRIDE)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if bytes.len() < needed {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(Self {
+            bytes: &bytes[..needed],
+            count,
+        })
+    }
+
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Decode the target at `index`. Each call deserializes 71 bytes onto the
+    /// stack — no heap allocation.
+    pub fn get(&self, index: u32) -> Result<GeolocationTarget, ProgramError> {
+        if index >= self.count {
+            return Err(ProgramError::InvalidArgument);
+        }
+        let start = (index as usize) * STRIDE;
+        let slice = &self.bytes[start..start + STRIDE];
+        borsh::from_slice(slice).map_err(|_| ProgramError::InvalidAccountData)
+    }
+
+    /// Sequentially-decoded iterator.
+    pub fn iter(&self) -> impl Iterator<Item = Result<GeolocationTarget, ProgramError>> + '_ {
+        (0..self.count).map(move |i| self.get(i))
+    }
+
+    /// Index of the first target satisfying `pred`, or `None`. Stops scanning
+    /// at the first match.
+    pub fn find_match<F>(&self, mut pred: F) -> Result<Option<u32>, ProgramError>
+    where
+        F: FnMut(&GeolocationTarget) -> bool,
+    {
+        for i in 0..self.count {
+            let t = self.get(i)?;
+            if pred(&t) {
+                return Ok(Some(i));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::geolocation_user::GeoLocationTargetType;
+    use borsh::BorshSerialize;
+    use solana_program::pubkey::Pubkey;
+    use std::net::Ipv4Addr;
+
+    fn sample_target(seed: u32) -> GeolocationTarget {
+        let octets = seed.to_be_bytes();
+        GeolocationTarget {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(10, octets[1], octets[2], octets[3]),
+            location_offset_port: 8000 + (seed as u16 & 0x0fff),
+            target_pk: Pubkey::new_from_array([seed as u8; 32]),
+            geoprobe_pk: Pubkey::new_from_array([(seed as u8).wrapping_add(1); 32]),
+        }
+    }
+
+    fn pack(targets: &[GeolocationTarget]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(targets.len() * STRIDE);
+        for t in targets {
+            t.serialize(&mut out).unwrap();
+        }
+        out
+    }
+
+    #[test]
+    fn stride_matches_wire_format() {
+        // The cursor's STRIDE constant is load-bearing; if a future field
+        // change shifts the wire size, all the byte arithmetic in the
+        // mutating helpers breaks silently. This guards against that.
+        let target = sample_target(0);
+        let bytes = borsh::to_vec(&target).unwrap();
+        assert_eq!(bytes.len(), STRIDE);
+    }
+
+    #[test]
+    fn iter_round_trips() {
+        let targets: Vec<_> = (0..5).map(sample_target).collect();
+        let bytes = pack(&targets);
+        let cursor = TargetsCursor::new(&bytes, 5).unwrap();
+        let decoded: Vec<_> = cursor.iter().map(|r| r.unwrap()).collect();
+        assert_eq!(decoded, targets);
+    }
+
+    #[test]
+    fn find_match_returns_index() {
+        let targets: Vec<_> = (0..10).map(sample_target).collect();
+        let bytes = pack(&targets);
+        let cursor = TargetsCursor::new(&bytes, 10).unwrap();
+        let needle = sample_target(7);
+        let idx = cursor.find_match(|t| *t == needle).unwrap();
+        assert_eq!(idx, Some(7));
+    }
+
+    #[test]
+    fn find_match_returns_none() {
+        let targets: Vec<_> = (0..3).map(sample_target).collect();
+        let bytes = pack(&targets);
+        let cursor = TargetsCursor::new(&bytes, 3).unwrap();
+        let result = cursor.find_match(|t| t.location_offset_port == 0).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_out_of_range_errors() {
+        let cursor = TargetsCursor::new(&[], 0).unwrap();
+        assert_eq!(
+            cursor.get(0).unwrap_err(),
+            ProgramError::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn new_rejects_short_buffer() {
+        let bytes = vec![0u8; STRIDE - 1];
+        assert_eq!(
+            TargetsCursor::new(&bytes, 1).unwrap_err(),
+            ProgramError::InvalidAccountData
+        );
+    }
+
+    #[test]
+    fn new_ignores_trailing_bytes() {
+        // Cursor only owns the targets section; trailing bytes (e.g. the
+        // following `result_destination` length prefix) are correctly out
+        // of scope.
+        let target = sample_target(42);
+        let mut bytes = pack(std::slice::from_ref(&target));
+        bytes.extend_from_slice(&[0xab, 0xcd, 0xef]); // simulated trailing data
+        let cursor = TargetsCursor::new(&bytes, 1).unwrap();
+        assert_eq!(cursor.len(), 1);
+        assert_eq!(cursor.get(0).unwrap(), target);
+    }
+}

--- a/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
+++ b/smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs
@@ -79,6 +79,43 @@ impl<'a> TargetsCursor<'a> {
     }
 }
 
+/// Insert `target_bytes` at the end of the targets section in `data`, shifting
+/// any trailing bytes (e.g. `result_destination`) by `+STRIDE`. The buffer
+/// must already be sized to the post-append length (i.e. caller has resized
+/// the account by `+STRIDE` first). Patches the `u32` count at
+/// `targets_offset - 4`. Returns the new count.
+pub fn append_target_bytes(
+    data: &mut [u8],
+    targets_offset: usize,
+    targets_count: u32,
+    target_bytes: &[u8; STRIDE],
+) -> Result<u32, ProgramError> {
+    let count_offset = targets_offset
+        .checked_sub(4)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let new_count = targets_count
+        .checked_add(1)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let insert_at = targets_offset
+        .checked_add((targets_count as usize) * STRIDE)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let new_len = data.len();
+    let old_len = new_len
+        .checked_sub(STRIDE)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let trailing_len = old_len
+        .checked_sub(insert_at)
+        .ok_or(ProgramError::InvalidAccountData)?;
+
+    if trailing_len > 0 {
+        data.copy_within(insert_at..insert_at + trailing_len, insert_at + STRIDE);
+    }
+    data[insert_at..insert_at + STRIDE].copy_from_slice(target_bytes);
+    data[count_offset..count_offset + 4].copy_from_slice(&new_count.to_le_bytes());
+
+    Ok(new_count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,5 +210,118 @@ mod tests {
         let cursor = TargetsCursor::new(&bytes, 1).unwrap();
         assert_eq!(cursor.len(), 1);
         assert_eq!(cursor.get(0).unwrap(), target);
+    }
+
+    /// Build a buffer mimicking the targets-and-trailing layout:
+    /// `[count: u32 LE][targets_count * STRIDE bytes][trailing bytes]`.
+    /// `targets_offset` is 4 (the count prefix is the first thing). Returns
+    /// the buffer and the targets_offset.
+    fn synthetic_buffer(targets: &[GeolocationTarget], trailing: &[u8]) -> (Vec<u8>, usize) {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(targets.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&pack(targets));
+        buf.extend_from_slice(trailing);
+        let targets_offset = 4;
+        (buf, targets_offset)
+    }
+
+    fn target_bytes(t: &GeolocationTarget) -> [u8; STRIDE] {
+        let mut buf = [0u8; STRIDE];
+        let mut out: &mut [u8] = &mut buf;
+        t.serialize(&mut out).unwrap();
+        buf
+    }
+
+    #[test]
+    fn append_bytes_into_empty_targets_no_trailing() {
+        let (mut data, targets_offset) = synthetic_buffer(&[], &[]);
+        let new_target = sample_target(7);
+        // Caller must resize first.
+        data.resize(data.len() + STRIDE, 0);
+
+        let new_count = append_target_bytes(
+            &mut data,
+            targets_offset,
+            0,
+            &target_bytes(&new_target),
+        )
+        .unwrap();
+
+        assert_eq!(new_count, 1);
+        // Verify the count prefix updated.
+        assert_eq!(u32::from_le_bytes(data[0..4].try_into().unwrap()), 1);
+        // Verify the bytes round-trip.
+        let cursor = TargetsCursor::new(&data[targets_offset..targets_offset + STRIDE], 1).unwrap();
+        assert_eq!(cursor.get(0).unwrap(), new_target);
+    }
+
+    #[test]
+    fn append_bytes_with_trailing_shifts_correctly() {
+        let existing: Vec<_> = (0..3).map(sample_target).collect();
+        let trailing = b"\x05\x00\x00\x00hello"; // mimics result_destination = "hello"
+        let (mut data, targets_offset) = synthetic_buffer(&existing, trailing);
+        let new_target = sample_target(99);
+        let pre_len = data.len();
+        data.resize(pre_len + STRIDE, 0);
+
+        let new_count = append_target_bytes(
+            &mut data,
+            targets_offset,
+            existing.len() as u32,
+            &target_bytes(&new_target),
+        )
+        .unwrap();
+
+        assert_eq!(new_count, (existing.len() + 1) as u32);
+        // Existing targets unchanged.
+        let cursor = TargetsCursor::new(
+            &data[targets_offset..targets_offset + new_count as usize * STRIDE],
+            new_count,
+        )
+        .unwrap();
+        for (i, original) in existing.iter().enumerate() {
+            assert_eq!(&cursor.get(i as u32).unwrap(), original);
+        }
+        // New target at the end.
+        assert_eq!(cursor.get(existing.len() as u32).unwrap(), new_target);
+        // Trailing bytes intact at the new offset.
+        let trailing_offset = targets_offset + new_count as usize * STRIDE;
+        assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+    }
+
+    #[test]
+    fn append_bytes_round_trip_oracle() {
+        // Oracle: keep a Vec<GeolocationTarget> mirror; after each append,
+        // the borsh-serialized Vec must match the cursor view of `data`.
+        let mut oracle: Vec<GeolocationTarget> = Vec::new();
+        let trailing = b"\x00\x00\x00\x00"; // empty result_destination
+        let (mut data, targets_offset) = synthetic_buffer(&oracle, trailing);
+
+        for i in 0..50 {
+            let new = sample_target(1000 + i);
+            data.resize(data.len() + STRIDE, 0);
+            let new_count = append_target_bytes(
+                &mut data,
+                targets_offset,
+                oracle.len() as u32,
+                &target_bytes(&new),
+            )
+            .unwrap();
+            oracle.push(new);
+            assert_eq!(new_count, oracle.len() as u32);
+
+            // Every existing target should still be readable.
+            let cursor = TargetsCursor::new(
+                &data[targets_offset..targets_offset + new_count as usize * STRIDE],
+                new_count,
+            )
+            .unwrap();
+            for (j, expected) in oracle.iter().enumerate() {
+                assert_eq!(&cursor.get(j as u32).unwrap(), expected);
+            }
+            // Trailing bytes intact.
+            let trailing_offset = targets_offset + new_count as usize * STRIDE;
+            assert_eq!(&data[trailing_offset..trailing_offset + trailing.len()], trailing);
+        }
     }
 }

--- a/smartcontract/programs/doublezero-geolocation/tests/add_target_cu_benchmark.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/add_target_cu_benchmark.rs
@@ -7,7 +7,7 @@
 //!         --test add_target_cu_benchmark -p doublezero-geolocation --release \
 //!         -- --ignored --nocapture
 //!
-//! After the cursor refactor (#3591) the targets section is read and written
+//! With the cursor-based read/write paths the targets section is processed
 //! in place, so heap usage no longer scales with N. CU on the per-call dup
 //! scan is now the binding constraint.
 
@@ -202,10 +202,9 @@ async fn measure_add_target(target_count: usize) -> Measurement {
 #[tokio::test]
 #[ignore = "benchmark - run explicitly via `cargo test --test add_target_cu_benchmark -- --ignored --nocapture`"]
 async fn benchmark_add_target_cu_scaling() {
-    // Sweep up through where CU becomes the binding constraint. Pre-cursor
-    // (issue #3591) this OOM'd at N≈250 due to heap; post-cursor heap is
-    // bounded so we can climb until the dup-scan exhausts the 1.4 M CU
-    // budget.
+    // Sweep up through where CU becomes the binding constraint. Before the
+    // cursor refactor this OOM'd at N≈250 due to heap; with bounded heap we
+    // can climb until the dup-scan exhausts the 1.4 M CU budget.
     // MAX_TARGETS is currently 4096 and add_target rejects beyond that, so
     // 4095 is the highest reachable sample. Raising MAX_TARGETS based on
     // these measurements is a separate PR.

--- a/smartcontract/programs/doublezero-geolocation/tests/add_target_cu_benchmark.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/add_target_cu_benchmark.rs
@@ -1,0 +1,229 @@
+//! CU benchmark for `add_target` to inform `MAX_TARGETS`.
+//!
+//! Run under SBF (CU and heap behavior under the native processor are not
+//! meaningful):
+//!
+//!     SBF_OUT_DIR=$(pwd)/target/deploy cargo test \
+//!         --test add_target_cu_benchmark -p doublezero-geolocation --release \
+//!         -- --ignored --nocapture
+//!
+//! After the cursor refactor (#3591) the targets section is read and written
+//! in place, so heap usage no longer scales with N. CU on the per-call dup
+//! scan is now the binding constraint.
+
+#![allow(unused_mut)]
+
+use doublezero_geolocation::{
+    entrypoint::process_instruction,
+    instructions::GeolocationInstruction,
+    pda::{get_geo_probe_pda, get_geolocation_user_pda},
+    processors::geolocation_user::add_target::AddTargetArgs,
+    state::{
+        accounttype::AccountType,
+        geo_probe::GeoProbe,
+        geolocation_user::{
+            FlatPerEpochConfig, GeoLocationTargetType, GeolocationBillingConfig,
+            GeolocationPaymentStatus, GeolocationTarget, GeolocationUser, GeolocationUserStatus,
+        },
+    },
+};
+use solana_program_test::*;
+use solana_sdk::{
+    account::AccountSharedData,
+    compute_budget::ComputeBudgetInstruction,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    rent::Rent,
+    signature::Signer,
+    transaction::Transaction,
+};
+use std::net::Ipv4Addr;
+
+const PROBE_CODE: &str = "bench-probe";
+const USER_CODE: &str = "bench-user";
+
+fn build_user_account(
+    program_id: &Pubkey,
+    owner: &Pubkey,
+    target_count: usize,
+    geoprobe_pk: Pubkey,
+) -> (AccountSharedData, usize) {
+    let mut targets = Vec::with_capacity(target_count);
+    for i in 0..target_count {
+        // Pre-populated entries skip validate_public_ip; using 10.x to keep them
+        // distinct from the real public IP we'll add at measurement time.
+        let octets = (i as u32).to_be_bytes();
+        targets.push(GeolocationTarget {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(10, octets[1], octets[2], octets[3]),
+            location_offset_port: 8000,
+            target_pk: Pubkey::default(),
+            geoprobe_pk,
+        });
+    }
+
+    let user = GeolocationUser {
+        account_type: AccountType::GeolocationUser,
+        owner: *owner,
+        code: USER_CODE.to_string(),
+        token_account: Pubkey::new_unique(),
+        payment_status: GeolocationPaymentStatus::Paid,
+        billing: GeolocationBillingConfig::FlatPerEpoch(FlatPerEpochConfig::default()),
+        status: GeolocationUserStatus::Activated,
+        targets,
+        result_destination: String::new(),
+    };
+
+    let data = borsh::to_vec(&user).unwrap();
+    let lamports = Rent::default()
+        .minimum_balance(data.len())
+        .saturating_mul(2)
+        .max(10_000_000_000);
+    let bytes = data.len();
+    let mut account = AccountSharedData::new(lamports, bytes, program_id);
+    account.set_data_from_slice(&data);
+    (account, bytes)
+}
+
+fn build_probe_account(program_id: &Pubkey) -> AccountSharedData {
+    let probe = GeoProbe {
+        account_type: AccountType::GeoProbe,
+        owner: Pubkey::new_unique(),
+        exchange_pk: Pubkey::new_unique(),
+        public_ip: Ipv4Addr::new(8, 8, 8, 8),
+        location_offset_port: 4242,
+        metrics_publisher_pk: Pubkey::new_unique(),
+        reference_count: 0,
+        code: PROBE_CODE.to_string(),
+        parent_devices: vec![],
+        target_update_count: 0,
+    };
+
+    let data = borsh::to_vec(&probe).unwrap();
+    let lamports = Rent::default().minimum_balance(data.len()).max(1_000_000);
+    let mut account = AccountSharedData::new(lamports, data.len(), program_id);
+    account.set_data_from_slice(&data);
+    account
+}
+
+struct Measurement {
+    bytes: usize,
+    cu: u64,
+    status: &'static str,
+    detail: String,
+}
+
+async fn measure_add_target(target_count: usize) -> Measurement {
+    let program_id = Pubkey::new_unique();
+    // Avoid `set_compute_max_units` — it pins the runtime ComputeBudget to
+    // defaults and silently overrides per-tx ComputeBudget instructions. The
+    // per-tx `set_compute_unit_limit` below covers our 1.4M budget instead.
+    let program_test = ProgramTest::new(
+        "doublezero_geolocation",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    let payer_pubkey = context.payer.pubkey();
+
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, USER_CODE);
+    let (probe_pda, _) = get_geo_probe_pda(&program_id, PROBE_CODE);
+
+    let (user_account, user_bytes) =
+        build_user_account(&program_id, &payer_pubkey, target_count, probe_pda);
+    context.set_account(&user_pda, &user_account);
+    context.set_account(&probe_pda, &build_probe_account(&program_id));
+
+    let ixs = vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+        Instruction::new_with_borsh(
+            program_id,
+            &GeolocationInstruction::AddTarget(AddTargetArgs {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                location_offset_port: 9000,
+                target_pk: Pubkey::default(),
+            }),
+            vec![
+                AccountMeta::new(user_pda, false),
+                AccountMeta::new(probe_pda, false),
+                AccountMeta::new(payer_pubkey, true),
+                AccountMeta::new_readonly(solana_program::system_program::id(), false),
+            ],
+        ),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &ixs,
+        Some(&payer_pubkey),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let outcome = context
+        .banks_client
+        .process_transaction_with_metadata(tx)
+        .await
+        .expect("banks client failure");
+
+    let metadata = outcome.metadata.expect("metadata");
+    let cu = metadata.compute_units_consumed;
+    let logs = &metadata.log_messages;
+
+    let (status, detail) = match outcome.result {
+        Ok(()) => ("ok", String::new()),
+        Err(e) => {
+            let oom = logs
+                .iter()
+                .any(|l| l.contains("memory allocation failed") || l.contains("out of memory"));
+            let cu_exhausted = logs
+                .iter()
+                .any(|l| l.contains("exceeded CUs meter") || l.contains("compute meter"));
+            let status = if oom {
+                "OOM"
+            } else if cu_exhausted {
+                "CU"
+            } else {
+                "ERR"
+            };
+            (status, format!("{e:?}"))
+        }
+    };
+
+    Measurement {
+        bytes: user_bytes,
+        cu,
+        status,
+        detail,
+    }
+}
+
+#[tokio::test]
+#[ignore = "benchmark - run explicitly via `cargo test --test add_target_cu_benchmark -- --ignored --nocapture`"]
+async fn benchmark_add_target_cu_scaling() {
+    // Sweep up through where CU becomes the binding constraint. Pre-cursor
+    // (issue #3591) this OOM'd at N≈250 due to heap; post-cursor heap is
+    // bounded so we can climb until the dup-scan exhausts the 1.4 M CU
+    // budget.
+    // MAX_TARGETS is currently 4096 and add_target rejects beyond that, so
+    // 4095 is the highest reachable sample. Raising MAX_TARGETS based on
+    // these measurements is a separate PR.
+    let counts: &[usize] = &[0, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 4_095];
+
+    eprintln!("\nadd_target CU vs. existing target count (default 32 KiB BPF heap)");
+    eprintln!(
+        "  {:>6}   {:>10}   {:>10}   {:<6}   detail",
+        "N", "acct_bytes", "CU", "status"
+    );
+    for &n in counts {
+        let m = measure_add_target(n).await;
+        eprintln!(
+            "  {:>6}   {:>10}   {:>10}   {:<6}   {}",
+            n, m.bytes, m.cu, m.status, m.detail
+        );
+        if m.status == "CU" || m.status == "ERR" {
+            break;
+        }
+    }
+}

--- a/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/geolocation_user_test.rs
@@ -2070,3 +2070,168 @@ async fn test_set_result_destination_wrong_probe_count() {
         _ => panic!("Expected ProbeAccountCountMismatch error, got: {:?}", err),
     }
 }
+
+// `result_destination` lives at the tail of the account, after the targets section. `add_target`
+// shifts the tail forward by one stride, `remove_target` (swap-remove) shifts it back. Drives the
+// full add/remove cycle through `banks_client` so the in-place mutations get a CI signal.
+#[tokio::test]
+async fn test_result_destination_survives_add_remove_cycle() {
+    let (mut banks_client, program_id, recent_blockhash, payer, exchange_pubkey) =
+        setup_test_with_exchange(ExchangeStatus::Activated).await;
+
+    let probe1_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-cycle-1",
+    )
+    .await;
+    let probe2_pda = create_geo_probe(
+        &mut banks_client,
+        &program_id,
+        &recent_blockhash,
+        &payer,
+        &exchange_pubkey,
+        "probe-cycle-2",
+    )
+    .await;
+
+    let user_code = "user-cycle";
+    let ix = build_create_user_ix(
+        &program_id,
+        user_code,
+        &Pubkey::new_unique(),
+        &payer.pubkey(),
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+    let (user_pda, _) = get_geolocation_user_pda(&program_id, user_code);
+
+    // Add first target referencing probe1.
+    let add1_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe1_pda,
+        &payer.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            location_offset_port: 8923,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add1_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Stamp the result_destination with one target in place.
+    let expected_destination = "185.199.108.1:9000".to_string();
+    let set_ix = build_set_result_destination_ix(
+        &program_id,
+        &user_pda,
+        &payer.pubkey(),
+        &[probe1_pda],
+        SetResultDestinationArgs {
+            destination: expected_destination.clone(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[set_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, expected_destination);
+
+    // Add a second target — shifts the tail forward by one stride.
+    let add2_ix = build_add_target_ix(
+        &program_id,
+        &user_pda,
+        &probe2_pda,
+        &payer.pubkey(),
+        AddTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(1, 1, 1, 1),
+            location_offset_port: 8924,
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[add2_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, expected_destination);
+    assert_eq!(user.targets.len(), 2);
+
+    // Remove the first target — swap-remove pulls target2 into slot 0 and shifts the tail back.
+    let rm1_ix = build_remove_target_ix(
+        &program_id,
+        &user_pda,
+        &probe1_pda,
+        &payer.pubkey(),
+        RemoveTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(8, 8, 8, 8),
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[rm1_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, expected_destination);
+    assert_eq!(user.targets.len(), 1);
+    assert_eq!(user.targets[0].ip_address, Ipv4Addr::new(1, 1, 1, 1));
+
+    // Remove the last remaining target — trailing-section truncation, no swap.
+    let rm2_ix = build_remove_target_ix(
+        &program_id,
+        &user_pda,
+        &probe2_pda,
+        &payer.pubkey(),
+        RemoveTargetArgs {
+            target_type: GeoLocationTargetType::Outbound,
+            ip_address: Ipv4Addr::new(1, 1, 1, 1),
+            target_pk: Pubkey::default(),
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[rm2_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        *recent_blockhash.read().await,
+    );
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let account = banks_client.get_account(user_pda).await.unwrap().unwrap();
+    let user = GeolocationUser::try_from(&account.data[..]).unwrap();
+    assert_eq!(user.result_destination, expected_destination);
+    assert!(user.targets.is_empty());
+}


### PR DESCRIPTION
Resolves: #3591

## Summary of Changes
- Replace `GeolocationUser::try_from` with a new `GeolocationUserView` parser that records the targets section's byte offset and **skips** past the packed `Vec<GeolocationTarget>` instead of materializing it. Per-call heap usage is now bounded by the user's `code` and `result_destination` lengths, independent of `N`.
- Add a `TargetsCursor` for reads and free byte-level helpers (`append_target_bytes`, `swap_remove_target_bytes`) for in-place mutations against the account buffer. Each one stack-decodes a single 71-byte `GeolocationTarget` at a time.
- Refactor every on-chain write path (`add_target`, `remove_target`, `delete`, `update`, `update_payment_status`, `set_result_destination`) to use the new view + cursor instead of materializing the full user. `set_result_destination` rewrites its probe-validation as a streaming cursor scan with a small bounded `unique_from_targets` set, removing the previous `HashSet<Pubkey>` heap risk.
- Add a `stride_matches_wire_format` test plus an interleaved append/swap-remove oracle test that drives the byte helpers against a `Vec<GeolocationTarget>` mirror — catches off-by-one errors in the byte arithmetic.
- Add a CU benchmark (`tests/add_target_cu_benchmark.rs`) that sweeps `add_target` from N=0 up through N=4095. Pre-cursor this OOM'd at N≈250; post-cursor the full `MAX_TARGETS=4096` cap is now reachable, with N=4095 consuming ~913 K of the 1.4 M CU budget. Linear at ~221 CU/existing-target.

**Out of scope** (deliberate, separate PRs):
- `MAX_TARGETS` is intentionally untouched at 4096. Raising it should be a separate change with its own benchmark sweep above the current cap.
- No SDK / CLI / Go changes — wire format and instruction discriminators are unchanged.

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Core logic | 8 | +551 / -88 | +463 |
| Scaffolding (state/mod.rs) | 1 | +2 / -0 | +2 |
| Tests (inline + benchmark) | 3 | +690 / -0 | +690 |

Roughly 60% of the diff is tests (inline cursor/view tests + the benchmark). Production code change is ~460 net lines, and the processor refactors are net-small — most of the volume lives in the two new self-contained state modules.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-geolocation/src/state/targets_cursor.rs` (+502/-0) — new module: `STRIDE` const + `stride_matches_wire_format` canary, `TargetsCursor<'a>` (`get`, `iter`, `find_match`), and the `append_target_bytes` / `swap_remove_target_bytes` byte-level mutators with an interleaved oracle test.
- `smartcontract/programs/doublezero-geolocation/src/state/geolocation_user_view.rs` (+384/-0) — new module: `GeolocationUserView` parses metadata and skips the targets section, then exposes `cursor`, `append_target`, `swap_remove_target`, `write_prefix`, `write_result_destination` helpers that handle the resize + memmove bookkeeping in place.
- `smartcontract/programs/doublezero-geolocation/tests/add_target_cu_benchmark.rs` (+229/-0) — `#[ignore]` benchmark sweeping `add_target` CU vs. existing-target count up to MAX_TARGETS-1.
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/set_result_destination.rs` (+65/-30) — replaces the `HashSet<Pubkey>` of unique probes with a streaming cursor scan + bounded sorted `Vec<Pubkey>` (capped at `provided.len() + 1`) that preserves the original error semantics for count-mismatch vs. unrelated-probe cases.
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/add_target.rs` (+22/-18) — switches to View + cursor for the dup-scan and `view.append_target` for the write.
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/remove_target.rs` (+20/-21) — switches to View + cursor for the index lookup and `view.swap_remove_target` for the delete.
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/update_payment_status.rs` (+9/-7) — reads via View, writes via `view.write_prefix`.
- `smartcontract/programs/doublezero-geolocation/src/processors/geolocation_user/delete.rs` (+5/-5) — `view.targets_count != 0` check replaces `user.targets.is_empty()`.

</details>

## Testing Verification
- 67 lib unit tests pass, including 30 new ones across the cursor and view modules: `stride_matches_wire_format`, cursor `iter` / `get` / `find_match` correctness, header round-trip across N=0..1000, byte-helper edge cases (last-index swap-remove, empty trailing, out-of-range, truncated buffer), and an interleaved append/swap-remove oracle test that diffs against a `Vec<GeolocationTarget>` mirror.
- 29 existing integration tests pass unmodified — wire format and instruction discriminators are unchanged.
- `cargo clippy --all-targets -- -Dclippy::all -Dwarnings` clean.
- `cargo +nightly fmt --check` clean.
- Empirical: `add_target` benchmark at N=4095 lands at 913,095 CU and 290,851 account bytes (was OOM at N≈250 pre-cursor). Numbers posted to issue #3591.
