### PR TITLE
client/doublezerod/latency: fix flaky TestSingleSocketPing — race + stray-reply misattribution

### DIFF
--- a/client/doublezerod/internal/latency/singlesocket.go
+++ b/client/doublezerod/internal/latency/singlesocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -96,11 +97,20 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 			}
 
 			for _, idx := range indices {
-				if !states[idx].rtts[seq].got {
-					states[idx].rtts[seq].got = true
-					states[idx].rtts[seq].rtt = receiveTime.Sub(states[idx].rtts[seq].sent)
-					totalReceived.Add(1)
+				// Lock pairs with the sender's write of `.sent` below. The kernel
+				// roundtrip provides a logical happens-before, but the race
+				// detector can't see across socket I/O — explicit synchronization
+				// is required.
+				states[idx].mu.Lock()
+				if states[idx].rtts[seq].got {
+					states[idx].mu.Unlock()
+					continue
 				}
+				sent := states[idx].rtts[seq].sent
+				states[idx].rtts[seq].got = true
+				states[idx].rtts[seq].rtt = receiveTime.Sub(sent)
+				states[idx].mu.Unlock()
+				totalReceived.Add(1)
 			}
 		}
 	}()
@@ -122,7 +132,9 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 				slog.Error("latency: failed to marshal ICMP message", "target", t.IP, "error", err)
 				continue
 			}
+			states[i].mu.Lock()
 			states[i].rtts[seq].sent = time.Now()
+			states[i].mu.Unlock()
 			_, err = conn.WriteTo(b, &net.IPAddr{IP: t.IP})
 			if err != nil {
 				slog.Error("latency: failed to send ICMP echo", "target", t.IP, "error", err)
@@ -154,17 +166,27 @@ type rttEntry struct {
 
 type probeState struct {
 	target ProbeTarget
-	rtts   [pingCount]rttEntry
+	// mu protects concurrent access to rtts[*].sent between the sender (main)
+	// goroutine and the reader goroutine. The other rtts fields are only
+	// written by the reader and read by buildResults after readerDone closes.
+	mu   sync.Mutex
+	rtts [pingCount]rttEntry
 }
 
 func buildResults(states []probeState) []LatencyResult {
 	results := make([]LatencyResult, len(states))
-	for i, s := range states {
+	// Iterate by index so we don't copy probeState (which contains a Mutex).
+	// Safe to read rtts without locking: this is called only after
+	// readerDone closes, which establishes happens-before with the reader
+	// goroutine, and the sender goroutine has long since finished.
+	for i := range states {
+		s := &states[i]
 		var received int
 		var total, minRtt, maxRtt time.Duration
 		minRtt = time.Hour // sentinel
 
-		for _, r := range s.rtts {
+		for j := range s.rtts {
+			r := &s.rtts[j]
 			if r.got {
 				received++
 				total += r.rtt

--- a/client/doublezerod/internal/latency/singlesocket.go
+++ b/client/doublezerod/internal/latency/singlesocket.go
@@ -44,13 +44,6 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 		states[i].target = t
 	}
 
-	// Build a lookup from destination IP to list of target indices (multiple
-	// targets can share an IP in theory, but typically they don't).
-	ipToIndices := make(map[string][]int, len(targets))
-	for i, t := range targets {
-		ipToIndices[t.IP.String()] = append(ipToIndices[t.IP.String()], i)
-	}
-
 	payload := make([]byte, pingPayload)
 
 	// Set read deadline for the entire probe session.
@@ -90,28 +83,41 @@ func SingleSocketPing(ctx context.Context, targets []ProbeTarget) []LatencyResul
 				continue
 			}
 
-			peerIP := peer.String()
-			indices, ok := ipToIndices[peerIP]
-			if !ok {
+			// Match by echo.ID = the target index we set when sending. Raw
+			// ICMP sockets preserve the ID byte-for-byte, so this filters out
+			// stray echo replies (e.g. responses to other processes' pings on
+			// the host) that would otherwise be misattributed to one of our
+			// slots and produce bogus RTTs.
+			idx := echo.ID
+			if idx < 0 || idx >= len(targets) {
+				continue
+			}
+			if peer.String() != targets[idx].IP.String() {
 				continue
 			}
 
-			for _, idx := range indices {
-				// Lock pairs with the sender's write of `.sent` below. The kernel
-				// roundtrip provides a logical happens-before, but the race
-				// detector can't see across socket I/O — explicit synchronization
-				// is required.
-				states[idx].mu.Lock()
-				if states[idx].rtts[seq].got {
-					states[idx].mu.Unlock()
-					continue
-				}
-				sent := states[idx].rtts[seq].sent
-				states[idx].rtts[seq].got = true
-				states[idx].rtts[seq].rtt = receiveTime.Sub(sent)
+			// Lock pairs with the sender's write of `.sent` below. The kernel
+			// roundtrip provides a logical happens-before, but the race
+			// detector can't see across socket I/O — explicit synchronization
+			// is required.
+			states[idx].mu.Lock()
+			if states[idx].rtts[seq].got {
 				states[idx].mu.Unlock()
-				totalReceived.Add(1)
+				continue
 			}
+			sent := states[idx].rtts[seq].sent
+			if sent.IsZero() {
+				// Reply arrived before the matching send was recorded —
+				// shouldn't happen given the echo.ID match, but defensive:
+				// computing receiveTime.Sub(zero) would saturate to
+				// MaxDuration and poison the result.
+				states[idx].mu.Unlock()
+				continue
+			}
+			states[idx].rtts[seq].got = true
+			states[idx].rtts[seq].rtt = receiveTime.Sub(sent)
+			states[idx].mu.Unlock()
+			totalReceived.Add(1)
 		}
 	}()
 


### PR DESCRIPTION
## Summary of Changes
Two distinct bugs in `SingleSocketPing` were combining to make `TestSingleSocketPing_Localhost` flaky in CI:

- **Data race on `rttEntry.sent`.** The sender goroutine wrote `states[i].rtts[seq].sent = time.Now()` while the reader goroutine read it inside `receiveTime.Sub(...)` to compute RTT. The kernel socket roundtrip provides logical happens-before but Go's race detector can't see across socket I/O, so this surfaced as an actual race report. Fixed with a per-state `sync.Mutex` covering the cross-goroutine access; the reader's update block is now one critical section with `totalReceived.Add(1)` outside the lock.
- **Stray echo replies were misattributed to pending slots.** The reader filtered incoming ICMP replies by peer IP and `seq` only, not by `echo.ID`. Any ambient echo reply on the host (e.g. responses to other processes' pings to localhost) with a sequence in `[0, pingCount)` was matched to one of our slots — whose `sent` was zero, so `receiveTime.Sub(zero)` saturated to `MaxDuration` and poisoned `min`/`avg`/`max` in `buildResults`. This is what produced the `got 61562 <= 20520 <= 9223372036854775807` assertion seen in CI. Fixed by matching on `echo.ID` (we set it to the target index when sending; raw ICMP sockets under `NET_RAW` preserve it), with a defensive peer-IP sanity check and `IsZero` guard on `sent` for belt-and-suspenders correctness. The `ipToIndices` map is no longer needed.

`buildResults` switches to index-based iteration so it doesn't copy `probeState` (which now contains a `sync.Mutex`) and trip govet. No locking is needed there — it runs only after `readerDone` closes, which establishes happens-before with the reader.

Originally surfaced as the flaky `go-test` failure in PR #3592 CI; isolated and fixed here so it can land independently.

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Core logic | 1 | +47 / -19 | +28 |

Single-file fix, no test changes — existing tests now pass cleanly under \`-race\`.

<details>
<summary>Key files (click to expand)</summary>

- \`client/doublezerod/internal/latency/singlesocket.go\` — adds \`sync.Mutex\` to \`probeState\`, locks around \`.sent\` accesses, switches the reader to match incoming replies by \`echo.ID\` (with peer-IP sanity check), drops the now-redundant \`ipToIndices\` map, and refactors \`buildResults\` to iterate by index.

</details>

## Testing Verification
- \`go test -race -count=20 -run TestSingleSocketPing ./client/doublezerod/internal/latency/...\` inside \`dz-go-test\` (which mirrors CI's \`NET_RAW\`/\`NET_ADMIN\` capabilities) — clean across 20 iterations, no race output, no assertion failures.
- \`go test -race ./client/doublezerod/internal/latency/...\` — full latency package, single pass — \`ok ... 56.161s\`.
- \`golangci-lint run ./client/doublezerod/internal/latency/...\` — \`0 issues\`.
- \`go vet ./client/doublezerod/internal/latency/...\` — clean.