### PR TITLE
geolocation/sdk: bump compute budget for target-scan instructions

### DIFF
--- a/sdk/geolocation/go/add_target.go
+++ b/sdk/geolocation/go/add_target.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"github.com/near/borsh-go"
 )
 
@@ -43,11 +44,16 @@ func (c *AddTargetInstructionConfig) Validate() error {
 	return nil
 }
 
-func BuildAddTargetInstruction(
+// BuildAddTargetInstructions returns the instruction list to add a target: a
+// SetComputeUnitLimit prefix sized for MaxTargets followed by the AddTarget call.
+// The onchain handler does an O(n) duplicate scan that exhausts the default 200K CU
+// budget below ~750 targets; the SDK owns this so callers don't have to. Pass the
+// returned slice to executor.ExecuteTransactions.
+func BuildAddTargetInstructions(
 	programID solana.PublicKey,
 	signerPK solana.PublicKey,
 	config AddTargetInstructionConfig,
-) (solana.Instruction, error) {
+) ([]solana.Instruction, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
@@ -84,9 +90,13 @@ func BuildAddTargetInstruction(
 		{PublicKey: solana.SystemProgramID, IsSigner: false, IsWritable: false},
 	}
 
-	return &solana.GenericInstruction{
+	mainIx := &solana.GenericInstruction{
 		ProgID:        programID,
 		AccountValues: accounts,
 		DataBytes:     data,
-	}, nil
+	}
+
+	budgetIx := computebudget.NewSetComputeUnitLimitInstruction(TargetMutationComputeUnitLimit).Build()
+
+	return []solana.Instruction{budgetIx, mainIx}, nil
 }

--- a/sdk/geolocation/go/add_target_test.go
+++ b/sdk/geolocation/go/add_target_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // addTargetMainIx returns the AddTarget instruction from the slice (index 1, after
-// the SetComputeUnitLimit prefix). assertHasComputeBudget verifies the prefix.
+// the SetComputeUnitLimit prefix). assertComputeBudgetPrefix verifies the prefix.
 func addTargetMainIx(t *testing.T, ixs []solana.Instruction) solana.Instruction {
 	t.Helper()
 	require.Len(t, ixs, 2, "expected [SetComputeUnitLimit, AddTarget]")

--- a/sdk/geolocation/go/add_target_test.go
+++ b/sdk/geolocation/go/add_target_test.go
@@ -8,14 +8,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildAddTargetInstruction_Outbound(t *testing.T) {
+// addTargetMainIx returns the AddTarget instruction from the slice (index 1, after
+// the SetComputeUnitLimit prefix). assertHasComputeBudget verifies the prefix.
+func addTargetMainIx(t *testing.T, ixs []solana.Instruction) solana.Instruction {
+	t.Helper()
+	require.Len(t, ixs, 2, "expected [SetComputeUnitLimit, AddTarget]")
+	assertComputeBudgetPrefix(t, ixs[0])
+	return ixs[1]
+}
+
+// assertComputeBudgetPrefix checks that ix is a SetComputeUnitLimit instruction
+// requesting TargetMutationComputeUnitLimit. The discriminator for SetComputeUnitLimit
+// in the ComputeBudget program is 2 (RequestUnits=0, RequestHeapFrame=1,
+// SetComputeUnitLimit=2, SetComputeUnitPrice=3).
+func assertComputeBudgetPrefix(t *testing.T, ix solana.Instruction) {
+	t.Helper()
+	require.Equal(t, solana.ComputeBudget, ix.ProgramID(), "first ix must be ComputeBudget")
+	data, err := ix.Data()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(data), 5, "SetComputeUnitLimit data is 5 bytes: discriminator + u32")
+	require.Equal(t, uint8(2), data[0], "discriminator should be SetComputeUnitLimit (2)")
+	limit := uint32(data[1]) | uint32(data[2])<<8 | uint32(data[3])<<16 | uint32(data[4])<<24
+	require.Equal(t, geolocation.TargetMutationComputeUnitLimit, limit)
+}
+
+func TestBuildAddTargetInstructions_Outbound(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 	probePK := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            probePK,
 		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
@@ -24,7 +48,7 @@ func TestBuildAddTargetInstruction_Outbound(t *testing.T) {
 		TargetPK:           solana.NewWallet().PublicKey(),
 	})
 	require.NoError(t, err)
-	require.NotNil(t, ix)
+	ix := addTargetMainIx(t, ixs)
 
 	// Verify program ID.
 	require.Equal(t, programID, ix.ProgramID())
@@ -58,7 +82,7 @@ func TestBuildAddTargetInstruction_Outbound(t *testing.T) {
 	require.False(t, accounts[3].IsSigner)
 }
 
-func TestBuildAddTargetInstruction_Inbound(t *testing.T) {
+func TestBuildAddTargetInstructions_Inbound(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
@@ -66,7 +90,7 @@ func TestBuildAddTargetInstruction_Inbound(t *testing.T) {
 	probePK := solana.NewWallet().PublicKey()
 	targetPK := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            probePK,
 		TargetType:         geolocation.GeoLocationTargetTypeInbound,
@@ -75,7 +99,7 @@ func TestBuildAddTargetInstruction_Inbound(t *testing.T) {
 		TargetPK:           targetPK,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, ix)
+	ix := addTargetMainIx(t, ixs)
 
 	// Verify the instruction data discriminator is AddTarget (10).
 	data, err := ix.Data()
@@ -90,14 +114,14 @@ func TestBuildAddTargetInstruction_Inbound(t *testing.T) {
 	require.Len(t, accounts, 4)
 }
 
-func TestBuildAddTargetInstruction_OutboundIcmp(t *testing.T) {
+func TestBuildAddTargetInstructions_OutboundIcmp(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 	probePK := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            probePK,
 		TargetType:         geolocation.GeoLocationTargetTypeOutboundIcmp,
@@ -106,7 +130,7 @@ func TestBuildAddTargetInstruction_OutboundIcmp(t *testing.T) {
 		TargetPK:           solana.NewWallet().PublicKey(),
 	})
 	require.NoError(t, err)
-	require.NotNil(t, ix)
+	ix := addTargetMainIx(t, ixs)
 
 	// Verify the instruction data discriminator is AddTarget (10).
 	data, err := ix.Data()
@@ -117,7 +141,7 @@ func TestBuildAddTargetInstruction_OutboundIcmp(t *testing.T) {
 	require.Equal(t, uint8(2), data[1], "target type should be OutboundIcmp (2)")
 }
 
-func TestBuildAddTargetInstruction_NonPublicIP(t *testing.T) {
+func TestBuildAddTargetInstructions_NonPublicIP(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
@@ -165,7 +189,7 @@ func TestBuildAddTargetInstruction_NonPublicIP(t *testing.T) {
 			t.Run(tt.name+"/"+ttype.name, func(t *testing.T) {
 				t.Parallel()
 
-				_, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+				_, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 					Code:               "test-user",
 					ProbePK:            probePK,
 					TargetType:         ttype.t,
@@ -180,9 +204,9 @@ func TestBuildAddTargetInstruction_NonPublicIP(t *testing.T) {
 	}
 }
 
-// TestBuildAddTargetInstruction_PublicIPEdgeCases covers addresses adjacent to
+// TestBuildAddTargetInstructions_PublicIPEdgeCases covers addresses adjacent to
 // rejected ranges to confirm they still pass validation.
-func TestBuildAddTargetInstruction_PublicIPEdgeCases(t *testing.T) {
+func TestBuildAddTargetInstructions_PublicIPEdgeCases(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
@@ -205,7 +229,7 @@ func TestBuildAddTargetInstruction_PublicIPEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+			_, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 				Code:               "test-user",
 				ProbePK:            probePK,
 				TargetType:         geolocation.GeoLocationTargetTypeOutbound,
@@ -218,14 +242,14 @@ func TestBuildAddTargetInstruction_PublicIPEdgeCases(t *testing.T) {
 	}
 }
 
-func TestBuildAddTargetInstruction_InboundDefaultTargetPK(t *testing.T) {
+func TestBuildAddTargetInstructions_InboundDefaultTargetPK(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 	probePK := solana.NewWallet().PublicKey()
 
-	_, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	_, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            probePK,
 		TargetType:         geolocation.GeoLocationTargetTypeInbound,
@@ -235,4 +259,27 @@ func TestBuildAddTargetInstruction_InboundDefaultTargetPK(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "target public key is required for inbound target type")
+}
+
+// TestBuildAddTargetInstructions_ComputeBudgetPrefix is a focused regression test:
+// without the SetComputeUnitLimit prefix, the onchain duplicate scan exhausts CU at
+// ~743 targets in the wild. Asserting it here catches accidental removal in code review
+// without re-running the full stress test.
+func TestBuildAddTargetInstructions_ComputeBudgetPrefix(t *testing.T) {
+	t.Parallel()
+
+	programID := solana.NewWallet().PublicKey()
+	signerPK := solana.NewWallet().PublicKey()
+
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
+		Code:               "test-user",
+		ProbePK:            solana.NewWallet().PublicKey(),
+		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
+		IPAddress:          [4]uint8{8, 8, 8, 8},
+		LocationOffsetPort: 443,
+	})
+	require.NoError(t, err)
+	require.Len(t, ixs, 2)
+	assertComputeBudgetPrefix(t, ixs[0])
+	require.Equal(t, programID, ixs[1].ProgramID())
 }

--- a/sdk/geolocation/go/constants.go
+++ b/sdk/geolocation/go/constants.go
@@ -14,3 +14,9 @@ const (
 	MaxCodeLength    = 32
 	MaxTargets       = 4096
 )
+
+// CU budget covering AddTarget / RemoveTarget at MaxTargets. Both onchain handlers do
+// an O(n) scan of existing targets that exhausts the default 200K CU limit well before
+// MaxTargets (~743 in practice). Sized to match add_target_cu_benchmark.rs, which is
+// also the per-tx ceiling.
+const TargetMutationComputeUnitLimit uint32 = 1_400_000

--- a/sdk/geolocation/go/executor.go
+++ b/sdk/geolocation/go/executor.go
@@ -33,7 +33,7 @@ func WithWaitForVisibleTimeout(timeout time.Duration) ExecutorOption {
 	}
 }
 
-// WithFinalizationTimeout bounds how long ExecuteTransaction will poll for the
+// WithFinalizationTimeout bounds how long ExecuteTransactions will poll for the
 // transaction to reach Finalized commitment once it is visible on the cluster.
 // Callers can also cancel the context to cut the wait short.
 func WithFinalizationTimeout(timeout time.Duration) ExecutorOption {
@@ -59,10 +59,6 @@ func NewExecutor(log *slog.Logger, rpc ExecutorRPCClient, signer *solana.Private
 
 type ExecuteTransactionOptions struct {
 	SkipPreflight bool
-}
-
-func (e *executor) ExecuteTransaction(ctx context.Context, instruction solana.Instruction, opts *ExecuteTransactionOptions) (solana.Signature, *solanarpc.GetTransactionResult, error) {
-	return e.ExecuteTransactions(ctx, []solana.Instruction{instruction}, opts)
 }
 
 func (e *executor) ExecuteTransactions(ctx context.Context, instructions []solana.Instruction, opts *ExecuteTransactionOptions) (solana.Signature, *solanarpc.GetTransactionResult, error) {

--- a/sdk/geolocation/go/executor_test.go
+++ b/sdk/geolocation/go/executor_test.go
@@ -42,17 +42,9 @@ func TestExecuteTransaction_NoPrivateKey(t *testing.T) {
 
 	executor := geolocation.NewExecutor(slog.Default(), nil, nil, programID)
 
-	// Build a dummy instruction to pass to ExecuteTransaction.
-	dummyIx, err := geolocation.BuildAddTargetInstruction(programID, solana.NewWallet().PublicKey(), geolocation.AddTargetInstructionConfig{
-		Code:               "test-user",
-		ProbePK:            solana.NewWallet().PublicKey(),
-		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
-		IPAddress:          [4]uint8{8, 8, 8, 8},
-		LocationOffsetPort: 443,
-	})
-	require.NoError(t, err)
+	dummyIxs := dummyInstructionsFor(t, programID, solana.NewWallet().PublicKey())
 
-	_, _, err = executor.ExecuteTransaction(context.Background(), dummyIx, nil)
+	_, _, err := executor.ExecuteTransactions(context.Background(), dummyIxs, nil)
 	require.ErrorIs(t, err, geolocation.ErrNoPrivateKey)
 }
 
@@ -64,27 +56,20 @@ func TestExecuteTransaction_NoProgramID(t *testing.T) {
 
 	executor := geolocation.NewExecutor(slog.Default(), nil, &signer, zeroProgramID)
 
-	// Build a dummy instruction using a non-zero program ID (the builder needs it to derive PDAs).
+	// Build dummy instructions using a non-zero program ID (the builder needs it to derive PDAs).
 	// The executor checks its own programID field, not the instruction's.
 	validProgramID := solana.NewWallet().PublicKey()
-	dummyIx, err := geolocation.BuildAddTargetInstruction(validProgramID, solana.NewWallet().PublicKey(), geolocation.AddTargetInstructionConfig{
-		Code:               "test-user",
-		ProbePK:            solana.NewWallet().PublicKey(),
-		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
-		IPAddress:          [4]uint8{8, 8, 8, 8},
-		LocationOffsetPort: 443,
-	})
-	require.NoError(t, err)
+	dummyIxs := dummyInstructionsFor(t, validProgramID, solana.NewWallet().PublicKey())
 
-	_, _, err = executor.ExecuteTransaction(context.Background(), dummyIx, nil)
+	_, _, err := executor.ExecuteTransactions(context.Background(), dummyIxs, nil)
 	require.ErrorIs(t, err, geolocation.ErrNoProgramID)
 }
 
-// dummyInstructionFor returns a valid AddTarget instruction whose signer matches
-// the given wallet — sufficient for tx.Sign to succeed inside ExecuteTransaction.
-func dummyInstructionFor(t *testing.T, programID solana.PublicKey, signerPK solana.PublicKey) solana.Instruction {
+// dummyInstructionsFor returns a valid AddTarget instruction list whose signer
+// matches the given wallet — sufficient for tx.Sign to succeed inside ExecuteTransactions.
+func dummyInstructionsFor(t *testing.T, programID solana.PublicKey, signerPK solana.PublicKey) []solana.Instruction {
 	t.Helper()
-	ix, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            solana.NewWallet().PublicKey(),
 		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
@@ -92,7 +77,7 @@ func dummyInstructionFor(t *testing.T, programID solana.PublicKey, signerPK sola
 		LocationOffsetPort: 443,
 	})
 	require.NoError(t, err)
-	return ix
+	return ixs
 }
 
 func finalizedStatusResult() *solanarpc.GetSignatureStatusesResult {
@@ -132,9 +117,9 @@ func TestExecuteTransaction_HappyPath(t *testing.T) {
 	}
 
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	gotSig, res, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	gotSig, res, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.NoError(t, err)
 	require.Equal(t, sig, gotSig)
 	require.NotNil(t, res)
@@ -153,9 +138,9 @@ func TestExecuteTransaction_BlockhashError(t *testing.T) {
 		},
 	}
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.ErrorIs(t, err, wantErr)
 }
 
@@ -177,9 +162,9 @@ func TestExecuteTransaction_SendError(t *testing.T) {
 		},
 	}
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.ErrorIs(t, err, wantErr)
 }
 
@@ -223,9 +208,9 @@ func TestExecuteTransaction_ConfirmationTransitions(t *testing.T) {
 	}
 
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, call.Load(), int32(3), "should have polled through Processed/Confirmed before Finalized")
 }
@@ -254,9 +239,9 @@ func TestExecuteTransaction_WaitForVisibleTimeout(t *testing.T) {
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID,
 		geolocation.WithWaitForVisibleTimeout(200*time.Millisecond),
 	)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not visible")
 }
@@ -288,7 +273,7 @@ func TestExecuteTransaction_ContextCancellationDuringFinalization(t *testing.T) 
 	}
 
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -296,7 +281,7 @@ func TestExecuteTransaction_ContextCancellationDuringFinalization(t *testing.T) 
 		cancel()
 	}()
 
-	_, _, err := e.ExecuteTransaction(ctx, ix, nil)
+	_, _, err := e.ExecuteTransactions(ctx, ixs, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -329,9 +314,9 @@ func TestExecuteTransaction_FinalizationTimeout(t *testing.T) {
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID,
 		geolocation.WithFinalizationTimeout(500*time.Millisecond),
 	)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, nil)
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not finalized within")
 }
@@ -363,9 +348,9 @@ func TestExecuteTransaction_SkipPreflightPassthrough(t *testing.T) {
 	}
 
 	e := geolocation.NewExecutor(slog.Default(), rpc, &signer, programID)
-	ix := dummyInstructionFor(t, programID, signer.PublicKey())
+	ixs := dummyInstructionsFor(t, programID, signer.PublicKey())
 
-	_, _, err := e.ExecuteTransaction(context.Background(), ix, &geolocation.ExecuteTransactionOptions{SkipPreflight: true})
+	_, _, err := e.ExecuteTransactions(context.Background(), ixs, &geolocation.ExecuteTransactionOptions{SkipPreflight: true})
 	require.NoError(t, err)
 	require.True(t, observed.Load(), "mock should have received SkipPreflight=true")
 }

--- a/sdk/geolocation/go/executor_test.go
+++ b/sdk/geolocation/go/executor_test.go
@@ -35,7 +35,7 @@ func TestNewExecutor_WithTimeout(t *testing.T) {
 	require.NotNil(t, executor, "executor should not be nil with custom timeout")
 }
 
-func TestExecuteTransaction_NoPrivateKey(t *testing.T) {
+func TestExecuteTransactions_NoPrivateKey(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
@@ -48,7 +48,7 @@ func TestExecuteTransaction_NoPrivateKey(t *testing.T) {
 	require.ErrorIs(t, err, geolocation.ErrNoPrivateKey)
 }
 
-func TestExecuteTransaction_NoProgramID(t *testing.T) {
+func TestExecuteTransactions_NoProgramID(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -92,7 +92,7 @@ func finalizedTxResult() *solanarpc.GetTransactionResult {
 	return &solanarpc.GetTransactionResult{Meta: &solanarpc.TransactionMeta{}}
 }
 
-func TestExecuteTransaction_HappyPath(t *testing.T) {
+func TestExecuteTransactions_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -125,7 +125,7 @@ func TestExecuteTransaction_HappyPath(t *testing.T) {
 	require.NotNil(t, res)
 }
 
-func TestExecuteTransaction_BlockhashError(t *testing.T) {
+func TestExecuteTransactions_BlockhashError(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -144,7 +144,7 @@ func TestExecuteTransaction_BlockhashError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 }
 
-func TestExecuteTransaction_SendError(t *testing.T) {
+func TestExecuteTransactions_SendError(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -168,7 +168,7 @@ func TestExecuteTransaction_SendError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 }
 
-func TestExecuteTransaction_ConfirmationTransitions(t *testing.T) {
+func TestExecuteTransactions_ConfirmationTransitions(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -215,7 +215,7 @@ func TestExecuteTransaction_ConfirmationTransitions(t *testing.T) {
 	require.GreaterOrEqual(t, call.Load(), int32(3), "should have polled through Processed/Confirmed before Finalized")
 }
 
-func TestExecuteTransaction_WaitForVisibleTimeout(t *testing.T) {
+func TestExecuteTransactions_WaitForVisibleTimeout(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -246,7 +246,7 @@ func TestExecuteTransaction_WaitForVisibleTimeout(t *testing.T) {
 	require.Contains(t, err.Error(), "not visible")
 }
 
-func TestExecuteTransaction_ContextCancellationDuringFinalization(t *testing.T) {
+func TestExecuteTransactions_ContextCancellationDuringFinalization(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -286,7 +286,7 @@ func TestExecuteTransaction_ContextCancellationDuringFinalization(t *testing.T) 
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestExecuteTransaction_FinalizationTimeout(t *testing.T) {
+func TestExecuteTransactions_FinalizationTimeout(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey
@@ -321,7 +321,7 @@ func TestExecuteTransaction_FinalizationTimeout(t *testing.T) {
 	require.Contains(t, err.Error(), "not finalized within")
 }
 
-func TestExecuteTransaction_SkipPreflightPassthrough(t *testing.T) {
+func TestExecuteTransactions_SkipPreflightPassthrough(t *testing.T) {
 	t.Parallel()
 
 	signer := solana.NewWallet().PrivateKey

--- a/sdk/geolocation/go/instructions_test.go
+++ b/sdk/geolocation/go/instructions_test.go
@@ -17,7 +17,7 @@ func TestSDK_Geolocation_Instructions_AddTarget_Serialization(t *testing.T) {
 	probePK := solana.NewWallet().PublicKey()
 	targetPK := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildAddTargetInstruction(programID, signerPK, geolocation.AddTargetInstructionConfig{
+	ixs, err := geolocation.BuildAddTargetInstructions(programID, signerPK, geolocation.AddTargetInstructionConfig{
 		Code:               "test-user",
 		ProbePK:            probePK,
 		TargetType:         geolocation.GeoLocationTargetTypeOutbound,
@@ -26,6 +26,8 @@ func TestSDK_Geolocation_Instructions_AddTarget_Serialization(t *testing.T) {
 		TargetPK:           targetPK,
 	})
 	require.NoError(t, err)
+	require.Len(t, ixs, 2)
+	ix := ixs[1]
 
 	data, err := ix.Data()
 	require.NoError(t, err)
@@ -58,7 +60,7 @@ func TestSDK_Geolocation_Instructions_RemoveTarget_Serialization(t *testing.T) {
 	targetPK := solana.NewWallet().PublicKey()
 	serviceabilityGS := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildRemoveTargetInstruction(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+	ixs, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
 		Code:                      "test-user",
 		ProbePK:                   probePK,
 		TargetType:                geolocation.GeoLocationTargetTypeInbound,
@@ -67,6 +69,8 @@ func TestSDK_Geolocation_Instructions_RemoveTarget_Serialization(t *testing.T) {
 		ServiceabilityGlobalState: serviceabilityGS,
 	})
 	require.NoError(t, err)
+	require.Len(t, ixs, 2)
+	ix := ixs[1]
 
 	data, err := ix.Data()
 	require.NoError(t, err)

--- a/sdk/geolocation/go/remove_target.go
+++ b/sdk/geolocation/go/remove_target.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"github.com/near/borsh-go"
 )
 
@@ -41,11 +42,16 @@ func (c *RemoveTargetInstructionConfig) Validate() error {
 	return nil
 }
 
-func BuildRemoveTargetInstruction(
+// BuildRemoveTargetInstructions returns the instruction list to remove a target: a
+// SetComputeUnitLimit prefix sized for MaxTargets followed by the RemoveTarget call.
+// The onchain handler does an O(n) scan to find the target by fields; same budget
+// rationale as BuildAddTargetInstructions. Pass the returned slice to
+// executor.ExecuteTransactions.
+func BuildRemoveTargetInstructions(
 	programID solana.PublicKey,
 	signerPK solana.PublicKey,
 	config RemoveTargetInstructionConfig,
-) (solana.Instruction, error) {
+) ([]solana.Instruction, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
@@ -86,9 +92,13 @@ func BuildRemoveTargetInstruction(
 		{PublicKey: solana.SystemProgramID, IsSigner: false, IsWritable: false},
 	}
 
-	return &solana.GenericInstruction{
+	mainIx := &solana.GenericInstruction{
 		ProgID:        programID,
 		AccountValues: accounts,
 		DataBytes:     data,
-	}, nil
+	}
+
+	budgetIx := computebudget.NewSetComputeUnitLimitInstruction(TargetMutationComputeUnitLimit).Build()
+
+	return []solana.Instruction{budgetIx, mainIx}, nil
 }

--- a/sdk/geolocation/go/remove_target_test.go
+++ b/sdk/geolocation/go/remove_target_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildRemoveTargetInstruction_Valid(t *testing.T) {
+func TestBuildRemoveTargetInstructions_Valid(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
@@ -17,7 +17,7 @@ func TestBuildRemoveTargetInstruction_Valid(t *testing.T) {
 	targetPK := solana.NewWallet().PublicKey()
 	serviceabilityGS := solana.NewWallet().PublicKey()
 
-	ix, err := geolocation.BuildRemoveTargetInstruction(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+	ixs, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
 		Code:                      "test-user",
 		ProbePK:                   probePK,
 		TargetType:                geolocation.GeoLocationTargetTypeOutbound,
@@ -26,7 +26,9 @@ func TestBuildRemoveTargetInstruction_Valid(t *testing.T) {
 		ServiceabilityGlobalState: serviceabilityGS,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, ix)
+	require.Len(t, ixs, 2, "expected [SetComputeUnitLimit, RemoveTarget]")
+	assertComputeBudgetPrefix(t, ixs[0])
+	ix := ixs[1]
 
 	// Verify program ID.
 	require.Equal(t, programID, ix.ProgramID())
@@ -72,13 +74,13 @@ func TestBuildRemoveTargetInstruction_Valid(t *testing.T) {
 	require.False(t, accounts[5].IsSigner)
 }
 
-func TestBuildRemoveTargetInstruction_EmptyCode(t *testing.T) {
+func TestBuildRemoveTargetInstructions_EmptyCode(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 
-	_, err := geolocation.BuildRemoveTargetInstruction(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+	_, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
 		Code:                      "",
 		ProbePK:                   solana.NewWallet().PublicKey(),
 		TargetType:                geolocation.GeoLocationTargetTypeOutbound,
@@ -90,13 +92,13 @@ func TestBuildRemoveTargetInstruction_EmptyCode(t *testing.T) {
 	require.Contains(t, err.Error(), "code is required")
 }
 
-func TestBuildRemoveTargetInstruction_ZeroProbePK(t *testing.T) {
+func TestBuildRemoveTargetInstructions_ZeroProbePK(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 
-	_, err := geolocation.BuildRemoveTargetInstruction(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+	_, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
 		Code:                      "test-user",
 		ProbePK:                   solana.PublicKey{},
 		TargetType:                geolocation.GeoLocationTargetTypeOutbound,
@@ -108,13 +110,13 @@ func TestBuildRemoveTargetInstruction_ZeroProbePK(t *testing.T) {
 	require.Contains(t, err.Error(), "probe public key is required")
 }
 
-func TestBuildRemoveTargetInstruction_InboundZeroTargetPK(t *testing.T) {
+func TestBuildRemoveTargetInstructions_InboundZeroTargetPK(t *testing.T) {
 	t.Parallel()
 
 	programID := solana.NewWallet().PublicKey()
 	signerPK := solana.NewWallet().PublicKey()
 
-	_, err := geolocation.BuildRemoveTargetInstruction(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+	_, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
 		Code:                      "test-user",
 		ProbePK:                   solana.NewWallet().PublicKey(),
 		TargetType:                geolocation.GeoLocationTargetTypeInbound,
@@ -123,4 +125,27 @@ func TestBuildRemoveTargetInstruction_InboundZeroTargetPK(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "target public key is required for inbound target type")
+}
+
+// TestBuildRemoveTargetInstructions_ComputeBudgetPrefix mirrors the AddTarget regression
+// guard — RemoveTarget also does an O(n) scan onchain and would CU-fail at scale without
+// the prefix.
+func TestBuildRemoveTargetInstructions_ComputeBudgetPrefix(t *testing.T) {
+	t.Parallel()
+
+	programID := solana.NewWallet().PublicKey()
+	signerPK := solana.NewWallet().PublicKey()
+
+	ixs, err := geolocation.BuildRemoveTargetInstructions(programID, signerPK, geolocation.RemoveTargetInstructionConfig{
+		Code:                      "test-user",
+		ProbePK:                   solana.NewWallet().PublicKey(),
+		TargetType:                geolocation.GeoLocationTargetTypeOutbound,
+		IPAddress:                 [4]uint8{8, 8, 8, 8},
+		TargetPK:                  solana.NewWallet().PublicKey(),
+		ServiceabilityGlobalState: solana.NewWallet().PublicKey(),
+	})
+	require.NoError(t, err)
+	require.Len(t, ixs, 2)
+	assertComputeBudgetPrefix(t, ixs[0])
+	require.Equal(t, programID, ixs[1].ProgramID())
 }

--- a/smartcontract/sdk/rs/src/geolocation/client.rs
+++ b/smartcontract/sdk/rs/src/geolocation/client.rs
@@ -14,6 +14,7 @@ use solana_rpc_client_api::config::RpcProgramAccountsConfig;
 use solana_sdk::{
     account::Account,
     commitment_config::CommitmentConfig,
+    compute_budget::ComputeBudgetInstruction,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
@@ -21,6 +22,40 @@ use solana_sdk::{
 };
 use solana_system_interface::program;
 use std::{path::PathBuf, str::FromStr};
+
+/// CU budget for instructions that scan the targets section of a `GeolocationUser`.
+/// `AddTarget`, `RemoveTarget`, and `SetResultDestination` all walk every target onchain
+/// (duplicate check, find-by-fields, and unique-probe-set check respectively); each
+/// scan exhausts the default 200K CU limit well before the program's `MAX_TARGETS = 4096`
+/// upper bound (~743 in practice for AddTarget). Sized to match the value validated by
+/// `add_target_cu_benchmark.rs`, which is also the per-tx cap.
+pub const TARGET_SCAN_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// Returns the CU limit the SDK should request for a given geolocation instruction, or
+/// `None` to leave the runtime default (200K) in place. Exhaustive match: adding a new
+/// instruction variant forces a decision here.
+fn compute_unit_limit_for(instruction: &GeolocationInstruction) -> Option<u32> {
+    use GeolocationInstruction::*;
+    match instruction {
+        // O(n) walk over all targets onchain. See add_target_cu_benchmark.rs.
+        AddTarget(_) | RemoveTarget(_) | SetResultDestination(_) => {
+            Some(TARGET_SCAN_COMPUTE_UNIT_LIMIT)
+        }
+        // Cursor-based prefix-only writes; cost is O(1) in target count.
+        InitProgramConfig(_)
+        | UpdateProgramConfig(_)
+        | CreateGeoProbe(_)
+        | UpdateGeoProbe(_)
+        | DeleteGeoProbe
+        | AddParentDevice
+        | RemoveParentDevice(_)
+        | CreateGeolocationUser(_)
+        | UpdateGeolocationUser(_)
+        // DeleteGeolocationUser refuses if targets_count != 0, so it never scans.
+        | DeleteGeolocationUser
+        | UpdatePaymentStatus(_) => None,
+    }
+}
 
 #[automock]
 pub trait GeolocationClient {
@@ -117,21 +152,28 @@ impl GeolocationClient for GeoClient {
         let data = borsh::to_vec(&instruction)
             .map_err(|e| eyre!("failed to serialize instruction: {e}"))?;
 
-        let mut transaction = Transaction::new_with_payer(
-            &[Instruction::new_with_bytes(
-                self.program_id,
-                &data,
-                [
-                    accounts,
-                    vec![
-                        AccountMeta::new(payer.pubkey(), true),
-                        AccountMeta::new(program::id(), false),
-                    ],
-                ]
-                .concat(),
-            )],
-            Some(&payer.pubkey()),
+        let main_ix = Instruction::new_with_bytes(
+            self.program_id,
+            &data,
+            [
+                accounts,
+                vec![
+                    AccountMeta::new(payer.pubkey(), true),
+                    AccountMeta::new(program::id(), false),
+                ],
+            ]
+            .concat(),
         );
+
+        let instructions: Vec<Instruction> = match compute_unit_limit_for(&instruction) {
+            Some(limit) => vec![
+                ComputeBudgetInstruction::set_compute_unit_limit(limit),
+                main_ix,
+            ],
+            None => vec![main_ix],
+        };
+
+        let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
 
         let blockhash = self.client.get_latest_blockhash().map_err(|e| eyre!(e))?;
         transaction.sign(&[payer], blockhash);
@@ -155,5 +197,97 @@ impl GeolocationClient for GeoClient {
         self.client
             .send_and_confirm_transaction(&transaction)
             .map_err(|e| eyre!(e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use doublezero_geolocation::{
+        instructions::{
+            AddTargetArgs, CreateGeoProbeArgs, CreateGeolocationUserArgs, GeolocationInstruction,
+            InitProgramConfigArgs, RemoveParentDeviceArgs, RemoveTargetArgs,
+            SetResultDestinationArgs, UpdateGeoProbeArgs, UpdateGeolocationUserArgs,
+            UpdatePaymentStatusArgs, UpdateProgramConfigArgs,
+        },
+        state::geolocation_user::{GeoLocationTargetType, GeolocationPaymentStatus},
+    };
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn target_scan_instructions_request_max_compute_budget() {
+        // AddTarget, RemoveTarget, and SetResultDestination all walk every target in the
+        // user account onchain (duplicate check, find-by-fields, and unique-probe-set
+        // check respectively). At MAX_TARGETS=4096 the scan exceeds the default 200K CU
+        // limit; the SDK bumps every such transaction to the per-tx ceiling (1.4M) so
+        // consumers don't have to think about compute budgets up to that bound.
+        let target_scan: &[GeolocationInstruction] = &[
+            GeolocationInstruction::AddTarget(AddTargetArgs {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                location_offset_port: 0,
+                target_pk: Pubkey::default(),
+            }),
+            GeolocationInstruction::RemoveTarget(RemoveTargetArgs {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                target_pk: Pubkey::default(),
+            }),
+            GeolocationInstruction::SetResultDestination(SetResultDestinationArgs {
+                destination: String::new(),
+            }),
+        ];
+        for ix in target_scan {
+            assert_eq!(
+                compute_unit_limit_for(ix),
+                Some(TARGET_SCAN_COMPUTE_UNIT_LIMIT),
+                "{ix:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn non_target_instructions_use_default_compute_budget() {
+        // None ⇒ no ComputeBudgetInstruction prepended; the runtime default (200K CU) is
+        // sufficient for these. Listed exhaustively so a new variant cannot silently fall
+        // into either bucket — the match in compute_unit_limit_for is exhaustive too.
+        let no_budget: &[GeolocationInstruction] = &[
+            GeolocationInstruction::InitProgramConfig(InitProgramConfigArgs {}),
+            GeolocationInstruction::UpdateProgramConfig(UpdateProgramConfigArgs {
+                version: None,
+                min_compatible_version: None,
+            }),
+            GeolocationInstruction::CreateGeoProbe(CreateGeoProbeArgs {
+                code: "p".to_string(),
+                public_ip: Ipv4Addr::new(8, 8, 8, 8),
+                location_offset_port: 0,
+                metrics_publisher_pk: Pubkey::default(),
+            }),
+            GeolocationInstruction::UpdateGeoProbe(UpdateGeoProbeArgs {
+                public_ip: None,
+                location_offset_port: None,
+                metrics_publisher_pk: None,
+            }),
+            GeolocationInstruction::DeleteGeoProbe,
+            GeolocationInstruction::AddParentDevice,
+            GeolocationInstruction::RemoveParentDevice(RemoveParentDeviceArgs {
+                device_pk: Pubkey::default(),
+            }),
+            GeolocationInstruction::CreateGeolocationUser(CreateGeolocationUserArgs {
+                code: "u".to_string(),
+                token_account: Pubkey::default(),
+            }),
+            GeolocationInstruction::UpdateGeolocationUser(UpdateGeolocationUserArgs {
+                token_account: None,
+            }),
+            GeolocationInstruction::DeleteGeolocationUser,
+            GeolocationInstruction::UpdatePaymentStatus(UpdatePaymentStatusArgs {
+                payment_status: GeolocationPaymentStatus::Paid,
+                last_deduction_dz_epoch: None,
+            }),
+        ];
+        for ix in no_budget {
+            assert_eq!(compute_unit_limit_for(ix), None, "{ix:?}");
+        }
     }
 }


### PR DESCRIPTION
Resolves: #3595

## Summary of Changes
- Rust and Go geolocation SDKs now prepend a `SetComputeUnitLimit(1_400_000)` instruction to `AddTarget`, `RemoveTarget`, and (Rust only) `SetResultDestination` transactions. These handlers do an O(n) scan over every target onchain; the default 200K CU per-tx limit exhausted around 743 targets, far below the program's `MAX_TARGETS=4096` ceiling. Consumers no longer need to think about compute budgets up to that bound.
- Rust SDK uses an exhaustive `match` over `GeolocationInstruction`, so adding a new variant forces an explicit CU-budget decision rather than silently falling through to the default.
- Go SDK renames `Build{Add,Remove}TargetInstruction` → `Build{Add,Remove}TargetInstructions` and changes the return type from `solana.Instruction` to `[]solana.Instruction`. The rename surfaces the breaking type change as a compile error rather than a silent slice/single mismatch; callers feed the returned slice into `executor.ExecuteTransactions`.
- The Go SDK currently has no `SetResultDestination` builder, so that handler is only bumped on the Rust side.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     4 | +182 / -22  | +160 |
| Tests      |     4 | +129 / -68  |  +61 |

Mostly SDK plumbing with matching test updates; no scaffolding/config/docs.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/sdk/rs/src/geolocation/client.rs` — adds `TARGET_SCAN_COMPUTE_UNIT_LIMIT`, exhaustive-match `compute_unit_limit_for(...)` helper, and prepends the compute-budget instruction inside `GeoClient::execute_transaction`. Bucket-coverage unit tests for every variant.
- `sdk/geolocation/go/add_target.go` — `BuildAddTargetInstructions` returns `[]solana.Instruction` with a compute-budget prefix.
- `sdk/geolocation/go/remove_target.go` — same change for `BuildRemoveTargetInstructions`.
- `sdk/geolocation/go/constants.go` — adds `TargetMutationComputeUnitLimit`.
- `sdk/geolocation/go/{add_target,remove_target,instructions,executor}_test.go` — updated for new names/return type, plus regression tests asserting the prefix is present and requests the right limit.

</details>

## Testing Verification
- Reproduced the original failure mode (`exceeded CUs meter at BPF instruction` at ~743 targets) on software-devnet in CH7 prior to the fix; the stress run will now scale to `MAX_TARGETS=4096`.
- New unit tests in both SDKs assert per-variant bucket assignment and that `AddTarget`/`RemoveTarget` (and `SetResultDestination` in Rust) carry the 1.4M-CU prefix; the Rust tests use exhaustive variant lists so a new instruction can't silently slip through.
- Verified `add_target_cu_benchmark.rs` budget assumption (1.4M CU sufficient up to N=4095) is unchanged; this PR only flips the SDK to actually request that budget.