### PR TITLE
telemetry/bgpstatus: collect BGP state from all tenant VRF namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Telemetry
+  - Fix BGP status submitter to collect socket stats and tunnel interfaces from all tenant VRF namespaces (`ns-vrf<N>`), not only `ns-vrf1`; users whose tenant has a non-default `VrfId` were previously always reporting "tunnel not found" and had their onchain BGP status left stale
 - CLI
   - Add `--narrow` flag to `doublezero user list` that hides `location`, `cyoa_type`, `accesspass`, and `tunnel_net`, abbreviates `user_type`, and summarizes `groups` as one publisher entry plus one subscriber entry with independent `+N` overflow counts; default output is unchanged
 

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -423,7 +423,7 @@ func startBGPStatusSubmitter(
 		Log:                     log,
 		Executor:                executor,
 		ServiceabilityClient:    svcClient,
-		LocalNet:                localNet,
+		Collector:               bgpstatus.DefaultCollector(localNet),
 		LocalDevicePK:           localDevicePK,
 		BGPNamespace:            bgpNamespace,
 		Interval:                *bgpStatusInterval,

--- a/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
+++ b/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,12 +35,18 @@ type ServiceabilityClient interface {
 	GetProgramData(ctx context.Context) (*serviceability.ProgramData, error)
 }
 
+// NamespaceCollector collects BGP session state and local network interfaces
+// from a single Linux VRF network namespace. It returns the set of remote IP
+// strings with ESTABLISHED BGP sessions, the local interfaces, and any error.
+// Implement with DefaultCollector for production; use a mock in tests.
+type NamespaceCollector func(ctx context.Context, namespace string) (established map[string]struct{}, ifaces []netutil.Interface, err error)
+
 // Config holds all parameters for the BGP status submitter.
 type Config struct {
 	Log                     *slog.Logger
 	Executor                BGPStatusExecutor
 	ServiceabilityClient    ServiceabilityClient
-	LocalNet                netutil.LocalNet
+	Collector               NamespaceCollector
 	LocalDevicePK           solana.PublicKey
 	BGPNamespace            string
 	Interval                time.Duration // default: 60s
@@ -57,8 +65,8 @@ func (c *Config) validate() error {
 	if c.ServiceabilityClient == nil {
 		return errors.New("serviceability client is required")
 	}
-	if c.LocalNet == nil {
-		return errors.New("local net is required")
+	if c.Collector == nil {
+		return errors.New("collector is required")
 	}
 	if c.LocalDevicePK.IsZero() {
 		return errors.New("local device pubkey is required")
@@ -192,6 +200,27 @@ func computeEffectiveStatus(
 		return serviceability.BGPStatusUp
 	}
 	return serviceability.BGPStatusDown
+}
+
+// vrfNamespaces builds the list of Linux network namespaces to check for BGP
+// sockets and tunnel interfaces. It derives additional namespaces from tenant
+// VRF IDs by replacing the trailing numeric suffix of base (e.g. "ns-vrf1")
+// with each tenant's VrfId. The base namespace is always included first.
+func vrfNamespaces(base string, tenants []serviceability.Tenant) []string {
+	prefix := strings.TrimRight(base, "0123456789")
+	seen := map[string]struct{}{base: {}}
+	nss := []string{base}
+	for _, t := range tenants {
+		if t.VrfId == 0 {
+			continue
+		}
+		ns := prefix + strconv.FormatUint(uint64(t.VrfId), 10)
+		if _, ok := seen[ns]; !ok {
+			seen[ns] = struct{}{}
+			nss = append(nss, ns)
+		}
+	}
+	return nss
 }
 
 // shouldSubmit returns true when a submission is warranted: either the status

--- a/controlplane/telemetry/internal/bgpstatus/submitter.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter.go
@@ -5,6 +5,7 @@ package bgpstatus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -34,35 +35,66 @@ func (s *Submitter) run(ctx context.Context) error {
 	}
 }
 
+// DefaultCollector returns a NamespaceCollector that collects BGP socket stats
+// via netlink and local interfaces via Linux namespace switching.
+func DefaultCollector(localNet netutil.LocalNet) NamespaceCollector {
+	return func(ctx context.Context, namespace string) (map[string]struct{}, []netutil.Interface, error) {
+		rawSockets, err := state.GetBGPSocketStatsInNamespace(ctx, namespace)
+		if err != nil {
+			return nil, nil, fmt.Errorf("bgp sockets in %s: %w", namespace, err)
+		}
+		socks := make([]bgpSocket, len(rawSockets))
+		for i, rs := range rawSockets {
+			socks[i] = bgpSocket{RemoteIP: rs.RemoteIP, State: rs.State}
+		}
+		established := buildEstablishedIPSet(socks)
+
+		ifaces, err := netns.RunInNamespace(namespace, func() ([]netutil.Interface, error) {
+			return localNet.Interfaces()
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("interfaces in %s: %w", namespace, err)
+		}
+		return established, ifaces, nil
+	}
+}
+
 // tick collects BGP socket state, fetches activated users for this device,
 // maps each user to their tunnel peer IP, determines Up/Down status (with
 // grace period), and enqueues submission tasks for users whose status needs
 // updating.
 func (s *Submitter) tick(ctx context.Context) {
-	rawSockets, err := state.GetBGPSocketStatsInNamespace(ctx, s.cfg.BGPNamespace)
-	if err != nil {
-		s.log.Error("bgpstatus: failed to collect BGP sockets", "error", err)
-		return
-	}
-	sockets := make([]bgpSocket, len(rawSockets))
-	for i, rs := range rawSockets {
-		sockets[i] = bgpSocket{RemoteIP: rs.RemoteIP, State: rs.State}
-	}
-	establishedIPs := buildEstablishedIPSet(sockets)
-
 	programData, err := s.cfg.ServiceabilityClient.GetProgramData(ctx)
 	if err != nil {
 		s.log.Error("bgpstatus: failed to fetch program data", "error", err)
 		return
 	}
 
-	// Tunnel interfaces for user sessions live in the BGP VRF namespace (e.g. ns-vrf1),
-	// not the default namespace, so we must read them from there.
-	interfaces, err := netns.RunInNamespace(s.cfg.BGPNamespace, func() ([]netutil.Interface, error) {
-		return s.cfg.LocalNet.Interfaces()
-	})
-	if err != nil {
-		s.log.Error("bgpstatus: failed to get local interfaces", "error", err)
+	// User tunnel interfaces live in a per-tenant VRF namespace (e.g. ns-vrf1,
+	// ns-vrf2). Collect state from all relevant namespaces so that users whose
+	// tenant has VrfId != 1 are handled correctly.
+	// Tunnel IPs are globally unique (onchain-allocated), so merging is safe.
+	namespaces := vrfNamespaces(s.cfg.BGPNamespace, programData.Tenants)
+
+	establishedIPs := make(map[string]struct{})
+	var interfaces []netutil.Interface
+	successCount := 0
+
+	for _, ns := range namespaces {
+		established, ifaces, err := s.cfg.Collector(ctx, ns)
+		if err != nil {
+			s.log.Warn("bgpstatus: failed to collect namespace state", "namespace", ns, "error", err)
+			continue
+		}
+		for ip := range established {
+			establishedIPs[ip] = struct{}{}
+		}
+		interfaces = append(interfaces, ifaces...)
+		successCount++
+	}
+
+	if successCount == 0 {
+		s.log.Error("bgpstatus: failed to collect state from all namespaces", "namespaces", namespaces)
 		return
 	}
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
@@ -1,0 +1,232 @@
+//go:build linux
+
+package bgpstatus
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/jonboulle/clockwork"
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/netutil"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+)
+
+// staticCollector returns a NamespaceCollector that serves fixed data per namespace.
+func staticCollector(
+	established map[string]map[string]struct{},
+	ifaces map[string][]netutil.Interface,
+) NamespaceCollector {
+	return func(_ context.Context, ns string) (map[string]struct{}, []netutil.Interface, error) {
+		return established[ns], ifaces[ns], nil
+	}
+}
+
+// errCollector returns a NamespaceCollector that always fails.
+func errCollector(err error) NamespaceCollector {
+	return func(_ context.Context, _ string) (map[string]struct{}, []netutil.Interface, error) {
+		return nil, nil, err
+	}
+}
+
+// makeInterface builds a netutil.Interface with one IPv4 /31 address, so that
+// FindLocalTunnel can locate it and derive the peer IP.
+// cidr must be in host form, e.g. "10.0.2.0/31".
+func makeInterface(name, cidr string) netutil.Interface {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	ipnet.IP = ip.To4() // host IP, not network address
+	return netutil.Interface{Name: name, Addrs: []net.Addr{ipnet}}
+}
+
+// makeActivatedUser returns a User activated on devicePK with the given /31 tunnelNet.
+func makeActivatedUser(devicePK solana.PublicKey, tunnelNet [5]byte) serviceability.User {
+	u := serviceability.User{}
+	copy(u.DevicePubKey[:], devicePK[:])
+	userPK := solana.NewWallet().PublicKey()
+	copy(u.PubKey[:], userPK[:])
+	u.TunnelNet = tunnelNet
+	u.Status = serviceability.UserStatusActivated
+	return u
+}
+
+// ============================================================
+// tick() – multi-namespace collection
+// ============================================================
+
+// TestTick_SingleNamespace_SubmitsDown verifies baseline: when the collector
+// returns no interfaces (tunnel not found) and status was previously Up,
+// tick enqueues a Down submission.
+func TestTick_SingleNamespace_SubmitsDown(t *testing.T) {
+	devicePK := solana.NewWallet().PublicKey()
+	// tunnelNet 10.0.0.0/31
+	tunnelNet := [5]byte{10, 0, 0, 0, 31}
+	user := makeActivatedUser(devicePK, tunnelNet)
+	userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
+
+	exec := &mockExecutor{}
+	clk := clockwork.NewFakeClock()
+	svc := &mockSvcClient{data: &serviceability.ProgramData{Users: []serviceability.User{user}}}
+
+	// No tunnel interface → BGP is Down.
+	col := staticCollector(
+		map[string]map[string]struct{}{"ns-vrf1": {}},
+		map[string][]netutil.Interface{"ns-vrf1": nil},
+	)
+
+	s := newTestSubmitter(t, clk, exec, svc, col, devicePK, 0, 6*time.Hour)
+
+	// Seed the user's state as Up so a Down transition is warranted.
+	s.mu.Lock()
+	s.userState[userPK] = &userState{lastOnchainStatus: serviceability.BGPStatusUp}
+	s.mu.Unlock()
+
+	ctx := context.Background()
+	s.tick(ctx)
+
+	s.mu.Lock()
+	enqueued := len(s.taskCh)
+	s.mu.Unlock()
+
+	if enqueued != 1 {
+		t.Fatalf("expected 1 task enqueued, got %d", enqueued)
+	}
+	task := <-s.taskCh
+	if task.status != serviceability.BGPStatusDown {
+		t.Errorf("expected Down task, got %v", task.status)
+	}
+}
+
+// TestTick_MultiNamespace_UserInSecondVrf verifies that a user whose tunnel
+// lives in ns-vrf2 is found when the collector serves it there.
+func TestTick_MultiNamespace_UserInSecondVrf(t *testing.T) {
+	devicePK := solana.NewWallet().PublicKey()
+	tunnelNet := [5]byte{10, 0, 2, 0, 31} // 10.0.2.0/31
+
+	user := makeActivatedUser(devicePK, tunnelNet)
+	userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
+
+	exec := &mockExecutor{}
+	clk := clockwork.NewFakeClock()
+
+	// Tenant with VrfId=2 causes vrfNamespaces to include ns-vrf2.
+	tenant := serviceability.Tenant{}
+	tenant.VrfId = 2
+	svc := &mockSvcClient{data: &serviceability.ProgramData{
+		Users:   []serviceability.User{user},
+		Tenants: []serviceability.Tenant{tenant},
+	}}
+
+	// The tunnel (10.0.2.0/31) lives in ns-vrf2 with an ESTABLISHED BGP session.
+	iface := makeInterface("tu500", "10.0.2.0/31")
+	col := staticCollector(
+		map[string]map[string]struct{}{
+			"ns-vrf1": {},
+			"ns-vrf2": {"10.0.2.1": {}}, // peer IP is ESTABLISHED
+		},
+		map[string][]netutil.Interface{
+			"ns-vrf1": nil,
+			"ns-vrf2": {iface},
+		},
+	)
+
+	s := newTestSubmitter(t, clk, exec, svc, col, devicePK, 0, 6*time.Hour)
+	s.tick(context.Background())
+
+	s.mu.Lock()
+	enqueued := len(s.taskCh)
+	s.mu.Unlock()
+
+	if enqueued != 1 {
+		t.Fatalf("expected 1 task enqueued, got %d", enqueued)
+	}
+	task := <-s.taskCh
+	if task.status != serviceability.BGPStatusUp {
+		t.Errorf("expected Up task, got %v", task.status)
+	}
+	if solana.PublicKeyFromBytes(task.user.PubKey[:]).String() != userPK {
+		t.Errorf("unexpected user in task")
+	}
+}
+
+// TestTick_MultiNamespace_PartialFailure verifies that when one namespace
+// collection fails, tick continues and processes users in the remaining
+// namespaces instead of aborting.
+func TestTick_MultiNamespace_PartialFailure(t *testing.T) {
+	devicePK := solana.NewWallet().PublicKey()
+	// User whose tunnel is in ns-vrf1 (the working namespace).
+	tunnelNet := [5]byte{10, 0, 1, 0, 31}
+	user := makeActivatedUser(devicePK, tunnelNet)
+	userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
+
+	exec := &mockExecutor{}
+	clk := clockwork.NewFakeClock()
+
+	tenant := serviceability.Tenant{}
+	tenant.VrfId = 2
+	svc := &mockSvcClient{data: &serviceability.ProgramData{
+		Users:   []serviceability.User{user},
+		Tenants: []serviceability.Tenant{tenant},
+	}}
+
+	// ns-vrf2 fails; ns-vrf1 has the tunnel and an established session.
+	iface := makeInterface("tu501", "10.0.1.0/31")
+	col := func(_ context.Context, ns string) (map[string]struct{}, []netutil.Interface, error) {
+		if ns == "ns-vrf2" {
+			return nil, nil, errors.New("namespace unreachable")
+		}
+		return map[string]struct{}{"10.0.1.1": {}}, []netutil.Interface{iface}, nil
+	}
+
+	s := newTestSubmitter(t, clk, exec, svc, col, devicePK, 0, 6*time.Hour)
+	s.tick(context.Background())
+
+	s.mu.Lock()
+	enqueued := len(s.taskCh)
+	s.mu.Unlock()
+
+	if enqueued != 1 {
+		t.Fatalf("expected 1 task enqueued, got %d", enqueued)
+	}
+	task := <-s.taskCh
+	if task.status != serviceability.BGPStatusUp {
+		t.Errorf("expected Up task, got %v", task.status)
+	}
+	if solana.PublicKeyFromBytes(task.user.PubKey[:]).String() != userPK {
+		t.Errorf("unexpected user in task")
+	}
+}
+
+// TestTick_MultiNamespace_AllFail verifies that when every namespace fails,
+// tick aborts and enqueues no tasks.
+func TestTick_MultiNamespace_AllFail(t *testing.T) {
+	devicePK := solana.NewWallet().PublicKey()
+	user := makeActivatedUser(devicePK, [5]byte{10, 0, 0, 0, 31})
+	userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
+
+	exec := &mockExecutor{}
+	clk := clockwork.NewFakeClock()
+	svc := &mockSvcClient{data: &serviceability.ProgramData{Users: []serviceability.User{user}}}
+
+	s := newTestSubmitter(t, clk, exec, svc, errCollector(errors.New("all broken")), devicePK, 0, 6*time.Hour)
+
+	// Pre-seed as Up so we know a Down transition would be attempted if tick ran.
+	s.mu.Lock()
+	s.userState[userPK] = &userState{lastOnchainStatus: serviceability.BGPStatusUp}
+	s.mu.Unlock()
+
+	s.tick(context.Background())
+
+	s.mu.Lock()
+	enqueued := len(s.taskCh)
+	s.mu.Unlock()
+
+	if enqueued != 0 {
+		t.Errorf("expected no tasks when all namespaces fail, got %d", enqueued)
+	}
+}

--- a/controlplane/telemetry/internal/bgpstatus/submitter_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_test.go
@@ -64,24 +64,34 @@ func makeUser(pubkey solana.PublicKey, devicePK solana.PublicKey, tunnelNet [5]b
 	return u
 }
 
-// newTestSubmitter creates a Submitter with the given clock and executor,
-// using MockLocalNet backed by the provided interfaces.
+// noopCollector returns a NamespaceCollector that always succeeds with empty results.
+// Used by tests that never call tick() and only exercise the worker.
+func noopCollector() NamespaceCollector {
+	return func(_ context.Context, _ string) (map[string]struct{}, []netutil.Interface, error) {
+		return nil, nil, nil
+	}
+}
+
+// newTestSubmitter creates a Submitter with the given clock, executor, and collector.
 func newTestSubmitter(
 	t *testing.T,
 	clk clockwork.Clock,
 	exec BGPStatusExecutor,
 	svcClient ServiceabilityClient,
-	ifaces []netutil.Interface,
+	collector NamespaceCollector,
 	devicePK solana.PublicKey,
 	gracePeriod time.Duration,
 	refreshInterval time.Duration,
 ) *Submitter {
 	t.Helper()
+	if collector == nil {
+		collector = noopCollector()
+	}
 	s, err := NewSubmitter(Config{
 		Log:                     newTestLogger(t),
 		Executor:                exec,
 		ServiceabilityClient:    svcClient,
-		LocalNet:                &netutil.MockLocalNet{InterfacesFunc: func() ([]netutil.Interface, error) { return ifaces, nil }},
+		Collector:               collector,
 		LocalDevicePK:           devicePK,
 		BGPNamespace:            "ns-vrf1",
 		Interval:                time.Hour, // irrelevant; tests call tick() directly
@@ -244,6 +254,49 @@ func TestShouldSubmit_PeriodicRefresh(t *testing.T) {
 	}
 	if !shouldSubmit(us, serviceability.BGPStatusUp, now, 6*time.Hour) {
 		t.Error("expected submit when periodic refresh interval elapsed")
+	}
+}
+
+// ============================================================
+// vrfNamespaces
+// ============================================================
+
+func TestVrfNamespaces_NoTenants(t *testing.T) {
+	nss := vrfNamespaces("ns-vrf1", nil)
+	if len(nss) != 1 || nss[0] != "ns-vrf1" {
+		t.Errorf("expected [ns-vrf1], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_SameVrf(t *testing.T) {
+	tenants := []serviceability.Tenant{{VrfId: 1}}
+	nss := vrfNamespaces("ns-vrf1", tenants)
+	if len(nss) != 1 || nss[0] != "ns-vrf1" {
+		t.Errorf("expected [ns-vrf1], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_AdditionalVrf(t *testing.T) {
+	tenants := []serviceability.Tenant{{VrfId: 1}, {VrfId: 2}}
+	nss := vrfNamespaces("ns-vrf1", tenants)
+	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf2" {
+		t.Errorf("expected [ns-vrf1 ns-vrf2], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_Deduplication(t *testing.T) {
+	tenants := []serviceability.Tenant{{VrfId: 2}, {VrfId: 2}, {VrfId: 2}}
+	nss := vrfNamespaces("ns-vrf1", tenants)
+	if len(nss) != 2 {
+		t.Errorf("expected 2 unique namespaces, got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_SkipsZeroVrfId(t *testing.T) {
+	tenants := []serviceability.Tenant{{VrfId: 0}, {VrfId: 3}}
+	nss := vrfNamespaces("ns-vrf1", tenants)
+	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf3" {
+		t.Errorf("expected [ns-vrf1 ns-vrf3], got %v", nss)
 	}
 }
 
@@ -461,12 +514,12 @@ func TestNewSubmitter_MissingFields(t *testing.T) {
 		name string
 		cfg  Config
 	}{
-		{"no log", Config{Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, LocalNet: &netutil.MockLocalNet{}, LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
-		{"no executor", Config{Log: slog.Default(), ServiceabilityClient: &mockSvcClient{}, LocalNet: &netutil.MockLocalNet{}, LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
-		{"no svc client", Config{Log: slog.Default(), Executor: &mockExecutor{}, LocalNet: &netutil.MockLocalNet{}, LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
-		{"no local net", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
-		{"zero device pk", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, LocalNet: &netutil.MockLocalNet{}, BGPNamespace: "ns-vrf1"}},
-		{"no namespace", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, LocalNet: &netutil.MockLocalNet{}, LocalDevicePK: solana.NewWallet().PublicKey()}},
+		{"no log", Config{Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, Collector: noopCollector(), LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
+		{"no executor", Config{Log: slog.Default(), ServiceabilityClient: &mockSvcClient{}, Collector: noopCollector(), LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
+		{"no svc client", Config{Log: slog.Default(), Executor: &mockExecutor{}, Collector: noopCollector(), LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
+		{"no collector", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, LocalDevicePK: solana.NewWallet().PublicKey(), BGPNamespace: "ns-vrf1"}},
+		{"zero device pk", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, Collector: noopCollector(), BGPNamespace: "ns-vrf1"}},
+		{"no namespace", Config{Log: slog.Default(), Executor: &mockExecutor{}, ServiceabilityClient: &mockSvcClient{}, Collector: noopCollector(), LocalDevicePK: solana.NewWallet().PublicKey()}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -489,7 +542,7 @@ func TestTaskChannel_DropWhenFull(t *testing.T) {
 		Log:                     slog.Default(),
 		Executor:                exec,
 		ServiceabilityClient:    &mockSvcClient{data: &serviceability.ProgramData{}},
-		LocalNet:                &netutil.MockLocalNet{InterfacesFunc: func() ([]netutil.Interface, error) { return nil, nil }},
+		Collector:               noopCollector(),
 		LocalDevicePK:           devicePK,
 		BGPNamespace:            "ns-vrf1",
 		Interval:                time.Hour,

--- a/e2e/user_bgp_status_test.go
+++ b/e2e/user_bgp_status_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -212,6 +213,217 @@ func TestE2E_UserBGPStatus(t *testing.T) {
 			}
 			return false
 		}, 60*time.Second, 5*time.Second, "user BGP status never reached Down onchain")
+	}) {
+		t.Fail()
+	}
+}
+
+// TestE2E_UserBGPStatus_NonDefaultTenant verifies that the BGP status submitter
+// correctly reports Up and Down for a user whose tunnel lives in a non-default
+// VRF namespace (VrfId != 1), exercising the multi-namespace collection path
+// added to support per-tenant VRF isolation.
+func TestE2E_UserBGPStatus_NonDefaultTenant(t *testing.T) {
+	t.Parallel()
+
+	log := newTestLoggerForTest(t)
+
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	serviceabilityProgramKeypairPath := filepath.Join(currentDir, "data", "serviceability-program-keypair.json")
+
+	telemetryKeypair := solana.NewWallet().PrivateKey
+	telemetryKeypairJSON, _ := json.Marshal(telemetryKeypair[:])
+	telemetryKeypairPath := t.TempDir() + "/dz1-telemetry-keypair.json"
+	require.NoError(t, os.WriteFile(telemetryKeypairPath, telemetryKeypairJSON, 0600))
+	telemetryKeypairPK := telemetryKeypair.PublicKey()
+
+	minBalanceSOL := 3.0
+	topUpSOL := 5.0
+	dn, err := devnet.New(devnet.DevnetSpec{
+		DeployID:  "dz-e2e-" + t.Name(),
+		DeployDir: t.TempDir(),
+		CYOANetwork: devnet.CYOANetworkSpec{
+			CIDRPrefix: subnetCIDRPrefix,
+		},
+		DeviceTunnelNet: "192.168.100.0/24",
+		Manager: devnet.ManagerSpec{
+			ServiceabilityProgramKeypairPath: serviceabilityProgramKeypairPath,
+		},
+		Funder: devnet.FunderSpec{
+			Verbose:       true,
+			MinBalanceSOL: minBalanceSOL,
+			TopUpSOL:      topUpSOL,
+			Interval:      3 * time.Second,
+		},
+	}, log, dockerClient, subnetAllocator)
+	require.NoError(t, err)
+
+	err = dn.Start(t.Context(), nil)
+	require.NoError(t, err)
+
+	device, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
+		Code:               "dz1",
+		Location:           "ewr",
+		Exchange:           "xewr",
+		MetricsPublisherPK: telemetryKeypairPK.String(),
+		CYOANetworkIPHostID:          8,
+		CYOANetworkAllocatablePrefix: 29,
+		LoopbackInterfaces: map[string]string{
+			"Loopback255": "vpnv4",
+			"Loopback256": "ipv4",
+		},
+		Telemetry: devnet.DeviceTelemetrySpec{
+			Enabled:                  true,
+			KeypairPath:              telemetryKeypairPath,
+			ManagementNS:             "ns-management",
+			Verbose:                  true,
+			BGPStatusEnable:          true,
+			BGPStatusInterval:        5 * time.Second,
+			BGPStatusRefreshInterval: 1 * time.Hour,
+		},
+	})
+	require.NoError(t, err)
+
+	requireEventuallyFunded(t, log, dn.Ledger.GetRPCClient(), telemetryKeypairPK, minBalanceSOL, "telemetry publisher")
+
+	client, err := dn.AddClient(t.Context(), devnet.ClientSpec{
+		CYOANetworkIPHostID: 100,
+	})
+	require.NoError(t, err)
+
+	tdn := &TestDevnet{Devnet: dn, log: log}
+
+	t.Run("wait_for_device_activation", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				return false
+			}
+			for _, d := range data.Devices {
+				if d.Code == device.Spec.Code && d.Status == serviceability.DeviceStatusActivated {
+					return true
+				}
+			}
+			return false
+		}, 60*time.Second, 2*time.Second, "device was not activated within timeout")
+	})
+
+	// Create a non-default tenant so the user's tunnel lands in VrfId != 1.
+	if !t.Run("create_tenant", func(t *testing.T) {
+		_, err := dn.Manager.Exec(t.Context(), []string{"doublezero", "tenant", "create", "--code", "tenant-alpha"})
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	vrfID := getTenantVrfID(t, dn, "tenant-alpha")
+	require.NotZero(t, vrfID, "tenant VRF ID must be non-zero")
+	require.NotEqual(t, uint16(1), vrfID, "tenant VRF ID must differ from the default to exercise the multi-namespace path")
+	vrfName := fmt.Sprintf("vrf%d", vrfID)
+
+	if !t.Run("connect", func(t *testing.T) {
+		_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c",
+			"doublezero access-pass set --accesspass-type prepaid --tenant tenant-alpha --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey,
+		})
+		require.NoError(t, err)
+
+		_, err = client.Exec(t.Context(), []string{"doublezero", "connect", "ibrl", "tenant-alpha"})
+		require.NoError(t, err)
+
+		err = client.WaitForTunnelUp(t.Context(), 90*time.Second)
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_user_activation", func(t *testing.T) {
+		err := tdn.WaitForUserActivation(t, 1)
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_bgp_session_established", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			summary, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPBGPSummary](t.Context(), device, arista.ShowIPBGPSummaryCmd(vrfName))
+			if err != nil {
+				log.Debug("bgp status: failed to fetch BGP summary", "vrf", vrfName, "error", err)
+				return false
+			}
+			vrf, ok := summary.VRFs[vrfName]
+			if !ok {
+				log.Debug("bgp status: vrf not found in BGP summary", "vrf", vrfName)
+				return false
+			}
+			for ip, peer := range vrf.Peers {
+				if peer.PeerState == "Established" {
+					log.Debug("bgp status: BGP session established", "vrf", vrfName, "peer", ip)
+					return true
+				}
+			}
+			log.Debug("bgp status: no established BGP sessions yet", "vrf", vrfName, "peers", vrf.Peers)
+			return false
+		}, 90*time.Second, 5*time.Second, "BGP session never reached Established state in "+vrfName)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_bgp_status_up_onchain", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				log.Debug("bgp status: failed to fetch program data", "error", err)
+				return false
+			}
+			for _, user := range data.Users {
+				if user.Status != serviceability.UserStatusActivated {
+					continue
+				}
+				if user.BgpStatus == uint8(serviceability.BGPStatusUp) {
+					log.Debug("bgp status: user BGP status is Up onchain", "user", solana.PublicKeyFromBytes(user.PubKey[:]).String())
+					return true
+				}
+				log.Debug("bgp status: user BGP status not yet Up", "bgpStatus", user.BgpStatus)
+			}
+			return false
+		}, 60*time.Second, 5*time.Second, "user BGP status never reached Up onchain for non-default tenant")
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("disconnect", func(t *testing.T) {
+		client.Exec(t.Context(), []string{"bash", "-c", "pkill -9 doublezerod || true"}) //nolint:errcheck
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_bgp_status_down_onchain", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				log.Debug("bgp status: failed to fetch program data", "error", err)
+				return false
+			}
+			for _, user := range data.Users {
+				if user.Status != serviceability.UserStatusActivated {
+					continue
+				}
+				if user.BgpStatus == uint8(serviceability.BGPStatusDown) {
+					log.Debug("bgp status: user BGP status is Down onchain", "user", solana.PublicKeyFromBytes(user.PubKey[:]).String())
+					return true
+				}
+				log.Debug("bgp status: user BGP status not yet Down", "bgpStatus", user.BgpStatus)
+			}
+			return false
+		}, 60*time.Second, 5*time.Second, "user BGP status never reached Down onchain for non-default tenant")
 	}) {
 		t.Fail()
 	}

--- a/e2e/user_bgp_status_test.go
+++ b/e2e/user_bgp_status_test.go
@@ -310,9 +310,12 @@ func TestE2E_UserBGPStatus_NonDefaultTenant(t *testing.T) {
 		}, 60*time.Second, 2*time.Second, "device was not activated within timeout")
 	})
 
-	// Create a non-default tenant so the user's tunnel lands in VrfId != 1.
-	if !t.Run("create_tenant", func(t *testing.T) {
-		_, err := dn.Manager.Exec(t.Context(), []string{"doublezero", "tenant", "create", "--code", "tenant-alpha"})
+	// Create two tenants: the first consumes VrfId=1 (the default), so the
+	// second ("tenant-alpha") receives VrfId=2, guaranteeing a non-default VRF.
+	if !t.Run("create_tenants", func(t *testing.T) {
+		_, err := dn.Manager.Exec(t.Context(), []string{"doublezero", "tenant", "create", "--code", "tenant-placeholder"})
+		require.NoError(t, err)
+		_, err = dn.Manager.Exec(t.Context(), []string{"doublezero", "tenant", "create", "--code", "tenant-alpha"})
 		require.NoError(t, err)
 	}) {
 		t.FailNow()


### PR DESCRIPTION
## Summary of Changes
- Users whose tenant has `VrfId != 1` have their GRE tunnel interface placed in `ns-vrf<N>` on the Arista device, but the BGP status submitter was only checking `ns-vrf1`. This caused a persistent "tunnel not found" debug log and left those users' onchain BGP status permanently stale.
- Fix: on each tick, derive the full set of VRF namespaces from `programData.Tenants` via a new `vrfNamespaces` helper, then collect BGP socket stats and local interfaces from all of them before the per-user loop. Tunnel IPs are globally unique (onchain-allocated), so merging across namespaces is safe.
- Introduced `NamespaceCollector` as an injectable function type in `Config`, replacing `LocalNet`. `DefaultCollector` wraps the real Linux calls; tests supply a mock without any Linux syscalls.

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     2 | +82  / -21   |  +61 |
| Scaffolding  |     1 | +1   / -1    |   0  |
| Tests        |     3 | +508 / -11   | +497 |

Mostly test additions; the fix itself is compact -- ~60 net lines across two core files.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/internal/bgpstatus/submitter.go` -- adds `DefaultCollector` (wraps Linux calls), rewrites `tick()` to loop over all VRF namespaces and merge results; aborts only if every namespace fails
- `controlplane/telemetry/internal/bgpstatus/bgpstatus.go` -- adds `NamespaceCollector` func type, `vrfNamespaces` helper (derives namespace list from tenant VRF IDs), replaces `LocalNet` with `Collector` in `Config`
- `controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go` -- four new `tick()` behavioral tests: user in ns-vrf2 found and reported Up; partial namespace failure continues; all-namespace failure aborts
- `controlplane/telemetry/internal/bgpstatus/submitter_test.go` -- migrates test helpers to `NamespaceCollector`, adds five `vrfNamespaces` unit tests (dedup, zero VrfId skip, multi-tenant)
- `e2e/user_bgp_status_test.go` -- adds `TestE2E_UserBGPStatus_NonDefaultTenant`: creates a tenant (VrfId != 1), connects a client under it, and verifies Up -> Down BGP status transitions onchain
- `controlplane/telemetry/cmd/telemetry/main.go` -- wires `DefaultCollector(localNet)` into `bgpstatus.Config`

</details>

## Testing Verification
- All existing `bgpstatus` unit tests pass unchanged
- `TestVrfNamespaces_*` (5 cases): deduplication, zero VrfId skip, base namespace always included, additional VRF appended
- `TestTick_*` (4 cases, Linux): user in ns-vrf2 is found and reported Up; one failing namespace is warned and skipped while others succeed; all namespaces failing aborts the tick with no submissions
- `TestE2E_UserBGPStatus_NonDefaultTenant`: end-to-end validation that a user in a non-default tenant VRF reaches BGP status Up onchain when the session is established, and Down after the daemon is killed