### PR TITLE
telemetry: add agent version fields to WriteDeviceLatencySamples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Telemetry
+  - Add `agent_version` and `agent_commit` to `WriteDeviceLatencySamples` so the onchain header is refreshed on every write (~60s) instead of only at initialization; fixes stale version reporting after mid-epoch agent upgrades ([#3598](https://github.com/malbeclabs/doublezero/issues/3598))
+
 ## [v0.20.0](https://github.com/malbeclabs/doublezero/compare/client/v0.19.0...client/v0.20.0) - 2026-04-29
 
 ### Breaking

--- a/controlplane/internet-latency-collector/internal/exporter/ledger.go
+++ b/controlplane/internet-latency-collector/internal/exporter/ledger.go
@@ -29,7 +29,7 @@ const (
 	//
 	// When the buffer is full reaches this capacity, the calls to `Add` will block until the
 	// buffer has space again.
-	partitionBufferCapacity = telemetry.MaxSamplesPerBatch
+	partitionBufferCapacity = telemetry.MaxInternetLatencySamplesPerBatch
 )
 
 type ServiceabilityProgramClient interface {

--- a/controlplane/internet-latency-collector/internal/exporter/submitter.go
+++ b/controlplane/internet-latency-collector/internal/exporter/submitter.go
@@ -104,8 +104,8 @@ func (s *Submitter) SubmitSamples(ctx context.Context, partitionKey PartitionKey
 		return nil
 	}
 
-	for i := 0; i < len(samples); i += telemetry.MaxSamplesPerBatch {
-		end := min(i+telemetry.MaxSamplesPerBatch, len(samples))
+	for i := 0; i < len(samples); i += telemetry.MaxInternetLatencySamplesPerBatch {
+		end := min(i+telemetry.MaxInternetLatencySamplesPerBatch, len(samples))
 		batch := samples[i:end]
 
 		rtts := make([]uint32, len(batch))

--- a/controlplane/internet-latency-collector/internal/exporter/submitter_test.go
+++ b/controlplane/internet-latency-collector/internal/exporter/submitter_test.go
@@ -435,7 +435,7 @@ func TestInternetLatency_Submitter(t *testing.T) {
 		}
 
 		key := newTestPartitionKey()
-		buffer := buffer.NewMemoryPartitionedBuffer[exporter.PartitionKey, exporter.Sample](sdktelemetry.MaxSamplesPerBatch)
+		buffer := buffer.NewMemoryPartitionedBuffer[exporter.PartitionKey, exporter.Sample](sdktelemetry.MaxInternetLatencySamplesPerBatch)
 
 		// Set up the submitter.
 		submitter, err := exporter.NewSubmitter(log, &exporter.SubmitterConfig{
@@ -480,7 +480,7 @@ func TestInternetLatency_Submitter(t *testing.T) {
 
 		require.Equal(t, 23, calls, "expected 23 submission calls for 5500 samples with max 245 per call")
 		for i := range 22 {
-			assert.Equal(t, sdktelemetry.MaxSamplesPerBatch, samplesPerCall[i])
+			assert.Equal(t, sdktelemetry.MaxInternetLatencySamplesPerBatch, samplesPerCall[i])
 		}
 		assert.Equal(t, 110, samplesPerCall[22], "last call should contain 110 samples")
 	})

--- a/controlplane/telemetry/internal/telemetry/submitter.go
+++ b/controlplane/telemetry/internal/telemetry/submitter.go
@@ -124,6 +124,8 @@ func (s *Submitter) SubmitSamples(ctx context.Context, partitionKey PartitionKey
 			Epoch:                      &partitionKey.Epoch,
 			StartTimestampMicroseconds: uint64(minTimestamp.UnixMicro()),
 			Samples:                    rtts,
+			AgentVersion:               s.cfg.AgentVersion,
+			AgentCommit:                s.cfg.AgentCommit,
 		}
 
 		_, _, err := s.cfg.ProgramClient.WriteDeviceLatencySamples(ctx, writeConfig)

--- a/controlplane/telemetry/internal/telemetry/submitter.go
+++ b/controlplane/telemetry/internal/telemetry/submitter.go
@@ -92,8 +92,8 @@ func (s *Submitter) SubmitSamples(ctx context.Context, partitionKey PartitionKey
 		return nil
 	}
 
-	for i := 0; i < len(samples); i += telemetry.MaxSamplesPerBatch {
-		end := min(i+telemetry.MaxSamplesPerBatch, len(samples))
+	for i := 0; i < len(samples); i += telemetry.MaxDeviceLatencySamplesPerBatch {
+		end := min(i+telemetry.MaxDeviceLatencySamplesPerBatch, len(samples))
 		batch := samples[i:end]
 
 		rtts := make([]uint32, len(batch))

--- a/controlplane/telemetry/internal/telemetry/submitter_test.go
+++ b/controlplane/telemetry/internal/telemetry/submitter_test.go
@@ -481,7 +481,7 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 			if i == 23 {
 				assert.Equal(t, 3, samplesPerCall[i])
 			} else {
-				assert.Equal(t, sdktelemetry.MaxSamplesPerBatch, samplesPerCall[i])
+				assert.Equal(t, sdktelemetry.MaxDeviceLatencySamplesPerBatch, samplesPerCall[i])
 			}
 		}
 	})

--- a/controlplane/telemetry/internal/telemetry/submitter_test.go
+++ b/controlplane/telemetry/internal/telemetry/submitter_test.go
@@ -475,11 +475,11 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 
-		// 5500 / 245 = 22 full batches + 110 remaining = 23 calls.
-		require.Equal(t, 23, calls, "expected 23 submission calls for 5500 samples")
-		for i := range 23 {
-			if i == 22 {
-				assert.Equal(t, 110, samplesPerCall[i])
+		// 5500 / 239 = 23 full batches + 3 remaining = 24 calls.
+		require.Equal(t, 24, calls, "expected 24 submission calls for 5500 samples")
+		for i := range 24 {
+			if i == 23 {
+				assert.Equal(t, 3, samplesPerCall[i])
 			} else {
 				assert.Equal(t, sdktelemetry.MaxSamplesPerBatch, samplesPerCall[i])
 			}

--- a/controlplane/telemetry/internal/telemetry/submitter_test.go
+++ b/controlplane/telemetry/internal/telemetry/submitter_test.go
@@ -806,6 +806,44 @@ func TestAgentTelemetry_Submitter(t *testing.T) {
 		}
 	})
 
+	t.Run("passes_agent_version_and_commit_to_write", func(t *testing.T) {
+		t.Parallel()
+
+		log := log.With("test", t.Name())
+
+		var receivedConfig sdktelemetry.WriteDeviceLatencySamplesInstructionConfig
+
+		telemetryProgram := &mockTelemetryProgramClient{
+			WriteDeviceLatencySamplesFunc: func(ctx context.Context, config sdktelemetry.WriteDeviceLatencySamplesInstructionConfig) (solana.Signature, *solanarpc.GetTransactionResult, error) {
+				receivedConfig = config
+				return solana.Signature{}, nil, nil
+			},
+		}
+
+		buf := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](1024)
+		buf.Add(newTestPartitionKey(), newTestSample())
+
+		submitter, err := telemetry.NewSubmitter(log, &telemetry.SubmitterConfig{
+			Interval:       time.Hour,
+			Buffer:         buf,
+			ProgramClient:  telemetryProgram,
+			MaxAttempts:    1,
+			MaxConcurrency: 10,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
+			GetCurrentEpoch: func(ctx context.Context) (uint64, error) {
+				return 100, nil
+			},
+			AgentVersion: "1.2.3",
+			AgentCommit:  "aabbccdd",
+		})
+		require.NoError(t, err)
+
+		submitter.Tick(context.Background())
+
+		assert.Equal(t, "1.2.3", receivedConfig.AgentVersion)
+		assert.Equal(t, "aabbccdd", receivedConfig.AgentCommit)
+	})
+
 	t.Run("drops_failed_samples_when_requeue_would_meet_capacity", func(t *testing.T) {
 		t.Parallel()
 

--- a/e2e/sdk_device_telemetry_test.go
+++ b/e2e/sdk_device_telemetry_test.go
@@ -361,7 +361,7 @@ func TestE2E_SDK_Telemetry_DeviceLatencySamples(t *testing.T) {
 			LinkPK:                     la2ToNy5LinkPK,
 			Epoch:                      &epoch,
 			StartTimestampMicroseconds: secondStartTimestampMicroseconds,
-			Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch),
+			Samples:                    make([]uint32, telemetry.MaxDeviceLatencySamplesPerBatch),
 		})
 		require.NoError(t, err)
 		for _, msg := range res.Meta.LogMessages {
@@ -382,7 +382,7 @@ func TestE2E_SDK_Telemetry_DeviceLatencySamples(t *testing.T) {
 			LinkPK:                     la2ToNy5LinkPK,
 			Epoch:                      &epoch,
 			StartTimestampMicroseconds: secondStartTimestampMicroseconds,
-			Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch+1),
+			Samples:                    make([]uint32, telemetry.MaxDeviceLatencySamplesPerBatch+1),
 		})
 		require.ErrorIs(t, err, telemetry.ErrSamplesBatchTooLarge)
 	})

--- a/e2e/sdk_internet_telemetry_test.go
+++ b/e2e/sdk_internet_telemetry_test.go
@@ -297,7 +297,7 @@ func TestE2E_SDK_Telemetry_InternetLatencySamples(t *testing.T) {
 			DataProviderName:           dataProvider1Name,
 			Epoch:                      epoch,
 			StartTimestampMicroseconds: secondStartTimestampMicroseconds,
-			Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch),
+			Samples:                    make([]uint32, telemetry.MaxInternetLatencySamplesPerBatch),
 		})
 		require.NoError(t, err)
 		for _, msg := range res.Meta.LogMessages {
@@ -317,7 +317,7 @@ func TestE2E_SDK_Telemetry_InternetLatencySamples(t *testing.T) {
 			DataProviderName:           dataProvider1Name,
 			Epoch:                      epoch,
 			StartTimestampMicroseconds: secondStartTimestampMicroseconds,
-			Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch+1),
+			Samples:                    make([]uint32, telemetry.MaxInternetLatencySamplesPerBatch+1),
 		})
 		require.ErrorIs(t, err, telemetry.ErrSamplesBatchTooLarge)
 	})

--- a/smartcontract/programs/doublezero-telemetry/src/instructions.rs
+++ b/smartcontract/programs/doublezero-telemetry/src/instructions.rs
@@ -93,6 +93,8 @@ mod tests {
             WriteDeviceLatencySamplesArgs {
                 start_timestamp_microseconds: 1000,
                 samples: vec![],
+                agent_version: [0; 16],
+                agent_commit: [0; 8],
             },
         ));
         test_instruction(TelemetryInstruction::InitializeInternetLatencySamples(

--- a/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
+++ b/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
@@ -33,9 +33,11 @@ impl fmt::Debug for WriteDeviceLatencySamplesArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "start_timestamp_microseconds: {}, samples: {}",
+            "start_timestamp_microseconds: {}, samples: {}, agent_version: {}, agent_commit: {}",
             self.start_timestamp_microseconds,
-            self.samples.len()
+            self.samples.len(),
+            String::from_utf8_lossy(&self.agent_version),
+            String::from_utf8_lossy(&self.agent_commit),
         )
     }
 }

--- a/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
+++ b/smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs
@@ -25,6 +25,8 @@ use solana_program::{
 pub struct WriteDeviceLatencySamplesArgs {
     pub start_timestamp_microseconds: u64,
     pub samples: Vec<u32>,
+    pub agent_version: [u8; 16],
+    pub agent_commit: [u8; 8],
 }
 
 impl fmt::Debug for WriteDeviceLatencySamplesArgs {
@@ -125,6 +127,16 @@ pub fn process_write_device_latency_samples(
     // Set the first-write timestamp exactly once.
     if header.start_timestamp_microseconds == 0 {
         header.start_timestamp_microseconds = args.start_timestamp_microseconds;
+    }
+
+    // Update agent version fields when non-zero (old agents omit these, defaulting
+    // to zero via BorshDeserializeIncremental, so we skip the update to preserve
+    // the version set at initialization).
+    if args.agent_version != [0; 16] {
+        header.agent_version = args.agent_version;
+    }
+    if args.agent_commit != [0; 8] {
+        header.agent_commit = args.agent_commit;
     }
 
     // Pre-check the total size after append to avoid realloc panics.

--- a/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/test_helpers.rs
@@ -488,6 +488,35 @@ impl TelemetryProgramHelper {
             TelemetryInstruction::WriteDeviceLatencySamples(WriteDeviceLatencySamplesArgs {
                 start_timestamp_microseconds,
                 samples,
+                agent_version: [0; 16],
+                agent_commit: [0; 8],
+            }),
+            &[agent],
+            vec![
+                AccountMeta::new(latency_samples_pda, false),
+                AccountMeta::new(agent.pubkey(), true),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            ],
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_device_latency_samples_with_version(
+        &mut self,
+        agent: &Keypair,
+        latency_samples_pda: Pubkey,
+        samples: Vec<u32>,
+        start_timestamp_microseconds: u64,
+        agent_version: [u8; 16],
+        agent_commit: [u8; 8],
+    ) -> Result<(), BanksClientError> {
+        self.execute_transaction(
+            TelemetryInstruction::WriteDeviceLatencySamples(WriteDeviceLatencySamplesArgs {
+                start_timestamp_microseconds,
+                samples,
+                agent_version,
+                agent_commit,
             }),
             &[agent],
             vec![
@@ -544,6 +573,8 @@ impl TelemetryProgramHelper {
         let args = WriteDeviceLatencySamplesArgs {
             start_timestamp_microseconds: timestamp,
             samples,
+            agent_version: [0; 16],
+            agent_commit: [0; 8],
         };
 
         let ix = TelemetryInstruction::WriteDeviceLatencySamples(args)

--- a/smartcontract/programs/doublezero-telemetry/tests/write_device_latency_samples_tests.rs
+++ b/smartcontract/programs/doublezero-telemetry/tests/write_device_latency_samples_tests.rs
@@ -395,6 +395,8 @@ async fn test_write_device_latency_samples_fail_agent_not_signer() {
     let args = WriteDeviceLatencySamplesArgs {
         start_timestamp_microseconds: 1_700_000_000_000_000,
         samples: vec![1000, 1100],
+        agent_version: [0; 16],
+        agent_commit: [0; 8],
     };
 
     let ix = TelemetryInstruction::WriteDeviceLatencySamples(args)
@@ -855,4 +857,86 @@ async fn test_write_device_latency_samples_fail_samples_batch_too_large() {
         }
         e => panic!("unexpected error: {e:?}"),
     }
+}
+
+#[tokio::test]
+async fn test_write_device_latency_samples_updates_agent_version() {
+    let mut ledger = LedgerHelper::new().await.unwrap();
+
+    let payer_pubkey = ledger
+        .context
+        .lock()
+        .unwrap()
+        .payer
+        .insecure_clone()
+        .pubkey();
+    let contributor_pk = ledger
+        .serviceability
+        .create_contributor("CONTRIB".to_string(), payer_pubkey)
+        .await
+        .unwrap();
+
+    let (agent, origin_device_pk, target_device_pk, link_pk) = ledger
+        .seed_with_two_linked_devices(contributor_pk)
+        .await
+        .unwrap();
+    ledger.wait_for_new_blockhash().await.unwrap();
+
+    let pda = ledger
+        .telemetry
+        .initialize_device_latency_samples(
+            &agent,
+            origin_device_pk,
+            target_device_pk,
+            link_pk,
+            1,
+            5_000_000,
+        )
+        .await
+        .unwrap();
+
+    // Write samples with version "2.0.0" / commit "11223344".
+    let mut version = [0u8; 16];
+    version[..5].copy_from_slice(b"2.0.0");
+    let mut commit = [0u8; 8];
+    commit[..8].copy_from_slice(b"11223344");
+
+    ledger
+        .telemetry
+        .write_device_latency_samples_with_version(
+            &agent,
+            pda,
+            vec![1000, 1100],
+            1_700_000_000_000_000,
+            version,
+            commit,
+        )
+        .await
+        .unwrap();
+
+    // Verify header shows new version and commit.
+    let account = ledger.get_account(pda).await.unwrap().unwrap();
+    let data = DeviceLatencySamples::try_from(&account.data[..]).unwrap();
+    assert_eq!(data.header.agent_version, version);
+    assert_eq!(data.header.agent_commit, commit);
+
+    // Write again with zero version/commit (simulating old agent).
+    ledger
+        .telemetry
+        .write_device_latency_samples_with_version(
+            &agent,
+            pda,
+            vec![1200],
+            1_700_000_000_000_001,
+            [0; 16],
+            [0; 8],
+        )
+        .await
+        .unwrap();
+
+    // Verify header still shows "2.0.0" / "11223344".
+    let account = ledger.get_account(pda).await.unwrap().unwrap();
+    let data = DeviceLatencySamples::try_from(&account.data[..]).unwrap();
+    assert_eq!(data.header.agent_version, version);
+    assert_eq!(data.header.agent_commit, commit);
 }

--- a/smartcontract/sdk/go/telemetry/client.go
+++ b/smartcontract/sdk/go/telemetry/client.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrAccountNotFound      = errors.New("account not found")
-	ErrSamplesBatchTooLarge = fmt.Errorf("samples batch too large, must not exceed %d samples", MaxSamplesPerBatch)
+	ErrSamplesBatchTooLarge = errors.New("samples batch too large")
 	ErrSamplesAccountFull   = errors.New("samples account is full")
 )
 
@@ -291,7 +291,7 @@ func (c *Client) WriteDeviceLatencySamples(
 	config WriteDeviceLatencySamplesInstructionConfig,
 ) (solana.Signature, *solanarpc.GetTransactionResult, error) {
 
-	if len(config.Samples) > MaxSamplesPerBatch {
+	if len(config.Samples) > MaxDeviceLatencySamplesPerBatch {
 		return solana.Signature{}, nil, ErrSamplesBatchTooLarge
 	}
 
@@ -397,7 +397,7 @@ func (c *Client) WriteInternetLatencySamples(
 	config WriteInternetLatencySamplesInstructionConfig,
 ) (solana.Signature, *solanarpc.GetTransactionResult, error) {
 
-	if len(config.Samples) > MaxSamplesPerBatch {
+	if len(config.Samples) > MaxInternetLatencySamplesPerBatch {
 		return solana.Signature{}, nil, ErrSamplesBatchTooLarge
 	}
 

--- a/smartcontract/sdk/go/telemetry/client_device_test.go
+++ b/smartcontract/sdk/go/telemetry/client_device_test.go
@@ -727,7 +727,7 @@ func TestSDK_Telemetry_Client_WriteDeviceLatencySamples_SamplesBatchTooLarge(t *
 		LinkPK:                     solana.NewWallet().PublicKey(),
 		Epoch:                      &epoch,
 		StartTimestampMicroseconds: 1_600_000_000,
-		Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch+1),
+		Samples:                    make([]uint32, telemetry.MaxDeviceLatencySamplesPerBatch+1),
 	}
 
 	sig, tx, err := client.WriteDeviceLatencySamples(context.Background(), config)

--- a/smartcontract/sdk/go/telemetry/client_internet_test.go
+++ b/smartcontract/sdk/go/telemetry/client_internet_test.go
@@ -323,7 +323,7 @@ func TestSDK_Telemetry_Client_WriteInternetLatencySamples_SamplesBatchTooLarge(t
 		DataProviderName:           "test-data-provider-1",
 		Epoch:                      42,
 		StartTimestampMicroseconds: 1_600_000_000,
-		Samples:                    make([]uint32, telemetry.MaxSamplesPerBatch+1),
+		Samples:                    make([]uint32, telemetry.MaxInternetLatencySamplesPerBatch+1),
 	}
 
 	sig, tx, err := client.WriteInternetLatencySamples(context.Background(), config)

--- a/smartcontract/sdk/go/telemetry/constants.go
+++ b/smartcontract/sdk/go/telemetry/constants.go
@@ -28,7 +28,7 @@ const (
 	// conservative MTU size of 1280 bytes which, after accounting for headers, leaves 1232 bytes
 	// for packet data like serialized transactions.
 	// https://docs.anza.xyz/proposals/versioned-transactions#problem
-	MaxSamplesPerBatch = 245 // 980 bytes
+	MaxSamplesPerBatch = 239 // 956 bytes
 
 	// MaxDeviceLatencySamplesPerAccount is the maximum number of samples that can be written to a single device latency samples account.
 	// This provides space for just over 12 samples per minute, or 1 sample every 5 seconds.

--- a/smartcontract/sdk/go/telemetry/constants.go
+++ b/smartcontract/sdk/go/telemetry/constants.go
@@ -21,14 +21,16 @@ const (
 	// when the given PDA does not exist.
 	InstructionErrorAccountDoesNotExist = 1011
 
-	// MaxSamplesPerBatch is the maximum number of samples that can be written in a single batch.
-	//
 	// Messages transmitted to Solana validators must not exceed the IPv6 MTU size to ensure fast
 	// and reliable network transmission of cluster info over UDP. Solana's networking stack uses a
 	// conservative MTU size of 1280 bytes which, after accounting for headers, leaves 1232 bytes
 	// for packet data like serialized transactions.
 	// https://docs.anza.xyz/proposals/versioned-transactions#problem
-	MaxSamplesPerBatch = 239 // 956 bytes
+	//
+	// MaxDeviceLatencySamplesPerBatch accounts for the agent_version (16 bytes) and
+	// agent_commit (8 bytes) fields in WriteDeviceLatencySamples.
+	MaxDeviceLatencySamplesPerBatch   = 239 // 956 bytes of samples
+	MaxInternetLatencySamplesPerBatch = 245 // 980 bytes of samples
 
 	// MaxDeviceLatencySamplesPerAccount is the maximum number of samples that can be written to a single device latency samples account.
 	// This provides space for just over 12 samples per minute, or 1 sample every 5 seconds.

--- a/smartcontract/sdk/go/telemetry/write_device_latency_samples.go
+++ b/smartcontract/sdk/go/telemetry/write_device_latency_samples.go
@@ -15,6 +15,8 @@ type WriteDeviceLatencySamplesInstructionConfig struct {
 	Epoch                      *uint64
 	StartTimestampMicroseconds uint64
 	Samples                    []uint32
+	AgentVersion               string
+	AgentCommit                string
 }
 
 func (c *WriteDeviceLatencySamplesInstructionConfig) Validate() error {
@@ -47,14 +49,23 @@ func BuildWriteDeviceLatencySamplesInstruction(
 	epoch := *config.Epoch
 
 	// Serialize the instruction data.
+	var agentVersion [16]byte
+	copy(agentVersion[:], config.AgentVersion)
+	var agentCommit [8]byte
+	copy(agentCommit[:], config.AgentCommit)
+
 	data, err := borsh.Serialize(struct {
 		Discriminator              uint8
 		StartTimestampMicroseconds uint64
 		Samples                    []uint32
+		AgentVersion               [16]byte
+		AgentCommit                [8]byte
 	}{
 		Discriminator:              uint8(WriteDeviceLatencySamplesInstructionIndex),
 		StartTimestampMicroseconds: config.StartTimestampMicroseconds,
 		Samples:                    config.Samples,
+		AgentVersion:               agentVersion,
+		AgentCommit:                agentCommit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize args: %w", err)

--- a/smartcontract/sdk/go/telemetry/write_device_latency_samples_test.go
+++ b/smartcontract/sdk/go/telemetry/write_device_latency_samples_test.go
@@ -128,6 +128,8 @@ func TestSDK_Telemetry_WriteDeviceLatencySamples_BorshEncoding(t *testing.T) {
 		Epoch:                      &epoch,
 		StartTimestampMicroseconds: timestamp,
 		Samples:                    samples,
+		AgentVersion:               "1.2.3",
+		AgentCommit:                "aabbccdd",
 	}
 
 	ix, err := telemetry.BuildWriteDeviceLatencySamplesInstruction(programID, config)
@@ -137,6 +139,8 @@ func TestSDK_Telemetry_WriteDeviceLatencySamples_BorshEncoding(t *testing.T) {
 		Discriminator              uint8
 		StartTimestampMicroseconds uint64
 		Samples                    []uint32
+		AgentVersion               [16]byte
+		AgentCommit                [8]byte
 	}
 
 	data, err := ix.Data()
@@ -148,4 +152,48 @@ func TestSDK_Telemetry_WriteDeviceLatencySamples_BorshEncoding(t *testing.T) {
 	require.Equal(t, uint8(telemetry.WriteDeviceLatencySamplesInstructionIndex), decoded.Discriminator)
 	require.Equal(t, timestamp, decoded.StartTimestampMicroseconds)
 	require.Equal(t, samples, decoded.Samples)
+
+	var expectedVersion [16]byte
+	copy(expectedVersion[:], "1.2.3")
+	require.Equal(t, expectedVersion, decoded.AgentVersion)
+
+	var expectedCommit [8]byte
+	copy(expectedCommit[:], "aabbccdd")
+	require.Equal(t, expectedCommit, decoded.AgentCommit)
+}
+
+func TestSDK_Telemetry_WriteDeviceLatencySamples_BorshEncoding_EmptyVersion(t *testing.T) {
+	t.Parallel()
+
+	programID := solana.NewWallet().PublicKey()
+	epoch := uint64(555)
+	config := telemetry.WriteDeviceLatencySamplesInstructionConfig{
+		AgentPK:                    solana.NewWallet().PublicKey(),
+		OriginDevicePK:             solana.NewWallet().PublicKey(),
+		TargetDevicePK:             solana.NewWallet().PublicKey(),
+		LinkPK:                     solana.NewWallet().PublicKey(),
+		Epoch:                      &epoch,
+		StartTimestampMicroseconds: 1_650_000_000,
+		Samples:                    []uint32{100},
+	}
+
+	ix, err := telemetry.BuildWriteDeviceLatencySamplesInstruction(programID, config)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Discriminator              uint8
+		StartTimestampMicroseconds uint64
+		Samples                    []uint32
+		AgentVersion               [16]byte
+		AgentCommit                [8]byte
+	}
+
+	data, err := ix.Data()
+	require.NoError(t, err)
+
+	err = borsh.Deserialize(&decoded, data)
+	require.NoError(t, err)
+
+	require.Equal(t, [16]byte{}, decoded.AgentVersion)
+	require.Equal(t, [8]byte{}, decoded.AgentCommit)
 }


### PR DESCRIPTION
Resolves: #3598

## Summary of Changes
- Add `agent_version` (`[u8; 16]`) and `agent_commit` (`[u8; 8]`) trailing fields to `WriteDeviceLatencySamplesArgs` so the onchain header is refreshed on every write (~60s) instead of only at initialization; fixes stale version reporting after mid-epoch agent upgrades
- Use `BorshDeserializeIncremental` for backward compatibility — old agents omit these fields (defaulting to zero), and the processor skips the update when zero
- Split the shared `MaxSamplesPerBatch` constant into `MaxDeviceLatencySamplesPerBatch` (239) and `MaxInternetLatencySamplesPerBatch` (245) so the 24-byte overhead from version fields only reduces the device latency batch limit, not the internet latency batch limit

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +32 / -5    |  +27 |
| Scaffolding  |     5 | +12 / -8    |   +4 |
| Tests        |     9 | +215 / -14  | +201 |
| Docs         |     1 | +3 / -0     |   +3 |
| **Total**    |    18 | +262 / -27  | +235 |

Mostly tests; core logic is ~27 net lines across the Rust processor and Go SDK.

<details>
<summary>Key files (click to expand)</summary>

- [`smartcontract/programs/doublezero-telemetry/src/processors/telemetry/write_device_latency_samples.rs`](https://github.com/malbeclabs/doublezero/pull/3599/files#diff-9335be59e115f067912007e5b3001ce87f53185c22eea94d3d415b97b88bbaad) — Add `agent_version`/`agent_commit` to args struct; update onchain header when non-zero
- [`smartcontract/sdk/go/telemetry/write_device_latency_samples.go`](https://github.com/malbeclabs/doublezero/pull/3599/files#diff-c1132a25a1e301583712f3ec7f9a395c71aa3cd5503b2cefcdd81fe61ea77914) — Serialize version/commit strings into fixed-size byte arrays for Borsh encoding
- [`smartcontract/sdk/go/telemetry/constants.go`](https://github.com/malbeclabs/doublezero/pull/3599/files#diff-cc57e05567ede10215cde46f8eba2fe189bbff5395846251e20db9fc3c9eed2a) — Split `MaxSamplesPerBatch` into per-instruction constants (239 device / 245 internet)
- [`controlplane/telemetry/internal/telemetry/submitter.go`](https://github.com/malbeclabs/doublezero/pull/3599/files#diff-71c7c65c268c9f40ba1a5a78b3a0740268a543208924b94895f0f1de91a064d4) — Wire `AgentVersion`/`AgentCommit` from config into write instruction
- [`smartcontract/sdk/go/telemetry/client.go`](https://github.com/malbeclabs/doublezero/pull/3599/files#diff-80b8d7ca3aa6fd5d642584653ca346aee5be57bc77e79a89db885b782566c0ff) — Use per-instruction batch limits for device vs internet latency writes

</details>

## Testing Verification
- New Rust integration test `test_write_device_latency_samples_updates_agent_version` verifies version update on write and zero-field preservation
- Submitter tests updated for new batch sizes (device: 5500/239 = 24 calls, internet: 5500/245 = 23 calls)
- New submitter test `passes_agent_version_and_commit_to_write` verifies fields propagate from config to instruction