### PR TITLE
serviceability: allow count > max in Device::validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   - Fix BGP status submitter to collect socket stats and tunnel interfaces from all tenant VRF namespaces (`ns-vrf<N>`), not only `ns-vrf1`; users whose tenant has a non-default `VrfId` were previously always reporting "tunnel not found" and had their onchain BGP status left stale
 - CLI
   - Add `--narrow` flag to `doublezero user list` that hides `location`, `cyoa_type`, `accesspass`, and `tunnel_net`, abbreviates `user_type`, and summarizes `groups` as one publisher entry plus one subscriber entry with independent `+N` overflow counts; default output is unchanged
+- Smartcontract
+  - Allow `count > max` in `Device::validate` for all four per-device caps (`max_users`, `max_unicast_users`, `max_multicast_subscribers`, `max_multicast_publishers`) so operators can lower a cap below the live count; admission-time gates in user create still reject new connections when at capacity, letting the live count drain through natural churn
 
 ## [v0.19.0](https://github.com/malbeclabs/doublezero/compare/client/v0.18.0...client/v0.19.0) - 2026-04-24
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -572,47 +572,10 @@ impl Validate for Device {
             msg!("Invalid device prefixes: {:?}", self.dz_prefixes);
             return Err(DoubleZeroError::InvalidDzPrefix);
         }
-        // users_count + reserved_seats must be <= max_users when max_users > 0
-        if self.users_count + self.reserved_seats > self.max_users {
-            msg!(
-                "Max users exceeded or invalid: users_count = {}, reserved_seats = {}, max_users = {}",
-                self.users_count,
-                self.reserved_seats,
-                self.max_users
-            );
-            return Err(DoubleZeroError::MaxUsersExceeded);
-        }
-        // unicast_users_count must be <= max_unicast_users when max_unicast_users > 0
-        if self.max_unicast_users > 0 && self.unicast_users_count > self.max_unicast_users {
-            msg!(
-                "Max unicast users exceeded: unicast_users_count = {}, max_unicast_users = {}",
-                self.unicast_users_count,
-                self.max_unicast_users
-            );
-            return Err(DoubleZeroError::MaxUnicastUsersExceeded);
-        }
-        // multicast_subscribers_count must be <= max_multicast_subscribers when max_multicast_subscribers > 0
-        if self.max_multicast_subscribers > 0
-            && self.multicast_subscribers_count > self.max_multicast_subscribers
-        {
-            msg!(
-                "Max multicast subscribers exceeded: multicast_subscribers_count = {}, max_multicast_subscribers = {}",
-                self.multicast_subscribers_count,
-                self.max_multicast_subscribers
-            );
-            return Err(DoubleZeroError::MaxMulticastSubscribersExceeded);
-        }
-        // multicast_publishers_count must be <= max_multicast_publishers when max_multicast_publishers > 0
-        if self.max_multicast_publishers > 0
-            && self.multicast_publishers_count > self.max_multicast_publishers
-        {
-            msg!(
-                "Max multicast publishers exceeded: multicast_publishers_count = {}, max_multicast_publishers = {}",
-                self.multicast_publishers_count,
-                self.max_multicast_publishers
-            );
-            return Err(DoubleZeroError::MaxMulticastPublishersExceeded);
-        }
+        // Note: count <= max invariants are enforced at user-creation admission
+        // time (see processors/user/create_core.rs), not here. Allowing count > max
+        // in stored state lets operators lower a cap below the live count and drain
+        // it down through natural churn.
         // validate Interfaces
         for interface in &self.interfaces {
             interface.validate()?;
@@ -961,7 +924,9 @@ mod tests {
     }
 
     #[test]
-    fn test_state_device_validate_error_max_users_exceeded() {
+    fn test_state_device_validate_count_exceeds_max_is_allowed() {
+        // count > max is allowed in stored state so operators can shrink a cap
+        // below the live count; admission gates prevent further growth.
         let val = Device {
             account_type: AccountType::Device,
             owner: Pubkey::new_unique(),
@@ -983,17 +948,16 @@ mod tests {
             max_users: 5,
             device_health: DeviceHealth::ReadyForUsers,
             desired_status: DeviceDesiredStatus::Pending,
-            unicast_users_count: 0,
-            multicast_subscribers_count: 0,
-            max_unicast_users: 0,
-            max_multicast_subscribers: 0,
+            unicast_users_count: 4,
+            multicast_subscribers_count: 3,
+            max_unicast_users: 2,
+            max_multicast_subscribers: 1,
             reserved_seats: 0,
-            multicast_publishers_count: 0,
-            max_multicast_publishers: 0,
+            multicast_publishers_count: 2,
+            max_multicast_publishers: 1,
         };
 
-        let err = val.validate();
-        assert_eq!(err.unwrap_err(), DoubleZeroError::MaxUsersExceeded);
+        assert!(val.validate().is_ok());
     }
 
     #[test]
@@ -1390,12 +1354,11 @@ mod test_device_validate_errors {
     }
 
     #[test]
-    fn test_max_users_exceeded() {
+    fn test_max_users_count_exceeds_max_is_allowed() {
         let mut device = base_device();
         device.users_count = 11;
         device.max_users = 10;
-        let err = device.validate();
-        assert_eq!(err.unwrap_err(), DoubleZeroError::MaxUsersExceeded);
+        assert!(device.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes the four `count <= max` invariants from `Device::validate` (`max_users`, `max_unicast_users`, `max_multicast_subscribers`, `max_multicast_publishers`) so operators can lower a per-device cap below the live count.
- Admission-time gates in `processors/user/create_core.rs` continue to reject new users when the cap is hit, so reducing the cap simply prevents further growth and the live count drains through natural churn.
- Restores the pre-#2259 behavior for `max_users`, and extends the same operator-friendly behavior to the per-type caps added in #2863.

## Why

Today `doublezero device update --max-multicast-subscribers N` (or any of the other caps) fails with `MaxMulticastSubscribersExceeded` whenever the current count exceeds N — making the cap a hard floor at the live count. There's no graceful way to shrink a cap. The structural invariant in `validate()` duplicates the admission check at user creation time; only the admission check meaningfully gates behavior, so removing the structural one is safe.

Example on testnet:

```
$ doublezero --env testnet device update --pubkey 6E1fuqbDBG5ejhYEGKHNkWG5mSTczjy4R77XCKEdUtpb --max-multicast-subscribers 1
Program log: Max multicast subscribers exceeded: multicast_subscribers_count = 2, max_multicast_subscribers = 1
Error: Max multicast subscribers exceeded
```

## Testing Verification

- Updated the two unit tests that asserted the old behavior (`test_state_device_validate_error_max_users_exceeded`, `test_max_users_exceeded`) to instead assert that `validate()` succeeds when `count > max` for all four caps.
- Ran integration tests in `device_test.rs` (11 pass) and `user_tests.rs` (6 pass) to confirm nothing else relied on the structural invariant.