### PR TITLE
geolocation: add CLI to update user payment token account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - Fix BGP status submitter to collect socket stats and tunnel interfaces from all tenant VRF namespaces (`ns-vrf<N>`), not only `ns-vrf1`; users whose tenant has a non-default `VrfId` were previously always reporting "tunnel not found" and had their onchain BGP status left stale
 - CLI
   - Add `--narrow` flag to `doublezero user list` that hides `location`, `cyoa_type`, `accesspass`, and `tunnel_net`, abbreviates `user_type`, and summarizes `groups` as one publisher entry plus one subscriber entry with independent `+N` overflow counts; default output is unchanged
+  - Add `doublezero-geolocation user update --user <code-or-pubkey> --token-account <pubkey>` to update a geolocation user's payment token account; the underlying `UpdateGeolocationUser` instruction was already onchain but had no CLI entrypoint
 - Smartcontract
   - Allow `count > max` in `Device::validate` for all four per-device caps (`max_users`, `max_unicast_users`, `max_multicast_subscribers`, `max_multicast_publishers`) so operators can lower a cap below the live count; admission-time gates in user create still reject new connections when at capacity, letting the live count drain through natural churn
 

--- a/client/doublezero-geolocation-cli/src/cli/user.rs
+++ b/client/doublezero-geolocation-cli/src/cli/user.rs
@@ -4,7 +4,7 @@ use doublezero_cli::geolocation::user::{
     delete::DeleteGeolocationUserCliCommand, get::GetGeolocationUserCliCommand,
     list::ListGeolocationUserCliCommand, remove_target::RemoveTargetCliCommand,
     set_result_destination::SetResultDestinationCliCommand,
-    update_payment_status::UpdatePaymentStatusCliCommand,
+    update::UpdateGeolocationUserCliCommand, update_payment_status::UpdatePaymentStatusCliCommand,
 };
 
 #[derive(Args, Debug)]
@@ -19,6 +19,8 @@ pub enum UserCommands {
     Create(CreateGeolocationUserCliCommand),
     /// Delete a geolocation user
     Delete(DeleteGeolocationUserCliCommand),
+    /// Update a geolocation user's payment token account
+    Update(UpdateGeolocationUserCliCommand),
     /// Get details of a specific user
     Get(GetGeolocationUserCliCommand),
     /// List all geolocation users

--- a/client/doublezero-geolocation-cli/src/main.rs
+++ b/client/doublezero-geolocation-cli/src/main.rs
@@ -117,6 +117,7 @@ fn main() -> eyre::Result<()> {
         Command::User(cmd) => match cmd.command {
             UserCommands::Create(args) => args.execute(&client, &mut handle),
             UserCommands::Delete(args) => args.execute(&client, &mut handle),
+            UserCommands::Update(args) => args.execute(&client, &mut handle),
             UserCommands::Get(args) => args.execute(&client, &mut handle),
             UserCommands::List(args) => args.execute(&client, &mut handle),
             UserCommands::AddTarget(args) => args.execute(&client, &mut handle),

--- a/smartcontract/cli/src/geoclicommand.rs
+++ b/smartcontract/cli/src/geoclicommand.rs
@@ -12,6 +12,7 @@ use doublezero_sdk::{
             delete::DeleteGeolocationUserCommand, get::GetGeolocationUserCommand,
             list::ListGeolocationUserCommand, remove_target::RemoveTargetCommand,
             set_result_destination::SetResultDestinationCommand,
+            update::UpdateGeolocationUserCommand,
             update_payment_status::UpdatePaymentStatusCommand,
         },
         programconfig::init::InitProgramConfigCommand,
@@ -43,6 +44,8 @@ pub trait GeoCliCommand {
         cmd: CreateGeolocationUserCommand,
     ) -> eyre::Result<(Signature, Pubkey)>;
     fn delete_geolocation_user(&self, cmd: DeleteGeolocationUserCommand)
+        -> eyre::Result<Signature>;
+    fn update_geolocation_user(&self, cmd: UpdateGeolocationUserCommand)
         -> eyre::Result<Signature>;
     fn get_geolocation_user(
         &self,
@@ -131,6 +134,13 @@ impl GeoCliCommand for GeoCliCommandImpl<'_> {
     fn delete_geolocation_user(
         &self,
         cmd: DeleteGeolocationUserCommand,
+    ) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+
+    fn update_geolocation_user(
+        &self,
+        cmd: UpdateGeolocationUserCommand,
     ) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }

--- a/smartcontract/cli/src/geolocation/user/mod.rs
+++ b/smartcontract/cli/src/geolocation/user/mod.rs
@@ -5,4 +5,5 @@ pub mod get;
 pub mod list;
 pub mod remove_target;
 pub mod set_result_destination;
+pub mod update;
 pub mod update_payment_status;

--- a/smartcontract/cli/src/geolocation/user/update.rs
+++ b/smartcontract/cli/src/geolocation/user/update.rs
@@ -1,0 +1,102 @@
+use crate::{geoclicommand::GeoCliCommand, validators::validate_pubkey_or_code};
+use clap::Args;
+use doublezero_sdk::geolocation::geolocation_user::{
+    get::GetGeolocationUserCommand, update::UpdateGeolocationUserCommand,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct UpdateGeolocationUserCliCommand {
+    /// User pubkey or code
+    #[arg(long, value_parser = validate_pubkey_or_code)]
+    pub user: String,
+    /// New payment token account
+    #[arg(long)]
+    pub token_account: Pubkey,
+}
+
+impl UpdateGeolocationUserCliCommand {
+    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+        let (_, resolved_user) = client.get_geolocation_user(GetGeolocationUserCommand {
+            pubkey_or_code: self.user,
+        })?;
+
+        let sig = client.update_geolocation_user(UpdateGeolocationUserCommand {
+            code: resolved_user.code,
+            token_account: Some(self.token_account),
+        })?;
+
+        writeln!(out, "Signature: {sig}")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geoclicommand::MockGeoCliCommand;
+    use doublezero_geolocation::state::{
+        accounttype::AccountType,
+        geolocation_user::{
+            FlatPerEpochConfig, GeolocationBillingConfig, GeolocationPaymentStatus,
+            GeolocationUser, GeolocationUserStatus,
+        },
+    };
+    use mockall::predicate;
+    use solana_sdk::signature::Signature;
+
+    fn make_user(token_account: Pubkey) -> GeolocationUser {
+        GeolocationUser {
+            account_type: AccountType::GeolocationUser,
+            owner: Pubkey::new_unique(),
+            code: "geo-user-01".to_string(),
+            token_account,
+            payment_status: GeolocationPaymentStatus::Paid,
+            billing: GeolocationBillingConfig::FlatPerEpoch(FlatPerEpochConfig {
+                rate: 1000,
+                last_deduction_dz_epoch: 42,
+            }),
+            status: GeolocationUserStatus::Activated,
+            targets: vec![],
+            result_destination: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_cli_update_geolocation_user() {
+        let mut client = MockGeoCliCommand::new();
+
+        let user_pk = Pubkey::from_str_const("BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB");
+        let new_token = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+        let signature = Signature::new_unique();
+
+        let user = make_user(Pubkey::new_unique());
+
+        client
+            .expect_get_geolocation_user()
+            .with(predicate::eq(GetGeolocationUserCommand {
+                pubkey_or_code: "geo-user-01".to_string(),
+            }))
+            .returning(move |_| Ok((user_pk, user.clone())));
+
+        client
+            .expect_update_geolocation_user()
+            .with(predicate::eq(UpdateGeolocationUserCommand {
+                code: "geo-user-01".to_string(),
+                token_account: Some(new_token),
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = UpdateGeolocationUserCliCommand {
+            user: "geo-user-01".to_string(),
+            token_account: new_token,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("Signature:"));
+    }
+}


### PR DESCRIPTION
## Summary of Changes
- Add `user update` subcommand to `doublezero-geolocation` that submits the existing on-chain `UpdateGeolocationUser` instruction (previously unreachable from the CLI)
- Subcommand takes `--user <code-or-pubkey>` (resolved via `GetGeolocationUserCommand`, mirroring `delete`) and `--token-account <pubkey>`, then issues the update against the resolved code
- Extends the `GeoCliCommand` trait with `update_geolocation_user` so the new CLI path goes through the same mockable boundary as the rest of the geolocation CLI

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net  |
|-------------|------:|-------------|-----:|
| Core logic  |     1 | +35 / -0    |  +35 |
| Scaffolding |     4 | +15 / -1    |  +14 |
| Tests       |     1 | +67 / -0    |  +67 |

Almost entirely additive: one new CLI command file (production + tests) plus thin wiring in four existing files (trait method, subcommand enum, dispatch, mod declaration).

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/geolocation/user/update.rs` — new `UpdateGeolocationUserCliCommand` (clap struct + `execute`) and a unit test asserting the command resolves the user and emits the expected SDK call
- `smartcontract/cli/src/geoclicommand.rs` — adds `update_geolocation_user` to the `GeoCliCommand` trait and `GeoCliCommandImpl`
- `client/doublezero-geolocation-cli/src/cli/user.rs` — adds the `Update` variant to `UserCommands` and re-exports the new CLI struct
- `client/doublezero-geolocation-cli/src/main.rs` — dispatches `UserCommands::Update` to `args.execute(&client, &mut handle)`
- `smartcontract/cli/src/geolocation/user/mod.rs` — registers the new `update` module

</details>

## Testing Verification
- New unit test `test_cli_update_geolocation_user` verifies the CLI resolves a user by code and submits `UpdateGeolocationUserCommand { code, token_account: Some(..) }`
- `cargo test -p doublezero_cli geolocation::user` — 28/28 passing including the new test
- `cargo build -p doublezero_cli -p doublezero-geolocation-cli` clean
- `cargo clippy -p doublezero_cli -p doublezero-geolocation-cli --all-targets -- -Dclippy::all -Dwarnings` clean
