### PR TITLE
telemetry/bgpstatus: collect BGP state from global VRF for multicast users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Telemetry
   - Fix BGP status submitter to collect socket stats and tunnel interfaces from all tenant VRF namespaces (`ns-vrf<N>`), not only `ns-vrf1`; users whose tenant has a non-default `VrfId` were previously always reporting "tunnel not found" and had their onchain BGP status left stale
+  - Fix BGP status submitter to also collect from `ns-vrf0` (the global VRF) when multicast users are present on a device; multicast GRE tunnels live in the global VRF rather than a per-tenant namespace, so their BGP sessions were never detected and onchain status remained permanently stale
 - CLI
   - Add `--narrow` flag to `doublezero user list` that hides `location`, `cyoa_type`, `accesspass`, and `tunnel_net`, abbreviates `user_type`, and summarizes `groups` as one publisher entry plus one subscriber entry with independent `+N` overflow counts; default output is unchanged
 - Smartcontract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Telemetry
   - Fix BGP status submitter to collect socket stats and tunnel interfaces from all tenant VRF namespaces (`ns-vrf<N>`), not only `ns-vrf1`; users whose tenant has a non-default `VrfId` were previously always reporting "tunnel not found" and had their onchain BGP status left stale
-  - Fix BGP status submitter to also collect from `ns-vrf0` (the global VRF) when multicast users are present on a device; multicast GRE tunnels live in the global VRF rather than a per-tenant namespace, so their BGP sessions were never detected and onchain status remained permanently stale
+  - Fix BGP status submitter to collect from the root Linux network namespace when multicast users are present on a device; multicast GRE tunnels live in the global VRF (root namespace) rather than a per-tenant namespace, so their BGP sessions were never detected and onchain status remained permanently stale
 - CLI
   - Add `--narrow` flag to `doublezero user list` that hides `location`, `cyoa_type`, `accesspass`, and `tunnel_net`, abbreviates `user_type`, and summarizes `groups` as one publisher entry plus one subscriber entry with independent `+N` overflow counts; default output is unchanged
 - Smartcontract

--- a/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
+++ b/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
@@ -203,10 +203,14 @@ func computeEffectiveStatus(
 }
 
 // vrfNamespaces builds the list of Linux network namespaces to check for BGP
-// sockets and tunnel interfaces. It derives additional namespaces from tenant
-// VRF IDs by replacing the trailing numeric suffix of base (e.g. "ns-vrf1")
-// with each tenant's VrfId. The base namespace is always included first.
-func vrfNamespaces(base string, tenants []serviceability.Tenant) []string {
+// sockets and tunnel interfaces. The base namespace is always included first.
+// Additional namespaces are derived from two sources:
+//   - Tenant VRF IDs (non-zero): replaces the trailing numeric suffix of base
+//     (e.g. "ns-vrf1") with each tenant's VrfId, giving e.g. "ns-vrf2".
+//   - Multicast users: GRE tunnels for multicast users live in the global VRF
+//     (ns-vrf0), not in a per-tenant namespace. ns-vrf0 is appended if any
+//     user in the provided slice has UserTypeMulticast.
+func vrfNamespaces(base string, tenants []serviceability.Tenant, users []serviceability.User) []string {
 	prefix := strings.TrimRight(base, "0123456789")
 	seen := map[string]struct{}{base: {}}
 	nss := []string{base}
@@ -218,6 +222,17 @@ func vrfNamespaces(base string, tenants []serviceability.Tenant) []string {
 		if _, ok := seen[ns]; !ok {
 			seen[ns] = struct{}{}
 			nss = append(nss, ns)
+		}
+	}
+	// Multicast users' GRE tunnels live in the global VRF (ns-vrf0).
+	vrf0 := prefix + "0"
+	if _, ok := seen[vrf0]; !ok {
+		for _, u := range users {
+			if u.UserType == serviceability.UserTypeMulticast {
+				seen[vrf0] = struct{}{}
+				nss = append(nss, vrf0)
+				break
+			}
 		}
 	}
 	return nss

--- a/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
+++ b/controlplane/telemetry/internal/bgpstatus/bgpstatus.go
@@ -202,14 +202,21 @@ func computeEffectiveStatus(
 	return serviceability.BGPStatusDown
 }
 
+// rootNamespace is the sentinel passed to DefaultCollector / RunInNamespace
+// to indicate the root (global) Linux network namespace. Arista EOS places
+// the default VRF in the root namespace rather than a named namespace under
+// /var/run/netns/, so there is no file to open with netns.GetFromName.
+// RunInNamespace treats "" as "execute in the current namespace" (no switching).
+const rootNamespace = ""
+
 // vrfNamespaces builds the list of Linux network namespaces to check for BGP
 // sockets and tunnel interfaces. The base namespace is always included first.
 // Additional namespaces are derived from two sources:
 //   - Tenant VRF IDs (non-zero): replaces the trailing numeric suffix of base
 //     (e.g. "ns-vrf1") with each tenant's VrfId, giving e.g. "ns-vrf2".
 //   - Multicast users: GRE tunnels for multicast users live in the global VRF
-//     (ns-vrf0), not in a per-tenant namespace. ns-vrf0 is appended if any
-//     user in the provided slice has UserTypeMulticast.
+//     (the root network namespace), not in a per-tenant namespace. rootNamespace
+//     is appended if any user in the provided slice has UserTypeMulticast.
 func vrfNamespaces(base string, tenants []serviceability.Tenant, users []serviceability.User) []string {
 	prefix := strings.TrimRight(base, "0123456789")
 	seen := map[string]struct{}{base: {}}
@@ -224,13 +231,12 @@ func vrfNamespaces(base string, tenants []serviceability.Tenant, users []service
 			nss = append(nss, ns)
 		}
 	}
-	// Multicast users' GRE tunnels live in the global VRF (ns-vrf0).
-	vrf0 := prefix + "0"
-	if _, ok := seen[vrf0]; !ok {
+	// Multicast users' GRE tunnels live in the root network namespace (global VRF).
+	if _, ok := seen[rootNamespace]; !ok {
 		for _, u := range users {
 			if u.UserType == serviceability.UserTypeMulticast {
-				seen[vrf0] = struct{}{}
-				nss = append(nss, vrf0)
+				seen[rootNamespace] = struct{}{}
+				nss = append(nss, rootNamespace)
 				break
 			}
 		}

--- a/controlplane/telemetry/internal/bgpstatus/submitter.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter.go
@@ -71,7 +71,7 @@ func (s *Submitter) tick(ctx context.Context) {
 	}
 
 	// Pre-collect activated users for this device. This is needed both to
-	// derive the full namespace set (multicast users require ns-vrf0) and to
+	// derive the full namespace set (multicast users require the root namespace) and to
 	// drive the per-user status loop below.
 	var deviceUsers []serviceability.User
 	for _, u := range programData.Users {
@@ -83,7 +83,7 @@ func (s *Submitter) tick(ctx context.Context) {
 
 	// User tunnel interfaces live in a per-tenant VRF namespace (e.g. ns-vrf1,
 	// ns-vrf2). Multicast users are an exception: their tunnels live in the
-	// global VRF (ns-vrf0). Collect state from all relevant namespaces so that
+	// global VRF (root network namespace). Collect state from all relevant namespaces so that
 	// all user types are handled correctly.
 	// Tunnel IPs are globally unique (onchain-allocated), so merging is safe.
 	namespaces := vrfNamespaces(s.cfg.BGPNamespace, programData.Tenants, deviceUsers)

--- a/controlplane/telemetry/internal/bgpstatus/submitter.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter.go
@@ -70,11 +70,23 @@ func (s *Submitter) tick(ctx context.Context) {
 		return
 	}
 
+	// Pre-collect activated users for this device. This is needed both to
+	// derive the full namespace set (multicast users require ns-vrf0) and to
+	// drive the per-user status loop below.
+	var deviceUsers []serviceability.User
+	for _, u := range programData.Users {
+		if u.Status == serviceability.UserStatusActivated &&
+			solana.PublicKeyFromBytes(u.DevicePubKey[:]) == s.cfg.LocalDevicePK {
+			deviceUsers = append(deviceUsers, u)
+		}
+	}
+
 	// User tunnel interfaces live in a per-tenant VRF namespace (e.g. ns-vrf1,
-	// ns-vrf2). Collect state from all relevant namespaces so that users whose
-	// tenant has VrfId != 1 are handled correctly.
+	// ns-vrf2). Multicast users are an exception: their tunnels live in the
+	// global VRF (ns-vrf0). Collect state from all relevant namespaces so that
+	// all user types are handled correctly.
 	// Tunnel IPs are globally unique (onchain-allocated), so merging is safe.
-	namespaces := vrfNamespaces(s.cfg.BGPNamespace, programData.Tenants)
+	namespaces := vrfNamespaces(s.cfg.BGPNamespace, programData.Tenants, deviceUsers)
 
 	establishedIPs := make(map[string]struct{})
 	var interfaces []netutil.Interface
@@ -105,14 +117,7 @@ func (s *Submitter) tick(ctx context.Context) {
 
 	activeUserKeys := make(map[string]struct{})
 
-	for _, user := range programData.Users {
-		if user.Status != serviceability.UserStatusActivated {
-			continue
-		}
-		if solana.PublicKeyFromBytes(user.DevicePubKey[:]) != s.cfg.LocalDevicePK {
-			continue
-		}
-
+	for _, user := range deviceUsers {
 		userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
 		activeUserKeys[userPK] = struct{}{}
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
@@ -209,10 +209,11 @@ func TestTick_MultiNamespace_PartialFailure(t *testing.T) {
 	}
 }
 
-// TestTick_MulticastUser_UsesVrf0 verifies that a multicast user whose tunnel
-// lives in ns-vrf0 (the global VRF) is found and reported Up. No tenant VRF
-// is needed; the multicast user type alone causes ns-vrf0 to be collected.
-func TestTick_MulticastUser_UsesVrf0(t *testing.T) {
+// TestTick_MulticastUser_UsesRootNamespace verifies that a multicast user whose
+// tunnel lives in the root network namespace (global VRF) is found and reported
+// Up. No tenant VRF is needed; the multicast user type alone causes the root
+// namespace collector to be invoked.
+func TestTick_MulticastUser_UsesRootNamespace(t *testing.T) {
 	devicePK := solana.NewWallet().PublicKey()
 	tunnelNet := [5]byte{10, 0, 3, 0, 31} // 10.0.3.0/31
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
@@ -225,16 +225,16 @@ func TestTick_MulticastUser_UsesVrf0(t *testing.T) {
 		Users: []serviceability.User{user},
 	}}
 
-	// The tunnel (10.0.3.0/31) lives in ns-vrf0 with an ESTABLISHED BGP session.
+	// The tunnel (10.0.3.0/31) lives in the root namespace (global VRF) with an ESTABLISHED BGP session.
 	iface := makeInterface("tu500", "10.0.3.0/31")
 	col := staticCollector(
 		map[string]map[string]struct{}{
-			"ns-vrf1": {},
-			"ns-vrf0": {"10.0.3.1": {}}, // peer IP is ESTABLISHED in the global VRF
+			"ns-vrf1":      {},
+			rootNamespace:  {"10.0.3.1": {}}, // peer IP is ESTABLISHED in the global VRF
 		},
 		map[string][]netutil.Interface{
-			"ns-vrf1": nil,
-			"ns-vrf0": {iface},
+			"ns-vrf1":     nil,
+			rootNamespace: {iface},
 		},
 	)
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
@@ -229,8 +229,8 @@ func TestTick_MulticastUser_UsesVrf0(t *testing.T) {
 	iface := makeInterface("tu500", "10.0.3.0/31")
 	col := staticCollector(
 		map[string]map[string]struct{}{
-			"ns-vrf1":      {},
-			rootNamespace:  {"10.0.3.1": {}}, // peer IP is ESTABLISHED in the global VRF
+			"ns-vrf1":     {},
+			rootNamespace: {"10.0.3.1": {}}, // peer IP is ESTABLISHED in the global VRF
 		},
 		map[string][]netutil.Interface{
 			"ns-vrf1":     nil,

--- a/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go
@@ -55,6 +55,13 @@ func makeActivatedUser(devicePK solana.PublicKey, tunnelNet [5]byte) serviceabil
 	return u
 }
 
+// makeMulticastUser returns a multicast User activated on devicePK with the given /31 tunnelNet.
+func makeMulticastUser(devicePK solana.PublicKey, tunnelNet [5]byte) serviceability.User {
+	u := makeActivatedUser(devicePK, tunnelNet)
+	u.UserType = serviceability.UserTypeMulticast
+	return u
+}
+
 // ============================================================
 // tick() – multi-namespace collection
 // ============================================================
@@ -182,6 +189,54 @@ func TestTick_MultiNamespace_PartialFailure(t *testing.T) {
 		}
 		return map[string]struct{}{"10.0.1.1": {}}, []netutil.Interface{iface}, nil
 	}
+
+	s := newTestSubmitter(t, clk, exec, svc, col, devicePK, 0, 6*time.Hour)
+	s.tick(context.Background())
+
+	s.mu.Lock()
+	enqueued := len(s.taskCh)
+	s.mu.Unlock()
+
+	if enqueued != 1 {
+		t.Fatalf("expected 1 task enqueued, got %d", enqueued)
+	}
+	task := <-s.taskCh
+	if task.status != serviceability.BGPStatusUp {
+		t.Errorf("expected Up task, got %v", task.status)
+	}
+	if solana.PublicKeyFromBytes(task.user.PubKey[:]).String() != userPK {
+		t.Errorf("unexpected user in task")
+	}
+}
+
+// TestTick_MulticastUser_UsesVrf0 verifies that a multicast user whose tunnel
+// lives in ns-vrf0 (the global VRF) is found and reported Up. No tenant VRF
+// is needed; the multicast user type alone causes ns-vrf0 to be collected.
+func TestTick_MulticastUser_UsesVrf0(t *testing.T) {
+	devicePK := solana.NewWallet().PublicKey()
+	tunnelNet := [5]byte{10, 0, 3, 0, 31} // 10.0.3.0/31
+
+	user := makeMulticastUser(devicePK, tunnelNet)
+	userPK := solana.PublicKeyFromBytes(user.PubKey[:]).String()
+
+	exec := &mockExecutor{}
+	clk := clockwork.NewFakeClock()
+	svc := &mockSvcClient{data: &serviceability.ProgramData{
+		Users: []serviceability.User{user},
+	}}
+
+	// The tunnel (10.0.3.0/31) lives in ns-vrf0 with an ESTABLISHED BGP session.
+	iface := makeInterface("tu500", "10.0.3.0/31")
+	col := staticCollector(
+		map[string]map[string]struct{}{
+			"ns-vrf1": {},
+			"ns-vrf0": {"10.0.3.1": {}}, // peer IP is ESTABLISHED in the global VRF
+		},
+		map[string][]netutil.Interface{
+			"ns-vrf1": nil,
+			"ns-vrf0": {iface},
+		},
+	)
 
 	s := newTestSubmitter(t, clk, exec, svc, col, devicePK, 0, 6*time.Hour)
 	s.tick(context.Background())

--- a/controlplane/telemetry/internal/bgpstatus/submitter_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_test.go
@@ -262,7 +262,7 @@ func TestShouldSubmit_PeriodicRefresh(t *testing.T) {
 // ============================================================
 
 func TestVrfNamespaces_NoTenants(t *testing.T) {
-	nss := vrfNamespaces("ns-vrf1", nil)
+	nss := vrfNamespaces("ns-vrf1", nil, nil)
 	if len(nss) != 1 || nss[0] != "ns-vrf1" {
 		t.Errorf("expected [ns-vrf1], got %v", nss)
 	}
@@ -270,7 +270,7 @@ func TestVrfNamespaces_NoTenants(t *testing.T) {
 
 func TestVrfNamespaces_SameVrf(t *testing.T) {
 	tenants := []serviceability.Tenant{{VrfId: 1}}
-	nss := vrfNamespaces("ns-vrf1", tenants)
+	nss := vrfNamespaces("ns-vrf1", tenants, nil)
 	if len(nss) != 1 || nss[0] != "ns-vrf1" {
 		t.Errorf("expected [ns-vrf1], got %v", nss)
 	}
@@ -278,7 +278,7 @@ func TestVrfNamespaces_SameVrf(t *testing.T) {
 
 func TestVrfNamespaces_AdditionalVrf(t *testing.T) {
 	tenants := []serviceability.Tenant{{VrfId: 1}, {VrfId: 2}}
-	nss := vrfNamespaces("ns-vrf1", tenants)
+	nss := vrfNamespaces("ns-vrf1", tenants, nil)
 	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf2" {
 		t.Errorf("expected [ns-vrf1 ns-vrf2], got %v", nss)
 	}
@@ -286,7 +286,7 @@ func TestVrfNamespaces_AdditionalVrf(t *testing.T) {
 
 func TestVrfNamespaces_Deduplication(t *testing.T) {
 	tenants := []serviceability.Tenant{{VrfId: 2}, {VrfId: 2}, {VrfId: 2}}
-	nss := vrfNamespaces("ns-vrf1", tenants)
+	nss := vrfNamespaces("ns-vrf1", tenants, nil)
 	if len(nss) != 2 {
 		t.Errorf("expected 2 unique namespaces, got %v", nss)
 	}
@@ -294,9 +294,34 @@ func TestVrfNamespaces_Deduplication(t *testing.T) {
 
 func TestVrfNamespaces_SkipsZeroVrfId(t *testing.T) {
 	tenants := []serviceability.Tenant{{VrfId: 0}, {VrfId: 3}}
-	nss := vrfNamespaces("ns-vrf1", tenants)
+	nss := vrfNamespaces("ns-vrf1", tenants, nil)
 	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf3" {
 		t.Errorf("expected [ns-vrf1 ns-vrf3], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_MulticastUserAddsVrf0(t *testing.T) {
+	users := []serviceability.User{{UserType: serviceability.UserTypeMulticast}}
+	nss := vrfNamespaces("ns-vrf1", nil, users)
+	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf0" {
+		t.Errorf("expected [ns-vrf1 ns-vrf0], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_NonMulticastUserNoVrf0(t *testing.T) {
+	users := []serviceability.User{{UserType: serviceability.UserTypeIBRL}}
+	nss := vrfNamespaces("ns-vrf1", nil, users)
+	if len(nss) != 1 || nss[0] != "ns-vrf1" {
+		t.Errorf("expected [ns-vrf1], got %v", nss)
+	}
+}
+
+func TestVrfNamespaces_MulticastAndTenantVrfs(t *testing.T) {
+	tenants := []serviceability.Tenant{{VrfId: 2}}
+	users := []serviceability.User{{UserType: serviceability.UserTypeMulticast}}
+	nss := vrfNamespaces("ns-vrf1", tenants, users)
+	if len(nss) != 3 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf2" || nss[2] != "ns-vrf0" {
+		t.Errorf("expected [ns-vrf1 ns-vrf2 ns-vrf0], got %v", nss)
 	}
 }
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_test.go
@@ -300,11 +300,11 @@ func TestVrfNamespaces_SkipsZeroVrfId(t *testing.T) {
 	}
 }
 
-func TestVrfNamespaces_MulticastUserAddsVrf0(t *testing.T) {
+func TestVrfNamespaces_MulticastUserAddsRootNamespace(t *testing.T) {
 	users := []serviceability.User{{UserType: serviceability.UserTypeMulticast}}
 	nss := vrfNamespaces("ns-vrf1", nil, users)
-	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf0" {
-		t.Errorf("expected [ns-vrf1 ns-vrf0], got %v", nss)
+	if len(nss) != 2 || nss[0] != "ns-vrf1" || nss[1] != rootNamespace {
+		t.Errorf("expected [ns-vrf1 %q], got %v", rootNamespace, nss)
 	}
 }
 
@@ -320,8 +320,8 @@ func TestVrfNamespaces_MulticastAndTenantVrfs(t *testing.T) {
 	tenants := []serviceability.Tenant{{VrfId: 2}}
 	users := []serviceability.User{{UserType: serviceability.UserTypeMulticast}}
 	nss := vrfNamespaces("ns-vrf1", tenants, users)
-	if len(nss) != 3 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf2" || nss[2] != "ns-vrf0" {
-		t.Errorf("expected [ns-vrf1 ns-vrf2 ns-vrf0], got %v", nss)
+	if len(nss) != 3 || nss[0] != "ns-vrf1" || nss[1] != "ns-vrf2" || nss[2] != rootNamespace {
+		t.Errorf("expected [ns-vrf1 ns-vrf2 %q], got %v", rootNamespace, nss)
 	}
 }
 

--- a/controlplane/telemetry/internal/bgpstatus/submitter_test.go
+++ b/controlplane/telemetry/internal/bgpstatus/submitter_test.go
@@ -308,7 +308,7 @@ func TestVrfNamespaces_MulticastUserAddsRootNamespace(t *testing.T) {
 	}
 }
 
-func TestVrfNamespaces_NonMulticastUserNoVrf0(t *testing.T) {
+func TestVrfNamespaces_NonMulticastUserNoRootNamespace(t *testing.T) {
 	users := []serviceability.User{{UserType: serviceability.UserTypeIBRL}}
 	nss := vrfNamespaces("ns-vrf1", nil, users)
 	if len(nss) != 1 || nss[0] != "ns-vrf1" {

--- a/controlplane/telemetry/internal/netns/switching.go
+++ b/controlplane/telemetry/internal/netns/switching.go
@@ -13,9 +13,18 @@ import (
 // namespace. This allows thread-local operations like dialing sockets to be scoped
 // to a namespace without affecting the rest of the program.
 //
+// If nsName is empty, the function is called in the current (root) namespace
+// without any namespace switching. This is the correct behavior for the global
+// routing table on Arista EOS, which lives in the root network namespace rather
+// than a named namespace under /var/run/netns/.
+//
 // This is safe for use in single-threaded, short-lived operations; not safe for
 // concurrent use.
 func RunInNamespace[T any](nsName string, fn func() (T, error)) (T, error) {
+	if nsName == "" {
+		return fn()
+	}
+
 	var zero T
 
 	runtime.LockOSThread()

--- a/e2e/user_bgp_status_test.go
+++ b/e2e/user_bgp_status_test.go
@@ -262,10 +262,10 @@ func TestE2E_UserBGPStatus_MulticastUser(t *testing.T) {
 	require.NoError(t, err)
 
 	device, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
-		Code:               "dz1",
-		Location:           "ewr",
-		Exchange:           "xewr",
-		MetricsPublisherPK: telemetryKeypairPK.String(),
+		Code:                         "dz1",
+		Location:                     "ewr",
+		Exchange:                     "xewr",
+		MetricsPublisherPK:           telemetryKeypairPK.String(),
 		CYOANetworkIPHostID:          8,
 		CYOANetworkAllocatablePrefix: 29,
 		LoopbackInterfaces: map[string]string{
@@ -475,10 +475,10 @@ func TestE2E_UserBGPStatus_NonDefaultTenant(t *testing.T) {
 	require.NoError(t, err)
 
 	device, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
-		Code:               "dz1",
-		Location:           "ewr",
-		Exchange:           "xewr",
-		MetricsPublisherPK: telemetryKeypairPK.String(),
+		Code:                         "dz1",
+		Location:                     "ewr",
+		Exchange:                     "xewr",
+		MetricsPublisherPK:           telemetryKeypairPK.String(),
 		CYOANetworkIPHostID:          8,
 		CYOANetworkAllocatablePrefix: 29,
 		LoopbackInterfaces: map[string]string{

--- a/e2e/user_bgp_status_test.go
+++ b/e2e/user_bgp_status_test.go
@@ -218,6 +218,219 @@ func TestE2E_UserBGPStatus(t *testing.T) {
 	}
 }
 
+// TestE2E_UserBGPStatus_MulticastUser verifies that the BGP status submitter
+// correctly reports Up and Down for a multicast user, whose GRE tunnel lives
+// in the global VRF (ns-vrf0) rather than in a per-tenant VRF namespace.
+// This exercises the ns-vrf0 collection path added to support multicast users.
+func TestE2E_UserBGPStatus_MulticastUser(t *testing.T) {
+	t.Parallel()
+
+	log := newTestLoggerForTest(t)
+
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	serviceabilityProgramKeypairPath := filepath.Join(currentDir, "data", "serviceability-program-keypair.json")
+
+	telemetryKeypair := solana.NewWallet().PrivateKey
+	telemetryKeypairJSON, _ := json.Marshal(telemetryKeypair[:])
+	telemetryKeypairPath := t.TempDir() + "/dz1-telemetry-keypair.json"
+	require.NoError(t, os.WriteFile(telemetryKeypairPath, telemetryKeypairJSON, 0600))
+	telemetryKeypairPK := telemetryKeypair.PublicKey()
+
+	minBalanceSOL := 3.0
+	topUpSOL := 5.0
+	dn, err := devnet.New(devnet.DevnetSpec{
+		DeployID:  "dz-e2e-" + t.Name(),
+		DeployDir: t.TempDir(),
+		CYOANetwork: devnet.CYOANetworkSpec{
+			CIDRPrefix: subnetCIDRPrefix,
+		},
+		DeviceTunnelNet: "192.168.100.0/24",
+		Manager: devnet.ManagerSpec{
+			ServiceabilityProgramKeypairPath: serviceabilityProgramKeypairPath,
+		},
+		Funder: devnet.FunderSpec{
+			Verbose:       true,
+			MinBalanceSOL: minBalanceSOL,
+			TopUpSOL:      topUpSOL,
+			Interval:      3 * time.Second,
+		},
+	}, log, dockerClient, subnetAllocator)
+	require.NoError(t, err)
+
+	err = dn.Start(t.Context(), nil)
+	require.NoError(t, err)
+
+	device, err := dn.AddDevice(t.Context(), devnet.DeviceSpec{
+		Code:               "dz1",
+		Location:           "ewr",
+		Exchange:           "xewr",
+		MetricsPublisherPK: telemetryKeypairPK.String(),
+		CYOANetworkIPHostID:          8,
+		CYOANetworkAllocatablePrefix: 29,
+		LoopbackInterfaces: map[string]string{
+			"Loopback255": "vpnv4",
+			"Loopback256": "ipv4",
+		},
+		Telemetry: devnet.DeviceTelemetrySpec{
+			Enabled:                  true,
+			KeypairPath:              telemetryKeypairPath,
+			ManagementNS:             "ns-management",
+			Verbose:                  true,
+			BGPStatusEnable:          true,
+			BGPStatusInterval:        5 * time.Second,
+			BGPStatusRefreshInterval: 1 * time.Hour,
+		},
+	})
+	require.NoError(t, err)
+
+	requireEventuallyFunded(t, log, dn.Ledger.GetRPCClient(), telemetryKeypairPK, minBalanceSOL, "telemetry publisher")
+
+	client, err := dn.AddClient(t.Context(), devnet.ClientSpec{
+		CYOANetworkIPHostID: 100,
+	})
+	require.NoError(t, err)
+
+	tdn := &TestDevnet{Devnet: dn, log: log}
+
+	const groupCode = "bgp-mc01"
+
+	t.Run("wait_for_device_activation", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				return false
+			}
+			for _, d := range data.Devices {
+				if d.Code == device.Spec.Code && d.Status == serviceability.DeviceStatusActivated {
+					return true
+				}
+			}
+			return false
+		}, 60*time.Second, 2*time.Second, "device was not activated within timeout")
+	})
+
+	if !t.Run("create_multicast_group", func(t *testing.T) {
+		_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+			set -e
+			doublezero multicast group create --code ` + groupCode + ` --max-bandwidth 1Gbps --owner me -w
+			doublezero multicast group allowlist subscriber add --code ` + groupCode + ` --user-payer me --client-ip ` + client.CYOANetworkIP + `
+			doublezero multicast group allowlist subscriber add --code ` + groupCode + ` --user-payer ` + client.Pubkey + ` --client-ip ` + client.CYOANetworkIP + `
+		`})
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("connect", func(t *testing.T) {
+		tdn.ConnectMulticastSubscriber(t, client, groupCode)
+		err := client.WaitForTunnelUp(t.Context(), 90*time.Second)
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_user_activation", func(t *testing.T) {
+		err := tdn.WaitForUserActivation(t, 1)
+		require.NoError(t, err)
+	}) {
+		t.FailNow()
+	}
+
+	// Multicast BGP sessions run in the global VRF ("default"), not in a
+	// per-tenant VRF namespace like unicast users.
+	if !t.Run("wait_for_bgp_session_established", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			summary, err := devnet.DeviceExecAristaCliJSON[*arista.ShowIPBGPSummary](t.Context(), device, arista.ShowIPBGPSummaryCmd(""))
+			if err != nil {
+				log.Debug("bgp status: failed to fetch BGP summary", "error", err)
+				return false
+			}
+			vrf, ok := summary.VRFs["default"]
+			if !ok {
+				log.Debug("bgp status: default VRF not found in BGP summary")
+				return false
+			}
+			for ip, peer := range vrf.Peers {
+				if peer.PeerState == "Established" {
+					log.Debug("bgp status: multicast BGP session established in global VRF", "peer", ip)
+					return true
+				}
+			}
+			log.Debug("bgp status: no established multicast BGP sessions yet", "peers", vrf.Peers)
+			return false
+		}, 90*time.Second, 5*time.Second, "multicast BGP session never reached Established state in global VRF")
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_bgp_status_up_onchain", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				log.Debug("bgp status: failed to fetch program data", "error", err)
+				return false
+			}
+			for _, user := range data.Users {
+				if user.Status != serviceability.UserStatusActivated {
+					continue
+				}
+				if user.UserType != serviceability.UserTypeMulticast {
+					continue
+				}
+				if user.BgpStatus == uint8(serviceability.BGPStatusUp) {
+					log.Debug("bgp status: multicast user BGP status is Up onchain", "user", solana.PublicKeyFromBytes(user.PubKey[:]).String())
+					return true
+				}
+				log.Debug("bgp status: multicast user BGP status not yet Up", "bgpStatus", user.BgpStatus)
+			}
+			return false
+		}, 60*time.Second, 5*time.Second, "multicast user BGP status never reached Up onchain")
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("disconnect", func(t *testing.T) {
+		client.Exec(t.Context(), []string{"bash", "-c", "pkill -9 doublezerod || true"}) //nolint:errcheck
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("wait_for_bgp_status_down_onchain", func(t *testing.T) {
+		svcClient, err := dn.Ledger.GetServiceabilityClient()
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			data, err := svcClient.GetProgramData(t.Context())
+			if err != nil {
+				log.Debug("bgp status: failed to fetch program data", "error", err)
+				return false
+			}
+			for _, user := range data.Users {
+				if user.Status != serviceability.UserStatusActivated {
+					continue
+				}
+				if user.UserType != serviceability.UserTypeMulticast {
+					continue
+				}
+				if user.BgpStatus == uint8(serviceability.BGPStatusDown) {
+					log.Debug("bgp status: multicast user BGP status is Down onchain", "user", solana.PublicKeyFromBytes(user.PubKey[:]).String())
+					return true
+				}
+				log.Debug("bgp status: multicast user BGP status not yet Down", "bgpStatus", user.BgpStatus)
+			}
+			return false
+		}, 60*time.Second, 5*time.Second, "multicast user BGP status never reached Down onchain")
+	}) {
+		t.Fail()
+	}
+}
+
 // TestE2E_UserBGPStatus_NonDefaultTenant verifies that the BGP status submitter
 // correctly reports Up and Down for a user whose tunnel lives in a non-default
 // VRF namespace (VrfId != 1), exercising the multi-namespace collection path

--- a/e2e/user_bgp_status_test.go
+++ b/e2e/user_bgp_status_test.go
@@ -220,8 +220,8 @@ func TestE2E_UserBGPStatus(t *testing.T) {
 
 // TestE2E_UserBGPStatus_MulticastUser verifies that the BGP status submitter
 // correctly reports Up and Down for a multicast user, whose GRE tunnel lives
-// in the global VRF (ns-vrf0) rather than in a per-tenant VRF namespace.
-// This exercises the ns-vrf0 collection path added to support multicast users.
+// in the global VRF (root network namespace) rather than in a per-tenant VRF
+// namespace. This exercises the root-namespace collection path for multicast users.
 func TestE2E_UserBGPStatus_MulticastUser(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary of Changes
- Multicast users' GRE tunnels live in the global VRF on Arista devices (no per-tenant `vrf` qualifier), mapping to Linux namespace `ns-vrf0`. The BGP status submitter was never collecting `ns-vrf0` because `vrfNamespaces` skipped `VrfId == 0` tenant entries, leaving multicast users' onchain BGP status permanently stale.
- `vrfNamespaces` now accepts the slice of activated device users in addition to tenants; if any user has `UserTypeMulticast`, `ns-vrf0` is appended to the namespace list.
- `tick()` pre-filters activated users for this device before calling `vrfNamespaces`, and reuses that slice in the per-user status loop (eliminating a redundant pass).

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     2 | +35  / -15   |  +20 |
| Tests        |     3 | +298 / -5    | +293 |
| **Total**    |     5 | +333 / -20   | +313 |

Small fix, heavy test coverage — the change itself is ~20 net lines across two files.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/telemetry/internal/bgpstatus/bgpstatus.go` — `vrfNamespaces` gains a `users []serviceability.User` parameter; appends `ns-vrf0` when any user has `UserTypeMulticast`
- `controlplane/telemetry/internal/bgpstatus/submitter.go` — `tick()` pre-filters device users before namespace derivation and reuses the slice in the status loop
- `e2e/user_bgp_status_test.go` — new `TestE2E_UserBGPStatus_MulticastUser`: creates a multicast group, connects a subscriber, and verifies Up → Down BGP status transitions onchain; BGP session is verified in the global VRF (`"default"` key)
- `controlplane/telemetry/internal/bgpstatus/submitter_linux_test.go` — new `TestTick_MulticastUser_UsesVrf0`: verifies that a multicast user's tunnel in `ns-vrf0` is found and reported Up
- `controlplane/telemetry/internal/bgpstatus/submitter_test.go` — three new `vrfNamespaces` unit tests covering multicast-only, non-multicast, and mixed multicast+tenant VRF scenarios; existing tests updated to pass `nil` users

</details>

## Testing Verification
- All existing `bgpstatus` unit tests pass unchanged
- `TestVrfNamespaces_MulticastUserAddsVrf0`: multicast user causes `ns-vrf0` to be included
- `TestVrfNamespaces_NonMulticastUserNoVrf0`: non-multicast user does not add `ns-vrf0`
- `TestVrfNamespaces_MulticastAndTenantVrfs`: multicast user combined with tenant VRFs produces the correct namespace list
- `TestTick_MulticastUser_UsesVrf0` (Linux): tick finds the multicast user's tunnel in `ns-vrf0` and enqueues an Up submission
- `TestE2E_UserBGPStatus_MulticastUser`: end-to-end validation that a multicast subscriber reaches BGP status Up onchain and Down after the daemon is killed