### PR TITLE
controller: hoist unknown BGP peer cleanup before main router bgp block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Controller
+  - Fix unknown BGP peer cleanup in the Arista EOS template: hoist per-peer `no neighbor X` removal into its own `router bgp 65342` block so EOS's silent context-exit on `no neighbor` for a non-existent peer can't misroute subsequent peers' removal commands ([#3627](https://github.com/malbeclabs/doublezero/pull/3627))
 - Telemetry
   - Add `agent_version` and `agent_commit` to `WriteDeviceLatencySamples` so the onchain header is refreshed on every write (~60s) instead of only at initialization; fixes stale version reporting after mid-epoch agent upgrades ([#3598](https://github.com/malbeclabs/doublezero/issues/3598))
 

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
@@ -86,24 +86,40 @@ mpls icmp ip source-interface Loopback255
 default interface Tunnel{{$i}}
 {{- end}}
 router bgp 65342
+   no neighbor 172.16.0.1
+   address-family ipv4
+      no neighbor 172.16.0.1
+   !
+   address-family vpn-ipv4
+      no neighbor 172.16.0.1
+   !
+   vrf vrf1
+      no neighbor 172.16.0.1
+!
+router bgp 65342
+   no neighbor 169.254.0.13
+   address-family ipv4
+      no neighbor 169.254.0.13
+   !
+   address-family vpn-ipv4
+      no neighbor 169.254.0.13
+   !
+   vrf vrf1
+      no neighbor 169.254.0.13
+!
+router bgp 65342
    router-id 14.14.14.14
    timers bgp 1 3
    distance bgp 20 200 200
    address-family ipv4
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.13
    !
    address-family vpn-ipv4
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.13
    !
    vrf vrf1
       rd 65342:1
       route-target import vpn-ipv4 65342:1
       route-target export vpn-ipv4 65342:1
       router-id 2.2.2.2
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.13
 !
 router isis 1
    net 49.0000.0e0e.0e0e.0000.00

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
@@ -116,6 +116,28 @@ interface Tunnel501
    no shutdown
 !
 router bgp 65342
+   no neighbor 172.16.0.1
+   address-family ipv4
+      no neighbor 172.16.0.1
+   !
+   address-family vpn-ipv4
+      no neighbor 172.16.0.1
+   !
+   vrf vrf1
+      no neighbor 172.16.0.1
+!
+router bgp 65342
+   no neighbor 169.254.0.7
+   address-family ipv4
+      no neighbor 169.254.0.7
+   !
+   address-family vpn-ipv4
+      no neighbor 169.254.0.7
+   !
+   vrf vrf1
+      no neighbor 169.254.0.7
+!
+router bgp 65342
    router-id 14.14.14.14
    timers bgp 1 3
    distance bgp 20 200 200
@@ -130,12 +152,8 @@ router bgp 65342
    neighbor 169.254.0.3 maximum-accepted-routes 1
    address-family ipv4
       neighbor 169.254.0.3 activate
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.7
    !
    address-family vpn-ipv4
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.7
    !
    vrf vrf1
       rd 65342:1
@@ -151,8 +169,6 @@ router bgp 65342
       neighbor 169.254.0.1 route-map RM-USER-500-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
-      no neighbor 172.16.0.1
-      no neighbor 169.254.0.7
 !
 router isis 1
    net 49.0000.0e0e.0e0e.0000.00

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
@@ -116,14 +116,23 @@ interface Tunnel502
    no shutdown
 !
 router bgp 65342
-   router-id 14.14.14.14
-   timers bgp 1 3
-   distance bgp 20 200 200
+   no neighbor 169.254.0.7
    address-family ipv4
       no neighbor 169.254.0.7
    !
    address-family vpn-ipv4
       no neighbor 169.254.0.7
+   !
+   vrf vrf1
+      no neighbor 169.254.0.7
+!
+router bgp 65342
+   router-id 14.14.14.14
+   timers bgp 1 3
+   distance bgp 20 200 200
+   address-family ipv4
+   !
+   address-family vpn-ipv4
    !
    vrf vrf1
       rd 65342:1
@@ -157,7 +166,6 @@ router bgp 65342
       neighbor 169.254.0.5 route-map RM-USER-502-OUT out
       neighbor 169.254.0.5 maximum-routes 1
       neighbor 169.254.0.5 maximum-accepted-routes 1
-      no neighbor 169.254.0.7
 !
 router isis 1
    net 49.0000.0e0e.0e0e.0000.00

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -198,6 +198,21 @@ interface Tunnel{{ .Id }}
 !
 {{- end }}
 {{- end }}
+{{- range $peer := .UnknownBgpPeers }}
+router bgp 65342
+   no neighbor {{ $peer }}
+   address-family ipv4
+      no neighbor {{ $peer }}
+   !
+   address-family vpn-ipv4
+      no neighbor {{ $peer }}
+   !
+   {{- range $vrfId := $.UnicastVrfs }}
+   vrf vrf{{ $vrfId }}
+      no neighbor {{ $peer }}
+   {{- end }}
+!
+{{- end }}
 router bgp 65342
    router-id {{ .Device.Vpn4vLoopbackIP }}
    timers bgp 1 3
@@ -256,18 +271,12 @@ router bgp 65342
       no neighbor {{ .PeerIP }} activate
    {{- end }}
    {{- end }}
-   {{- range .UnknownBgpPeers }}
-      no neighbor {{ . }}
-   {{- end }}
    !
    address-family vpn-ipv4
       {{- range .Vpnv4BgpPeers }}
       {{- if ne .PeerIP.String $.Device.Vpn4vLoopbackIP.String }}
       neighbor {{ .PeerIP }} activate
       {{- end }}
-      {{- end }}
-      {{- range .UnknownBgpPeers }}
-      no neighbor {{ . }}
       {{- end }}
       {{- if $.FlexAlgoEnabled }}
       next-hop resolution ribs tunnel-rib colored system-colored-tunnel-rib tunnel-rib system-tunnel-rib
@@ -296,9 +305,6 @@ router bgp 65342
       neighbor {{ .OverlayDstIP }} shutdown
       {{- end }}
       {{- end }}
-      {{- end }}
-      {{- range $.UnknownBgpPeers }}
-      no neighbor {{ . }}
       {{- end }}
 {{- end }}
 !


### PR DESCRIPTION
## Summary of Changes
- Hoist `UnknownBgpPeers` `no neighbor X` emission into a per-peer block that re-enters `router bgp 65342` before the main config, removing the inline cleanup loops from `address-family ipv4`, `address-family vpn-ipv4`, and the per-VRF block.
- Each peer's removal now starts with a clean `router bgp 65342` re-entry and explicitly emits `no neighbor X` at top-level **and** in each AF/VRF, so cleanup is comprehensive and isolated per peer.
- Refresh fixtures to match the new emission order: `unknown.peer.removal.tmpl`, `e2e.peer.removal.tmpl`, `e2e.last.user.tmpl`.

## Fundamental Bug Being Fixed

The previous template emitted `no neighbor X` per unknown peer **inside** `address-family ipv4`, `address-family vpn-ipv4`, and each `vrf vrfN` block. EOS silently exits AF/VRF context when `no neighbor X` is issued for a peer that doesn't exist there. With a list of unknown peers, this means:

1. First peer in the list doesn't exist in the AF → EOS exits AF context.
2. Second peer's `no neighbor X` runs at `router bgp` top-level instead of inside the AF.
3. All subsequent peers continue at the wrong context.

So the cleanup was **order-dependent and non-deterministic**: depending on which peer happened to iterate first, you'd either get the intended per-AF/VRF cleanup for the whole list or a partial mix where only the first peer got AF treatment and the rest got incidental top-level deletion. The bug rarely produced observable damage because top-level deletion is also "remove this peer," and `UnknownBgpPeers` are by definition peers that should be fully removed — but the cleanup behavior was unreliable in principle.

RFC-18 made the bug visible by adding `next-hop resolution ribs ...` (an AF-only command) immediately after the `UnknownBgpPeers` loop in `address-family vpn-ipv4`. When the loop's first peer triggered context-exit, the new command landed at `router bgp` top-level and EOS rejected it as `Invalid input`. That was the surface symptom; the real defect was structural and pre-existing.

The fix:
- One `router bgp 65342` re-entry per unknown peer means context corruption inside one peer's cleanup is bounded to that single iteration.
- Each peer's cleanup explicitly covers top-level + each AF + each VRF, so removal is comprehensive regardless of where the peer was actually configured.
- Removes the three inline loops in the main BGP block, eliminating the source of context-bleed for any AF-scoped command emitted later in the template.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     1 | +15 / -9    |  +6  |
| Fixtures   |     3 | +55 / -15   | +40  |

Single-file template change with three matching fixture refreshes.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/controller/internal/controller/templates/tunnel.tmpl` — adds the per-peer cleanup block (top-level + per-AF + per-VRF `no neighbor`), removes the three inline `UnknownBgpPeers` ranges.
- `controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl` — updated expected output for two unknown peers.
- `controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl` — updated expected output for two unknown peers.
- `controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl` — updated expected output for one unknown peer.

</details>

## Testing Verification
- Bug reproduced on physical EOS (chi-dn-dzd8, 7130LBR): `no neighbor X` for a non-existent peer inside `address-family vpn-ipv4` followed by `next-hop resolution ribs tunnel-rib system-tunnel-rib` is rejected as `Invalid input`. Control test (same command without preceding `no neighbor`) is accepted normally — proving the rejection is caused by silent context-exit, not by the command itself.
- Fix verified on the same hardware: cleanup block targeting three non-existent peer IPs (including `169.254.1.7`, exact-match canary one digit off from real `169.254.1.6`) produces zero diff. A sentinel command emitted after the cleanup correctly lands at `router bgp 65342` top-level context. All real neighbors untouched. Session aborted; device state restored.
