### PR TITLE
workflows: add infra_branch input to devnet component release workflows

### DIFF
--- a/.github/workflows/release.devnet.activator.daily.yml
+++ b/.github/workflows/release.devnet.activator.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.activator.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: activator
       playbook: playbooks/activators.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.agent.daily.yml
+++ b/.github/workflows/release.devnet.agent.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.agent.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: agent
       playbook: playbooks/agents.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.client.daily.yml
+++ b/.github/workflows/release.devnet.client.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.client.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: client
       playbook: playbooks/validators.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.controller.daily.yml
+++ b/.github/workflows/release.devnet.controller.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.controller.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: controller
       playbook: playbooks/controllers.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.device-telemetry-agent.daily.yml
+++ b/.github/workflows/release.devnet.device-telemetry-agent.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.device-telemetry-agent.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: device-telemetry-agent
       playbook: playbooks/device_telemetry_agent.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.funder.yml
+++ b/.github/workflows/release.devnet.funder.yml
@@ -2,6 +2,12 @@ name: release.devnet.funder.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: funder
       playbook: playbooks/funders.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.geoprobe-agent.daily.yml
+++ b/.github/workflows/release.devnet.geoprobe-agent.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.geoprobe-agent.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: geoprobe-agent
       playbook: playbooks/geoprobe_agents.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.geoprobe-target.daily.yml
+++ b/.github/workflows/release.devnet.geoprobe-target.daily.yml
@@ -2,6 +2,12 @@ name: release.devnet.geoprobe-target.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: geoprobe-target
       playbook: playbooks/geoprobe_targets.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.internet-latency-collector.yml
+++ b/.github/workflows/release.devnet.internet-latency-collector.yml
@@ -2,6 +2,12 @@ name: release.devnet.internet-latency-collector.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: internet-latency-collector
       playbook: playbooks/internet_latency_collectors.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.monitor.yml
+++ b/.github/workflows/release.devnet.monitor.yml
@@ -2,6 +2,12 @@ name: release.devnet.monitor.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: monitor
       playbook: playbooks/monitors.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.devnet.qa.agent.yml
+++ b/.github/workflows/release.devnet.qa.agent.yml
@@ -2,6 +2,12 @@ name: release.devnet.qa.agent.daily
 
 on:
   workflow_dispatch:
+    inputs:
+      infra_branch:
+        description: 'Branch of malbeclabs/infra to use for ansible playbooks'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -9,6 +15,7 @@ jobs:
     with:
       component: qa-agent
       playbook: playbooks/qa_agents.yml
+      infra_branch: ${{ inputs.infra_branch }}
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary of Changes
* Add `infra_branch` workflow_dispatch input to 11 individual devnet component release workflows, matching the pattern already in `release.devnet.all.daily.yml`
* This lets operators specify a custom `malbeclabs/infra` branch when deploying a single component to devnet, enabling testing of ansible changes alongside code changes without running the full "all" workflow
* Not including `release.devnet.doublezero.monitor.tool.yml` (standalone GoReleaser, no ansible) and `release.devnet.smartcontract.daily.yml` (direct Solana deploy, no ansible) since they don't use the infra repo
* Fixes #3630

## Testing Verification
* Verified all 11 modified workflows have identical `infra_branch` input definition matching the reference in `release.devnet.all.daily.yml`
* Confirmed each workflow passes `infra_branch: ${{ inputs.infra_branch }}` through to `release.daily.yml` which already handles the input
* Input is optional with empty string default — fully backward-compatible with existing manual dispatches and scheduled triggers
