### PR TITLE
client: rename SOCKET_PATH_OVERRIDE to GLOBAL_SOCKET_PATH

### DIFF
--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> eyre::Result<()> {
     let app = App::parse();
 
     if let Some(sock_file) = &app.sock_file {
-        ServiceControllerImpl::set_default_socket_path(sock_file.to_string_lossy());
+        ServiceControllerImpl::set_global_socket_path(sock_file.to_string_lossy());
     }
 
     if let Some(keypair) = &app.keypair {

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -12,7 +12,7 @@ use tabled::{derive::display, Tabled};
 
 const DEFAULT_SOCKET_PATH: &str = "/var/run/doublezerod/doublezerod.sock";
 const NANOS_TO_MS: f64 = 1000000.0;
-static SOCKET_PATH_OVERRIDE: OnceLock<String> = OnceLock::new();
+static GLOBAL_SOCKET_PATH: OnceLock<String> = OnceLock::new();
 
 #[derive(Clone, Tabled, Deserialize, Serialize, Debug)]
 pub struct LatencyRecord {
@@ -201,14 +201,14 @@ pub struct ServiceControllerImpl {
 }
 
 impl ServiceControllerImpl {
-    pub fn set_default_socket_path(socket_path: impl Into<String>) {
-        let _ = SOCKET_PATH_OVERRIDE.set(socket_path.into());
+    pub fn set_global_socket_path(socket_path: impl Into<String>) {
+        let _ = GLOBAL_SOCKET_PATH.set(socket_path.into());
     }
 
     pub fn new(socket_path: Option<String>) -> ServiceControllerImpl {
         ServiceControllerImpl {
             socket_path: socket_path.unwrap_or_else(|| {
-                SOCKET_PATH_OVERRIDE
+                GLOBAL_SOCKET_PATH
                     .get()
                     .cloned()
                     .unwrap_or_else(|| DEFAULT_SOCKET_PATH.to_string())


### PR DESCRIPTION
## Summary

- Renames the internal static `SOCKET_PATH_OVERRIDE` to `GLOBAL_SOCKET_PATH` and the  setter `set_default_socket_path` to `set_global_socket_path` to better reflect their actual role: they represent the process-wide socket path set once at startup, not an "override" of anything

Leftover naming cleanup from #3634.

## Testing Verification

- No behavioral change; covered by existing unit test `test_service_controller_uses_explicit_socket_path_for_checks`