### PR TITLE
chore: cover multiple VRFs for unit test

### DIFF
--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
@@ -19,8 +19,10 @@ router pim sparse-mode
       rp address 10.0.0.0 239.0.0.0/24 override
 !
 vrf instance vrf1
+vrf instance vrf2
 ip routing
 ip routing vrf vrf1
+ip routing vrf vrf2
 !
 ntp server 0.pool.ntp.org
 ntp server 1.pool.ntp.org
@@ -95,7 +97,7 @@ interface Tunnel500
 interface Tunnel501
    description USER-UCAST-501
    ip access-group SEC-USER-501-IN in
-   vrf vrf1
+   vrf vrf2
    mtu 9216
    ip address 169.254.0.2/31
    tunnel mode gre
@@ -108,7 +110,7 @@ interface Tunnel501
 interface Tunnel502
    description USER-UCAST-502
    ip access-group SEC-USER-502-IN in
-   vrf vrf1
+   vrf vrf2
    mtu 9216
    ip address 169.254.0.4/31
    tunnel mode gre
@@ -127,6 +129,8 @@ router bgp 65342
       no neighbor 169.254.0.7
    !
    vrf vrf1
+      no neighbor 169.254.0.7
+   vrf vrf2
       no neighbor 169.254.0.7
 !
 router bgp 65342
@@ -151,6 +155,11 @@ router bgp 65342
       neighbor 169.254.0.1 route-map RM-USER-500-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
+   vrf vrf2
+      rd 65342:2
+      route-target import vpn-ipv4 65342:2
+      route-target export vpn-ipv4 65342:2
+      router-id 7.7.7.7
       no neighbor 169.254.0.3
       neighbor 169.254.0.3 remote-as 65000
       neighbor 169.254.0.3 local-as 21682 no-prepend replace-as

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -249,7 +249,7 @@ func TestRenderConfig(t *testing.T) {
 				MulticastGroupBlock:      "239.0.0.0/24",
 				TelemetryTWAMPListenPort: 862,
 				LocalASN:                 21682,
-				UnicastVrfs:              []uint16{1},
+				UnicastVrfs:              []uint16{1, 2},
 				Device: &Device{
 					Interfaces:            []Interface{},
 					PublicIP:              net.IP{7, 7, 7, 7},
@@ -278,7 +278,7 @@ func TestRenderConfig(t *testing.T) {
 							OverlayDstIP:  net.IP{169, 254, 0, 3},
 							DzIp:          net.IP{100, 0, 0, 1},
 							Allocated:     true,
-							VrfId:         1,
+							VrfId:         2,
 							MetroRouting:  true,
 						},
 						{
@@ -289,7 +289,7 @@ func TestRenderConfig(t *testing.T) {
 							OverlayDstIP:  net.IP{169, 254, 0, 5},
 							DzIp:          net.IP{100, 0, 0, 2},
 							Allocated:     true,
-							VrfId:         1,
+							VrfId:         2,
 							MetroRouting:  true,
 						},
 					},


### PR DESCRIPTION
## Summary of Changes
* Describe what changed in the PR
Updated `render_peer_removal_successful` in `controlplane/controller/internal/controller/render_test.go` to cover multi-VRF scenarios by switching `UnicastVrfs` from `[1]` → `[1, 2]` and assigning tunnels across VRFs (keeping tunnel 500 in VRF1; moving 501/502 to VRF2).
Updated the golden fixture `controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl` to match the expected rendered output for multi-VRF peer removal (adds vrf2 `routing/config` sections, moves tunnel VRF assignments, and ensures unknown-peer no neighbor cleanup is rendered under each VRF).

* Explain why the change is necessary
quoting from [this issue](https://github.com/malbeclabs/doublezero/issues/3633):
    > Today, this is only tested with one VRF. A regression in multi-VRF unknown peer removal would go undetected by the unit test suite. The existing multi.vrf.tunnel.tmpl fixture tests multi-VRF rendering but uses UnknownBgpPeers: nil, so it doesn't cover this case.
* Is there supporting documentation or external resources that explain the change? No
* Is a CHANGELOG.md update needed? No

## Testing Verification
* Ran the focused unit subtest:
```bash
go test ./controlplane/controller/internal/controller -run '^TestRenderConfig$/render_peer_removal_successful$' -v
```

Closes #3633 