### PR TITLE
e2e/qa: use dedicated restart playbooks for provisioning test

### DIFF
--- a/e2e/internal/qa/provisioning.go
+++ b/e2e/internal/qa/provisioning.go
@@ -543,7 +543,11 @@ func (p *ProvisioningTest) RunAnsibleAgentRestart(ctx context.Context, deviceCod
 		sshKeyFile = "~/.ssh/id_runner"
 	}
 
-	// Run agents.yml to restart doublezero-agent
+	// Run restart_agent.yml to update the daemon config with the new pubkey and restart
+	// doublezero-agent. Using a dedicated restart playbook rather than agents.yml because
+	// agents.yml only restarts the daemon as a handler when a new package is downloaded —
+	// it does nothing if the package version hasn't changed, leaving the daemon running
+	// with the old pubkey.
 	p.log.Info("Running Ansible to restart doublezero-agent", "device", deviceCode, "pubkey", newPubkey)
 	agentArgs := []string{
 		"ansible-playbook",
@@ -552,18 +556,19 @@ func (p *ProvisioningTest) RunAnsibleAgentRestart(ctx context.Context, deviceCod
 		"-e", fmt.Sprintf("bm_host=%s", p.bmHost),
 		"-e", fmt.Sprintf("env=%s", p.env),
 		"-e", fmt.Sprintf("ansible_ssh_private_key_file=%s", sshKeyFile),
-		filepath.Join(p.infraPath, "ansible/playbooks/agents.yml"),
+		filepath.Join(p.infraPath, "ansible/playbooks/restart_agent.yml"),
 	}
 	agentArgs = append(agentArgs, vaultArgs...)
 
 	cmd := exec.CommandContext(ctx, agentArgs[0], agentArgs[1:]...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("ansible agents.yml failed: %w, output: %s", err, string(output))
+		return fmt.Errorf("ansible restart_agent.yml failed: %w, output: %s", err, string(output))
 	}
-	p.log.Debug("Ansible agents.yml output", "output", string(output))
+	p.log.Debug("Ansible restart_agent.yml output", "output", string(output))
 
-	// Run device_telemetry_agent.yml to restart doublezero-telemetry
+	// Run restart_device_telemetry_agent.yml to update the daemon config and restart
+	// doublezero-telemetry. Same reasoning as above.
 	p.log.Info("Running Ansible to restart doublezero-telemetry", "device", deviceCode, "pubkey", newPubkey)
 	telemetryArgs := []string{
 		"ansible-playbook",
@@ -572,16 +577,16 @@ func (p *ProvisioningTest) RunAnsibleAgentRestart(ctx context.Context, deviceCod
 		"-e", fmt.Sprintf("bm_host=%s", p.bmHost),
 		"-e", fmt.Sprintf("env=%s", p.env),
 		"-e", fmt.Sprintf("ansible_ssh_private_key_file=%s", sshKeyFile),
-		filepath.Join(p.infraPath, "ansible/playbooks/device_telemetry_agent.yml"),
+		filepath.Join(p.infraPath, "ansible/playbooks/restart_device_telemetry_agent.yml"),
 	}
 	telemetryArgs = append(telemetryArgs, vaultArgs...)
 
 	cmd = exec.CommandContext(ctx, telemetryArgs[0], telemetryArgs[1:]...)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("ansible device_telemetry_agent.yml failed: %w, output: %s", err, string(output))
+		return fmt.Errorf("ansible restart_device_telemetry_agent.yml failed: %w, output: %s", err, string(output))
 	}
-	p.log.Debug("Ansible device_telemetry_agent.yml output", "output", string(output))
+	p.log.Debug("Ansible restart_device_telemetry_agent.yml output", "output", string(output))
 
 	return nil
 }

--- a/e2e/internal/qa/provisioning.go
+++ b/e2e/internal/qa/provisioning.go
@@ -593,13 +593,13 @@ func (p *ProvisioningTest) RunAnsibleAgentRestart(ctx context.Context, deviceCod
 
 func formatBandwidth(bps uint64) string {
 	if bps >= 1_000_000_000 {
-		return fmt.Sprintf("%d Gbps", bps/1_000_000_000)
+		return fmt.Sprintf("%dGbps", bps/1_000_000_000)
 	}
 	if bps >= 1_000_000 {
-		return fmt.Sprintf("%d Mbps", bps/1_000_000)
+		return fmt.Sprintf("%dMbps", bps/1_000_000)
 	}
 	if bps >= 1_000 {
-		return fmt.Sprintf("%d Kbps", bps/1_000)
+		return fmt.Sprintf("%dKbps", bps/1_000)
 	}
-	return fmt.Sprintf("%d bps", bps)
+	return fmt.Sprintf("%dbps", bps)
 }

--- a/e2e/qa_provisioning_test.go
+++ b/e2e/qa_provisioning_test.go
@@ -78,8 +78,7 @@ func TestQA_DeviceProvisioning(t *testing.T) {
 	if normalizeEnum(device.Health) == "ready-for-users" && normalizeEnum(device.Status) == "activated" {
 		t.Log("Device is healthy — previous provisioning verified")
 	} else {
-		t.Logf("WARNING: device is not healthy (status=%s health=%s) — previous provisioning may have failed, reprovisioning", device.Status, device.Health)
-		// TODO: fire an alert here
+		t.Errorf("device is not healthy (status=%s health=%s) — previous provisioning may have failed, reprovisioning", device.Status, device.Health)
 	}
 
 	oldPubkey := device.Pubkey


### PR DESCRIPTION
## Summary
- Switch `RunAnsibleAgentRestart` from `agents.yml` / `device_telemetry_agent.yml` to dedicated `restart_agent.yml` / `restart_device_telemetry_agent.yml` playbooks
- The old playbooks only restart daemons when a new package is downloaded; the new playbooks unconditionally update the daemon config with the current onchain pubkey and restart

## Context
The daily `TestQA_DeviceProvisioning` test re-creates dzd4 with a new keypair each day. The Ansible step at the end is supposed to push the new pubkey to the EOS daemon config and restart. But `agents.yml` only fires the restart handler when a new package version is downloaded — so on most days, the daemon kept running with the old pubkey, causing agent crashes and a vicious cycle where links could never be recreated.

Requires: malbeclabs/infra#1215 (adds the new restart playbooks)

## Testing Verification
- Verified `go build -tags=qa ./e2e/internal/qa/` compiles cleanly
- Confirmed the existing restart task files already contain the correct logic (query ledger, update EOS daemon config, shutdown/no shutdown)
