### PR TITLE
doublezero: add EdgeSeat access pass type and on-chain version info in -V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   - Add `AccessPassType::EdgeSeat(Pubkey)` variant to associate an access pass with a specific onchain Seat pubkey
   - Add `--accesspass-type edge-seat --seat <PUBKEY>` to `access-pass set`
   - Add `--edge-seat` and `--seat-pubkey` filters to `access-pass list`
+- CLI
+  - `doublezero -V` now shows client version, program version, and minimum required version fetched from the serviceability program
 
 ## [v0.20.0](https://github.com/malbeclabs/doublezero/compare/client/v0.19.0...client/v0.20.0) - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Smartcontract
+  - Add `AccessPassType::EdgeSeat(Pubkey)` variant to associate an access pass with a specific onchain Seat pubkey
+  - Add `--accesspass-type edge-seat --seat <PUBKEY>` to `access-pass set`
+  - Add `--edge-seat` and `--seat-pubkey` filters to `access-pass list`
+
 ## [v0.20.0](https://github.com/malbeclabs/doublezero/compare/client/v0.19.0...client/v0.20.0) - 2026-04-29
 
 ### Breaking

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -21,17 +21,19 @@ use crate::cli::{
     location::LocationCommands,
     user::UserCommands,
 };
-use doublezero_cli::{checkversion::check_version, doublezerocommand::CliCommandImpl};
+use doublezero_cli::{
+    checkversion::check_version, doublezerocommand::CliCommandImpl, version::VersionCliCommand,
+};
 use doublezero_sdk::{DZClient, ProgramVersion};
 
 #[derive(Parser, Debug)]
 #[command(term_width = 0)]
 #[command(name = "DoubleZero")]
-#[command(version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
+#[command(disable_version_flag = true)]
 #[command(about = "DoubleZero client tool", long_about = None)]
 struct App {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
     /// DZ env (testnet, devnet, or mainnet-beta)
     #[arg(short, long, value_name = "ENV", global = true)]
     env: Option<String>,
@@ -50,6 +52,9 @@ struct App {
     /// Suppress version warning output
     #[arg(long, global = true)]
     no_version_warning: bool,
+    /// Print version information
+    #[arg(short = 'V', long = "version", action = clap::ArgAction::SetTrue)]
+    version: bool,
 }
 
 #[tokio::main]
@@ -93,22 +98,38 @@ async fn main() -> eyre::Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
 
+    if app.version {
+        let local_version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        return VersionCliCommand.execute(&client, local_version, &mut handle);
+    }
+
+    let command = match app.command {
+        Some(cmd) => cmd,
+        None => {
+            App::command().print_help()?;
+            println!();
+            return Ok(());
+        }
+    };
+
     // Skip version check for Status command to allow checking status of services when the program is running
-    if !app.no_version_warning
-        && !matches!(app.command, Command::Status(_))
-        && !matches!(app.command, Command::Enable(_))
-        && !matches!(app.command, Command::Disable(_))
-        && !matches!(app.command, Command::Address(_))
-        && !matches!(app.command, Command::Balance(_))
-        && !matches!(app.command, Command::Export(_))
-        && !matches!(app.command, Command::Completion(_))
-    {
+    let skip_version_check = matches!(
+        &command,
+        Command::Status(_)
+            | Command::Enable(_)
+            | Command::Disable(_)
+            | Command::Address(_)
+            | Command::Balance(_)
+            | Command::Export(_)
+            | Command::Completion(_)
+    );
+    if !app.no_version_warning && !skip_version_check {
         let stderr = std::io::stderr();
         let mut err_handle = stderr.lock();
         check_version(&client, &mut err_handle, ProgramVersion::current())?;
     }
 
-    let res = match app.command {
+    let res = match command {
         Command::Address(args) => args.execute(&client, &mut handle),
         Command::Balance(args) => args.execute(&client, &mut handle),
         Command::Connect(args) => args.execute(&client).await,

--- a/smartcontract/cli/src/accesspass/list.rs
+++ b/smartcontract/cli/src/accesspass/list.rs
@@ -22,6 +22,12 @@ pub struct ListAccessPassCliCommand {
     /// Solana identity public key
     #[arg(long)]
     pub solana_identity: Option<Pubkey>,
+    /// List EdgeSeat access passes
+    #[arg(long, default_value_t = false)]
+    pub edge_seat: bool,
+    /// Seat public key
+    #[arg(long)]
+    pub seat_pubkey: Option<Pubkey>,
     /// Client IP address
     #[arg(long)]
     pub client_ip: Option<Ipv4Addr>,
@@ -100,6 +106,16 @@ impl ListAccessPassCliCommand {
             access_passes.retain(|(_, access_pass)| {
                 access_pass.accesspass_type == AccessPassType::SolanaValidator(solana_identity)
             });
+        }
+        // Filter access passes by EdgeSeat type
+        if self.edge_seat {
+            access_passes.retain(|(_, access_pass)| {
+                matches!(access_pass.accesspass_type, AccessPassType::EdgeSeat(_))
+            });
+        }
+        // Filter access passes by seat pubkey
+        if let Some(seat_pk) = self.seat_pubkey {
+            access_passes.retain(|(_, ap)| ap.accesspass_type == AccessPassType::EdgeSeat(seat_pk));
         }
         // Filter access passes by client IP
         if let Some(client_ip) = self.client_ip {
@@ -359,6 +375,8 @@ mod tests {
             tenant: None,
             solana_validator: false,
             solana_identity: None,
+            edge_seat: false,
+            seat_pubkey: None,
             multicast_group_publisher: None,
             multicast_group_subscriber: None,
             not_multicast_group_publisher: None,
@@ -376,6 +394,8 @@ mod tests {
             prepaid: false,
             solana_validator: false,
             solana_identity: None,
+            edge_seat: false,
+            seat_pubkey: None,
             tenant: None,
             json: false,
             json_compact: true,

--- a/smartcontract/cli/src/accesspass/set.rs
+++ b/smartcontract/cli/src/accesspass/set.rs
@@ -17,6 +17,7 @@ pub enum CliAccessPassType {
     SolanaValidator,
     SolanaRPC,
     Others,
+    EdgeSeat,
 }
 
 #[derive(Args, Debug)]
@@ -45,6 +46,9 @@ pub struct SetAccessPassCliCommand {
     /// Specifies the key for other access pass types. Required if accesspass_type is others.
     #[arg(long, required_if_eq("accesspass_type", "others"))]
     pub others_key: Option<String>,
+    /// Seat pubkey for EdgeSeat access pass type. Required if accesspass_type is edge-seat.
+    #[arg(long, required_if_eq("accesspass_type", "edge_seat"))]
+    pub seat: Option<Pubkey>,
     /// Tenant code allowed for this access pass
     #[arg(long = "tenant")]
     pub tenant: Option<String>,
@@ -86,6 +90,10 @@ impl SetAccessPassCliCommand {
                 _ => eyre::bail!(
                     "Others access pass type requires --others-name <STRING> and --others-key <STRING>"
                 ),
+            },
+            CliAccessPassType::EdgeSeat => match self.seat {
+                Some(seat_pk) => AccessPassType::EdgeSeat(seat_pk),
+                None => eyre::bail!("EdgeSeat access pass type requires --seat <PUBKEY>"),
             },
         };
 
@@ -180,6 +188,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -214,6 +223,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -269,6 +279,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -323,6 +334,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -374,6 +386,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -408,6 +421,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -441,6 +455,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: Some("custom-name".to_string()),
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -497,6 +512,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: Some("custom-name".to_string()),
             others_key: Some("custom-key".to_string()),
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -528,6 +544,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -555,6 +572,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -583,6 +601,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: Some(too_long.clone()),
         }
         .execute(&client, &mut output);
@@ -628,6 +647,7 @@ mod tests {
             allow_multiple_ip: true,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -671,6 +691,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: Some("acme".to_string()),
         }
         .execute(&client, &mut output);
@@ -711,6 +732,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -752,6 +774,7 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
@@ -794,9 +817,101 @@ mod tests {
             allow_multiple_ip: false,
             others_name: None,
             others_key: None,
+            seat: None,
             tenant: None,
         }
         .execute(&client, &mut output);
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_edge_seat_missing_seat() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::EdgeSeat,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+            seat: None,
+            tenant: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            "EdgeSeat access pass type requires --seat <PUBKEY>"
+        );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_edge_seat_success() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        let (_pda_pubkey, _bump_seed) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let seat_pk = Pubkey::new_unique();
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::EdgeSeat(seat_pk),
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: 11,
+                allow_multiple_ip: false,
+                tenant: Pubkey::default(),
+            }))
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let res = SetAccessPassCliCommand {
+            accesspass_type: CliAccessPassType::EdgeSeat,
+            client_ip: Some(client_ip),
+            user_payer: payer.to_string(),
+            epochs: "1".into(),
+            solana_validator: None,
+            allow_multiple_ip: false,
+            others_name: None,
+            others_key: None,
+            seat: Some(seat_pk),
+            tenant: None,
+        }
+        .execute(&client, &mut output);
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
+        );
     }
 }

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -34,3 +34,4 @@ pub mod topology;
 pub mod user;
 pub mod util;
 pub mod validators;
+pub mod version;

--- a/smartcontract/cli/src/version.rs
+++ b/smartcontract/cli/src/version.rs
@@ -1,0 +1,23 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_sdk::commands::programconfig::get::GetProgramConfigCommand;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct VersionCliCommand;
+
+impl VersionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(
+        self,
+        client: &C,
+        local_version: &str,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        writeln!(out, "client version:       {local_version}")?;
+        if let Ok((_, pconfig)) = client.get_program_config(GetProgramConfigCommand) {
+            writeln!(out, "program version:      {}", pconfig.version)?;
+            writeln!(out, "min required version: {}", pconfig.min_compatible_version)?;
+        }
+        Ok(())
+    }
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -130,6 +130,13 @@ pub fn process_set_access_pass(
         }
     }
 
+    if let AccessPassType::EdgeSeat(seat_pk) = value.accesspass_type {
+        if seat_pk == Pubkey::default() {
+            msg!("EdgeSeat access pass type requires a seat pubkey");
+            return Err(DoubleZeroError::InvalidSolanaPubkey.into());
+        }
+    }
+
     let clock = Clock::get()?;
     let current_epoch = clock.epoch;
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -39,6 +39,16 @@ pub enum AccessPassType {
         Pubkey,
     ),
     Others(String, String), // (type_name, key)
+    EdgeSeat(
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                serialize_with = "doublezero_program_common::serializer::serialize_pubkey_as_string",
+                deserialize_with = "doublezero_program_common::serializer::deserialize_pubkey_from_string"
+            )
+        )]
+        Pubkey,
+    ),
 }
 
 impl AccessPassType {
@@ -48,6 +58,7 @@ impl AccessPassType {
             AccessPassType::SolanaValidator(_) => "solana_validator".to_string(),
             AccessPassType::SolanaRPC(_) => "solana_rpc".to_string(),
             AccessPassType::Others(type_name, _) => type_name.clone(),
+            AccessPassType::EdgeSeat(_) => "edge_seat".to_string(),
         }
     }
 }
@@ -61,6 +72,7 @@ impl fmt::Display for AccessPassType {
             AccessPassType::Others(type_name, key) => {
                 write!(f, "others: {} ({})", type_name, key)
             }
+            AccessPassType::EdgeSeat(seat_pk) => write!(f, "edge_seat: {seat_pk}"),
         }
     }
 }
@@ -128,6 +140,13 @@ impl Validate for AccessPassType {
                 }
                 Ok(())
             }
+            AccessPassType::EdgeSeat(seat_pk) => {
+                if *seat_pk == Pubkey::default() {
+                    msg!("Invalid EdgeSeat Pubkey: {}", seat_pk);
+                    return Err(DoubleZeroError::InvalidSolanaPubkey);
+                }
+                Ok(())
+            }
             _ => Ok(()),
         }
     }
@@ -187,6 +206,7 @@ impl fmt::Display for AccessPass {
             AccessPassType::Others(type_name, details) => {
                 write!(f, "Others: {} ({})", type_name, details)
             }
+            AccessPassType::EdgeSeat(seat_pk) => write!(f, "EdgeSeat: ({seat_pk})"),
         }
     }
 }


### PR DESCRIPTION
## Summary of Changes
- Adds `AccessPassType::EdgeSeat(Pubkey)` variant to associate an access pass with a specific onchain Seat pubkey; validated in the program processor and exposed via `access-pass set --accesspass-type edge-seat --seat <PUBKEY>`
- Adds `--edge-seat` and `--seat-pubkey` filters to `access-pass list` to scope results to EdgeSeat passes
- Replaces the static `-V`/`--version` output with a live RPC call that shows client version, program version, and minimum required version from the serviceability program

## Diff Breakdown
| Category    | Files | Lines (+/-)    | Net  |
|-------------|-------|----------------|------|
| Core logic  |     5 | +188 / -0      | +188 |
| Scaffolding |     2 | +35  / -13     |  +22 |
| Docs        |     1 | +7   / -0      |   +7 |

Primarily net-new core logic; no deletions in business logic.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/accesspass/set.rs` — adds `EdgeSeat` to `CliAccessPassType`, `--seat` arg, success/error test cases
- `smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs` — adds `EdgeSeat(Pubkey)` variant with serde support, `Display`, and `Validate`
- `smartcontract/cli/src/accesspass/list.rs` — adds `--edge-seat` and `--seat-pubkey` filter flags with retain logic
- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs` — rejects default pubkey for EdgeSeat passes
- `smartcontract/cli/src/version.rs` — new `VersionCliCommand` fetching `ProgramConfig` to display client, program, and min required versions
- `client/doublezero/src/main.rs` — replaces static clap version flag with custom `-V` that calls `VersionCliCommand`

</details>

## Testing Verification
- `test_cli_accesspass_set_edge_seat_success` verifies the happy path with a valid seat pubkey
- `test_cli_accesspass_set_edge_seat_missing_seat` verifies the error message when `--seat` is omitted
- `doublezero -V` manually verified to print three version lines when an RPC endpoint is reachable, and gracefully omits the program/min lines when it is not