### PR TITLE
doublezero: enrich `-V` with onchain version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
   - Allow ip_net to be passed when creating a device interface if the interface is CYOA/DIA/user_tunnel_endpoint
 - Telemetry
   - Add `agent_version` and `agent_commit` to `WriteDeviceLatencySamples` so the onchain header is refreshed on every write (~60s) instead of only at initialization; fixes stale version reporting after mid-epoch agent upgrades ([#3598](https://github.com/malbeclabs/doublezero/issues/3598))
+- CLI
+  - `doublezero -V` now shows client version, program version, and minimum required version fetched from the serviceability program
 
 ## [v0.20.0](https://github.com/malbeclabs/doublezero/compare/client/v0.19.0...client/v0.20.0) - 2026-04-29
 

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -21,18 +21,20 @@ use crate::cli::{
     location::LocationCommands,
     user::UserCommands,
 };
-use doublezero_cli::{checkversion::check_version, doublezerocommand::CliCommandImpl};
+use doublezero_cli::{
+    checkversion::check_version, doublezerocommand::CliCommandImpl, version::VersionCliCommand,
+};
 use doublezero_sdk::{DZClient, ProgramVersion};
 use servicecontroller::ServiceControllerImpl;
 
 #[derive(Parser, Debug)]
 #[command(term_width = 0)]
 #[command(name = "DoubleZero")]
-#[command(version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
+#[command(disable_version_flag = true)]
 #[command(about = "DoubleZero client tool", long_about = None)]
 struct App {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
     /// DZ env (testnet, devnet, or mainnet-beta)
     #[arg(short, long, value_name = "ENV", global = true)]
     env: Option<String>,
@@ -60,6 +62,9 @@ struct App {
     /// Suppress version warning output
     #[arg(long, global = true)]
     no_version_warning: bool,
+    /// Print version information
+    #[arg(short = 'V', long = "version", action = clap::ArgAction::SetTrue)]
+    version: bool,
 }
 
 #[tokio::main]
@@ -107,22 +112,38 @@ async fn main() -> eyre::Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
 
+    if app.version {
+        let local_version = option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        return VersionCliCommand.execute(&client, local_version, &mut handle);
+    }
+
+    let command = match app.command {
+        Some(cmd) => cmd,
+        None => {
+            App::command().print_help()?;
+            println!();
+            return Ok(());
+        }
+    };
+
     // Skip version check for Status command to allow checking status of services when the program is running
-    if !app.no_version_warning
-        && !matches!(app.command, Command::Status(_))
-        && !matches!(app.command, Command::Enable(_))
-        && !matches!(app.command, Command::Disable(_))
-        && !matches!(app.command, Command::Address(_))
-        && !matches!(app.command, Command::Balance(_))
-        && !matches!(app.command, Command::Export(_))
-        && !matches!(app.command, Command::Completion(_))
-    {
+    let skip_version_check = matches!(
+        &command,
+        Command::Status(_)
+            | Command::Enable(_)
+            | Command::Disable(_)
+            | Command::Address(_)
+            | Command::Balance(_)
+            | Command::Export(_)
+            | Command::Completion(_)
+    );
+    if !app.no_version_warning && !skip_version_check {
         let stderr = std::io::stderr();
         let mut err_handle = stderr.lock();
         check_version(&client, &mut err_handle, ProgramVersion::current())?;
     }
 
-    let res = match app.command {
+    let res = match command {
         Command::Address(args) => args.execute(&client, &mut handle),
         Command::Balance(args) => args.execute(&client, &mut handle),
         Command::Connect(args) => args.execute(&client).await,

--- a/smartcontract/cli/src/lib.rs
+++ b/smartcontract/cli/src/lib.rs
@@ -34,3 +34,4 @@ pub mod topology;
 pub mod user;
 pub mod util;
 pub mod validators;
+pub mod version;

--- a/smartcontract/cli/src/version.rs
+++ b/smartcontract/cli/src/version.rs
@@ -16,7 +16,11 @@ impl VersionCliCommand {
         writeln!(out, "client version:       {local_version}")?;
         if let Ok((_, pconfig)) = client.get_program_config(GetProgramConfigCommand) {
             writeln!(out, "program version:      {}", pconfig.version)?;
-            writeln!(out, "min required version: {}", pconfig.min_compatible_version)?;
+            writeln!(
+                out,
+                "min required version: {}",
+                pconfig.min_compatible_version
+            )?;
         }
         Ok(())
     }

--- a/smartcontract/cli/src/version.rs
+++ b/smartcontract/cli/src/version.rs
@@ -1,0 +1,23 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_sdk::commands::programconfig::get::GetProgramConfigCommand;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct VersionCliCommand;
+
+impl VersionCliCommand {
+    pub fn execute<C: CliCommand, W: Write>(
+        self,
+        client: &C,
+        local_version: &str,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        writeln!(out, "client version:       {local_version}")?;
+        if let Ok((_, pconfig)) = client.get_program_config(GetProgramConfigCommand) {
+            writeln!(out, "program version:      {}", pconfig.version)?;
+            writeln!(out, "min required version: {}", pconfig.min_compatible_version)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary of Changes
- `doublezero -V` now prints three lines: client version, program version, and minimum required version fetched from the serviceability program
- Replaced clap's built-in `--version` flag with a custom `-V`/`--version` handler so the flag can trigger an async-compatible RPC call

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     2 | +57 / -13    |  +44 |
| Scaffolding  |     1 | +1  / -0     |   +1 |
| Docs         |     1 | +2  / -0     |   +2 |
| **Total**    |     4 | +60 / -13    | +47  |

Small, focused change: new module with version display logic wired into the CLI entry point.

<details>
<summary>Key files (click to expand)</summary>

- [`client/doublezero/src/main.rs`](https://github.com/malbeclabs/doublezero/pull/3642/files#diff-9b18c350b4f1b096b7187215002603fceaaa72368cbe6b66dacfd105ea8eace2) -- disables clap's default version flag, adds custom `-V` handler that fetches onchain config before printing
- [`smartcontract/cli/src/version.rs`](https://github.com/malbeclabs/doublezero/pull/3642/files#diff-1339850f37fb8e7a390e371c2a91724d89b93507a867820d9dbb3357961654ef) -- new `VersionCliCommand` that writes client version, program version, and min required version to stdout

</details>

## Testing Verification
- Ran `doublezero -V` against devnet: output shows all three version lines when RPC is reachable, and gracefully omits program/min lines when the call fails
- `make rust-lint` passes clean