### PR TITLE
sdk/serviceability: make enum String() methods defensive against unknown values

### DIFF
--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -149,11 +149,15 @@ const (
 )
 
 func (d DeviceDeviceType) String() string {
-	return [...]string{
+	s := [...]string{
 		"hybrid",
 		"transit",
 		"edge",
-	}[d]
+	}
+	if int(d) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", d)
+	}
+	return s[d]
 }
 
 type DeviceStatus uint8
@@ -266,7 +270,7 @@ const (
 )
 
 func (i InterfaceStatus) String() string {
-	return [...]string{
+	s := [...]string{
 		"invalid",
 		"unmanaged",
 		"pending",
@@ -274,7 +278,11 @@ func (i InterfaceStatus) String() string {
 		"deleting",
 		"rejecting",
 		"unlinked",
-	}[i]
+	}
+	if int(i) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", i)
+	}
+	return s[i]
 }
 
 func (i InterfaceStatus) MarshalJSON() ([]byte, error) {
@@ -290,11 +298,15 @@ const (
 )
 
 func (i InterfaceType) String() string {
-	return [...]string{
+	s := [...]string{
 		"invalid",
 		"loopback",
 		"physical",
-	}[i]
+	}
+	if int(i) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", i)
+	}
+	return s[i]
 }
 
 func (i InterfaceType) MarshalJSON() ([]byte, error) {
@@ -312,13 +324,17 @@ const (
 )
 
 func (l LoopbackType) String() string {
-	return [...]string{
+	s := [...]string{
 		"none",
 		"vpnv4",
 		"ipv4",
 		"pim_rp_addr",
 		"reserved",
-	}[l]
+	}
+	if int(l) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", l)
+	}
+	return s[l]
 }
 
 func (l LoopbackType) MarshalJSON() ([]byte, error) {
@@ -337,14 +353,18 @@ const (
 )
 
 func (l InterfaceCYOA) String() string {
-	return [...]string{
+	s := [...]string{
 		"none",
 		"gre_over_dia",
 		"gre_over_fabric",
 		"gre_over_private_peering",
 		"gre_over_public_peering",
 		"gre_over_cable",
-	}[l]
+	}
+	if int(l) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", l)
+	}
+	return s[l]
 }
 
 func (l InterfaceCYOA) MarshalJSON() ([]byte, error) {
@@ -359,10 +379,14 @@ const (
 )
 
 func (l InterfaceDIA) String() string {
-	return [...]string{
+	s := [...]string{
 		"none",
 		"dia",
-	}[l]
+	}
+	if int(l) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", l)
+	}
+	return s[l]
 }
 
 func (l InterfaceDIA) MarshalJSON() ([]byte, error) {
@@ -377,10 +401,14 @@ const (
 )
 
 func (l RoutingMode) String() string {
-	return [...]string{
+	s := [...]string{
 		"static",
 		"bgp",
-	}[l]
+	}
+	if int(l) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", l)
+	}
+	return s[l]
 }
 
 func (l RoutingMode) MarshalJSON() ([]byte, error) {
@@ -789,11 +817,15 @@ const (
 	TenantPaymentStatusPaid
 )
 
-func (s TenantPaymentStatus) String() string {
-	return [...]string{
+func (t TenantPaymentStatus) String() string {
+	s := [...]string{
 		"delinquent",
 		"paid",
-	}[s]
+	}
+	if int(t) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+	return s[t]
 }
 
 func (s TenantPaymentStatus) MarshalJSON() ([]byte, error) {
@@ -860,12 +892,16 @@ const (
 const UserTypeIBRLWithAllocIP = UserTypeIBRLWithAllocatedIP
 
 func (u UserUserType) String() string {
-	return [...]string{
+	s := [...]string{
 		"ibrl",
 		"ibrl_with_allocated_ip",
 		"edge_filtering",
 		"multicast",
-	}[u]
+	}
+	if int(u) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", u)
+	}
+	return s[u]
 }
 
 func (u UserUserType) MarshalJSON() ([]byte, error) {
@@ -883,14 +919,18 @@ const (
 )
 
 func (c CyoaType) String() string {
-	return [...]string{
+	s := [...]string{
 		"unknown",
 		"gre_over_dia",
 		"gre_over_fabric",
 		"gre_over_private_peering",
 		"gre_over_public_peering",
 		"gre_over_cable",
-	}[c]
+	}
+	if int(c) >= len(s) {
+		return fmt.Sprintf("unknown(%d)", c)
+	}
+	return s[c]
 }
 
 func (c CyoaType) MarshalJSON() ([]byte, error) {

--- a/smartcontract/sdk/go/serviceability/state_test.go
+++ b/smartcontract/sdk/go/serviceability/state_test.go
@@ -2,6 +2,7 @@ package serviceability_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
@@ -430,6 +431,90 @@ func TestCustomJSONMarshal(t *testing.T) {
 				require.NoError(t, err)
 				assert.JSONEq(t, tc.expected, string(actualJSON), "The marshaled JSON should match the expected output.")
 			}
+		})
+	}
+}
+
+func TestEnumStringDefensive(t *testing.T) {
+	testCases := []struct {
+		name           string
+		maxValidValue  uint8
+		maxValidString string
+		stringFunc     func(v uint8) string
+	}{
+		{
+			name:           "DeviceDeviceType",
+			maxValidValue:  2,
+			maxValidString: "edge",
+			stringFunc:     func(v uint8) string { return serviceability.DeviceDeviceType(v).String() },
+		},
+		{
+			name:           "InterfaceStatus",
+			maxValidValue:  6,
+			maxValidString: "unlinked",
+			stringFunc:     func(v uint8) string { return serviceability.InterfaceStatus(v).String() },
+		},
+		{
+			name:           "InterfaceType",
+			maxValidValue:  2,
+			maxValidString: "physical",
+			stringFunc:     func(v uint8) string { return serviceability.InterfaceType(v).String() },
+		},
+		{
+			name:           "LoopbackType",
+			maxValidValue:  4,
+			maxValidString: "reserved",
+			stringFunc:     func(v uint8) string { return serviceability.LoopbackType(v).String() },
+		},
+		{
+			name:           "InterfaceCYOA",
+			maxValidValue:  5,
+			maxValidString: "gre_over_cable",
+			stringFunc:     func(v uint8) string { return serviceability.InterfaceCYOA(v).String() },
+		},
+		{
+			name:           "InterfaceDIA",
+			maxValidValue:  1,
+			maxValidString: "dia",
+			stringFunc:     func(v uint8) string { return serviceability.InterfaceDIA(v).String() },
+		},
+		{
+			name:           "RoutingMode",
+			maxValidValue:  1,
+			maxValidString: "bgp",
+			stringFunc:     func(v uint8) string { return serviceability.RoutingMode(v).String() },
+		},
+		{
+			name:           "TenantPaymentStatus",
+			maxValidValue:  1,
+			maxValidString: "paid",
+			stringFunc:     func(v uint8) string { return serviceability.TenantPaymentStatus(v).String() },
+		},
+		{
+			name:           "UserUserType",
+			maxValidValue:  3,
+			maxValidString: "multicast",
+			stringFunc:     func(v uint8) string { return serviceability.UserUserType(v).String() },
+		},
+		{
+			name:           "CyoaType",
+			maxValidValue:  5,
+			maxValidString: "gre_over_cable",
+			stringFunc:     func(v uint8) string { return serviceability.CyoaType(v).String() },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name+"/max_valid", func(t *testing.T) {
+			assert.Equal(t, tc.maxValidString, tc.stringFunc(tc.maxValidValue))
+		})
+
+		t.Run(tc.name+"/out_of_range", func(t *testing.T) {
+			var result string
+			assert.NotPanics(t, func() {
+				result = tc.stringFunc(255)
+			})
+			assert.Equal(t, fmt.Sprintf("unknown(%d)", 255), result)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

* Add bounds checks to 10 array-indexed `String()` methods in the Go serviceability SDK so out-of-range enum values return `"unknown(N)"` instead of panicking
* Prevents SDK crashes when onchain layout changes (e.g., RFC-18 flex-algo migration) cause deserialization offset drift — turns a panic into a diagnosable log line
* Fixes #3650

Affected methods: `DeviceDeviceType`, `InterfaceStatus`, `InterfaceType`, `LoopbackType`, `InterfaceCYOA`, `InterfaceDIA`, `RoutingMode`, `TenantPaymentStatus`, `UserUserType`, `CyoaType`.

## Testing Verification

* Added `TestEnumStringDefensive` with 20 subtests covering all 10 enum types — validates both max valid boundary values and out-of-range (255) behavior
* All existing tests pass with no regressions (serviceability package: 0.274s)
* Verified the SDK package builds cleanly
