### PR TITLE
smartcontract: revert default Interface to V2; keep V3 for migrate/backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Smartcontract
+  - Stop writing `InterfaceV3` from `CreateDeviceInterface` and `UpdateDeviceInterface`; `CurrentInterfaceVersion` is now `InterfaceV2`. `MigrateDeviceInterfaces` and `BackfillTopology` continue to write `InterfaceV3` since they are admin-controlled and need the `flex_algo_node_segments` field
+
 ## [v0.21.0](https://github.com/malbeclabs/doublezero/compare/client/v0.20.0...client/v0.21.0) - 2026-05-01
 
 ### Breaking

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -259,7 +259,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .map(|(i, ip)| {
-                Interface::V3(CurrentInterfaceVersion {
+                Interface::V2(CurrentInterfaceVersion {
                     status: InterfaceStatus::Activated,
                     name: format!("Loopback{}", i),
                     interface_type: InterfaceType::Loopback,
@@ -274,7 +274,6 @@ mod tests {
                     ip_net: NetworkV4::new(ip, 32).unwrap(),
                     node_segment_idx: 0,
                     user_tunnel_endpoint: true,
-                    flex_algo_node_segments: vec![],
                 })
             })
             .collect();

--- a/controlplane/doublezero-admin/src/cli/migrate.rs
+++ b/controlplane/doublezero-admin/src/cli/migrate.rs
@@ -107,7 +107,7 @@ impl FlexAlgoMigrateCliCommand {
 
             for (device_pubkey, device) in &device_entries {
                 let needs_backfill = device.interfaces.iter().any(|iface| {
-                    let current = iface.into_current_version();
+                    let current = iface.into_v3();
                     current.loopback_type == LoopbackType::Vpnv4
                         && !current
                             .flex_algo_node_segments

--- a/e2e/compatibility_test.go
+++ b/e2e/compatibility_test.go
@@ -126,15 +126,17 @@ var knownIncompatibilities = map[string]knownIncompat{
 	"write/device_interface_create_3": {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
 	"write/device_interface_create_4": {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
 
-	// RFC-18 mandatory upgrade boundary: all operations that read device accounts
-	// (set_unlinked, link create/update/delete) require a CLI that understands the new
-	// InterfaceV3 format (flex_algo_node_segments). v0.17.0 was released before RFC-18
-	// and sends InterfaceV1, so it is incompatible. set_unlinked uses cascadeKnownFail
-	// so that downstream link phases are skipped rather than run-and-fail.
-	"write/device_interface_set_unlinked":   {ranges: []versionRange{{before: "0.19.0"}}},
-	"write/device_interface_set_unlinked_2": {ranges: []versionRange{{before: "0.19.0"}}},
-	"write/device_interface_set_unlinked_3": {ranges: []versionRange{{before: "0.19.0"}}},
-	"write/device_interface_set_unlinked_4": {ranges: []versionRange{{before: "0.19.0"}}},
+	// device interface set-unlinked: v0.12.0–0.15.x cascade-fail because their
+	// MTU-2048 creates leave no interface for set-unlinked to update. v0.16.0+
+	// can update interfaces against the current (V2-default) program.
+	"write/device_interface_set_unlinked":   {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
+	"write/device_interface_set_unlinked_2": {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
+	"write/device_interface_set_unlinked_3": {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
+	"write/device_interface_set_unlinked_4": {ranges: []versionRange{{from: "0.12.0", before: "0.16.0"}}},
+
+	// RFC-18 mandatory upgrade boundary: link operations that read device accounts
+	// require a CLI that understands the new account layout. v0.18.0 and earlier
+	// were released before RFC-18 and are incompatible.
 	"write/link_create_wan":                 {ranges: []versionRange{{before: "0.19.0"}}},
 	"write/link_create_dzx":                 {ranges: []versionRange{{before: "0.19.0"}}},
 	"write/link_accept_dzx":                 {ranges: []versionRange{{before: "0.19.0"}}},

--- a/smartcontract/cli/src/device/interface/create.rs
+++ b/smartcontract/cli/src/device/interface/create.rs
@@ -223,7 +223,6 @@ mod tests {
                 ip_net: "185.189.47.80/32".parse().unwrap(),
                 node_segment_idx: 0,
                 user_tunnel_endpoint: false,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,
@@ -322,7 +321,6 @@ mod tests {
                 ip_net: "10.0.0.1/24".parse().unwrap(),
                 node_segment_idx: 0,
                 user_tunnel_endpoint: true,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,

--- a/smartcontract/cli/src/device/interface/delete.rs
+++ b/smartcontract/cli/src/device/interface/delete.rs
@@ -109,7 +109,6 @@ mod tests {
                     ip_net: "10.0.0.1/24".parse().unwrap(),
                     node_segment_idx: 12,
                     user_tunnel_endpoint: true,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
                 CurrentInterfaceVersion {
@@ -127,7 +126,6 @@ mod tests {
                     ip_net: "10.0.1.1/24".parse().unwrap(),
                     node_segment_idx: 13,
                     user_tunnel_endpoint: false,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
             ],

--- a/smartcontract/cli/src/device/interface/get.rs
+++ b/smartcontract/cli/src/device/interface/get.rs
@@ -136,7 +136,6 @@ mod tests {
                 ip_net: "10.0.0.1/24".parse().unwrap(),
                 node_segment_idx: 42,
                 user_tunnel_endpoint: true,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,

--- a/smartcontract/cli/src/device/interface/list.rs
+++ b/smartcontract/cli/src/device/interface/list.rs
@@ -164,7 +164,6 @@ mod tests {
                     ip_net: "10.0.0.1/24".parse().unwrap(),
                     node_segment_idx: 12,
                     user_tunnel_endpoint: true,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
                 CurrentInterfaceVersion {
@@ -183,7 +182,6 @@ mod tests {
                     ip_net: "10.0.1.1/24".parse().unwrap(),
                     node_segment_idx: 13,
                     user_tunnel_endpoint: false,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
             ],

--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -242,7 +242,6 @@ mod tests {
                     ip_net: "10.0.0.1/24".parse().unwrap(),
                     node_segment_idx: 0,
                     user_tunnel_endpoint: true,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
                 CurrentInterfaceVersion {
@@ -260,7 +259,6 @@ mod tests {
                     ip_net: "10.0.1.1/24".parse().unwrap(),
                     node_segment_idx: 0,
                     user_tunnel_endpoint: false,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
             ],
@@ -378,7 +376,6 @@ mod tests {
                 ip_net: "10.0.0.1/32".parse().unwrap(),
                 node_segment_idx: 0,
                 user_tunnel_endpoint: false,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,
@@ -427,7 +424,6 @@ mod tests {
                 ip_net: "185.189.47.80/32".parse().unwrap(),
                 node_segment_idx: 0,
                 user_tunnel_endpoint: false,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,
@@ -524,7 +520,6 @@ mod tests {
                 ip_net: "10.0.0.1/24".parse().unwrap(),
                 node_segment_idx: 0,
                 user_tunnel_endpoint: true,
-                flex_algo_node_segments: vec![],
             }
             .to_interface()],
             max_users: 255,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
@@ -240,7 +240,6 @@ pub fn process_create_device_interface(
             ip_net,
             node_segment_idx,
             user_tunnel_endpoint: value.user_tunnel_endpoint,
-            flex_algo_node_segments: vec![],
         }
         .to_interface(),
     );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/migrate_interfaces.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/migrate_interfaces.rs
@@ -231,11 +231,8 @@ pub fn process_migrate_device_interfaces(
     // Convert all V1/V2 interfaces to V3 (adding empty flex_algo_node_segments vec).
     let migrated: Vec<Interface> = device
         .interfaces
-        .drain(..)
-        .map(|iface| match iface {
-            Interface::V3(_) => iface,
-            _ => Interface::V3(iface.into_current_version()),
-        })
+        .iter()
+        .map(|iface| Interface::V3(iface.into_v3()))
         .collect();
     device.interfaces = migrated;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/topology/backfill.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/topology/backfill.rs
@@ -126,12 +126,12 @@ pub fn process_topology_backfill(
         let mut device = Device::try_from(&device_account.data.borrow()[..])?;
         let mut modified = false;
         for iface in device.interfaces.iter_mut() {
-            let iface_v2 = iface.into_current_version();
-            if iface_v2.loopback_type != LoopbackType::Vpnv4 {
+            let ifc = iface.into_v3();
+            if ifc.loopback_type != LoopbackType::Vpnv4 {
                 continue;
             }
             // Skip if already has a segment for this topology (idempotent)
-            if iface_v2
+            if ifc
                 .flex_algo_node_segments
                 .iter()
                 .any(|s| &s.topology == topology_key)
@@ -151,7 +151,7 @@ pub fn process_topology_backfill(
                     });
                 }
                 _ => {
-                    let mut upgraded = iface.into_current_version();
+                    let mut upgraded = iface.into_v3();
                     upgraded.flex_algo_node_segments.push(FlexAlgoNodeSegment {
                         topology: *topology_key,
                         node_segment_idx,

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -1013,7 +1013,6 @@ mod tests {
             ip_net: "10.0.0.1/24".parse().unwrap(),
             node_segment_idx: 42,
             user_tunnel_endpoint: true,
-            flex_algo_node_segments: vec![],
         }
         .to_interface();
         let val = Device {
@@ -1084,7 +1083,6 @@ mod tests {
                     ip_net: "10.0.0.1/24".parse().unwrap(),
                     node_segment_idx: 42,
                     user_tunnel_endpoint: true,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
                 CurrentInterfaceVersion {
@@ -1102,7 +1100,6 @@ mod tests {
                     ip_net: "10.0.1.1/24".parse().unwrap(),
                     node_segment_idx: 24,
                     user_tunnel_endpoint: false,
-                    flex_algo_node_segments: vec![],
                 }
                 .to_interface(),
             ],

--- a/smartcontract/programs/doublezero-serviceability/src/state/interface.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/interface.rs
@@ -373,6 +373,29 @@ impl TryFrom<&InterfaceV1> for InterfaceV2 {
     }
 }
 
+impl TryFrom<&InterfaceV3> for InterfaceV2 {
+    type Error = ProgramError;
+
+    fn try_from(data: &InterfaceV3) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: data.status,
+            name: data.name.clone(),
+            interface_type: data.interface_type,
+            interface_cyoa: data.interface_cyoa,
+            interface_dia: data.interface_dia,
+            loopback_type: data.loopback_type,
+            bandwidth: data.bandwidth,
+            cir: data.cir,
+            mtu: data.mtu,
+            routing_mode: data.routing_mode,
+            vlan_id: data.vlan_id,
+            ip_net: data.ip_net,
+            node_segment_idx: data.node_segment_idx,
+            user_tunnel_endpoint: data.user_tunnel_endpoint,
+        })
+    }
+}
+
 impl Default for InterfaceV2 {
     fn default() -> Self {
         Self {
@@ -496,10 +519,18 @@ impl borsh::BorshDeserialize for Interface {
     }
 }
 
-pub type CurrentInterfaceVersion = InterfaceV3;
+pub type CurrentInterfaceVersion = InterfaceV2;
 
 impl Interface {
     pub fn into_current_version(&self) -> CurrentInterfaceVersion {
+        match self {
+            Interface::V1(v1) => v1.try_into().unwrap_or_default(),
+            Interface::V2(v2) => v2.clone(),
+            Interface::V3(v3) => v3.try_into().unwrap_or_default(),
+        }
+    }
+
+    pub fn into_v3(&self) -> InterfaceV3 {
         match self {
             Interface::V1(v1) => v1.try_into().unwrap_or_default(),
             Interface::V2(v2) => v2.clone().into(),

--- a/smartcontract/programs/doublezero-serviceability/tests/migrate_interfaces_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/migrate_interfaces_test.rs
@@ -765,7 +765,7 @@ async fn test_migrate_device_interfaces_legacy_account() {
         matches!(migrated_device.interfaces[0], Interface::V3(_)),
         "Migrated interface must be V3"
     );
-    let migrated_iface = migrated_device.interfaces[0].into_current_version();
+    let migrated_iface = migrated_device.interfaces[0].into_v3();
     assert_eq!(
         migrated_iface.flex_algo_node_segments.len(),
         0,

--- a/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
@@ -1690,7 +1690,7 @@ async fn test_topology_backfill_populates_vpnv4_loopbacks() {
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found");
-    let iface = device.interfaces[0].into_current_version();
+    let iface = device.interfaces[0].into_v3();
     assert_eq!(
         iface.flex_algo_node_segments.len(),
         0,
@@ -1722,7 +1722,7 @@ async fn test_topology_backfill_populates_vpnv4_loopbacks() {
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found after backfill");
-    let iface = device.interfaces[0].into_current_version();
+    let iface = device.interfaces[0].into_v3();
     assert_eq!(
         iface.flex_algo_node_segments.len(),
         1,
@@ -1749,7 +1749,7 @@ async fn test_topology_backfill_populates_vpnv4_loopbacks() {
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found after second backfill");
-    let iface = device.interfaces[0].into_current_version();
+    let iface = device.interfaces[0].into_v3();
     assert_eq!(
         iface.flex_algo_node_segments.len(),
         1,
@@ -2052,7 +2052,7 @@ async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found");
-    let iface = device.interfaces[0].into_current_version();
+    let iface = device.interfaces[0].into_v3();
     assert_eq!(
         iface.node_segment_idx, 1,
         "Base node_segment_idx should be 1 (first ID from SegmentRoutingIds)"
@@ -2100,7 +2100,7 @@ async fn test_topology_backfill_allocates_sr_id_from_onchain_resource() {
     let device = get_device(&mut banks_client, device_pubkey)
         .await
         .expect("Device not found after backfill");
-    let iface = device.interfaces[0].into_current_version();
+    let iface = device.interfaces[0].into_v3();
     assert_eq!(
         iface.node_segment_idx, 1,
         "Base node_segment_idx must remain 1"


### PR DESCRIPTION
## Summary

- Revert `CurrentInterfaceVersion` to `InterfaceV2` so `CreateDeviceInterface` and `UpdateDeviceInterface` stop writing the RFC-18 `InterfaceV3` encoding onchain. V3 is staying for now just for compilation support for Topology.
- Keep `MigrateDeviceInterfaces` and `BackfillTopology` writing `InterfaceV3` — both are admin-controlled and `flex_algo_node_segments` only lives on V3, so the migrate/backfill paths still need it.
- Add `TryFrom<&InterfaceV3> for InterfaceV2` and a new `Interface::into_v3()` accessor so call sites can opt into the V3 view (backfill idempotency check, admin migrate-needed check) without forcing V3 on everyone via `into_current_version()`.

## Testing Verification

- `make rust-lint` clean
- `make rust-test` passes (79 test groups, 0 failures), including the targeted `test_migrate_device_interfaces_legacy_account`, `test_topology_backfill_populates_vpnv4_loopbacks`, and `test_topology_backfill_allocates_sr_id_from_onchain_resource` which exercise the V3 paths that must keep working
- Verified `process_create_device_interface` now produces an `Interface::V2` variant (discriminant 1) via the existing `test_state_device_serialization`