### PR TITLE
feat: move dns lookup to run independently

### DIFF
--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -30,16 +30,17 @@ import (
 )
 
 const (
-	defaultTWAMPListenPort       = 8925
-	defaultSignedTWAMPListenPort = 8924
-	defaultUDPListenPort         = 8923
-	defaultProbeInterval         = 30 * time.Second
-	defaultTWAMPSenderTimeout    = 1 * time.Second
-	defaultTWAMPReflectorTimeout = 1 * time.Second
-	defaultMaxOffsetAge          = 1 * time.Hour
-	defaultEvictionInterval      = 30 * time.Minute
-	defaultVerifyInterval        = 29 * time.Second
-	discoveryInterval            = 60 * time.Second
+	defaultTWAMPListenPort            = 8925
+	defaultSignedTWAMPListenPort      = 8924
+	defaultUDPListenPort              = 8923
+	defaultProbeInterval              = 30 * time.Second
+	defaultTWAMPSenderTimeout         = 1 * time.Second
+	defaultTWAMPReflectorTimeout      = 1 * time.Second
+	defaultMaxOffsetAge               = 1 * time.Hour
+	defaultEvictionInterval           = 30 * time.Minute
+	defaultVerifyInterval             = 29 * time.Second
+	discoveryInterval                 = 60 * time.Second
+	defaultDeliveryDNSRefreshInterval = 5 * time.Minute
 )
 
 var (
@@ -612,6 +613,9 @@ func main() {
 
 	// Run main measurement loop. This runs regardless of whether trusted parents
 	// are configured at startup, since they may be added dynamically at runtime.
+	deliveryDNS := geoprobe.NewDeliveryDNSRefresher(log, defaultDeliveryDNSRefreshInterval)
+	go deliveryDNS.Start(ctx, defaultDeliveryDNSRefreshInterval)
+
 	go func() {
 		ml := &measurementLoop{
 			ctx:                ctx,
@@ -624,7 +628,7 @@ func main() {
 			getCurrentSlot:     getCurrentSlot,
 			signedReflector:    signedReflector,
 			metrics:            m,
-			dnsCache:           geoprobe.NewDNSCache(5 * time.Minute),
+			deliveryDNS:        deliveryDNS,
 			targetUpdateCh:     targetUpdateCh,
 			icmpTargetUpdateCh: icmpTargetUpdateCh,
 			inboundKeyCh:       inboundKeyCh,
@@ -740,7 +744,7 @@ type measurementLoop struct {
 	getCurrentSlot  func(ctx context.Context) (uint64, error)
 	signedReflector signed.Reflector
 	metrics         *geoprobe.Metrics
-	dnsCache        *geoprobe.DNSCache
+	deliveryDNS     *geoprobe.DeliveryDNSRefresher
 
 	targets           []geoprobe.ProbeAddress
 	icmpTargets       []geoprobe.ProbeAddress
@@ -798,6 +802,31 @@ func (ml *measurementLoop) reconcileTargets(
 	return newTargets, rttData
 }
 
+// uniqueDeliveryHostPorts returns distinct non-empty result-destination strings
+// from outbound and ICMP delivery maps.
+func uniqueDeliveryHostPorts(outbound, icmp map[geoprobe.ProbeAddress]string) []string {
+	seen := make(map[string]struct{})
+	for _, v := range outbound {
+		if v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	for _, v := range icmp {
+		if v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return out
+}
+
+func (ml *measurementLoop) updateDesiredDeliveryDNS() {
+	ml.deliveryDNS.SetDesiredHostPorts(uniqueDeliveryHostPorts(ml.deliveryAddrs, ml.icmpDeliveryAddrs))
+}
+
 func (ml *measurementLoop) run() error {
 	measureTicker := time.NewTicker(*probeInterval)
 	defer measureTicker.Stop()
@@ -820,6 +849,7 @@ func (ml *measurementLoop) run() error {
 			)
 			ml.targets = newTargets
 			ml.deliveryAddrs = update.DeliveryAddrs
+			ml.updateDesiredDeliveryDNS()
 			ml.metrics.TargetsDiscovered.Set(float64(len(ml.targets)))
 			ml.log.Info("Updated targets from discovery", "totalTargets", len(ml.targets))
 			if len(rttData) > 0 {
@@ -836,6 +866,7 @@ func (ml *measurementLoop) run() error {
 			)
 			ml.icmpTargets = newTargets
 			ml.icmpDeliveryAddrs = icmpUpdate.DeliveryAddrs
+			ml.updateDesiredDeliveryDNS()
 			ml.metrics.IcmpTargetsDiscovered.Set(float64(len(ml.icmpTargets)))
 			ml.log.Info("Updated ICMP targets from discovery", "totalIcmpTargets", len(ml.icmpTargets))
 			if len(rttData) > 0 {
@@ -954,11 +985,11 @@ func (ml *measurementLoop) sendCompositeOffsets(
 		_, isICMP := icmpTargets[addr]
 
 		if hasDelivery {
-			// Result destination override — resolve (may involve DNS).
-			resolved, resolveErr := ml.dnsCache.Resolve(deliveryDest)
-			if resolveErr != nil {
-				ml.log.Warn("Failed to resolve delivery address, skipping target",
-					"target", addr, "delivery", deliveryDest, "error", resolveErr)
+			// Result destination override — use addresses refreshed off the measurement loop.
+			resolved, ok := ml.deliveryDNS.Lookup(deliveryDest)
+			if !ok {
+				ml.log.Warn("Delivery address not ready or invalid, skipping target",
+					"target", addr, "delivery", deliveryDest)
 				continue
 			}
 			targetAddr = resolved

--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -44,7 +44,6 @@ const (
 	defaultDeliveryDNSTTL             = defaultDeliveryDNSRefreshInterval * 5 / 2
 )
 
-
 var (
 	env                        = flag.String("env", "", "The network environment to use (devnet, testnet, mainnet-beta).")
 	ledgerRPCURL               = flag.String("ledger-rpc-url", "", "The url of the ledger RPC. If env is provided, this flag is ignored.")

--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -44,6 +44,7 @@ const (
 	defaultDeliveryDNSTTL             = defaultDeliveryDNSRefreshInterval * 5 / 2
 )
 
+
 var (
 	env                        = flag.String("env", "", "The network environment to use (devnet, testnet, mainnet-beta).")
 	ledgerRPCURL               = flag.String("ledger-rpc-url", "", "The url of the ledger RPC. If env is provided, this flag is ignored.")

--- a/controlplane/telemetry/cmd/geoprobe-agent/main.go
+++ b/controlplane/telemetry/cmd/geoprobe-agent/main.go
@@ -41,6 +41,7 @@ const (
 	defaultVerifyInterval             = 29 * time.Second
 	discoveryInterval                 = 60 * time.Second
 	defaultDeliveryDNSRefreshInterval = 5 * time.Minute
+	defaultDeliveryDNSTTL             = defaultDeliveryDNSRefreshInterval * 5 / 2
 )
 
 var (
@@ -613,7 +614,7 @@ func main() {
 
 	// Run main measurement loop. This runs regardless of whether trusted parents
 	// are configured at startup, since they may be added dynamically at runtime.
-	deliveryDNS := geoprobe.NewDeliveryDNSRefresher(log, defaultDeliveryDNSRefreshInterval)
+	deliveryDNS := geoprobe.NewDeliveryDNSRefresher(log, defaultDeliveryDNSTTL)
 	go deliveryDNS.Start(ctx, defaultDeliveryDNSRefreshInterval)
 
 	go func() {

--- a/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher.go
+++ b/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher.go
@@ -1,0 +1,98 @@
+package geoprobe
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+)
+
+// DeliveryDNSRefresher runs periodic DNS resolution for result-destination host:port
+// strings off the measurement loop. The hot path uses DNSCache.LookupDeliveryUDPAddr
+// only (no DNS). Refreshes run at startup, when the desired set changes, and on a
+// fixed ticker (aligned with DNS cache TTL).
+type DeliveryDNSRefresher struct {
+	cache   *DNSCache
+	log     *slog.Logger
+	mu      sync.Mutex
+	desired map[string]struct{}
+
+	trigger chan struct{}
+}
+
+// NewDeliveryDNSRefresher builds a refresher that owns a DNSCache with the given TTL.
+func NewDeliveryDNSRefresher(log *slog.Logger, ttl time.Duration) *DeliveryDNSRefresher {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &DeliveryDNSRefresher{
+		cache:   NewDNSCache(ttl),
+		log:     log,
+		desired: make(map[string]struct{}),
+		trigger: make(chan struct{}, 1),
+	}
+}
+
+// Cache returns the underlying DNS cache for tests.
+func (r *DeliveryDNSRefresher) Cache() *DNSCache {
+	return r.cache
+}
+
+// Lookup resolves delivery addresses without blocking on DNS for hostnames.
+func (r *DeliveryDNSRefresher) Lookup(hostPort string) (*net.UDPAddr, bool) {
+	return r.cache.LookupDeliveryUDPAddr(hostPort)
+}
+
+// SetDesiredHostPorts replaces the set of host:port strings that should stay resolved.
+// Triggers a coalesced background refresh (non-blocking).
+func (r *DeliveryDNSRefresher) SetDesiredHostPorts(hostPorts []string) {
+	r.mu.Lock()
+	r.desired = make(map[string]struct{}, len(hostPorts))
+	for _, h := range hostPorts {
+		if h != "" {
+			r.desired[h] = struct{}{}
+		}
+	}
+	r.mu.Unlock()
+
+	select {
+	case r.trigger <- struct{}{}:
+	default:
+	}
+}
+
+// Start runs refresh immediately, then on each refreshInterval tick and whenever
+// SetDesiredHostPorts signals. Blocks until ctx is canceled.
+func (r *DeliveryDNSRefresher) Start(ctx context.Context, refreshInterval time.Duration) {
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	r.refresh()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.refresh()
+		case <-r.trigger:
+			r.refresh()
+		}
+	}
+}
+
+func (r *DeliveryDNSRefresher) refresh() {
+	r.mu.Lock()
+	hostPorts := make([]string, 0, len(r.desired))
+	for h := range r.desired {
+		hostPorts = append(hostPorts, h)
+	}
+	r.mu.Unlock()
+
+	for _, hp := range hostPorts {
+		if _, err := r.cache.Resolve(hp); err != nil {
+			r.log.Warn("delivery DNS refresh failed", "hostPort", hp, "error", err)
+		}
+	}
+}

--- a/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher.go
+++ b/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher.go
@@ -11,7 +11,7 @@ import (
 // DeliveryDNSRefresher runs periodic DNS resolution for result-destination host:port
 // strings off the measurement loop. The hot path uses DNSCache.LookupDeliveryUDPAddr
 // only (no DNS). Refreshes run at startup, when the desired set changes, and on a
-// fixed ticker (aligned with DNS cache TTL).
+// fixed ticker (shorter than cache TTL so entries are refreshed before expiry).
 type DeliveryDNSRefresher struct {
 	cache   *DNSCache
 	log     *slog.Logger
@@ -32,11 +32,6 @@ func NewDeliveryDNSRefresher(log *slog.Logger, ttl time.Duration) *DeliveryDNSRe
 		desired: make(map[string]struct{}),
 		trigger: make(chan struct{}, 1),
 	}
-}
-
-// Cache returns the underlying DNS cache for tests.
-func (r *DeliveryDNSRefresher) Cache() *DNSCache {
-	return r.cache
 }
 
 // Lookup resolves delivery addresses without blocking on DNS for hostnames.

--- a/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher_test.go
+++ b/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher_test.go
@@ -1,0 +1,191 @@
+package geoprobe
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestDeliveryDNSRefresher_StartupRefresh(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
+	r.Cache().lookup = func(host string) ([]string, error) {
+		if host == "results.example.com" {
+			return []string{"93.184.216.34"}, nil
+		}
+		return nil, errors.New("unknown host")
+	}
+
+	r.SetDesiredHostPorts([]string{"results.example.com:9000"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Start(ctx, time.Hour)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatal("timeout waiting for DNS refresh")
+		default:
+			addr, ok := r.Lookup("results.example.com:9000")
+			if ok && addr.Port == 9000 && addr.IP.String() == "93.184.216.34" {
+				cancel()
+				<-done
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestDeliveryDNSRefresher_LookupIPWithoutWaitingForRefresh(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Start(ctx, time.Hour)
+
+	addr, ok := r.Lookup("185.199.108.1:9000")
+	if !ok {
+		t.Fatal("expected literal public IP lookup without background refresh")
+	}
+	if addr.IP.String() != "185.199.108.1" || addr.Port != 9000 {
+		t.Fatalf("unexpected addr: %v", addr)
+	}
+}
+
+func TestDeliveryDNSRefresher_DomainMissBeforeRefresh(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
+
+	_, ok := r.Lookup("results.example.com:9000")
+	if ok {
+		t.Fatal("expected cache miss before refresh")
+	}
+}
+
+func TestDeliveryDNSRefresher_SetDesiredTriggersRefresh(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
+	lookupCalls := 0
+	r.Cache().lookup = func(host string) ([]string, error) {
+		lookupCalls++
+		return []string{"93.184.216.34"}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Start(ctx, time.Hour)
+		close(done)
+	}()
+
+	r.SetDesiredHostPorts([]string{"other.example.com:8080"})
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatalf("timeout; lookupCalls=%d", lookupCalls)
+		default:
+			if _, ok := r.Lookup("other.example.com:8080"); ok {
+				if lookupCalls < 1 {
+					t.Fatal("expected at least one DNS lookup")
+				}
+				cancel()
+				<-done
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestLookupDeliveryUDPAddr_CachedDomain(t *testing.T) {
+	cache := NewDNSCache(5 * time.Minute)
+	cache.lookup = func(host string) ([]string, error) {
+		return []string{"93.184.216.34"}, nil
+	}
+
+	_, ok := cache.LookupDeliveryUDPAddr("results.example.com:9000")
+	if ok {
+		t.Fatal("expected miss before Resolve")
+	}
+
+	_, err := cache.Resolve("results.example.com:9000")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	addr, ok := cache.LookupDeliveryUDPAddr("results.example.com:9000")
+	if !ok {
+		t.Fatal("expected hit after Resolve")
+	}
+	if addr.Port != 9000 || addr.IP.String() != "93.184.216.34" {
+		t.Fatalf("addr %v", addr)
+	}
+}
+
+func TestLookupDeliveryUDPAddr_LiteralIP(t *testing.T) {
+	cache := NewDNSCache(5 * time.Minute)
+	addr, ok := cache.LookupDeliveryUDPAddr("185.199.108.1:9000")
+	if !ok {
+		t.Fatal("expected literal IP without Resolve")
+	}
+	if addr.IP.String() != "185.199.108.1" || addr.Port != 9000 {
+		t.Fatalf("addr %v", addr)
+	}
+}
+
+func TestLookupDeliveryUDPAddr_RejectsPrivateIP(t *testing.T) {
+	cache := NewDNSCache(5 * time.Minute)
+	_, ok := cache.LookupDeliveryUDPAddr("10.0.0.1:9000")
+	if ok {
+		t.Fatal("expected rejection for private IP")
+	}
+}
+
+func TestLookupDeliveryUDPAddr_ExpiredCache(t *testing.T) {
+	now := time.Now()
+	cache := NewDNSCache(5 * time.Minute)
+	cache.now = func() time.Time { return now }
+	cache.lookup = func(host string) ([]string, error) {
+		return []string{"93.184.216.34"}, nil
+	}
+
+	_, err := cache.Resolve("results.example.com:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := cache.LookupDeliveryUDPAddr("results.example.com:9000")
+	if !ok {
+		t.Fatal("expected hit before expiry")
+	}
+
+	now = now.Add(6 * time.Minute)
+	_, ok = cache.LookupDeliveryUDPAddr("results.example.com:9000")
+	if ok {
+		t.Fatal("expected miss after TTL")
+	}
+}
+
+func TestLookupDeliveryUDPAddr_InvalidHostPort(t *testing.T) {
+	cache := NewDNSCache(5 * time.Minute)
+	_, ok := cache.LookupDeliveryUDPAddr("not-a-host-port")
+	if ok {
+		t.Fatal("expected invalid")
+	}
+}

--- a/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher_test.go
+++ b/controlplane/telemetry/internal/geoprobe/delivery_dns_refresher_test.go
@@ -12,7 +12,7 @@ import (
 func TestDeliveryDNSRefresher_StartupRefresh(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
-	r.Cache().lookup = func(host string) ([]string, error) {
+	r.cache.lookup = func(host string) ([]string, error) {
 		if host == "results.example.com" {
 			return []string{"93.184.216.34"}, nil
 		}
@@ -78,7 +78,7 @@ func TestDeliveryDNSRefresher_SetDesiredTriggersRefresh(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	r := NewDeliveryDNSRefresher(log, 5*time.Minute)
 	lookupCalls := 0
-	r.Cache().lookup = func(host string) ([]string, error) {
+	r.cache.lookup = func(host string) ([]string, error) {
 		lookupCalls++
 		return []string{"93.184.216.34"}, nil
 	}

--- a/controlplane/telemetry/internal/geoprobe/dns_cache.go
+++ b/controlplane/telemetry/internal/geoprobe/dns_cache.go
@@ -99,3 +99,50 @@ func (c *DNSCache) Resolve(hostPort string) (*net.UDPAddr, error) {
 
 	return &net.UDPAddr{IP: resolvedIP, Port: port}, nil
 }
+
+// LookupDeliveryUDPAddr returns a UDP address for delivery without performing DNS.
+// Literal IPs are parsed and validated against ValidateScope on every call (cheap).
+// Hostnames are only satisfied from the in-memory cache populated by Resolve (e.g.
+// from DeliveryDNSRefresher); if missing or expired, returns ok=false so callers can
+// skip sending until a background refresh succeeds.
+func (c *DNSCache) LookupDeliveryUDPAddr(hostPort string) (*net.UDPAddr, bool) {
+	host, portStr, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return nil, false
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, false
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		scopeCheck := ProbeAddress{Host: host}
+		if err := scopeCheck.ValidateScope(); err != nil {
+			return nil, false
+		}
+		return &net.UDPAddr{IP: ip, Port: port}, true
+	}
+
+	now := c.now()
+
+	c.mu.RLock()
+	entry, ok := c.entries[host]
+	c.mu.RUnlock()
+
+	if !ok || !now.Before(entry.expiresAt) {
+		return nil, false
+	}
+
+	resolvedIP := net.ParseIP(entry.ip)
+	if resolvedIP == nil {
+		return nil, false
+	}
+
+	scopeCheck := ProbeAddress{Host: entry.ip}
+	if err := scopeCheck.ValidateScope(); err != nil {
+		return nil, false
+	}
+
+	return &net.UDPAddr{IP: resolvedIP, Port: port}, true
+}


### PR DESCRIPTION
## Summary of Changes
* Describe what changed in the PR

   Introduced a `DeliveryDNSRefresher` that runs DNS for result-destination `host:port` strings outside the measurement loop: it refreshes on a 5-minute ticker, once at startup, and whenever the desired set of destinations changes (after outbound or ICMP target discovery updates). The measurement/send path now uses `DNSCache.LookupDeliveryUDPAddr`, which never performs `LookupHost` for hostnames—it only returns an address if the cache is already populated and still valid; literal public IPs are still resolved synchronously with the existing `ValidateScope()` checks. `sendCompositeOffsets` uses `deliveryDNS.Lookup` instead of `dnsCache.Resolve`, so slow or timing DNS no longer runs inside the RTT/measurement cycle. If a hostname is not ready yet, that target is skipped for that cycle with a warning log.

* Explain why the change is necessary
    Due to:  https://github.com/malbeclabs/doublezero/issues/3544
* Is there supporting documentation or external resources that explain the change? No
* Is a CHANGELOG.md update needed? No

## Testing Verification
* `go test` on `controlplane/telemetry/internal/geoprobe` for `DNSCache_*`, `DeliveryDNS_*`, and `LookupDelivery*` tests: **pass** (covers startup refresh, coalesced refresh after `SetDesiredHostPorts`, literal-IP lookup without waiting, domain miss before refresh, cache hit/miss/TTL, private IP rejection, invalid `host:port`).
* `GOOS=linux go build ./controlplane/telemetry/cmd/geoprobe-agent/`: succeeds (agent is `//go:build linux`).
* Note: `go test ./controlplane/telemetry/cmd/geoprobe-agent/...` may fail on macOS because main_test.go is not tagged linux while main.go is—run agent package tests on Linux / CI for a full green check.