### PR TITLE
fix: serviceability: return InvalidPublicIp for device public IP validation

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -705,7 +705,7 @@ impl Validate for Device {
         // Public IP must be a global address
         if self.device_type != DeviceType::Transit && !is_global(self.public_ip) {
             msg!("Invalid public IP: {}", self.public_ip);
-            return Err(DoubleZeroError::InvalidClientIp);
+            return Err(DoubleZeroError::InvalidPublicIp);
         }
         // Device prefixes must be present
         if self.dz_prefixes.is_empty() {
@@ -968,7 +968,7 @@ mod tests {
     }
 
     #[test]
-    fn test_state_device_validate_error_invalid_client_ip() {
+    fn test_state_device_validate_error_invalid_public_ip() {
         let val = Device {
             account_type: AccountType::Device,
             owner: Pubkey::new_unique(),
@@ -1000,7 +1000,7 @@ mod tests {
             max_multicast_publishers: 0,
         };
         let err = val.validate();
-        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidClientIp);
+        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidPublicIp);
     }
 
     #[test]
@@ -1460,7 +1460,7 @@ mod test_device_validate_errors {
         device.device_type = DeviceType::Edge;
         device.public_ip = "192.168.0.1".parse().unwrap();
         let err = device.validate();
-        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidClientIp);
+        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidPublicIp);
     }
 
     #[test]
@@ -1469,7 +1469,7 @@ mod test_device_validate_errors {
         device.device_type = DeviceType::Hybrid;
         device.public_ip = "192.168.0.1".parse().unwrap();
         let err = device.validate();
-        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidClientIp);
+        assert_eq!(err.unwrap_err(), DoubleZeroError::InvalidPublicIp);
     }
 
     #[test]

--- a/smartcontract/sdk/go/serviceability/errors_test.go
+++ b/smartcontract/sdk/go/serviceability/errors_test.go
@@ -147,21 +147,21 @@ func TestFormatRPCError(t *testing.T) {
 				"err": map[string]any{
 					"InstructionError": []any{
 						json.Number("1"),
-						map[string]any{"Custom": json.Number("26")},
+						map[string]any{"Custom": json.Number("62")},
 					},
 				},
 				"logs": []any{
 					"Program invoke [1]",
 					"Program log: Instruction: SetDeviceHealth(health: ReadyForUsers)",
 					"Program log: Invalid public IP: 0.1.2.3",
-					"Program failed: custom program error: 0x1a",
+					"Program failed: custom program error: 0x3e",
 				},
 			},
 		}
 		// Wrap it like executeTransaction does.
 		wrapped := fmt.Errorf("failed to send transaction: %w", rpcErr)
 		msg := formatRPCError(wrapped)
-		assert.Equal(t, "InvalidClientIp (program logs: [Invalid public IP: 0.1.2.3])", msg)
+		assert.Equal(t, "InvalidPublicIp (program logs: [Invalid public IP: 0.1.2.3])", msg)
 	})
 
 	t.Run("known code without interesting logs", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `Device::validate()` to return `InvalidPublicIp` (variant 62) instead of `InvalidClientIp` (variant 26) when the device public IP fails the `is_global()` check
- Update Go SDK error formatter test to use the correct error code so the test example is coherent

The bug caused the CLI to display "Invalid Client IP" when the program log said "Invalid public IP":

```
❯ doublezero device update --pubkey 4CkvmyquGN4qtXLNj3hpJcqYbb7PCanLbU1rQHHdp6xp --status drained
Program Logs:
Program GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah invoke [1]
Program log: Instruction: UpdateDevice(status: Some(Drained), resource_count: 0, )
Program log: Invalid public IP: 0.1.2.3
Program GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah consumed 8544 of 200000 compute units
Program GYhQDKuESrasNZGyhMJhGYFtbzNijYhcrN9poSqCQVah failed: custom program error: 0x1a
Error: Invalid Client IP
```

After this fix, the CLI will display "Invalid Public IP: IP conflicts with DZ prefix" which matches the `InvalidPublicIp` variant's error message.
