### PR TITLE
smartcontract: address PR #3648 review

### DIFF
--- a/smartcontract/cli/src/device/interface/update.rs
+++ b/smartcontract/cli/src/device/interface/update.rs
@@ -172,12 +172,13 @@ impl UpdateDeviceInterfaceCliCommand {
             .map_err(|e| eyre::eyre!("Invalid status: {}", e))?;
 
         // clap's `num_args = 0..` produces Some(vec!["", ...]) for `--topologies ""`,
-        // so strip empty/whitespace-only entries.
+        // so strip empty/whitespace-only entries. Topology PDAs are derived from
+        // the canonical uppercase name, so normalize here too.
         let topology_names = self.topologies.as_ref().map(|names| {
             names
                 .iter()
                 .filter(|n| !n.trim().is_empty())
-                .map(|n| n.trim().to_string())
+                .map(|n| n.trim().to_ascii_uppercase())
                 .collect::<Vec<_>>()
         });
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/interface/create.rs
@@ -31,6 +31,7 @@ use solana_program::{
     entrypoint::ProgramResult,
     pubkey::Pubkey,
 };
+use std::collections::HashSet;
 
 #[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone, Default)]
 pub struct DeviceInterfaceCreateArgs {
@@ -231,6 +232,7 @@ pub fn process_create_device_interface(
                 node_segment_idx = allocate_id(segment_routing_ids_ext)?;
 
                 // Allocate a flex-algo node segment for each topology
+                let mut seen: HashSet<Pubkey> = HashSet::with_capacity(topology_accounts.len());
                 for topo_account in &topology_accounts {
                     assert_eq!(
                         topo_account.owner, program_id,
@@ -243,6 +245,9 @@ pub fn process_create_device_interface(
                         AccountType::Topology,
                         "Invalid Topology Account Type"
                     );
+                    if !seen.insert(*topo_account.key) {
+                        return Err(DoubleZeroError::InvalidArgument.into());
+                    }
                     let topo_segment_idx = allocate_id(segment_routing_ids_ext)?;
                     flex_algo_node_segments.push(FlexAlgoNodeSegment {
                         topology: *topo_account.key,

--- a/smartcontract/programs/doublezero-serviceability/tests/interface_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/interface_onchain_allocation_test.rs
@@ -2380,3 +2380,72 @@ async fn test_update_topologies_allowed_for_contributor() {
     expected.sort();
     assert_eq!(topology_set(&device.interfaces[0]), expected);
 }
+
+/// Test: passing the same topology twice on CreateDeviceInterface is rejected
+/// as InvalidArgument before any SR ID is allocated for the duplicate.
+#[tokio::test]
+async fn test_create_device_interface_rejects_duplicate_topology_accounts() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    enable_onchain_allocation(&mut banks_client, program_id, globalstate_pubkey, &payer).await;
+
+    let topo_a = create_topology(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        "topo-a",
+        &payer,
+    )
+    .await;
+
+    let (device_pubkey, contributor_pubkey) =
+        setup_device(&mut banks_client, &payer, program_id, globalstate_pubkey).await;
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateDeviceInterface(DeviceInterfaceCreateArgs {
+            name: "Loopback0".to_string(),
+            loopback_type: LoopbackType::Vpnv4,
+            interface_cyoa: InterfaceCYOA::None,
+            interface_dia: InterfaceDIA::None,
+            bandwidth: 0,
+            cir: 0,
+            ip_net: None,
+            mtu: 9000,
+            routing_mode: RoutingMode::Static,
+            vlan_id: 0,
+            user_tunnel_endpoint: false,
+            use_onchain_allocation: true,
+            topology_count: 2,
+        }),
+        vec![
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new_readonly(topo_a, false),
+            AccountMeta::new_readonly(topo_a, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let err = result.expect_err("expected duplicate topology rejection");
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(code),
+        )) => {
+            assert_eq!(DoubleZeroError::InvalidArgument, code.into());
+        }
+        _ => panic!("Unexpected error: {err:?}"),
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/device/interface/create.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/create.rs
@@ -54,7 +54,16 @@ impl CreateDeviceInterfaceCommand {
             AccountMeta::new(globalstate_pubkey, false),
         ];
 
-        let mut topology_count: u8 = 0;
+        let topology_count: u8 =
+            if use_onchain_allocation && self.loopback_type == LoopbackType::Vpnv4 {
+                let n = self.topology_names.len();
+                u8::try_from(n).map_err(|_| {
+                    eyre::eyre!("too many topologies for one CreateDeviceInterface call: {n} > 255")
+                })?
+            } else {
+                0
+            };
+
         if use_onchain_allocation {
             let (device_tunnel_block_ext, _, _) = get_resource_extension_pda(
                 &client.get_program_id(),
@@ -73,7 +82,6 @@ impl CreateDeviceInterfaceCommand {
                 for name in &self.topology_names {
                     let (topology_pda, _) = get_topology_pda(&client.get_program_id(), name);
                     accounts.push(AccountMeta::new_readonly(topology_pda, false));
-                    topology_count += 1;
                 }
             }
         }

--- a/smartcontract/sdk/rs/src/commands/device/interface/update.rs
+++ b/smartcontract/sdk/rs/src/commands/device/interface/update.rs
@@ -56,7 +56,12 @@ impl UpdateDeviceInterfaceCommand {
 
         let onchain_allocation_enabled =
             is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation);
-        let update_topologies = self.topology_names.is_some() && onchain_allocation_enabled;
+        if self.topology_names.is_some() && !onchain_allocation_enabled {
+            return Err(eyre::eyre!(
+                "OnChainAllocation feature must be enabled to update topology assignments"
+            ));
+        }
+        let update_topologies = self.topology_names.is_some();
         let needs_seg_ext =
             (self.node_segment_idx.is_some() && onchain_allocation_enabled) || update_topologies;
 
@@ -68,12 +73,18 @@ impl UpdateDeviceInterfaceCommand {
             accounts.push(AccountMeta::new(seg_routing_pda, false));
         }
 
-        let mut topology_count: u8 = 0;
+        let topology_count: u8 = if let Some(names) = self.topology_names.as_ref() {
+            let n = names.len();
+            u8::try_from(n).map_err(|_| {
+                eyre::eyre!("too many topologies for one UpdateDeviceInterface call: {n} > 255")
+            })?
+        } else {
+            0
+        };
         if update_topologies {
             for name in self.topology_names.as_ref().unwrap() {
                 let (topology_pda, _) = get_topology_pda(&client.get_program_id(), name);
                 accounts.push(AccountMeta::new_readonly(topology_pda, false));
-                topology_count += 1;
             }
         }
 


### PR DESCRIPTION
## Summary

Address the four unresolved Copilot review threads on #3648:

- Reject duplicate topology PDAs in `CreateDeviceInterface` so a caller can't allocate two flex-algo SR IDs for the same topology — mirrors the existing dedupe in `UpdateDeviceInterface`.
- Compute `topology_count` via `u8::try_from(topology_names.len())` in the Rust SDK's `CreateDeviceInterfaceCommand` and `UpdateDeviceInterfaceCommand` so passing more than 255 topology names errors out instead of silently wrapping.
- In `UpdateDeviceInterfaceCommand`, return an error when topology reconciliation is requested but the `OnChainAllocation` feature flag is off, instead of silently dropping the request.
- Normalize CLI `--topologies` names with `to_ascii_uppercase` to match the canonical form used to derive topology PDAs.

Stacks on top of #3648 (base `bc/rfc18-devnet-fixes`).

Related RFC: rfcs/rfc-0018-flex-algo.md

## Testing Verification

- New `test_create_device_interface_rejects_duplicate_topology_accounts` in `interface_onchain_allocation_test.rs` exercises the dedupe path on `CreateDeviceInterface`.
- `cargo test -p doublezero-serviceability` — full smartcontract suite passes, including the existing `test_update_topologies_*` cases.
- `cargo test -p doublezero_sdk device::interface` and `cargo test -p doublezero_cli device::interface` cover the SDK / CLI changes.