### PR TITLE
sdk: compute limit increase for AssignTopologyNodeSegments

### DIFF
--- a/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
@@ -12,6 +12,8 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 /// appended by the client) we stay well under that limit at 16.
 pub const BACKFILL_BATCH_SIZE: usize = 16;
 
+pub const ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct AssignTopologyNodeSegmentsCommand {
     pub name: String,
@@ -41,11 +43,12 @@ impl AssignTopologyNodeSegmentsCommand {
                 accounts.push(AccountMeta::new(*device_pk, false));
             }
 
-            let sig = client.execute_transaction(
+            let sig = client.execute_transaction_with_compute_unit_limit(
                 DoubleZeroInstruction::AssignTopologyNodeSegments(AssignTopologyNodeSegmentsArgs {
                     name: self.name.clone(),
                 }),
                 accounts,
+                ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT,
             )?;
             signatures.push(sig);
         }
@@ -56,6 +59,7 @@ impl AssignTopologyNodeSegmentsCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT;
     use crate::{
         commands::topology::assign_node_segments::{
             AssignTopologyNodeSegmentsCommand, BACKFILL_BATCH_SIZE,
@@ -97,7 +101,7 @@ mod tests {
         let device2 = Pubkey::new_unique();
 
         client
-            .expect_execute_transaction()
+            .expect_execute_transaction_with_compute_unit_limit()
             .with(
                 predicate::eq(DoubleZeroInstruction::AssignTopologyNodeSegments(
                     AssignTopologyNodeSegmentsArgs {
@@ -111,8 +115,9 @@ mod tests {
                     AccountMeta::new(device1, false),
                     AccountMeta::new(device2, false),
                 ]),
+                predicate::eq(ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT),
             )
-            .returning(|_, _| Ok(Signature::new_unique()));
+            .returning(|_, _, _| Ok(Signature::new_unique()));
 
         let res = AssignTopologyNodeSegmentsCommand {
             name: "algo128".to_string(),
@@ -152,14 +157,15 @@ mod tests {
                 expected_accounts.push(AccountMeta::new(*device_pk, false));
             }
             client
-                .expect_execute_transaction()
+                .expect_execute_transaction_with_compute_unit_limit()
                 .times(1)
                 .in_sequence(&mut seq)
                 .with(
                     predicate::eq(expected_args.clone()),
                     predicate::eq(expected_accounts),
+                    predicate::eq(ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT),
                 )
-                .returning(|_, _| Ok(Signature::new_unique()));
+                .returning(|_, _, _| Ok(Signature::new_unique()));
         }
 
         let res = AssignTopologyNodeSegmentsCommand {

--- a/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
@@ -174,6 +174,6 @@ mod tests {
         }
         .execute(&client);
 
-        assert_eq!(res.unwrap().len(), 3);
+        assert_eq!(res.unwrap().len(), 9);
     }
 }

--- a/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
@@ -9,8 +9,8 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 
 /// Max device accounts per backfill transaction. Solana caps transactions at
 /// 32 accounts; with 5 non-device accounts (3 fixed PDAs + payer + system_program
-/// appended by the client) we stay well under that limit at 16.
-pub const BACKFILL_BATCH_SIZE: usize = 16;
+/// appended by the client) we stay well under that limit at 4.
+pub const BACKFILL_BATCH_SIZE: usize = 4;
 
 pub const ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 

--- a/smartcontract/sdk/rs/src/commands/topology/create.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/create.rs
@@ -226,7 +226,7 @@ mod tests {
             });
 
         client
-            .expect_execute_transaction()
+            .expect_execute_transaction_with_compute_unit_limit()
             .times(1)
             .in_sequence(&mut seq)
             .with(
@@ -241,8 +241,9 @@ mod tests {
                     AccountMeta::new_readonly(globalstate_pubkey, false),
                     AccountMeta::new(vpnv4_device_pk, false),
                 ]),
+                predicate::eq(1_400_000),
             )
-            .returning(|_, _| Ok(Signature::new_unique()));
+            .returning(|_, _, _| Ok(Signature::new_unique()));
 
         let res = CreateTopologyCommand {
             name: "algo128".to_string(),


### PR DESCRIPTION

## Summary of Changes
* AssignTopologyNodeSegments (in "link topology create") compute limit increased based on transaction failure in testing due to iterating over many devices.

## Testing Verification
* Unit tests updated
