### PR TITLE
smartcontract,client: skip access-pass epoch check for multicast users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Smartcontract
+  - Skip `last_access_epoch` enforcement for `UserType::Multicast` in `CreateSubscribeUser` and `CheckUserAccessPass`. Multicast access is gated by `mgroup_pub_allowlist` / `mgroup_sub_allowlist` on the access pass, not by epoch, so multicast users can be created and remain `Activated` regardless of the access-pass expiry. IBRL/unicast epoch enforcement is unchanged.
+- Client
+  - `doublezero connect multicast` no longer fails the client-side `check_accesspass` epoch check; only the AccessPass existence is verified for multicast. IBRL paths still enforce `last_access_epoch >= current_epoch`.
+
 ## [v0.22.0](https://github.com/malbeclabs/doublezero/compare/client/v0.21.0...client/v0.22.0) - 2026-05-08
 
 ### Breaking

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -126,7 +126,11 @@ impl ProvisioningCliCommand {
         let client_ip = super::helpers::resolve_client_ip(controller).await?;
         let client_ip_str = client_ip.to_string();
 
-        if !check_accesspass(client, client_ip)? {
+        let parsed_mode = self.parse_dz_mode()?;
+        // Multicast users are not subject to epoch expiry — only verify the AccessPass exists.
+        let enforce_epoch = !matches!(parsed_mode, ParsedDzMode::Multicast { .. });
+
+        if !check_accesspass(client, client_ip, enforce_epoch)? {
             println!(
                 "❌  Unable to find a valid AccessPass for the IP: {client_ip_str} UserPayer: {}",
                 client.get_payer()
@@ -140,7 +144,7 @@ impl ProvisioningCliCommand {
         spinner.println(format!("    DoubleZero ID: {}", client.get_payer()));
         spinner.println(format!("⚡  Provisioning for IP: {client_ip_str}"));
 
-        match self.parse_dz_mode()? {
+        match parsed_mode {
             ParsedDzMode::Ibrl(user_type, tenant) => {
                 self.execute_ibrl(client, controller, user_type, client_ip, tenant, &spinner)
                     .await
@@ -1014,6 +1018,7 @@ mod tests {
         pub mcast_groups: Arc<Mutex<HashMap<Pubkey, MulticastGroup>>>,
         pub tenants: Arc<Mutex<HashMap<Pubkey, Tenant>>>,
         pub default_tenant_pk: Pubkey,
+        pub accesspass: Arc<Mutex<AccessPass>>,
         /// Tracks which service types the daemon has "provisioned" (simulating
         /// what the reconciler would do). The status mock only returns entries
         /// for types in this set.
@@ -1075,6 +1080,24 @@ mod tests {
             let mut tenants = HashMap::new();
             tenants.insert(default_tenant_pk, default_tenant);
 
+            let client = create_test_client();
+            let payer = client.get_payer();
+            let accesspass = Arc::new(Mutex::new(AccessPass {
+                account_type: AccountType::AccessPass,
+                owner: payer,
+                bump_seed: 1,
+                client_ip: Ipv4Addr::new(1, 2, 3, 4),
+                user_payer: payer,
+                last_access_epoch: u64::MAX,
+                accesspass_type: AccessPassType::Prepaid,
+                connection_count: 0,
+                status: AccessPassStatus::Requested,
+                mgroup_pub_allowlist: vec![],
+                mgroup_sub_allowlist: vec![],
+                tenant_allowlist: vec![],
+                flags: 0,
+            }));
+
             let mut fixture = Self {
                 global_cfg: GlobalConfig {
                     account_type: AccountType::GlobalConfig,
@@ -1088,7 +1111,7 @@ mod tests {
                     multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
                     next_bgp_community: 10000,
                 },
-                client: create_test_client(),
+                client,
                 controller: MockServiceController::new(),
                 devices: Arc::new(Mutex::new(HashMap::new())),
                 users: Arc::new(Mutex::new(HashMap::new())),
@@ -1096,6 +1119,7 @@ mod tests {
                 mcast_groups: Arc::new(Mutex::new(HashMap::new())),
                 tenants: Arc::new(Mutex::new(tenants)),
                 default_tenant_pk,
+                accesspass,
                 provisioned_services: Arc::new(Mutex::new(HashSet::new())),
             };
 
@@ -1203,21 +1227,7 @@ mod tests {
                 &Ipv4Addr::new(1, 2, 3, 4),
                 &payer,
             );
-            let accesspass = AccessPass {
-                account_type: AccountType::AccessPass,
-                owner: payer,
-                bump_seed: 1,
-                client_ip: Ipv4Addr::new(1, 2, 3, 4),
-                user_payer: payer,
-                last_access_epoch: u64::MAX,
-                accesspass_type: AccessPassType::Prepaid,
-                connection_count: 0,
-                status: AccessPassStatus::Requested,
-                mgroup_pub_allowlist: vec![],
-                mgroup_sub_allowlist: vec![],
-                tenant_allowlist: vec![],
-                flags: 0,
-            };
+            let accesspass = fixture.accesspass.clone();
             fixture
                 .client
                 .expect_get_accesspass()
@@ -1225,7 +1235,9 @@ mod tests {
                     client_ip: Ipv4Addr::new(1, 2, 3, 4),
                     user_payer: payer,
                 }))
-                .returning_st(move |_| Ok(Some((accesspass_pk, accesspass.clone()))));
+                .returning_st(move |_| {
+                    Ok(Some((accesspass_pk, accesspass.lock().unwrap().clone())))
+                });
 
             let users = fixture.users.clone();
             fixture
@@ -1874,6 +1886,227 @@ mod tests {
             .execute_with_service_controller(&fixture.client, &fixture.controller)
             .await;
         assert!(result.is_ok());
+    }
+
+    /// Multicast connect succeeds when the AccessPass has last_access_epoch = 0 (expired).
+    /// Multicast access is gated by mgroup_*_allowlist, not by epoch.
+    #[tokio::test]
+    async fn test_connect_command_multicast_publisher_with_expired_accesspass() {
+        let mut fixture = TestFixture::new();
+        // Expire the access pass (last_access_epoch < current_epoch). The CLI must NOT
+        // reject the connect for multicast.
+        fixture.accesspass.lock().unwrap().last_access_epoch = 0;
+
+        let (mcast_group_pk, _mcast_group) = fixture.add_multicast_group("test-group", "239.0.0.1");
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+        let user = fixture.create_user(UserType::Multicast, device1_pk, "1.2.3.4");
+        fixture.expect_create_subscribe_user(
+            Pubkey::new_unique(),
+            &user,
+            mcast_group_pk,
+            true,
+            false,
+        );
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec!["test-group".to_string()],
+                sub_groups: vec![],
+            },
+            client_ip: Some(user.client_ip.to_string()),
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "multicast connect must succeed with expired access pass, got: {:?}",
+            result.err()
+        );
+    }
+
+    /// Multicast subscriber connect succeeds with expired access pass — symmetric to publisher.
+    #[tokio::test]
+    async fn test_connect_command_multicast_subscriber_with_expired_accesspass() {
+        let mut fixture = TestFixture::new();
+        fixture.accesspass.lock().unwrap().last_access_epoch = 0;
+
+        let (mcast_group_pk, _mcast_group) = fixture.add_multicast_group("test-group", "239.0.0.1");
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+        let user = fixture.create_user(UserType::Multicast, device1_pk, "1.2.3.4");
+        fixture.expect_create_subscribe_user(
+            Pubkey::new_unique(),
+            &user,
+            mcast_group_pk,
+            false,
+            true,
+        );
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec!["test-group".to_string()],
+            },
+            client_ip: Some(user.client_ip.to_string()),
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "multicast subscriber connect must succeed with expired access pass: {:?}",
+            result.err()
+        );
+    }
+
+    /// Existing IBRL user adding a multicast subscription with expired access pass succeeds.
+    /// Exercises the `(Some(ibrl), None)` branch of `find_or_create_user_and_subscribe`:
+    /// a separate Multicast user is created via CreateSubscribeUser on a different device.
+    #[tokio::test]
+    async fn test_add_multicast_to_existing_ibrl_user_with_expired_accesspass() {
+        let mut fixture = TestFixture::new();
+        fixture.accesspass.lock().unwrap().last_access_epoch = 0;
+
+        let (mcast_group_pk, _mcast_group) = fixture.add_multicast_group("test-group", "239.0.0.1");
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+        let (device2_pk, _device2) = fixture.add_device(DeviceType::Hybrid, 110, true);
+
+        // Existing IBRL user on device1
+        let ibrl_user = fixture.create_user(UserType::IBRL, device1_pk, "1.2.3.4");
+        let _ibrl_user_pk = fixture.add_user(&ibrl_user);
+
+        // Expect a new Multicast user to be created on device2 (concurrent tunnels = different device)
+        let mcast_user = fixture.create_user(UserType::Multicast, device2_pk, "1.2.3.4");
+        fixture.expect_create_subscribe_user(
+            Pubkey::new_unique(),
+            &mcast_user,
+            mcast_group_pk,
+            false,
+            true,
+        );
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec!["test-group".to_string()],
+            },
+            client_ip: Some(ibrl_user.client_ip.to_string()),
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "adding multicast to existing IBRL user must succeed with expired access pass: {:?}",
+            result.err()
+        );
+    }
+
+    /// Existing multicast user subscribes to a new group with expired access pass.
+    /// Exercises the `(_, Some(mcast))` branch of `find_or_create_user_and_subscribe`,
+    /// which calls UpdateMulticastGroupRoles (the on-chain processor never had an epoch
+    /// check; this test verifies the CLI gate no longer blocks it either).
+    #[tokio::test]
+    async fn test_connect_command_multicast_add_group_to_existing_user_with_expired_accesspass() {
+        let mut fixture = TestFixture::new();
+        fixture.accesspass.lock().unwrap().last_access_epoch = 0;
+
+        let (mcast_group_pk, _mcast_group) = fixture.add_multicast_group("test-group", "239.0.0.1");
+        let (mcast_group2_pk, _mcast_group2) =
+            fixture.add_multicast_group("test-group2", "239.0.0.2");
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+
+        // Existing multicast user already subscribed to test-group
+        let mut user = fixture.create_user(UserType::Multicast, device1_pk, "1.2.3.4");
+        user.subscribers.push(mcast_group_pk);
+        let user_pk = fixture.add_user(&user);
+
+        // Expect UpdateMulticastGroupRoles for the new group
+        fixture.expect_update_multicastgroup_roles(
+            user_pk,
+            mcast_group2_pk,
+            user.client_ip,
+            false,
+            true,
+        );
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec!["test-group2".to_string()],
+            },
+            client_ip: Some(user.client_ip.to_string()),
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "adding new group to existing multicast user must succeed with expired access pass: {:?}",
+            result.err()
+        );
+    }
+
+    /// Regression: IBRL connect still fails when the AccessPass has last_access_epoch < current_epoch.
+    #[tokio::test]
+    async fn test_connect_command_ibrl_with_expired_accesspass_fails() {
+        let mut fixture = TestFixture::new();
+        fixture.accesspass.lock().unwrap().last_access_epoch = 0;
+
+        let (_device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::IBRL {
+                tenant: Some("test-tenant".to_string()),
+                allocate_addr: false,
+            },
+            client_ip: Some("1.2.3.4".to_string()),
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_err(),
+            "IBRL connect must still fail with expired access pass"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("AccessPass"),
+            "expected AccessPass error, got: {err}"
+        );
     }
 
     async fn execute_multicast_test_succeed_adding_second_group(multicast_mode: MulticastMode) {

--- a/smartcontract/cli/src/requirements.rs
+++ b/smartcontract/cli/src/requirements.rs
@@ -100,8 +100,11 @@ pub fn check_balance(client: &dyn CliCommand, spinner: Option<&ProgressBar>) -> 
     }
 }
 
-pub fn check_accesspass(client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::Result<bool> {
-    let epoch = client.get_epoch()?;
+pub fn check_accesspass(
+    client: &dyn CliCommand,
+    client_ip: Ipv4Addr,
+    enforce_epoch: bool,
+) -> eyre::Result<bool> {
     let (_, accesspass) = client
         .get_accesspass(GetAccessPassCommand {
             client_ip,
@@ -109,6 +112,10 @@ pub fn check_accesspass(client: &dyn CliCommand, client_ip: Ipv4Addr) -> eyre::R
         })?
         .ok_or_else(|| eyre::eyre!("Access Pass not found"))?;
 
+    if !enforce_epoch {
+        return Ok(true);
+    }
+    let epoch = client.get_epoch()?;
     Ok(accesspass.last_access_epoch >= epoch)
 }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
@@ -6,7 +6,7 @@ use crate::{
     state::{
         accesspass::{AccessPass, AccessPassStatus},
         globalstate::GlobalState,
-        user::{User, UserStatus},
+        user::{User, UserStatus, UserType},
     },
 };
 use borsh::BorshSerialize;
@@ -98,7 +98,11 @@ pub fn process_check_access_pass_user(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    user.status = if accesspass.status == AccessPassStatus::Expired {
+    // Multicast users are not subject to epoch expiry — their access is gated by
+    // mgroup_*_allowlist, not by accesspass.last_access_epoch.
+    user.status = if user.user_type == UserType::Multicast {
+        UserStatus::Activated
+    } else if accesspass.status == AccessPassStatus::Expired {
         UserStatus::OutOfCredits
     } else {
         UserStatus::Activated

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
@@ -206,16 +206,19 @@ pub fn create_user_core(
         }
     }
 
-    // Check Initial epoch
-    let clock = Clock::get()?;
-    let current_epoch = clock.epoch;
-    if accesspass.last_access_epoch < current_epoch {
-        msg!(
-            "Invalid epoch last_access_epoch: {} < current_epoch: {}",
-            accesspass.last_access_epoch,
-            current_epoch
-        );
-        return Err(DoubleZeroError::AccessPassUnauthorized.into());
+    // Enforce epoch validity for unicast users only. Multicast access is
+    // governed by mgroup_*_allowlist on the access pass, not by epoch.
+    if user_type != UserType::Multicast {
+        let clock = Clock::get()?;
+        let current_epoch = clock.epoch;
+        if accesspass.last_access_epoch < current_epoch {
+            msg!(
+                "Invalid epoch last_access_epoch: {} < current_epoch: {}",
+                accesspass.last_access_epoch,
+                current_epoch
+            );
+            return Err(DoubleZeroError::AccessPassUnauthorized.into());
+        }
     }
 
     // Read validator_pubkey from AccessPass

--- a/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
@@ -38,8 +38,9 @@ use doublezero_serviceability::{
         },
         tenant::create::TenantCreateArgs,
         user::{
-            activate::UserActivateArgs, closeaccount::UserCloseAccountArgs,
-            create_subscribe::UserCreateSubscribeArgs, delete::UserDeleteArgs,
+            activate::UserActivateArgs, check_access_pass::CheckUserAccessPassArgs,
+            closeaccount::UserCloseAccountArgs, create_subscribe::UserCreateSubscribeArgs,
+            delete::UserDeleteArgs,
         },
     },
     resource::ResourceType,
@@ -1087,6 +1088,220 @@ async fn test_create_subscribe_user_ignores_tenant_allowlist() {
         .unwrap();
     assert_eq!(user.status, UserStatus::Pending);
     assert_eq!(user.subscribers, vec![mgroup_pubkey]);
+}
+
+/// Multicast user creation succeeds when the access-pass has last_access_epoch < current_epoch.
+///
+/// Regression test: multicast connections are not subject to epoch expiry — access is gated
+/// by mgroup_*_allowlist on the access pass. Setting `last_access_epoch = 0` (effectively
+/// expired) should not block `CreateSubscribeUser` for `UserType::Multicast`.
+#[tokio::test]
+async fn test_create_subscribe_user_ignores_expired_epoch() {
+    let client_ip = [100, 0, 0, 9];
+    let f = setup_create_subscribe_fixture(client_ip).await;
+    let CreateSubscribeFixture {
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        device_pubkey,
+        accesspass_pubkey,
+        mgroup_pubkey,
+        user_ip,
+        ..
+    } = f;
+
+    // Overwrite the access pass with last_access_epoch: 0 (expired)
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 0,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Multicast user creation should succeed even with last_access_epoch = 0
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::Multicast);
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: user_ip,
+            publisher: true,
+            subscriber: false,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+            owner: Pubkey::default(),
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let user = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user.status, UserStatus::Pending);
+    assert_eq!(user.publishers, vec![mgroup_pubkey]);
+    assert_eq!(user.user_type, UserType::Multicast);
+}
+
+/// CheckUserAccessPass keeps multicast users Activated when the access-pass is Expired.
+///
+/// Regression test: the activator's periodic re-check must not transition multicast users
+/// to OutOfCredits based on `last_access_epoch`, since multicast access is gated by
+/// mgroup_*_allowlist, not by epoch.
+#[tokio::test]
+async fn test_check_access_pass_multicast_stays_activated() {
+    let client_ip = [100, 0, 0, 10];
+    let f = setup_create_subscribe_fixture(client_ip).await;
+    let CreateSubscribeFixture {
+        mut banks_client,
+        payer,
+        program_id,
+        globalstate_pubkey,
+        device_pubkey,
+        accesspass_pubkey,
+        mgroup_pubkey,
+        user_ip,
+        user_tunnel_block,
+        multicast_publisher_block,
+        tunnel_ids,
+        dz_prefix_block,
+    } = f;
+
+    // Create a Pending multicast publisher user
+    let (user_pubkey, _) = get_user_pda(&program_id, &user_ip, UserType::Multicast);
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateSubscribeUser(UserCreateSubscribeArgs {
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: user_ip,
+            publisher: true,
+            subscriber: false,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+            owner: Pubkey::default(),
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(device_pubkey, false),
+            AccountMeta::new(mgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Activate the user (Pending → Activated)
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::ActivateUser(UserActivateArgs {
+            tunnel_id: 0,
+            tunnel_net: "0.0.0.0/0".parse().unwrap(),
+            dz_ip: [0, 0, 0, 0].into(),
+            dz_prefix_count: 1,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+        }),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(tunnel_ids, false),
+            AccountMeta::new(dz_prefix_block, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let user_activated = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(user_activated.status, UserStatus::Activated);
+
+    // Expire the access pass (last_access_epoch = 0)
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: user_ip,
+            last_access_epoch: 0,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Run CheckUserAccessPass — multicast user should NOT transition to OutOfCredits
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CheckUserAccessPass(CheckUserAccessPassArgs {}),
+        vec![
+            AccountMeta::new(user_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let user_after_check = get_account_data(&mut banks_client, user_pubkey)
+        .await
+        .expect("User should exist")
+        .get_user()
+        .unwrap();
+    assert_eq!(
+        user_after_check.status,
+        UserStatus::Activated,
+        "Multicast user must stay Activated when access-pass is Expired"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary of Changes
- Enables users to connect to send and receive multicast traffic even when their access pass does not have an active tenant access (i.e., `last_access_epoch < current_epoch`). Multicast access is gated by `mgroup_pub_allowlist` and `mgroup_sub_allowlist` on the access pass, not by the epoch credits used for IBRL/unicast.
- `create_subscribe_user` (program): no longer rejects `UserType::Multicast` with `AccessPassUnauthorized` when the access pass epoch is expired.
- `check_access_pass` (program): keeps multicast users in `Activated` status even when the access pass is in `Expired` state; IBRL/unicast still transition to `OutOfCredits`.
- `doublezero connect multicast` (client): only verifies the existence of the AccessPass; epoch enforcement is dropped for multicast flows. IBRL paths are unchanged and still require `last_access_epoch >= current_epoch`.
- `check_accesspass` (CLI helper) gains an `enforce_epoch` argument so callers can request existence-only verification.

## Testing Verification
- Added program-side test in `tests/create_subscribe_user_test.rs` covering multicast user creation when the access pass epoch is expired (must succeed) and confirming unicast behavior is unchanged.
- Added client-side tests in `command/connect.rs` for multicast publisher and multicast subscriber connect flows with an expired access pass, plus a case for an existing IBRL user adding a multicast subscription.
- Verified IBRL/unicast connect still fails with expired access pass via existing tests.
- `make rust-fmt` and `make rust-lint` clean.