### PR TITLE
sdk: document FeatureFlags bit 0 reservation in Go SDK

### DIFF
--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -81,9 +81,14 @@ type GlobalState struct {
 	UserAirdropLamports        uint64
 	HealthOraclePK             [32]byte
 	QAAllowlist                [][32]byte
-	FeatureFlags               Uint128
-	FeedAuthorityPK            [32]byte
-	PubKey                     [32]byte
+	// FeatureFlags is a bitmask of u128. Bit 0 is the deprecated
+	// OnChainAllocation flag (onchain allocation is now always on) and is
+	// reserved — it must never be reused for a new feature. Source of truth
+	// for bit assignments lives in
+	// smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs.
+	FeatureFlags    Uint128
+	FeedAuthorityPK [32]byte
+	PubKey          [32]byte
 }
 
 type Location struct {


### PR DESCRIPTION
## Summary

- Add a doc-comment on `GlobalState.FeatureFlags` in the Go SDK noting bit 0 is the deprecated `OnChainAllocation` flag and is reserved — must never be reused.
- Points readers at the Rust source of truth (`smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs`).

No code changes. Confirmed via `grep -rn '\.FeatureFlags' --include='*.go'` that no Go consumer interprets the field as named bits; usage is deserialization-only.

Phase 4, PR 4.4 of the activator-removal effort. Closes #3616. Tracker: #3607.

## Testing Verification

- `go build ./smartcontract/sdk/go/...` — clean.
- `go test ./smartcontract/sdk/go/...` — `serviceability`, `telemetry`, and root sdk packages all pass.
- Re-ran `grep -rn '\.FeatureFlags' --include='*.go'` from the repo root: output unchanged (one match in `deserialize.go`, deserialization-only).