### PR TITLE
sdk/serviceability: document feature_flags bit 0 reservation

### DIFF
--- a/sdk/serviceability/python/serviceability/state.py
+++ b/sdk/serviceability/python/serviceability/state.py
@@ -540,6 +540,10 @@ class GlobalState:
     user_airdrop_lamports: int = 0
     health_oracle_pk: Pubkey = Pubkey.default()
     qa_allowlist: list[Pubkey] = field(default_factory=list)
+    # u128 bitmask. Bit 0 is the deprecated OnChainAllocation flag (onchain
+    # allocation is now always on) and is reserved — must never be reused.
+    # Source of truth:
+    # smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs
     feature_flags: int = 0
     feed_authority_pk: Pubkey = Pubkey.default()
 

--- a/sdk/serviceability/typescript/serviceability/state.ts
+++ b/sdk/serviceability/typescript/serviceability/state.ts
@@ -307,6 +307,10 @@ export interface GlobalState {
   userAirdropLamports: bigint;
   healthOraclePk: PublicKey;
   qaAllowlist: PublicKey[];
+  // u128 bitmask. Bit 0 is the deprecated OnChainAllocation flag
+  // (onchain allocation is now always on) and is reserved — must never be
+  // reused. Source of truth:
+  // smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs.
   featureFlags: bigint;
   feedAuthorityPk: PublicKey;
 }


### PR DESCRIPTION
## Summary

- Add a doc comment on `GlobalState.featureFlags` (TS) and `GlobalState.feature_flags` (Python) noting bit 0 is the deprecated `OnChainAllocation` flag and is reserved.
- Both SDKs carry the field as an opaque u128 (`bigint` / `int`) — neither exposes a `FeatureFlag` enum, so the Rust rename does not propagate further than this comment.
- Each comment points readers at the Rust source of truth (`smartcontract/programs/doublezero-serviceability/src/state/feature_flags.rs`).

Phase 4, PR 4.3 of the activator-removal effort. Closes #3615. Tracker: #3607.

## Testing Verification

- `cd sdk/serviceability/python && uv run pytest` — 121 passed, 24 skipped (compat tests skipped without `SERVICEABILITY_COMPAT_TEST=1`).
- TS compile/test deferred to CI (no local `bun` available); change is comment-only.