### PR TITLE
e2e/qa: surface multicast test failures with richer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - SDK
   - Drop V3 handling from the Go, Python, and TypeScript serviceability readers: remove `DeserializeInterfaceV3` (Go) and the `version === 3` / `version == 3` legacy-slot branches (Python/TS); remove the `TestDeserializeInterfaceV3CrossLanguage` Go test. The forward-compat trailing `interfaces` vec continues to carry `flex_algo_node_segments` via the size-prefixed body — that path is unchanged ([#3664](https://github.com/malbeclabs/doublezero/issues/3664))
   - Let side-Z contributors update a link's `status` / `desired_status` / `delay_override_ns` via `UpdateLinkCommand`; the Rust SDK now auto-detects the signer's side and builds the 4-account side-Z preamble the on-chain processor expects, instead of always sending the side-A layout ([#3702](https://github.com/malbeclabs/doublezero/issues/3702))
+- E2E tests
+  - Make multicast QA failures self-explanatory: require a `Multicast`-typed status entry after multicast connect (instead of accepting a stale IBRL one), retry `MulticastJoin` briefly on "interface not found" to absorb the daemon/kernel race, snapshot host state once after 30s of zero packets, and heartbeat the publisher's tunnel status during send windows to catch silent regressions
 
 ## [v0.22.0](https://github.com/malbeclabs/doublezero/compare/client/v0.21.0...client/v0.22.0) - 2026-05-08
 

--- a/e2e/internal/qa/client_multicast.go
+++ b/e2e/internal/qa/client_multicast.go
@@ -20,6 +20,8 @@ const (
 	leaveMulticastGroupTimeout          = 90 * time.Second
 	waitForMulticastGroupCreatedTimeout = 90 * time.Second
 	waitForMulticastReportTimeout       = 90 * time.Second
+	multicastJoinRetryTimeout           = 15 * time.Second
+	multicastReportStallThreshold       = 30 * time.Second
 
 	multicastInterfaceName = "doublezero1"
 
@@ -219,6 +221,35 @@ func (c *Client) MulticastSend(ctx context.Context, group *MulticastGroup, durat
 	return nil
 }
 
+// MonitorStatusUntilDone polls tunnel status and info-logs any transition until
+// ctx is cancelled. Run as a goroutine alongside long-running multicast operations.
+func (c *Client) MonitorStatusUntilDone(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	prev := c.summarizeStatusesForLog(ctx)
+	c.log.Debug("Status monitor baseline", "host", c.Host, "statuses", prev)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cur := c.summarizeStatusesForLog(ctx)
+			if cur != prev {
+				c.log.Info("Status transition detected",
+					"host", c.Host,
+					"prev", prev,
+					"curr", cur,
+				)
+				prev = cur
+			}
+		}
+	}
+}
+
 func (c *Client) MulticastJoin(ctx context.Context, groups ...*MulticastGroup) error {
 	codes := make([]string, len(groups))
 	pbGroups := make([]*pb.MulticastGroup, len(groups))
@@ -231,14 +262,46 @@ func (c *Client) MulticastJoin(ctx context.Context, groups ...*MulticastGroup) e
 		}
 	}
 	c.log.Debug("Joining multicast groups", "host", c.Host, "codes", codes)
-	_, err := c.grpcClient.MulticastJoin(ctx, &pb.MulticastJoinRequest{
-		Groups: pbGroups,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to join multicast groups on host %s: %w", c.Host, err)
+
+	// The kernel interface can briefly lag the daemon's "status up" report.
+	deadline := time.Now().Add(multicastJoinRetryTimeout)
+	var lastErr error
+	for {
+		_, err := c.grpcClient.MulticastJoin(ctx, &pb.MulticastJoinRequest{
+			Groups: pbGroups,
+		})
+		if err == nil {
+			c.log.Debug("Joined multicast groups", "host", c.Host, "codes", codes)
+			return nil
+		}
+		lastErr = err
+		if !strings.Contains(err.Error(), "not found") || time.Now().After(deadline) {
+			break
+		}
+		c.log.Debug("Multicast interface not yet ready, retrying", "host", c.Host, "iface", multicastInterfaceName, "err", err)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("join cancelled on host %s while waiting for %s: %w", c.Host, multicastInterfaceName, ctx.Err())
+		case <-time.After(waitInterval):
+		}
 	}
-	c.log.Debug("Joined multicast groups", "host", c.Host, "codes", codes)
-	return nil
+
+	statusSummary := c.summarizeStatusesForLog(ctx)
+	return fmt.Errorf("failed to join multicast groups on host %s after %s: %w (host status: %s)",
+		c.Host, multicastJoinRetryTimeout, lastErr, statusSummary)
+}
+
+func (c *Client) summarizeStatusesForLog(ctx context.Context) string {
+	statuses, err := c.GetUserStatuses(ctx)
+	if err != nil {
+		return "<unavailable: " + err.Error() + ">"
+	}
+	parts := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		parts = append(parts, fmt.Sprintf("{type=%s tunnel=%s session=%q dzIP=%s}",
+			s.UserType, s.TunnelName, s.SessionStatus, s.DoubleZeroIp))
+	}
+	return strings.Join(parts, " ")
 }
 
 func (c *Client) WaitForMulticastReport(ctx context.Context, group *MulticastGroup) (*pb.MulticastReport, error) {
@@ -263,6 +326,8 @@ func (c *Client) WaitForMulticastReports(ctx context.Context, groups []*Multicas
 	c.log.Debug("Waiting for multicast reports", "host", c.Host, "codes", codes)
 
 	var reports map[string]*pb.MulticastReport
+	start := time.Now()
+	stallDiagnosticsDumped := false
 	err := poll.Until(ctx, func() (bool, error) {
 		resp, err := c.grpcClient.MulticastReport(ctx, &pb.MulticastReportRequest{
 			Groups: pbGroups,
@@ -287,6 +352,10 @@ func (c *Client) WaitForMulticastReports(ctx context.Context, groups []*Multicas
 		if allReceived {
 			reports = resp.Reports
 		}
+		if !allReceived && !stallDiagnosticsDumped && time.Since(start) > multicastReportStallThreshold {
+			c.dumpMulticastStallDiagnostics(ctx, groups, resp.Reports)
+			stallDiagnosticsDumped = true
+		}
 		return allReceived, nil
 	}, waitForMulticastReportTimeout, waitInterval)
 	if err != nil {
@@ -294,6 +363,50 @@ func (c *Client) WaitForMulticastReports(ctx context.Context, groups []*Multicas
 	}
 	c.log.Debug("Confirmed multicast reports", "host", c.Host, "codes", codes)
 	return reports, nil
+}
+
+func (c *Client) dumpMulticastStallDiagnostics(ctx context.Context, groups []*MulticastGroup, partial map[string]*pb.MulticastReport) {
+	statuses, statusErr := c.GetUserStatuses(ctx)
+	var mcStatus *pb.Status
+	if statusErr == nil {
+		mcStatus = FindMulticastStatus(statuses)
+	}
+	var ifacePresent string
+	switch {
+	case statusErr != nil:
+		ifacePresent = "unknown (status RPC failed)"
+	case mcStatus == nil:
+		ifacePresent = "no Multicast status entry — daemon does not have a multicast tunnel"
+	case mcStatus.TunnelName != multicastInterfaceName:
+		ifacePresent = fmt.Sprintf("unexpected tunnel name: daemon=%s want=%s", mcStatus.TunnelName, multicastInterfaceName)
+	case !IsStatusUp(mcStatus.SessionStatus):
+		ifacePresent = fmt.Sprintf("multicast status not up: %s", mcStatus.SessionStatus)
+	default:
+		ifacePresent = "ok"
+	}
+
+	routeCount := -1
+	if routes, err := c.GetInstalledRoutes(ctx); err == nil {
+		routeCount = len(routes)
+	}
+
+	perGroup := make([]string, 0, len(groups))
+	for _, g := range groups {
+		var pc uint64
+		if r := partial[g.IP.String()]; r != nil {
+			pc = r.PacketCount
+		}
+		perGroup = append(perGroup, fmt.Sprintf("%s(%s)=%d", g.Code, g.IP, pc))
+	}
+
+	c.log.Info("Multicast traffic stalled — diagnostic snapshot",
+		"host", c.Host,
+		"elapsed", multicastReportStallThreshold.String(),
+		"multicast_iface_check", ifacePresent,
+		"statuses", c.summarizeStatusesForLog(ctx),
+		"installed_route_count", routeCount,
+		"per_group_packets", strings.Join(perGroup, ", "),
+	)
 }
 
 func (c *Client) AddPublisherToMulticastGroupAllowlist(ctx context.Context, code string, pubkey solana.PublicKey, clientIP string) error {

--- a/e2e/qa_multicast_test.go
+++ b/e2e/qa_multicast_test.go
@@ -355,6 +355,8 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	require.Greater(t, reportB.PacketCount, uint64(0), "subscriberB received no packets from group B")
 	log.Info("Received multicast packets", "subscriber", subscriberB.Host, "group", groupB.Code, "packetCount", reportB.PacketCount)
 
+	phase1Cancel()
+
 	// --- Phase 2: Incremental subscription ---
 	// SubA adds group B without disconnecting — verify tunnel stays up, identity preserved, and receives from both.
 	log.Debug("Phase 2: incremental subscription (no disconnect)")
@@ -403,6 +405,8 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 
 	log.Debug("Phase 2 passed: incremental subscription verified",
 		"groupA_packets", reportA.PacketCount, "groupB_packets", reportB.PacketCount)
+
+	phase2Cancel()
 
 	// --- Phase 3: Incremental publish after subscribe (cross-role) ---
 	// SubA adds a publisher role on group A without disconnecting. Both roles use

--- a/e2e/qa_multicast_test.go
+++ b/e2e/qa_multicast_test.go
@@ -151,7 +151,7 @@ func TestQA_MulticastConnectivity(t *testing.T) {
 
 	// Wait for status of all clients to be up.
 	for _, client := range clients {
-		err := client.WaitForStatusUp(ctx)
+		err := client.WaitForMulticastStatusUp(ctx)
 		require.NoError(t, err, "failed to wait for status")
 	}
 
@@ -174,6 +174,10 @@ func validateMulticastConnectivity(t *testing.T, ctx context.Context, log *slog.
 	go func() {
 		_ = publisher.MulticastSend(ctx, group, 120*time.Second)
 	}()
+
+	monCtx, monCancel := context.WithCancel(ctx)
+	defer monCancel()
+	go publisher.MonitorStatusUntilDone(monCtx, 10*time.Second)
 
 	// Get multicast report from each subscriber.
 	for _, subscriber := range subscribers {
@@ -304,7 +308,7 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	log.Debug("Connecting publisher to both groups simultaneously", "codes", []string{groupA.Code, groupB.Code})
 	err = publisher.ConnectUserMulticast_Publisher_Wait(ctx, groupA.Code, groupB.Code)
 	require.NoError(t, err, "failed to connect publisher to groups")
-	err = publisher.WaitForStatusUp(ctx)
+	err = publisher.WaitForMulticastStatusUp(ctx)
 	require.NoError(t, err, "failed to wait for publisher status up")
 
 	// --- Phase 1: Selective fan-out ---
@@ -319,9 +323,9 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	err = subscriberB.ConnectUserMulticast_Subscriber_Wait(ctx, groupB.Code)
 	require.NoError(t, err, "failed to connect subscriberB to group B")
 
-	err = subscriberA.WaitForStatusUp(ctx)
+	err = subscriberA.WaitForMulticastStatusUp(ctx)
 	require.NoError(t, err, "failed to wait for subscriberA status up")
-	err = subscriberB.WaitForStatusUp(ctx)
+	err = subscriberB.WaitForMulticastStatusUp(ctx)
 	require.NoError(t, err, "failed to wait for subscriberB status up")
 
 	err = subscriberA.MulticastJoin(ctx, groupA)
@@ -336,6 +340,10 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	go func() {
 		_ = publisher.MulticastSend(ctx, groupB, 120*time.Second)
 	}()
+
+	phase1Ctx, phase1Cancel := context.WithCancel(ctx)
+	defer phase1Cancel()
+	go publisher.MonitorStatusUntilDone(phase1Ctx, 10*time.Second)
 
 	reportA, err := subscriberA.WaitForMulticastReport(ctx, groupA)
 	require.NoError(t, err, "failed to get report for group A from subscriberA")
@@ -359,7 +367,7 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	err = subscriberA.ConnectUserMulticast_Subscriber_AddTunnel(ctx, groupB.Code)
 	require.NoError(t, err, "failed to incrementally add group B to subscriberA")
 
-	err = subscriberA.WaitForStatusUp(ctx)
+	err = subscriberA.WaitForMulticastStatusUp(ctx)
 	require.NoError(t, err, "failed to wait for subscriberA status up after adding group B")
 
 	// Verify user pubkey is preserved (user was not recreated).
@@ -377,6 +385,10 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	go func() {
 		_ = publisher.MulticastSend(ctx, groupB, 120*time.Second)
 	}()
+
+	phase2Ctx, phase2Cancel := context.WithCancel(ctx)
+	defer phase2Cancel()
+	go publisher.MonitorStatusUntilDone(phase2Ctx, 10*time.Second)
 
 	reports, err := subscriberA.WaitForMulticastReports(ctx, []*qa.MulticastGroup{groupA, groupB})
 	require.NoError(t, err, "failed to get reports from both groups")
@@ -402,7 +414,7 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	err = subscriberA.ConnectUserMulticast_Publisher_AddTunnel(ctx, groupA.Code)
 	require.NoError(t, err, "failed to incrementally add publisher role to subscriberA")
 
-	err = subscriberA.WaitForStatusUp(ctx)
+	err = subscriberA.WaitForMulticastStatusUp(ctx)
 	require.NoError(t, err, "failed to wait for subscriberA status up as pub+sub")
 
 	err = subscriberA.MulticastJoin(ctx, groupA)
@@ -418,6 +430,11 @@ func TestQA_MulticastPublisherMultipleGroups(t *testing.T) {
 	go func() {
 		_ = subscriberA.MulticastSend(ctx, groupA, 120*time.Second)
 	}()
+
+	phase3Ctx, phase3Cancel := context.WithCancel(ctx)
+	defer phase3Cancel()
+	go publisher.MonitorStatusUntilDone(phase3Ctx, 10*time.Second)
+	go subscriberA.MonitorStatusUntilDone(phase3Ctx, 10*time.Second)
 
 	reportPubSub, err := subscriberA.WaitForMulticastReport(ctx, groupA)
 	require.NoError(t, err, "failed to get report for group A as pub+sub")


### PR DESCRIPTION
## Summary of Changes
- Require a `Multicast`-typed status entry after every multicast connect (`WaitForMulticastStatusUp` instead of `WaitForStatusUp`), so the test fails fast on a lingering IBRL status entry instead of proceeding and erroring 90s later at IGMP join.
- Retry `MulticastJoin` for up to 15s on "interface not found" errors to absorb the brief race between daemon status-up and kernel netlink creation of `doublezero1`. Final-failure error includes the host's tunnel status summary.
- Snapshot host state once after 30s of zero packets in `WaitForMulticastReports` (multicast interface health check, installed route count, per-group counts) instead of dozens of identical "packetCount=0" debug lines.
- Heartbeat the publisher's tunnel status every 10s during multicast send/report windows via new `MonitorStatusUntilDone`. Logs any transition in `(UserType, TunnelName, SessionStatus, DoubleZeroIp)` so silent state regressions become visible.

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net   |
|-------------|-------|-------------|-------|
| Core logic  |     1 | +120 / -7   | +113  |
| Tests       |     1 | +23  / -6   |  +17  |
| Docs        |     1 | +2   / -0   |   +2  |
| **Total**   |     3 | +145 / -13  | +132  |

Almost entirely diagnostic instrumentation in the QA harness; the test file itself only swaps wait helpers and wires the status monitor into each send window.

<details>
<summary>Key files (click to expand)</summary>

- `e2e/internal/qa/client_multicast.go` — adds `MonitorStatusUntilDone`, `summarizeStatusesForLog`, and `dumpMulticastStallDiagnostics`; rewrites `MulticastJoin` to retry on transient kernel-interface lag; adds stall-threshold snapshot to `WaitForMulticastReports`.
- `e2e/qa_multicast_test.go` — replaces six `WaitForStatusUp` calls with `WaitForMulticastStatusUp` across `TestQA_MulticastConnectivity` and `TestQA_MulticastPublisherMultipleGroups`; runs `MonitorStatusUntilDone` as a goroutine alongside each `MulticastSend` window.

</details>

## Testing Verification
- Ran `TestQA_MulticastConnectivity` and `TestQA_MulticastPublisherMultipleGroups` against devnet with 4 hosts (`chi-dn-bm1..4`). `MulticastPublisherMultipleGroups` passed in 191s through all three phases (selective fan-out, incremental subscription, cross-role publish).
- `MulticastConnectivity` triggered the targeted diagnostic on an unhealthy host: `failed to wait for Multicast status to be up on host chi-dn-bm1: ...` with the dump showing `sessionStatus="Network Unreachable" tunnelName=doublezero1 userType=Multicast`. Root cause was infrastructure (chi-dn-bm1 only reaches one device) — exactly the failure shape this change is intended to surface; with the prior code this would have been a generic `WaitForStatusUp` timeout.
- Verified the status-monitor baseline log appears once per phase on the happy path and no spurious transition events fire.