### PR TITLE
sdk: allow either side of a link to drain it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- client: break latency ties with avg latency ([#362](https://github.com/malbeclabs/doublezero/pull/3692))
-
 ### Breaking
 
 ### Changes
@@ -14,9 +12,11 @@ All notable changes to this project will be documented in this file.
   - Skip `last_access_epoch` enforcement for `UserType::Multicast` in `CreateSubscribeUser` and `CheckUserAccessPass`. Multicast access is gated by `mgroup_pub_allowlist` / `mgroup_sub_allowlist` on the access pass, not by epoch, so multicast users can be created and remain `Activated` regardless of the access-pass expiry. IBRL/unicast epoch enforcement is unchanged.
 - Client
   - `doublezero connect multicast` no longer fails the client-side `check_accesspass` epoch check; only the AccessPass existence is verified for multicast. IBRL paths still enforce `last_access_epoch >= current_epoch`.
+  - Break latency ties using average latency when ranking candidate devices ([#3692](https://github.com/malbeclabs/doublezero/pull/3692))
   - Delete `InterfaceV3` and the `InterfaceDeprecated::V3` variant from the serviceability program. V3 was added by an earlier change, never written to production accounts, and reverted in #3653 / no longer produced after #3667; this removes the dead type. Discriminant 3 is now an unused reserved slot in `InterfaceDeprecated`'s encoding space — unknown discriminants fall through to `InterfaceV2::default()`. Removes the V3 struct, its helper impls (`From<InterfaceV2>`, `TryFrom<&InterfaceV1>`, `Default`, `TryFrom<&InterfaceV3> for InterfaceV2`), V3 match arms in `InterfaceDeprecated::to_v2`/`size`/`Device::TryFrom`, and the V3 cross-language byte-layout debug test. On-disk write format is unchanged ([#3664](https://github.com/malbeclabs/doublezero/issues/3664))
 - SDK
   - Drop V3 handling from the Go, Python, and TypeScript serviceability readers: remove `DeserializeInterfaceV3` (Go) and the `version === 3` / `version == 3` legacy-slot branches (Python/TS); remove the `TestDeserializeInterfaceV3CrossLanguage` Go test. The forward-compat trailing `interfaces` vec continues to carry `flex_algo_node_segments` via the size-prefixed body — that path is unchanged ([#3664](https://github.com/malbeclabs/doublezero/issues/3664))
+  - Let side-Z contributors update a link's `status` / `desired_status` / `delay_override_ns` via `UpdateLinkCommand`; the Rust SDK now auto-detects the signer's side and builds the 4-account side-Z preamble the on-chain processor expects, instead of always sending the side-A layout ([#3702](https://github.com/malbeclabs/doublezero/issues/3702))
 
 ## [v0.22.0](https://github.com/malbeclabs/doublezero/compare/client/v0.21.0...client/v0.22.0) - 2026-05-08
 

--- a/smartcontract/sdk/rs/src/commands/link/update.rs
+++ b/smartcontract/sdk/rs/src/commands/link/update.rs
@@ -1,4 +1,10 @@
-use crate::{commands::link::get::GetLinkCommand, DoubleZeroClient, GetGlobalStateCommand};
+use crate::{
+    commands::{
+        contributor::get::GetContributorCommand, device::get::GetDeviceCommand,
+        link::get::GetLinkCommand,
+    },
+    DoubleZeroClient, GetGlobalStateCommand,
+};
 use doublezero_program_common::{types::NetworkV4, validate_account_code};
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
@@ -43,6 +49,21 @@ impl UpdateLinkCommand {
         .execute(client)
         .map_err(|_err| eyre::eyre!("Link not found"))?;
 
+        // Fetch to check if side Z is the caller
+        let payer = client.get_payer();
+
+        let (_, device_z) = GetDeviceCommand {
+            pubkey_or_code: link.side_z_pk.to_string(),
+        }
+        .execute(client)
+        .map_err(|_err| eyre::eyre!("Device Z not found"))?;
+
+        let (_, contributor_z) = GetContributorCommand {
+            pubkey_or_code: device_z.contributor_pk.to_string(),
+        }
+        .execute(client)
+        .map_err(|_err| eyre::eyre!("Contributor Z not found"))?;
+
         let code = self
             .code
             .as_ref()
@@ -61,11 +82,20 @@ impl UpdateLinkCommand {
             is_feature_enabled(globalstate.feature_flags, FeatureFlag::OnChainAllocation)
                 && updating_tunnel_resources;
 
-        let mut accounts = vec![
-            AccountMeta::new(self.pubkey, false),
-            AccountMeta::new(link.contributor_pk, false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ];
+        let mut accounts = if contributor_z.owner == payer {
+            vec![
+                AccountMeta::new(self.pubkey, false),
+                AccountMeta::new(device_z.contributor_pk, false),
+                AccountMeta::new(link.side_z_pk, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ]
+        } else {
+            vec![
+                AccountMeta::new(self.pubkey, false),
+                AccountMeta::new(link.contributor_pk, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ]
+        };
 
         // Device accounts needed when updating tunnel_net (for interface IP update)
         if self.tunnel_net.is_some() {
@@ -122,5 +152,144 @@ impl UpdateLinkCommand {
             }),
             accounts,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{tests::utils::create_test_client, MockDoubleZeroClient};
+    use doublezero_serviceability::{
+        pda::get_globalstate_pda,
+        state::{
+            accountdata::AccountData,
+            accounttype::AccountType,
+            contributor::{Contributor, ContributorStatus},
+            device::Device,
+            link::Link,
+        },
+    };
+    use mockall::predicate;
+
+    fn make_contributor(owner: Pubkey, code: &str) -> Contributor {
+        Contributor {
+            account_type: AccountType::Contributor,
+            owner,
+            index: 1,
+            bump_seed: 0,
+            status: ContributorStatus::Activated,
+            code: code.to_string(),
+            reference_count: 0,
+            ops_manager_pk: Pubkey::default(),
+        }
+    }
+
+    /// Builds and wires the get() mocks for `link`, `side_z` device, and `side_z`'s contributor.
+    /// `contributor_z_owner` controls whether the side-Z path is selected.
+    /// Returns `(link_pubkey, contributor_a_pk, contributor_z_pk, side_z_pk)`.
+    fn setup_link_and_contributors(
+        client: &mut MockDoubleZeroClient,
+        contributor_z_owner: Pubkey,
+    ) -> (Pubkey, Pubkey, Pubkey, Pubkey) {
+        let link_pubkey = Pubkey::new_unique();
+        let contributor_a_pk = Pubkey::new_unique();
+        let contributor_z_pk = Pubkey::new_unique();
+        let side_a_pk = Pubkey::new_unique();
+        let side_z_pk = Pubkey::new_unique();
+
+        let link = Link {
+            contributor_pk: contributor_a_pk,
+            side_a_pk,
+            side_z_pk,
+            ..Default::default()
+        };
+        let device_z = Device {
+            contributor_pk: contributor_z_pk,
+            ..Default::default()
+        };
+        let contributor_z = make_contributor(contributor_z_owner, "co_z");
+
+        client
+            .expect_get()
+            .with(predicate::eq(link_pubkey))
+            .returning(move |_| Ok(AccountData::Link(link.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(side_z_pk))
+            .returning(move |_| Ok(AccountData::Device(device_z.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(contributor_z_pk))
+            .returning(move |_| Ok(AccountData::Contributor(contributor_z.clone())));
+
+        (link_pubkey, contributor_a_pk, contributor_z_pk, side_z_pk)
+    }
+
+    fn drain_command(link_pubkey: Pubkey) -> UpdateLinkCommand {
+        UpdateLinkCommand {
+            pubkey: link_pubkey,
+            code: None,
+            contributor_pk: None,
+            tunnel_type: None,
+            bandwidth: None,
+            mtu: None,
+            delay_ns: None,
+            jitter_ns: None,
+            delay_override_ns: None,
+            status: Some(LinkStatus::SoftDrained),
+            desired_status: None,
+            tunnel_id: None,
+            tunnel_net: None,
+            link_topologies: None,
+            unicast_drained: None,
+        }
+    }
+
+    #[test]
+    fn test_update_link_side_z_uses_4_account_preamble() {
+        let mut client = create_test_client();
+        let payer = client.get_payer();
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        // contributor_z.owner == payer  =>  SDK should pick the side-Z layout
+        let (link_pubkey, _contributor_a_pk, contributor_z_pk, side_z_pk) =
+            setup_link_and_contributors(&mut client, payer);
+
+        client
+            .expect_execute_transaction()
+            .withf(move |_, accounts| {
+                accounts.len() == 4
+                    && accounts[0].pubkey == link_pubkey
+                    && accounts[1].pubkey == contributor_z_pk
+                    && accounts[2].pubkey == side_z_pk
+                    && accounts[3].pubkey == globalstate_pubkey
+            })
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = drain_command(link_pubkey).execute(&client);
+        assert!(res.is_ok(), "execute failed: {:?}", res);
+    }
+
+    #[test]
+    fn test_update_link_side_a_uses_3_account_preamble() {
+        let mut client = create_test_client();
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+
+        // contributor_z.owner != payer  =>  SDK should fall back to the side-A layout
+        let (link_pubkey, contributor_a_pk, _contributor_z_pk, _side_z_pk) =
+            setup_link_and_contributors(&mut client, Pubkey::new_unique());
+
+        client
+            .expect_execute_transaction()
+            .withf(move |_, accounts| {
+                accounts.len() == 3
+                    && accounts[0].pubkey == link_pubkey
+                    && accounts[1].pubkey == contributor_a_pk
+                    && accounts[2].pubkey == globalstate_pubkey
+            })
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = drain_command(link_pubkey).execute(&client);
+        assert!(res.is_ok(), "execute failed: {:?}", res);
     }
 }


### PR DESCRIPTION
Resolves: #3702

## Summary
- The on-chain `process_update_link` processor already accepts a side-Z signer (see `processors/link/update.rs:217-271`, covered by `link_dzx_test.rs`), but the Rust SDK only ever built the side-A account layout — so the CLI rejected drain requests from side-Z contributors with `NotAllowed`. Per RFC 9 line 88, either side should be able to drive `link.status` transitions.
- `UpdateLinkCommand` now reads `client.get_payer()`, fetches the side-Z `Device` and its `Contributor`, and compares the contributor's `owner` to the payer. If it matches side Z, the SDK emits the 4-account preamble `[link, side_z_contributor, side_z_device, globalstate, …]` the processor expects; otherwise it keeps the existing side-A 3-account preamble (which also covers the foundation-allowlist path).
- No CLI changes: `--contributor` continues to flow in only as an instruction arg; side detection is driven by which keypair signs.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | 0 | 0 |
| SDKs | +38 | -9 |
| Tests | +147 | 0 |

## Testing Verification
- New SDK unit tests assert the constructed `AccountMeta` layouts: `test_update_link_side_z_uses_4_account_preamble` and `test_update_link_side_a_uses_3_account_preamble`.
- The on-chain side-Z status-update path is already locked in by `programs/doublezero-serviceability/tests/link_dzx_test.rs::test_dzx_link`, which signs `HardDrained`/`SoftDrained`/`Activated` transitions with side-Z's keypair and the 4-account layout.