### PR TITLE
cli: map AdminGroupBits resource type to CLI

### DIFF
--- a/smartcontract/cli/src/resource/allocate.rs
+++ b/smartcontract/cli/src/resource/allocate.rs
@@ -43,7 +43,10 @@ impl From<AllocateResourceCliCommand> for AllocateResourceCommand {
             ResourceType::TunnelIds
             | ResourceType::LinkIds
             | ResourceType::SegmentRoutingIds
-            | ResourceType::VrfIds => IdOrIp::Id(x.parse::<u16>().expect("Failed to parse ID")),
+            | ResourceType::VrfIds
+            | ResourceType::AdminGroupBits => {
+                IdOrIp::Id(x.parse::<u16>().expect("Failed to parse ID"))
+            }
         });
 
         AllocateResourceCommand {

--- a/smartcontract/cli/src/resource/deallocate.rs
+++ b/smartcontract/cli/src/resource/deallocate.rs
@@ -45,7 +45,8 @@ impl From<DeallocateResourceCliCommand> for DeallocateResourceCommand {
             ResourceType::TunnelIds
             | ResourceType::LinkIds
             | ResourceType::SegmentRoutingIds
-            | ResourceType::VrfIds => {
+            | ResourceType::VrfIds
+            | ResourceType::AdminGroupBits => {
                 IdOrIp::Id(cmd.value.parse::<u16>().expect("Failed to parse ID"))
             }
         };

--- a/smartcontract/cli/src/resource/mod.rs
+++ b/smartcontract/cli/src/resource/mod.rs
@@ -20,6 +20,7 @@ pub enum ResourceType {
     LinkIds,
     SegmentRoutingIds,
     VrfIds,
+    AdminGroupBits,
 }
 
 pub fn resource_type_from(
@@ -45,6 +46,7 @@ pub fn resource_type_from(
         ResourceType::LinkIds => SdkResourceType::LinkIds,
         ResourceType::SegmentRoutingIds => SdkResourceType::SegmentRoutingIds,
         ResourceType::VrfIds => SdkResourceType::VrfIds,
+        ResourceType::AdminGroupBits => SdkResourceType::AdminGroupBits,
     }
 }
 
@@ -137,5 +139,17 @@ mod tests {
     fn test_segment_routing_ids() {
         let result = resource_type_from(ResourceType::SegmentRoutingIds, None, None);
         assert_eq!(result, SdkResourceType::SegmentRoutingIds);
+    }
+
+    #[test]
+    fn test_vrf_ids() {
+        let result = resource_type_from(ResourceType::VrfIds, None, None);
+        assert_eq!(result, SdkResourceType::VrfIds);
+    }
+
+    #[test]
+    fn test_admin_group_bits() {
+        let result = resource_type_from(ResourceType::AdminGroupBits, None, None);
+        assert_eq!(result, SdkResourceType::AdminGroupBits);
     }
 }


### PR DESCRIPTION
## Summary
- Add `AdminGroupBits` to the CLI's clap-facing `ResourceType` enum so `doublezero resource {get,allocate,deallocate,create,close} --resource-type admin-group-bits` is recognized.
- Map the new variant to `SdkResourceType::AdminGroupBits` in `resource_type_from`, and treat it as an ID-range singleton (alongside `LinkIds`/`SegmentRoutingIds`/`VrfIds`) in allocate/deallocate.

The SDK variant, processor (`IdRange(1, 127)`), and PDA derivation were already in place — only the CLI surface needed wiring.

## Testing Verification
- `cargo test -p doublezero_cli resource::` — all 43 tests pass, including new `test_admin_group_bits` and `test_vrf_ids` coverage.
- `cargo clippy -p doublezero_cli --all-targets -- -Dclippy::all -Dwarnings` clean.