### PR TITLE
smartcontract: allow tenant admin to set access pass for their own tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Smartcontract
+  - Tenant administrators can now create or update access passes scoped to their tenant without being added to the foundation allowlist; non-privileged callers cannot remove a tenant they do not administer from an existing access pass.
   - Skip `last_access_epoch` enforcement for `UserType::Multicast` in `CreateSubscribeUser` and `CheckUserAccessPass`. Multicast access is gated by `mgroup_pub_allowlist` / `mgroup_sub_allowlist` on the access pass, not by epoch, so multicast users can be created and remain `Activated` regardless of the access-pass expiry. IBRL/unicast epoch enforcement is unchanged.
 - Client
   - `doublezero connect multicast` no longer fails the client-side `check_accesspass` epoch check; only the AccessPass existence is verified for multicast. IBRL paths still enforce `last_access_epoch >= current_epoch`.

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -107,12 +107,33 @@ pub fn process_set_access_pass(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Parse the global state account & resolve authorization. A caller is allowed if any of:
+    //   - they are the sentinel authority,
+    //   - they are the feed authority,
+    //   - they are in the foundation allowlist, or
+    //   - they are an administrator of the tenant being added (tenant_add_account).
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if globalstate.sentinel_authority_pk != *payer_account.key
-        && globalstate.feed_authority_pk != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
+
+    let is_privileged = globalstate.sentinel_authority_pk == *payer_account.key
+        || globalstate.feed_authority_pk == *payer_account.key
+        || globalstate.foundation_allowlist.contains(payer_account.key);
+
+    // Pre-deserialize the tenant_add account when present so we can both authorize the caller
+    // and later increment its reference_count without double-reading it.
+    let tenant_add_pre = match tenant_add_account {
+        Some(acc) if acc.key != &Pubkey::default() => {
+            assert_eq!(*acc.owner, *program_id, "Invalid Tenant Add Account Owner");
+            Some(Tenant::try_from(acc)?)
+        }
+        _ => None,
+    };
+
+    let is_tenant_admin = tenant_add_pre
+        .as_ref()
+        .map(|t| t.administrators.contains(payer_account.key))
+        .unwrap_or(false);
+
+    if !is_privileged && !is_tenant_admin {
         msg!(
             "sentinel_authority_pk: {} feed_authority_pk: {} payer: {} foundation_allowlist: {:?}",
             globalstate.sentinel_authority_pk,
@@ -274,18 +295,17 @@ pub fn process_set_access_pass(
 
     if let Some(tenant_add_acc) = tenant_add_account {
         if tenant_add_acc.key != &Pubkey::default() {
-            // Validate added tenant account
-            assert_eq!(
-                *tenant_add_acc.owner, *program_id,
-                "Invalid Tenant Add Account Owner"
-            );
+            // We deserialized the tenant up front for authorization. Take it back here
+            // so we can mutate and persist the updated reference_count.
+            let mut tenant_add =
+                tenant_add_pre.expect("tenant_add_pre is Some when tenant_add_acc is non-default");
             assert!(
                 tenant_add_acc.is_writable,
                 "Tenant Add Account is not writable"
             );
-            let mut tenant_add = Tenant::try_from(tenant_add_acc)?;
 
-            // Validate payer is administrator of the tenant
+            // Foundation/sentinel/feed callers must still administer the tenant they add,
+            // matching the prior behavior.
             if !tenant_add.administrators.contains(payer_account.key) {
                 msg!(
                     "Payer {} is not an administrator of tenant {}",

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -278,7 +278,6 @@ pub fn process_set_access_pass(
     // Manage tenant reference counting for added/removed tenants (if provided)
     if let Some(tenant_remove_acc) = tenant_remove_account {
         if tenant_remove_acc.key != &Pubkey::default() {
-            // Validate removed tenant account
             assert_eq!(
                 *tenant_remove_acc.owner, *program_id,
                 "Invalid Tenant Remove Account Owner"
@@ -288,6 +287,19 @@ pub fn process_set_access_pass(
                 "Tenant Remove Account is not writable"
             );
             let mut tenant_remove = Tenant::try_from(tenant_remove_acc)?;
+
+            // Non-privileged callers may only remove a tenant they administer. Privileged
+            // callers (sentinel/feed/foundation) retain unrestricted removal authority to
+            // preserve prior behavior.
+            if !is_privileged && !tenant_remove.administrators.contains(payer_account.key) {
+                msg!(
+                    "Payer {} is not an administrator of tenant {} being removed",
+                    payer_account.key,
+                    tenant_remove_acc.key
+                );
+                return Err(DoubleZeroError::NotAllowed.into());
+            }
+
             tenant_remove.reference_count = tenant_remove.reference_count.saturating_sub(1);
             try_acc_write(&tenant_remove, tenant_remove_acc, payer_account, accounts)?;
         }

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -1419,3 +1419,139 @@ async fn test_set_accesspass_with_tenant_non_admin_fails() {
 
     println!("✅ SetAccessPass correctly rejected non-administrator payer for tenant (error 22)");
 }
+
+#[tokio::test]
+async fn test_set_accesspass_tenant_admin_cannot_replace_other_tenant() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    println!("🟢 Start test_set_accesspass_tenant_admin_cannot_replace_other_tenant");
+
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // Tenant A and its administrator.
+    let admin_acme = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &admin_acme.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+    let acme_code = "acme-tenant";
+    let (tenant_acme, _) = get_tenant_pda(&program_id, acme_code);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTenant(TenantCreateArgs {
+            code: acme_code.to_string(),
+            administrator: admin_acme.pubkey(),
+            token_account: None,
+            metro_routing: true,
+            route_liveness: false,
+        }),
+        vec![
+            AccountMeta::new(tenant_acme, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Tenant B and its administrator.
+    let admin_hyper = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &admin_hyper.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+    let hyper_code = "hyper-tenant";
+    let (tenant_hyper, _) = get_tenant_pda(&program_id, hyper_code);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTenant(TenantCreateArgs {
+            code: hyper_code.to_string(),
+            administrator: admin_hyper.pubkey(),
+            token_account: None,
+            metro_routing: true,
+            route_liveness: false,
+        }),
+        vec![
+            AccountMeta::new(tenant_hyper, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // admin_acme creates an access pass scoped to tenant_acme.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 80);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 10,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+            AccountMeta::new(Pubkey::default(), false),
+            AccountMeta::new(tenant_acme, false),
+        ],
+        &admin_acme,
+    )
+    .await;
+
+    // admin_hyper now attempts to update the same AP, asking the program to swap
+    // tenant_acme out for tenant_hyper. This is the SDK "replace" flow. Must fail.
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 20,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+            AccountMeta::new(tenant_acme, false), // tenant_remove (not administered by admin_hyper)
+            AccountMeta::new(tenant_hyper, false), // tenant_add
+        ],
+        &admin_hyper,
+    )
+    .await;
+
+    assert!(
+        res.is_err(),
+        "SetAccessPass must reject tenant_remove when payer does not administer the removed tenant"
+    );
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(8)"),
+        "Expected NotAllowed error (Custom(8)), got: {}",
+        error_string
+    );
+
+    println!("✅ SetAccessPass correctly rejected cross-tenant replacement");
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -6,7 +6,6 @@ use doublezero_serviceability::{
             check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs,
             set::SetAccessPassArgs,
         },
-        allowlist::foundation::add::AddFoundationAllowlistArgs,
         contributor::create::ContributorCreateArgs,
         device::{activate::DeviceActivateArgs, update::DeviceUpdateArgs},
         tenant::create::TenantCreateArgs,
@@ -1302,19 +1301,6 @@ async fn test_set_accesspass_with_tenant_admin_succeeds() {
             AccountMeta::new(globalstate_pubkey, false),
             AccountMeta::new(vrf_ids_pda, false),
         ],
-        &payer,
-    )
-    .await;
-
-    // Add tenant_admin to foundation_allowlist so they can create access passes
-    execute_transaction(
-        &mut banks_client,
-        recent_blockhash,
-        program_id,
-        DoubleZeroInstruction::AddFoundationAllowlist(AddFoundationAllowlistArgs {
-            pubkey: tenant_admin.pubkey(),
-        }),
-        vec![AccountMeta::new(globalstate_pubkey, false)],
         &payer,
     )
     .await;

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -8,6 +8,7 @@ use doublezero_serviceability::{
         },
         contributor::create::ContributorCreateArgs,
         device::{activate::DeviceActivateArgs, update::DeviceUpdateArgs},
+        globalstate::setauthority::SetAuthorityArgs,
         tenant::create::TenantCreateArgs,
         user::create::UserCreateArgs,
         *,
@@ -1554,4 +1555,215 @@ async fn test_set_accesspass_tenant_admin_cannot_replace_other_tenant() {
     );
 
     println!("✅ SetAccessPass correctly rejected cross-tenant replacement");
+}
+
+#[tokio::test]
+async fn test_set_accesspass_with_sentinel_authority_succeeds() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    println!("🟢 Start test_set_accesspass_with_sentinel_authority_succeeds");
+
+    // Promote a brand-new keypair to sentinel authority.
+    let sentinel = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &sentinel.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            sentinel_authority_pk: Some(sentinel.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // Sentinel (not in foundation_allowlist) creates an access pass without --tenant.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 90);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &sentinel,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get AccessPass")
+        .get_accesspass()
+        .unwrap();
+
+    assert_eq!(accesspass.owner, sentinel.pubkey());
+    assert!(accesspass.tenant_allowlist.is_empty());
+
+    println!("✅ SetAccessPass succeeded for sentinel authority");
+}
+
+#[tokio::test]
+async fn test_set_accesspass_with_feed_authority_succeeds() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    println!("🟢 Start test_set_accesspass_with_feed_authority_succeeds");
+
+    // Promote a brand-new keypair to feed authority.
+    let feed = Keypair::new();
+    transfer(&mut banks_client, &payer, &feed.pubkey(), 10_000_000_000).await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            feed_authority_pk: Some(feed.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // Feed (not in foundation_allowlist) creates an access pass without --tenant.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 91);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &feed,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("Unable to get AccessPass")
+        .get_accesspass()
+        .unwrap();
+
+    assert_eq!(accesspass.owner, feed.pubkey());
+    assert!(accesspass.tenant_allowlist.is_empty());
+
+    println!("✅ SetAccessPass succeeded for feed authority");
+}
+
+#[tokio::test]
+async fn test_set_accesspass_tenant_admin_without_tenant_accounts_fails() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    println!("🟢 Start test_set_accesspass_tenant_admin_without_tenant_accounts_fails");
+
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+
+    // Tenant exists with admin = tenant_admin keypair.
+    let tenant_admin = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &tenant_admin.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+    let tenant_code = "scoped-tenant";
+    let (tenant_pubkey, _) = get_tenant_pda(&program_id, tenant_code);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTenant(TenantCreateArgs {
+            code: tenant_code.to_string(),
+            administrator: tenant_admin.pubkey(),
+            token_account: None,
+            metro_routing: true,
+            route_liveness: false,
+        }),
+        vec![
+            AccountMeta::new(tenant_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(vrf_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // tenant_admin attempts to create an access pass WITHOUT passing the tenant accounts.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 92);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+
+    let res = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 100,
+            allow_multiple_ip: false,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &tenant_admin,
+    )
+    .await;
+
+    assert!(
+        res.is_err(),
+        "SetAccessPass must reject a tenant administrator when no tenant accounts are supplied"
+    );
+
+    let error_string = format!("{:?}", res.unwrap_err());
+    assert!(
+        error_string.contains("Custom(8)"),
+        "Expected NotAllowed error (Custom(8)), got: {}",
+        error_string
+    );
+
+    println!("✅ SetAccessPass correctly rejected tenant admin without tenant accounts");
 }


### PR DESCRIPTION
## Summary

- `SetAccessPass` previously required the caller to be sentinel, feed, or in the foundation allowlist. Tenant administrators were rejected with `NotAllowed (Custom(8))` even when scoping the operation to a tenant they administer. This adds a fourth authorization path: a caller listed in `Tenant.administrators` of the `tenant_add` account is now accepted.
- Added a removal guard so non-privileged callers cannot remove a tenant they do not administer from an existing access pass. This closes the cross-tenant replacement vector exposed by the SDK's auto-fill of `tenant_remove` with whatever tenant is first in the access pass's `tenant_allowlist`.
- All changes are local to `processors/accesspass/set.rs`. No CLI, SDK, or onchain state layout changes. Foundation/sentinel/feed paths behave identically to before.
- Tightened the existing `test_set_accesspass_with_tenant_admin_succeeds` to drop its foundation-allowlist workaround so it now honestly exercises the new authorization branch.

## Testing Verification

- Sentinel authority creates an access pass without tenant accounts (new positive test).
- Feed authority creates an access pass without tenant accounts (new positive test).
- Tenant administrator creates an access pass scoped to their tenant without being added to the foundation allowlist (existing test, now without the workaround).
- Tenant administrator calling `SetAccessPass` without supplying the tenant accounts is rejected with `Custom(8)` (new negative test).
- A tenant administrator cannot update an access pass to swap out another tenant they do not administer; the SDK "replace" flow is rejected with `Custom(8)` (new negative test).
- Existing `test_set_accesspass_unauthorized_payer_fails` and `test_set_accesspass_with_tenant_non_admin_fails` continue to fail with the expected codes (`Custom(8)` and `Custom(22)` respectively), confirming the redundant administrator check in the reference-count block is preserved.