### PR TITLE
cli: add doublezero geolocation probe subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - cli: `config set` accepts `--geo-program-id`; `config get` and `config set` print Geolocation Program ID
+- cli: `doublezero geolocation probe ...` mirrors `doublezero-geolocation probe ...`; new `--geo-program-id` global flag
 
 ## [v0.23.0](https://github.com/malbeclabs/doublezero/compare/client/v0.22.0...client/v0.23.0) - 2026-05-15
 

--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -3,9 +3,9 @@ use crate::{
     cli::{
         accesspass::AccessPassCliCommand, config::ConfigCliCommand,
         contributor::ContributorCliCommand, device::DeviceCliCommand, exchange::ExchangeCliCommand,
-        globalconfig::GlobalConfigCliCommand, link::LinkCliCommand, location::LocationCliCommand,
-        permission::PermissionCliCommand, resource::ResourceCliCommand, tenant::TenantCliCommand,
-        user::UserCliCommand,
+        geolocation::GeolocationCliCommand, globalconfig::GlobalConfigCliCommand,
+        link::LinkCliCommand, location::LocationCliCommand, permission::PermissionCliCommand,
+        resource::ResourceCliCommand, tenant::TenantCliCommand, user::UserCliCommand,
     },
     command::{
         connect::ProvisioningCliCommand, disable::DisableCliCommand,
@@ -97,6 +97,9 @@ pub enum Command {
     /// Manage multicast
     #[command()]
     Multicast(MulticastCliCommand),
+    /// Manage geolocation probes and users
+    #[command()]
+    Geolocation(GeolocationCliCommand),
     /// Export all data to files
     #[command()]
     Export(ExportCliCommand),

--- a/client/doublezero/src/cli/geolocation/mod.rs
+++ b/client/doublezero/src/cli/geolocation/mod.rs
@@ -1,0 +1,17 @@
+use clap::{Args, Subcommand};
+
+pub mod probe;
+
+use probe::ProbeCliCommand;
+
+#[derive(Args, Debug)]
+pub struct GeolocationCliCommand {
+    #[command(subcommand)]
+    pub command: GeolocationCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum GeolocationCommands {
+    /// Manage geolocation probes
+    Probe(ProbeCliCommand),
+}

--- a/client/doublezero/src/cli/geolocation/probe.rs
+++ b/client/doublezero/src/cli/geolocation/probe.rs
@@ -1,0 +1,30 @@
+use clap::{Args, Subcommand};
+use doublezero_cli::geolocation::probe::{
+    add_parent::AddParentGeoProbeCliCommand, create::CreateGeoProbeCliCommand,
+    delete::DeleteGeoProbeCliCommand, get::GetGeoProbeCliCommand, list::ListGeoProbeCliCommand,
+    remove_parent::RemoveParentGeoProbeCliCommand, update::UpdateGeoProbeCliCommand,
+};
+
+#[derive(Args, Debug)]
+pub struct ProbeCliCommand {
+    #[command(subcommand)]
+    pub command: ProbeCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProbeCommands {
+    /// Create a new geolocation probe
+    Create(CreateGeoProbeCliCommand),
+    /// Update an existing probe
+    Update(UpdateGeoProbeCliCommand),
+    /// Delete a probe
+    Delete(DeleteGeoProbeCliCommand),
+    /// Get details of a specific probe
+    Get(GetGeoProbeCliCommand),
+    /// List all probes
+    List(ListGeoProbeCliCommand),
+    /// Add a parent device to a probe
+    AddParent(AddParentGeoProbeCliCommand),
+    /// Remove a parent device from a probe
+    RemoveParent(RemoveParentGeoProbeCliCommand),
+}

--- a/client/doublezero/src/cli/mod.rs
+++ b/client/doublezero/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod contributor;
 pub mod device;
 pub mod exchange;
+pub mod geolocation;
 pub mod globalconfig;
 pub mod link;
 pub mod location;

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -13,6 +13,7 @@ use crate::cli::{
     config::ConfigCommands,
     device::{DeviceCommands, InterfaceCommands},
     exchange::ExchangeCommands,
+    geolocation::{probe::ProbeCommands, GeolocationCommands},
     globalconfig::{
         AirdropCommands, AuthorityCommands, FeatureFlagsCommands, FoundationAllowlistCommands,
         GlobalConfigCommands, QaAllowlistCommands,
@@ -22,9 +23,11 @@ use crate::cli::{
     user::UserCommands,
 };
 use doublezero_cli::{
-    checkversion::check_version, doublezerocommand::CliCommandImpl, version::VersionCliCommand,
+    checkversion::check_version, doublezerocommand::CliCommandImpl,
+    geoclicommand::GeoCliCommandImpl, version::VersionCliCommand,
 };
-use doublezero_sdk::{DZClient, ProgramVersion};
+use doublezero_sdk::{geolocation::client::GeoClient, DZClient, ProgramVersion};
+use doublezero_serviceability::pda::get_globalstate_pda;
 use servicecontroller::ServiceControllerImpl;
 
 #[derive(Parser, Debug)]
@@ -47,6 +50,9 @@ struct App {
     /// DZ program ID (testnet or devnet)
     #[arg(long, value_name = "PROGRAM_ID", global = true)]
     program_id: Option<String>,
+    /// Geolocation program ID
+    #[arg(long, value_name = "GEO_PROGRAM_ID", global = true)]
+    geo_program_id: Option<String>,
     /// Path to the keypair file
     #[arg(long, value_name = "KEYPAIR", global = true)]
     keypair: Option<PathBuf>,
@@ -106,7 +112,7 @@ async fn main() -> eyre::Result<()> {
         (app.url, app.ws, app.program_id)
     };
 
-    let dzclient = DZClient::new(url, ws, program_id, app.keypair)?;
+    let dzclient = DZClient::new(url.clone(), ws, program_id, app.keypair.clone())?;
     let client = CliCommandImpl::new(&dzclient);
 
     let stdout = std::io::stdout();
@@ -350,6 +356,25 @@ async fn main() -> eyre::Result<()> {
             cli::multicast::MulticastCommands::Publish(args) => args.execute(&client).await,
             cli::multicast::MulticastCommands::Unpublish(args) => args.execute(&client).await,
         },
+
+        Command::Geolocation(command) => {
+            let geo_client =
+                GeoClient::new(url.clone(), app.geo_program_id.clone(), app.keypair.clone())?;
+            let svc_program_id = *dzclient.get_program_id();
+            let (globalstate_pk, _) = get_globalstate_pda(&svc_program_id);
+            let geo_cli = GeoCliCommandImpl::new(&geo_client, &dzclient, globalstate_pk);
+            match command.command {
+                GeolocationCommands::Probe(command) => match command.command {
+                    ProbeCommands::Create(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::Update(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::Delete(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::Get(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::List(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::AddParent(args) => args.execute(&geo_cli, &mut handle),
+                    ProbeCommands::RemoveParent(args) => args.execute(&geo_cli, &mut handle),
+                },
+            }
+        }
 
         Command::Resource(command) => match command.command {
             cli::resource::ResourceCommands::Allocate(args) => args.execute(&client, &mut handle),


### PR DESCRIPTION
## Summary of Changes
- Adds `doublezero geolocation probe <create|update|delete|get|list|add-parent|remove-parent>` to the main `doublezero` CLI, mirroring `doublezero-geolocation probe ...`
- Adds a new `--geo-program-id` global flag (resolution: flag → config `geo_program_id` → built-in default)
- Carries the `GeoClient` + `GeoCliCommandImpl` construction needed for any future `geolocation` subtree work; the `user` subtree lands in a follow-up

> **Stack:** This PR is stacked on top of #3711 (`bdz/config-geo-program-id`).

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net  |
|-------------|-------|-------------|------|
| Scaffolding |     5 | +82 / -6    |  +76 |
| Docs        |     1 | +1 / -0     |   +1 |

Pure clap wiring and dispatch — no new business logic. All probe command implementations are inherited unchanged from \`doublezero_cli::geolocation::probe::*\`.

<details>
<summary>Key files (click to expand)</summary>

- \`client/doublezero/src/main.rs\` — adds \`--geo-program-id\` field on \`App\`, imports \`GeoClient\` / \`GeoCliCommandImpl\` / \`get_globalstate_pda\`, adds \`Command::Geolocation\` match arm that builds the geo client inline and dispatches the 7 probe subcommands
- \`client/doublezero/src/cli/geolocation/probe.rs\` — new module: \`ProbeCliCommand\` + \`ProbeCommands\` enum with 7 variants imported from \`doublezero_cli::geolocation::probe::*\`
- \`client/doublezero/src/cli/geolocation/mod.rs\` — new module: \`GeolocationCliCommand\` + \`GeolocationCommands\` enum (currently \`Probe\` only)
- \`client/doublezero/src/cli/command.rs\` — adds \`Geolocation(GeolocationCliCommand)\` variant on the top-level \`Command\` enum, alongside \`Multicast\`
- \`client/doublezero/src/cli/mod.rs\` — registers \`pub mod geolocation;\`

</details>

## Testing Verification
- \`doublezero geolocation probe --help\` lists all 7 subcommands (\`create\`, \`update\`, \`delete\`, \`get\`, \`list\`, \`add-parent\`, \`remove-parent\`)
- \`doublezero --help\` shows the new \`geolocation\` command and the \`--geo-program-id\` flag with metavar \`<GEO_PROGRAM_ID>\`