### PR TITLE
cli: add doublezero geolocation user subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- cli: `config set` accepts `--geo-program-id`; `config get` and `config set` print Geolocation Program ID
-- cli: `doublezero geolocation probe ...` mirrors `doublezero-geolocation probe ...`; new `--geo-program-id` global flag
 - CLI
+  - cli: `doublezero geolocation` `probe ...` and `user ...` mirrors `doublezero-geolocation` versions; new `--geo-program-id` global flag, `config get/set` include Geolocation Program ID.
   - Drop the activator-only pollers from `doublezero` (user and multicastgroup activation waits). The `--wait` flag on `user create`, `user create-subscribe`, `user subscribe`, `multicastgroup create`, and `multicastgroup update` now fetches the post-create state once instead of polling — creates are atomic to `Activated` post-RFC-11, so the wait loop was watching a transition that no longer happens ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
   - Trim the `Rejected` status arm from the device and link activation pollers; `Rejected` was itself an activator-driven transition ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
 - Client

--- a/client/doublezero/src/cli/geolocation/mod.rs
+++ b/client/doublezero/src/cli/geolocation/mod.rs
@@ -1,8 +1,10 @@
 use clap::{Args, Subcommand};
 
 pub mod probe;
+pub mod user;
 
 use probe::ProbeCliCommand;
+use user::UserCliCommand;
 
 #[derive(Args, Debug)]
 pub struct GeolocationCliCommand {
@@ -14,4 +16,6 @@ pub struct GeolocationCliCommand {
 pub enum GeolocationCommands {
     /// Manage geolocation probes
     Probe(ProbeCliCommand),
+    /// Manage geolocation users and targets
+    User(UserCliCommand),
 }

--- a/client/doublezero/src/cli/geolocation/user.rs
+++ b/client/doublezero/src/cli/geolocation/user.rs
@@ -1,0 +1,36 @@
+use clap::{Args, Subcommand};
+use doublezero_cli::geolocation::user::{
+    add_target::AddTargetCliCommand, create::CreateGeolocationUserCliCommand,
+    delete::DeleteGeolocationUserCliCommand, get::GetGeolocationUserCliCommand,
+    list::ListGeolocationUserCliCommand, remove_target::RemoveTargetCliCommand,
+    set_result_destination::SetResultDestinationCliCommand,
+    update::UpdateGeolocationUserCliCommand, update_payment_status::UpdatePaymentStatusCliCommand,
+};
+
+#[derive(Args, Debug)]
+pub struct UserCliCommand {
+    #[command(subcommand)]
+    pub command: UserCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum UserCommands {
+    /// Create a new geolocation user
+    Create(CreateGeolocationUserCliCommand),
+    /// Delete a geolocation user
+    Delete(DeleteGeolocationUserCliCommand),
+    /// Update a geolocation user's payment token account
+    Update(UpdateGeolocationUserCliCommand),
+    /// Get details of a specific user
+    Get(GetGeolocationUserCliCommand),
+    /// List all geolocation users
+    List(ListGeolocationUserCliCommand),
+    /// Add a target to a user
+    AddTarget(AddTargetCliCommand),
+    /// Remove a target from a user
+    RemoveTarget(RemoveTargetCliCommand),
+    /// Set result destination for geolocation results
+    SetResultDestination(SetResultDestinationCliCommand),
+    /// Update payment status (foundation-only)
+    UpdatePayment(UpdatePaymentStatusCliCommand),
+}

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -13,7 +13,9 @@ use crate::cli::{
     config::ConfigCommands,
     device::{DeviceCommands, InterfaceCommands},
     exchange::ExchangeCommands,
-    geolocation::{probe::ProbeCommands, GeolocationCommands},
+    geolocation::{
+        probe::ProbeCommands, user::UserCommands as GeoUserCommands, GeolocationCommands,
+    },
     globalconfig::{
         AirdropCommands, AuthorityCommands, FeatureFlagsCommands, FoundationAllowlistCommands,
         GlobalConfigCommands, QaAllowlistCommands,
@@ -372,6 +374,19 @@ async fn main() -> eyre::Result<()> {
                     ProbeCommands::List(args) => args.execute(&geo_cli, &mut handle),
                     ProbeCommands::AddParent(args) => args.execute(&geo_cli, &mut handle),
                     ProbeCommands::RemoveParent(args) => args.execute(&geo_cli, &mut handle),
+                },
+                GeolocationCommands::User(command) => match command.command {
+                    GeoUserCommands::Create(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::Delete(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::Update(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::Get(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::List(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::AddTarget(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::RemoveTarget(args) => args.execute(&geo_cli, &mut handle),
+                    GeoUserCommands::SetResultDestination(args) => {
+                        args.execute(&geo_cli, &mut handle)
+                    }
+                    GeoUserCommands::UpdatePayment(args) => args.execute(&geo_cli, &mut handle),
                 },
             }
         }


### PR DESCRIPTION
Stacked on #3713 (PR 2: `doublezero geolocation probe`).

## Summary of Changes
- Adds `doublezero geolocation user <create|delete|update|get|list|add-target|remove-target|set-result-destination|update-payment>` to the `doublezero` CLI, mirroring the existing `doublezero-geolocation user` surface
- Wires `UserCliCommand` / `UserCommands` via the existing `Command::Geolocation` dispatch arm (no new client construction — reuses `GeoClient` / `GeoCliCommandImpl` from the probe arm)

## Diff Breakdown
| Category    | Files | Lines (+/-)  | Net  |
|-------------|-------|--------------|------|
| Core logic  |     2 | +98  / -6    | +92  |
| Scaffolding |     6 | +138 / -6    | +132 |
| Docs        |     1 | +4   / -0    | +4   |

Purely additive clap wiring for the PR-3 slice; the larger `config/set.rs` changes are from the base PRs (1–2) included in this diff.

<details>
<summary>Key files (click to expand)</summary>

- `client/doublezero/src/cli/geolocation/user.rs` — new file: clap `UserCliCommand` / `UserCommands` enum mirroring `doublezero-geolocation-cli/src/cli/user.rs`
- `client/doublezero/src/main.rs` — `GeolocationCommands::User` dispatch arm; `GeoUserCommands` import alias
- `client/doublezero/src/cli/geolocation/mod.rs` — registers `pub mod user` and adds `User(UserCliCommand)` variant to `GeolocationCommands`
- `smartcontract/cli/src/config/set.rs` — (base PR 1) `--geo-program-id` flag, validation, persistence, and two new tests
- `smartcontract/cli/src/config/get.rs` — (base PR 1) displays Geolocation Program ID in `config get` output

</details>

## Testing Verification
- `cargo check -p doublezero` — clean
- `make rust-fmt && make rust-lint` — clean (all 8 crates)
- `doublezero geolocation user --help` — lists all 9 subcommands: `create`, `delete`, `update`, `get`, `list`, `add-target`, `remove-target`, `set-result-destination`, `update-payment`