### PR TITLE
cli: add hidden init-geolocation-config command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - CLI
-  - cli: `doublezero geolocation` `probe ...` and `user ...` mirrors `doublezero-geolocation` versions; new `--geo-program-id` global flag, `config get/set` include Geolocation Program ID.
+  - `doublezero geolocation` `probe ...` and `user ...` mirrors `doublezero-geolocation` versions; new `--geo-program-id` global flag, `config get/set` include Geolocation Program ID; new `-init-geolocation-config` for init of geolocation program
   - Drop the activator-only pollers from `doublezero` (user and multicastgroup activation waits). The `--wait` flag on `user create`, `user create-subscribe`, `user subscribe`, `multicastgroup create`, and `multicastgroup update` now fetches the post-create state once instead of polling — creates are atomic to `Activated` post-RFC-11, so the wait loop was watching a transition that no longer happens ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
   - Trim the `Rejected` status arm from the device and link activation pollers; `Rejected` was itself an activator-driven transition ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
 - Client

--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -17,7 +17,8 @@ use clap::{Args, Subcommand};
 use clap_complete::Shell;
 use doublezero_cli::{
     account::GetAccountCliCommand, accounts::GetAccountsCliCommand, address::AddressCliCommand,
-    balance::BalanceCliCommand, export::ExportCliCommand, init::InitCliCommand,
+    balance::BalanceCliCommand, export::ExportCliCommand,
+    geolocation::programconfig::init::InitProgramConfigCliCommand, init::InitCliCommand,
     keygen::KeyGenCliCommand, logcommand::LogCliCommand, migrate::MigrateCliCommand,
 };
 
@@ -27,6 +28,8 @@ pub enum Command {
     Init(InitCliCommand),
     #[command(hide = true)]
     Migrate(MigrateCliCommand),
+    #[command(hide = true)]
+    InitGeolocationConfig(InitProgramConfigCliCommand),
     /// Connect your server to a doublezero device
     #[command()]
     Connect(ProvisioningCliCommand),

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -164,6 +164,14 @@ async fn main() -> eyre::Result<()> {
 
         Command::Init(args) => args.execute(&client, &mut handle),
         Command::Migrate(args) => args.execute(&client, &mut handle),
+        Command::InitGeolocationConfig(args) => {
+            let geo_client =
+                GeoClient::new(url.clone(), app.geo_program_id.clone(), app.keypair.clone())?;
+            let svc_program_id = *dzclient.get_program_id();
+            let (globalstate_pk, _) = get_globalstate_pda(&svc_program_id);
+            let geo_cli = GeoCliCommandImpl::new(&geo_client, &dzclient, globalstate_pk);
+            args.execute(&geo_cli, &mut handle)
+        }
         Command::Config(command) => match command.command {
             ConfigCommands::Get(args) => args.execute(&client, &mut handle),
             ConfigCommands::Set(args) => args.execute(&client, &mut handle),


### PR DESCRIPTION
Stacked on #3715 (PR 3: \`doublezero geolocation user\`). Base branch: \`bdz/geolocation-user-subtree\`.

## Summary of Changes
- Adds a hidden top-level \`doublezero init-geolocation-config\` command that delegates to \`InitProgramConfigCliCommand\`, mirroring \`doublezero-geolocation init-config\`
- Follows the same \`#[command(hide = true)]\` pattern as the existing \`Init\` and \`Migrate\` hidden commands

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Scaffolding  |     2 | +13 / -0    | +13  |
| Docs         |     1 | +1  / -0    |  +1  |

Pure wiring — no new logic, just hooking \`InitProgramConfigCliCommand\` into the existing \`doublezero\` binary.

<details>
<summary>Key files (click to expand)</summary>

- \`client/doublezero/src/cli/command.rs\` — adds \`InitGeolocationConfig(InitProgramConfigCliCommand)\` hidden variant; imports \`InitProgramConfigCliCommand\` into the \`doublezero_cli\` use block
- \`client/doublezero/src/main.rs\` — wires \`Command::InitGeolocationConfig\` dispatch arm; constructs \`GeoClient\` + \`GeoCliCommandImpl\` inline, identical to the \`Command::Geolocation\` pattern

</details>

## Testing Verification
- \`cargo check -p doublezero\` passes clean
- \`make rust-fmt && make rust-lint\` pass with no warnings
- \`doublezero init-geolocation-config --help\` shows the expected clap help (including \`--yes\`)
- \`doublezero --help | grep init-geolocation\` produces no output, confirming the command is hidden