### PR TITLE
e2e: migrate to doublezero geolocation commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   - Trim the `Rejected` status arm from the device and link activation pollers; `Rejected` was itself an activator-driven transition ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
 - Client
   - Simplify `doublezero connect`'s post-create user fetch to a fixed retry-on-RPC-lag get instead of waiting for `UserStatus::Activated`; the activator-driven transition is gone, so the fetch only needs to ride out replica lag ([#3614](https://github.com/malbeclabs/doublezero/issues/3614))
+- E2E
+  - Switch geolocation invocations to `doublezero geolocation ...` and `doublezero init-geolocation-config`
 
 ## [v0.23.0](https://github.com/malbeclabs/doublezero/compare/client/v0.22.0...client/v0.23.0) - 2026-05-15
 

--- a/e2e/docker/manager/scripts/init-config.sh
+++ b/e2e/docker/manager/scripts/init-config.sh
@@ -28,19 +28,19 @@ if [ -n "${DZ_GEOLOCATION_PROGRAM_KEYPAIR_PATH:-}" ]; then
 fi
 
 # Initialize doublezero CLI config.
+geo_flag=()
+if [ -n "${geolocation_program_id:-}" ]; then
+  geo_flag=(--geo-program-id "$geolocation_program_id")
+fi
 doublezero config set \
   --keypair /root/.config/doublezero/id.json \
   --url $DZ_LEDGER_URL \
   --ws $DZ_LEDGER_WS \
-  --program-id $serviceability_program_id
+  --program-id $serviceability_program_id \
+  "${geo_flag[@]}"
 echo "==> Config:"
 cat /root/.config/doublezero/cli/config.yml
 echo
-
-# Configure geolocation program ID if available.
-if [ -n "${geolocation_program_id:-}" ]; then
-  doublezero-geolocation config set --geo-program-id $geolocation_program_id
-fi
 
 # Configure the solana CLI.
 echo "==> Configuring solana CLI"

--- a/e2e/geoprobe_test.go
+++ b/e2e/geoprobe_test.go
@@ -312,7 +312,7 @@ func getExchangePK(t *testing.T, dn *devnet.Devnet, exchangeCode string) string 
 func createGeoprobeOnchain(t *testing.T, dn *devnet.Devnet, code, exchangePK, publicIP, signingKeypair string) string {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "probe", "create",
+		"doublezero", "geolocation", "probe", "create",
 		"--code", code,
 		"--exchange", exchangePK,
 		"--public-ip", publicIP,
@@ -341,7 +341,7 @@ func createGeoprobeOnchain(t *testing.T, dn *devnet.Devnet, code, exchangePK, pu
 func getGeoprobePK(t *testing.T, dn *devnet.Devnet, code string) string {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "probe", "get", "--probe", code, "--json",
+		"doublezero", "geolocation", "probe", "get", "--probe", code, "--json",
 	})
 	require.NoError(t, err, "probe get failed: %s", string(output))
 
@@ -357,7 +357,7 @@ func getGeoprobePK(t *testing.T, dn *devnet.Devnet, code string) string {
 func addGeoprobeParent(t *testing.T, dn *devnet.Devnet, code, devicePK string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "probe", "add-parent",
+		"doublezero", "geolocation", "probe", "add-parent",
 		"--probe", code,
 		"--device", devicePK,
 	})
@@ -870,7 +870,7 @@ func TestE2E_GeoprobeIcmpTargets(t *testing.T) {
 func createGeolocationUser(t *testing.T, dn *devnet.Devnet, code, tokenAccount string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "create",
+		"doublezero", "geolocation", "user", "create",
 		"--code", code,
 		"--token-account", tokenAccount,
 	})
@@ -881,7 +881,7 @@ func createGeolocationUser(t *testing.T, dn *devnet.Devnet, code, tokenAccount s
 func updateGeolocationUserPayment(t *testing.T, dn *devnet.Devnet, code, status string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "update-payment",
+		"doublezero", "geolocation", "user", "update-payment",
 		"--user", code,
 		"--status", status,
 	})
@@ -892,7 +892,7 @@ func updateGeolocationUserPayment(t *testing.T, dn *devnet.Devnet, code, status 
 func setGeolocationUserResultDestination(t *testing.T, dn *devnet.Devnet, userCode, destination string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "set-result-destination",
+		"doublezero", "geolocation", "user", "set-result-destination",
 		"--user", userCode,
 		"--destination", destination,
 	})
@@ -903,7 +903,7 @@ func setGeolocationUserResultDestination(t *testing.T, dn *devnet.Devnet, userCo
 func addGeolocationOutboundTarget(t *testing.T, dn *devnet.Devnet, userCode, targetIP string, targetPort int, probeCode string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "add-target",
+		"doublezero", "geolocation", "user", "add-target",
 		"--user", userCode,
 		"--type", "outbound",
 		"--target-ip", targetIP,
@@ -917,7 +917,7 @@ func addGeolocationOutboundTarget(t *testing.T, dn *devnet.Devnet, userCode, tar
 func addGeolocationOutboundIcmpTarget(t *testing.T, dn *devnet.Devnet, userCode, targetIP string, targetPort int, probeCode string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "add-target",
+		"doublezero", "geolocation", "user", "add-target",
 		"--user", userCode,
 		"--type", "outbound-icmp",
 		"--target-ip", targetIP,
@@ -931,7 +931,7 @@ func addGeolocationOutboundIcmpTarget(t *testing.T, dn *devnet.Devnet, userCode,
 func addGeolocationInboundTarget(t *testing.T, dn *devnet.Devnet, userCode, targetPK, probeCode string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero-geolocation", "user", "add-target",
+		"doublezero", "geolocation", "user", "add-target",
 		"--user", userCode,
 		"--type", "inbound",
 		"--target-signing-pubkey", targetPK,

--- a/e2e/internal/devnet/smartcontract_geolocation.go
+++ b/e2e/internal/devnet/smartcontract_geolocation.go
@@ -77,7 +77,7 @@ func (dn *Devnet) InitGeolocationProgramConfigIfNotInitialized(ctx context.Conte
 	dn.log.Debug("==> Initializing geolocation program config")
 
 	output, err := dn.Manager.Exec(ctx, []string{
-		"doublezero-geolocation", "init-config", "--yes",
+		"doublezero", "init-geolocation-config", "--yes",
 	}, docker.NoPrintOnError())
 	if err != nil {
 		outputStr := strings.ToLower(string(output))


### PR DESCRIPTION
## Summary of Changes
- Adds `doublezero geolocation probe ...` and `doublezero geolocation user ...` subcommand groups to the `doublezero` CLI, mirroring the standalone `doublezero-geolocation` binary
- Adds `doublezero init-geolocation-config` (hidden) mirroring `doublezero-geolocation init-config`
- Adds `--geo-program-id` to `doublezero config set` and `doublezero config get`; persists and prints the geolocation program ID alongside the serviceability program ID
- Migrates all e2e test invocations (`geoprobe_test.go`, `smartcontract_geolocation.go`) and the manager init script from `doublezero-geolocation ...` to `doublezero geolocation ...` / `doublezero init-geolocation-config` / `doublezero config set --geo-program-id`

This is PR 5 of 5 in a stacked series, stacked on top of PR #3717 (`bdz/init-geolocation-config`), which adds the geolocation CLI commands to the `doublezero_cli` library. PRs 1–4 must be merged first.

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     3 | +150 / -9    | +141 |
| Scaffolding  |     5 | +98 / -4     |  +94 |
| Tests        |     3 | +16 / -16    |   +0 |
| Docs         |     1 | +6 / -0      |   +6 |

Mostly new scaffolding and core logic adding geolocation commands to `doublezero`; e2e changes are pure renames with zero net churn.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/config/set.rs` — adds `--geo-program-id` flag, persistence, conflict detection with `--env`, output formatting, and tests
- `client/doublezero/src/main.rs` — dispatch for `Command::Geolocation` and `Command::InitGeolocationConfig`; constructs `GeoClient` with `--geo-program-id` global flag
- `client/doublezero/src/cli/geolocation/user.rs` — thin Clap wrapper exposing all `doublezero_cli` geolocation user subcommands
- `client/doublezero/src/cli/geolocation/probe.rs` — thin Clap wrapper exposing all `doublezero_cli` geolocation probe subcommands
- `client/doublezero/src/cli/command.rs` — registers `Geolocation` and `InitGeolocationConfig` variants in the top-level command enum
- `smartcontract/cli/src/config/get.rs` — adds Geolocation Program ID line to `config get` output
- `e2e/geoprobe_test.go` — replaces `"doublezero-geolocation"` with `"doublezero", "geolocation"` at all call sites
- `e2e/docker/manager/scripts/init-config.sh` — consolidates geo program ID into `doublezero config set --geo-program-id`; removes standalone `doublezero-geolocation config set` call

</details>

## Testing Verification
- `TestE2E_GeoprobeDiscovery` passed (208s runtime) — exercises `probe create`, `probe get`, `probe add-parent`, `user create`, `user update-payment`, `user add-target` (outbound + inbound), and `init-geolocation-config` via the new paths
- `TestE2E_GeoprobeIcmpTargets` and `TestE2E_GeoprobeResultDestination` were not run in this session; reviewer may want to verify those