### PR TITLE
smartcontract/serviceability: rename activator-only status variants to *Deprecated

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/INSTRUCTION_GUIDELINES.md
+++ b/smartcontract/programs/doublezero-serviceability/INSTRUCTION_GUIDELINES.md
@@ -72,7 +72,7 @@ let multicastgroup = MulticastGroup {
     code,
     multicast_ip: std::net::Ipv4Addr::UNSPECIFIED,
     max_bandwidth: value.max_bandwidth,
-    status: MulticastGroupStatus::Pending,
+    status: MulticastGroupStatus::PendingDeprecated,
     publisher_count: 0,
     subscriber_count: 0,
 };

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/activate.rs
@@ -76,7 +76,7 @@ pub fn process_activate_device(
 
     let mut device: Device = Device::try_from(device_account)?;
 
-    if device.status != DeviceStatus::Pending {
+    if device.status != DeviceStatus::PendingDeprecated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/reject.rs
@@ -71,11 +71,11 @@ pub fn process_reject_device(
 
     let mut device: Device = Device::try_from(device_account)?;
 
-    if device.status != DeviceStatus::Pending {
+    if device.status != DeviceStatus::PendingDeprecated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    device.status = DeviceStatus::Rejected;
+    device.status = DeviceStatus::RejectedDeprecated;
     msg!("Reason: {:?}", value.reason);
 
     try_acc_write(&device, device_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/activate.rs
@@ -120,7 +120,7 @@ pub fn process_activate_link(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    if link.status != LinkStatus::Pending {
+    if link.status != LinkStatus::PendingDeprecated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -191,7 +191,7 @@ pub fn process_create_link(
     let status = if value.link_type == LinkLinkType::DZX {
         LinkStatus::Requested
     } else {
-        LinkStatus::Pending
+        LinkStatus::PendingDeprecated
     };
 
     contributor.reference_count += 1;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/reject.rs
@@ -51,7 +51,7 @@ pub fn process_reject_link(
     // Allow foundation to reject Pending links
     // Allow Contributor B to reject Requested links
     let payer_account = match link.status {
-        LinkStatus::Pending => {
+        LinkStatus::PendingDeprecated => {
             let payer_account = next_account_info(accounts_iter)?;
             let system_program = next_account_info(accounts_iter)?;
 
@@ -106,7 +106,7 @@ pub fn process_reject_link(
 
     link.tunnel_id = 0;
     link.tunnel_net = NetworkV4::default();
-    link.status = LinkStatus::Rejected;
+    link.status = LinkStatus::RejectedDeprecated;
     msg!("Reason: {:?}", value.reason);
 
     try_acc_write(&link, link_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/activate.rs
@@ -78,7 +78,7 @@ pub fn process_activate_multicastgroup(
 
     let mut multicastgroup: MulticastGroup = MulticastGroup::try_from(multicastgroup_account)?;
 
-    if multicastgroup.status != MulticastGroupStatus::Pending {
+    if multicastgroup.status != MulticastGroupStatus::PendingDeprecated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/reject.rs
@@ -69,11 +69,11 @@ pub fn process_reject_multicastgroup(
 
     let mut multicastgroup: MulticastGroup = MulticastGroup::try_from(multicastgroup_account)?;
 
-    if multicastgroup.status != MulticastGroupStatus::Pending {
+    if multicastgroup.status != MulticastGroupStatus::PendingDeprecated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    multicastgroup.status = MulticastGroupStatus::Rejected;
+    multicastgroup.status = MulticastGroupStatus::RejectedDeprecated;
     msg!("Reason: {:?}", value.reason);
 
     try_acc_write(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
@@ -195,8 +195,8 @@ pub fn process_update_multicastgroup_roles(
     let has_role = value.publisher || value.subscriber;
     if has_role
         && user.status != UserStatus::Activated
-        && user.status != UserStatus::Updating
-        && user.status != UserStatus::Pending
+        && user.status != UserStatus::UpdatingDeprecated
+        && user.status != UserStatus::PendingDeprecated
     {
         msg!("UserStatus: {:?}", user.status);
         return Err(DoubleZeroError::InvalidStatus.into());

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/activate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/activate.rs
@@ -134,7 +134,8 @@ pub fn process_activate_user(
 
     let mut user: User = User::try_from(user_account)?;
 
-    if user.status != UserStatus::Pending && user.status != UserStatus::Updating {
+    if user.status != UserStatus::PendingDeprecated && user.status != UserStatus::UpdatingDeprecated
+    {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
@@ -261,7 +262,7 @@ pub fn process_activate_user(
     // On re-activation (Updating → Activated), leave the flag unchanged: the publishers list
     // may be empty after an unsubscribe, but the device counter that was incremented at
     // creation time hasn't changed and must still be decremented at delete time.
-    if user.status == UserStatus::Pending
+    if user.status == UserStatus::PendingDeprecated
         && user.user_type == UserType::Multicast
         && !user.publishers.is_empty()
     {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/ban.rs
@@ -63,7 +63,7 @@ pub fn process_ban_user(
     }
 
     let mut user: User = User::try_from(user_account)?;
-    if user.status != UserStatus::PendingBan {
+    if user.status != UserStatus::PendingBanDeprecated {
         return Err(DoubleZeroError::NotAllowed.into());
     }
     user.status = UserStatus::Banned;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
@@ -345,7 +345,7 @@ pub fn create_user_core(
         dz_ip: Ipv4Addr::UNSPECIFIED,
         tunnel_id: 0,
         tunnel_net: NetworkV4::default(),
-        status: UserStatus::Pending,
+        status: UserStatus::PendingDeprecated,
         publishers: vec![],
         subscribers: vec![],
         validator_pubkey,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/reject.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/reject.rs
@@ -65,14 +65,15 @@ pub fn process_reject_user(
 
     let mut user: User = User::try_from(user_account)?;
 
-    if user.status != UserStatus::Pending && user.status != UserStatus::Updating {
+    if user.status != UserStatus::PendingDeprecated && user.status != UserStatus::UpdatingDeprecated
+    {
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
     user.tunnel_id = 0;
     user.tunnel_net = NetworkV4::default();
     user.dz_ip = std::net::Ipv4Addr::UNSPECIFIED;
-    user.status = UserStatus::Rejected;
+    user.status = UserStatus::RejectedDeprecated;
     msg!("Reason: {:?}", value.reason);
 
     try_acc_write(&user, user_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/requestban.rs
@@ -155,12 +155,12 @@ mod tests {
 
     #[test]
     fn request_ban_disallowed_statuses() {
-        assert!(!can_request_ban(UserStatus::Pending));
+        assert!(!can_request_ban(UserStatus::PendingDeprecated));
         assert!(!can_request_ban(UserStatus::Deleting));
-        assert!(!can_request_ban(UserStatus::Rejected));
-        assert!(!can_request_ban(UserStatus::PendingBan));
+        assert!(!can_request_ban(UserStatus::RejectedDeprecated));
+        assert!(!can_request_ban(UserStatus::PendingBanDeprecated));
         assert!(!can_request_ban(UserStatus::Banned));
-        assert!(!can_request_ban(UserStatus::Updating));
+        assert!(!can_request_ban(UserStatus::UpdatingDeprecated));
         assert!(!can_request_ban(UserStatus::OutOfCredits));
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -63,11 +63,11 @@ impl FromStr for DeviceType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
     //Suspended = 2, // The suspended status is no longer used
     Deleting = 3,
-    Rejected = 4,
+    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
     Drained = 5,
     DeviceProvisioning = 6,
     LinkProvisioning = 7,
@@ -76,14 +76,14 @@ pub enum DeviceStatus {
 impl From<u8> for DeviceStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => DeviceStatus::Pending,
+            0 => DeviceStatus::PendingDeprecated,
             1 => DeviceStatus::Activated,
             3 => DeviceStatus::Deleting,
-            4 => DeviceStatus::Rejected,
+            4 => DeviceStatus::RejectedDeprecated,
             5 => DeviceStatus::Drained,
             6 => DeviceStatus::DeviceProvisioning,
             7 => DeviceStatus::LinkProvisioning,
-            _ => DeviceStatus::Pending,
+            _ => DeviceStatus::PendingDeprecated,
         }
     }
 }
@@ -91,10 +91,10 @@ impl From<u8> for DeviceStatus {
 impl fmt::Display for DeviceStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DeviceStatus::Pending => write!(f, "pending"),
+            DeviceStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             DeviceStatus::Activated => write!(f, "activated"),
             DeviceStatus::Deleting => write!(f, "deleting"),
-            DeviceStatus::Rejected => write!(f, "rejected"),
+            DeviceStatus::RejectedDeprecated => write!(f, "rejected (deprecated)"),
             DeviceStatus::Drained => write!(f, "drained"),
             DeviceStatus::DeviceProvisioning => write!(f, "device-provisioning"),
             DeviceStatus::LinkProvisioning => write!(f, "link-provisioning"),
@@ -107,10 +107,10 @@ impl FromStr for DeviceStatus {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "pending" => Ok(DeviceStatus::Pending),
+            "pending" | "pending (deprecated)" => Ok(DeviceStatus::PendingDeprecated),
             "activated" => Ok(DeviceStatus::Activated),
             "deleting" => Ok(DeviceStatus::Deleting),
-            "rejected" => Ok(DeviceStatus::Rejected),
+            "rejected" | "rejected (deprecated)" => Ok(DeviceStatus::RejectedDeprecated),
             "drained" => Ok(DeviceStatus::Drained),
             "device-provisioning" => Ok(DeviceStatus::DeviceProvisioning),
             "link-provisioning" => Ok(DeviceStatus::LinkProvisioning),
@@ -300,7 +300,7 @@ impl Default for Device {
             exchange_pk: Pubkey::default(),
             device_type: DeviceType::Hybrid,
             public_ip: Ipv4Addr::new(0, 0, 0, 0),
-            status: DeviceStatus::Pending,
+            status: DeviceStatus::PendingDeprecated,
             code: String::new(),
             dz_prefixes: Vec::new().into(),
             metrics_publisher_pk: Pubkey::default(),
@@ -763,7 +763,7 @@ mod tests {
         assert!(!device.is_device_eligible_for_provisioning());
 
         let device = Device {
-            status: DeviceStatus::Pending,
+            status: DeviceStatus::PendingDeprecated,
             device_type: DeviceType::Hybrid,
             users_count: 2,
             max_users: 5,
@@ -806,7 +806,7 @@ mod tests {
         assert_eq!(val.location_pk, Pubkey::default());
         assert_eq!(val.exchange_pk, Pubkey::default());
         assert_eq!(val.public_ip, Ipv4Addr::new(0, 0, 0, 0));
-        assert_eq!(val.status, DeviceStatus::Pending);
+        assert_eq!(val.status, DeviceStatus::PendingDeprecated);
         assert_eq!(val.device_type, DeviceType::Hybrid);
         assert_eq!(val.metrics_publisher_pk, Pubkey::default());
         assert_eq!(val.contributor_pk, Pubkey::default());

--- a/smartcontract/programs/doublezero-serviceability/src/state/exchange.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/exchange.rs
@@ -13,7 +13,7 @@ pub const BGP_COMMUNITY_MAX: u16 = 10999;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExchangeStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
     Suspended = 2,
 }
@@ -21,10 +21,10 @@ pub enum ExchangeStatus {
 impl From<u8> for ExchangeStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => ExchangeStatus::Pending,
+            0 => ExchangeStatus::PendingDeprecated,
             1 => ExchangeStatus::Activated,
             2 => ExchangeStatus::Suspended,
-            _ => ExchangeStatus::Pending,
+            _ => ExchangeStatus::PendingDeprecated,
         }
     }
 }
@@ -32,7 +32,7 @@ impl From<u8> for ExchangeStatus {
 impl fmt::Display for ExchangeStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ExchangeStatus::Pending => write!(f, "pending"),
+            ExchangeStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             ExchangeStatus::Activated => write!(f, "activated"),
             ExchangeStatus::Suspended => write!(f, "suspended"),
         }

--- a/smartcontract/programs/doublezero-serviceability/src/state/link.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/link.rs
@@ -54,11 +54,11 @@ impl fmt::Display for LinkLinkType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LinkStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
     //Suspended = 2, // The suspended status is no longer used
     Deleting = 3,
-    Rejected = 4,
+    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
     Requested = 5,
     HardDrained = 6,
     SoftDrained = 7,
@@ -68,15 +68,15 @@ pub enum LinkStatus {
 impl From<u8> for LinkStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => LinkStatus::Pending,
+            0 => LinkStatus::PendingDeprecated,
             1 => LinkStatus::Activated,
             3 => LinkStatus::Deleting,
-            4 => LinkStatus::Rejected,
+            4 => LinkStatus::RejectedDeprecated,
             5 => LinkStatus::Requested,
             6 => LinkStatus::HardDrained,
             7 => LinkStatus::SoftDrained,
             8 => LinkStatus::Provisioning,
-            _ => LinkStatus::Pending,
+            _ => LinkStatus::PendingDeprecated,
         }
     }
 }
@@ -86,10 +86,10 @@ impl FromStr for LinkStatus {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "pending" => Ok(LinkStatus::Pending),
+            "pending" | "pending (deprecated)" => Ok(LinkStatus::PendingDeprecated),
             "activated" => Ok(LinkStatus::Activated),
             "deleting" => Ok(LinkStatus::Deleting),
-            "rejected" => Ok(LinkStatus::Rejected),
+            "rejected" | "rejected (deprecated)" => Ok(LinkStatus::RejectedDeprecated),
             "requested" => Ok(LinkStatus::Requested),
             "hard-drained" => Ok(LinkStatus::HardDrained),
             "soft-drained" => Ok(LinkStatus::SoftDrained),
@@ -102,10 +102,10 @@ impl FromStr for LinkStatus {
 impl fmt::Display for LinkStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LinkStatus::Pending => write!(f, "pending"),
+            LinkStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             LinkStatus::Activated => write!(f, "activated"),
             LinkStatus::Deleting => write!(f, "deleting"),
-            LinkStatus::Rejected => write!(f, "rejected"),
+            LinkStatus::RejectedDeprecated => write!(f, "rejected (deprecated)"),
             LinkStatus::Requested => write!(f, "requested"),
             LinkStatus::HardDrained => write!(f, "hard-drained"),
             LinkStatus::SoftDrained => write!(f, "soft-drained"),
@@ -298,7 +298,7 @@ impl Default for Link {
             jitter_ns: 0,
             tunnel_id: 0,
             tunnel_net: NetworkV4::default(),
-            status: LinkStatus::Pending,
+            status: LinkStatus::PendingDeprecated,
             code: String::new(),
             contributor_pk: Pubkey::default(),
             side_a_iface_name: String::new(),
@@ -375,8 +375,8 @@ impl Validate for Link {
         }
         // Tunnel network must be private
         if self.status != LinkStatus::Requested
-            && self.status != LinkStatus::Pending
-            && self.status != LinkStatus::Rejected
+            && self.status != LinkStatus::PendingDeprecated
+            && self.status != LinkStatus::RejectedDeprecated
             && !self.tunnel_net.ip().is_private()
         {
             msg!("Invalid tunnel_net: {}", self.tunnel_net);
@@ -684,7 +684,7 @@ mod tests {
             tunnel_id: 1,
             tunnel_net: "8.8.8.8/25".parse().unwrap(),
             code: "test-123".to_string(),
-            status: LinkStatus::Rejected,
+            status: LinkStatus::RejectedDeprecated,
             side_a_iface_name: "eth0".to_string(),
             side_z_iface_name: "eth1".to_string(),
             delay_override_ns: 0,

--- a/smartcontract/programs/doublezero-serviceability/src/state/location.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/location.rs
@@ -12,7 +12,7 @@ use std::fmt;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LocationStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
     Suspended = 2,
 }
@@ -20,10 +20,10 @@ pub enum LocationStatus {
 impl From<u8> for LocationStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => LocationStatus::Pending,
+            0 => LocationStatus::PendingDeprecated,
             1 => LocationStatus::Activated,
             2 => LocationStatus::Suspended,
-            _ => LocationStatus::Pending,
+            _ => LocationStatus::PendingDeprecated,
         }
     }
 }
@@ -31,7 +31,7 @@ impl From<u8> for LocationStatus {
 impl fmt::Display for LocationStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LocationStatus::Pending => write!(f, "pending"),
+            LocationStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             LocationStatus::Activated => write!(f, "activated"),
             LocationStatus::Suspended => write!(f, "suspended"),
         }

--- a/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
@@ -12,22 +12,22 @@ use std::{fmt, net::Ipv4Addr};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MulticastGroupStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
     Suspended = 2,
     Deleting = 3,
-    Rejected = 4,
+    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
 }
 
 impl From<u8> for MulticastGroupStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => MulticastGroupStatus::Pending,
+            0 => MulticastGroupStatus::PendingDeprecated,
             1 => MulticastGroupStatus::Activated,
             2 => MulticastGroupStatus::Suspended,
             3 => MulticastGroupStatus::Deleting,
-            4 => MulticastGroupStatus::Rejected,
-            _ => MulticastGroupStatus::Pending,
+            4 => MulticastGroupStatus::RejectedDeprecated,
+            _ => MulticastGroupStatus::PendingDeprecated,
         }
     }
 }
@@ -35,11 +35,11 @@ impl From<u8> for MulticastGroupStatus {
 impl fmt::Display for MulticastGroupStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MulticastGroupStatus::Pending => write!(f, "pending"),
+            MulticastGroupStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             MulticastGroupStatus::Activated => write!(f, "activated"),
             MulticastGroupStatus::Suspended => write!(f, "suspended"),
             MulticastGroupStatus::Deleting => write!(f, "deleting"),
-            MulticastGroupStatus::Rejected => write!(f, "rejected"),
+            MulticastGroupStatus::RejectedDeprecated => write!(f, "rejected (deprecated)"),
         }
     }
 }
@@ -116,7 +116,7 @@ impl Default for MulticastGroup {
             tenant_pk: Pubkey::default(),
             multicast_ip: Ipv4Addr::new(0, 0, 0, 0),
             max_bandwidth: 0,
-            status: MulticastGroupStatus::Pending,
+            status: MulticastGroupStatus::PendingDeprecated,
             code: String::new(),
             publisher_count: 0,
             subscriber_count: 0,
@@ -174,8 +174,8 @@ impl Validate for MulticastGroup {
             return Err(DoubleZeroError::InvalidAccountType);
         }
         // Multicast IP must be in the range
-        if self.status != MulticastGroupStatus::Pending
-            && self.status != MulticastGroupStatus::Rejected
+        if self.status != MulticastGroupStatus::PendingDeprecated
+            && self.status != MulticastGroupStatus::RejectedDeprecated
             && !self.multicast_ip.is_multicast()
         {
             msg!("Invalid multicast IP: {}", self.multicast_ip);
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(val.tenant_pk, Pubkey::default());
         assert_eq!(val.multicast_ip, Ipv4Addr::new(0, 0, 0, 0));
         assert_eq!(val.max_bandwidth, 0);
-        assert_eq!(val.status, MulticastGroupStatus::Pending);
+        assert_eq!(val.status, MulticastGroupStatus::PendingDeprecated);
         assert_eq!(val.code, String::new());
         assert_eq!(val.publisher_count, 0);
         assert_eq!(val.subscriber_count, 0);
@@ -259,7 +259,7 @@ mod tests {
             tenant_pk: Pubkey::new_unique(),
             multicast_ip: Ipv4Addr::new(1, 1, 1, 1),
             max_bandwidth: 1000,
-            status: MulticastGroupStatus::Rejected,
+            status: MulticastGroupStatus::RejectedDeprecated,
             code: "test".to_string(),
             publisher_count: 0,
             subscriber_count: 0,

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -96,30 +96,30 @@ impl fmt::Display for UserCYOA {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UserStatus {
     #[default]
-    Pending = 0,
+    PendingDeprecated = 0, // activator-only; unreachable for new accounts
     Activated = 1,
-    SuspendedDeprecated = 2, // deprecated
+    SuspendedDeprecated = 2,
     Deleting = 3,
-    Rejected = 4,
-    PendingBan = 5,
+    RejectedDeprecated = 4,   // activator-only; unreachable for new accounts
+    PendingBanDeprecated = 5, // activator-only
     Banned = 6,
-    Updating = 7,
+    UpdatingDeprecated = 7, // activator-only intermediate state
     OutOfCredits = 8,
 }
 
 impl From<u8> for UserStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => UserStatus::Pending,
+            0 => UserStatus::PendingDeprecated,
             1 => UserStatus::Activated,
             2 => UserStatus::SuspendedDeprecated,
             3 => UserStatus::Deleting,
-            4 => UserStatus::Rejected,
-            5 => UserStatus::PendingBan,
+            4 => UserStatus::RejectedDeprecated,
+            5 => UserStatus::PendingBanDeprecated,
             6 => UserStatus::Banned,
-            7 => UserStatus::Updating,
+            7 => UserStatus::UpdatingDeprecated,
             8 => UserStatus::OutOfCredits,
-            _ => UserStatus::Pending,
+            _ => UserStatus::PendingDeprecated,
         }
     }
 }
@@ -127,13 +127,13 @@ impl From<u8> for UserStatus {
 impl fmt::Display for UserStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UserStatus::Pending => write!(f, "pending"),
+            UserStatus::PendingDeprecated => write!(f, "pending (deprecated)"),
             UserStatus::Activated => write!(f, "activated"),
-            UserStatus::SuspendedDeprecated => write!(f, "suspended"),
+            UserStatus::SuspendedDeprecated => write!(f, "suspended (deprecated)"),
             UserStatus::Deleting => write!(f, "deleting"),
-            UserStatus::Rejected => write!(f, "rejected"),
-            UserStatus::PendingBan => write!(f, "pending ban"),
-            UserStatus::Updating => write!(f, "updating"),
+            UserStatus::RejectedDeprecated => write!(f, "rejected (deprecated)"),
+            UserStatus::PendingBanDeprecated => write!(f, "pending ban (deprecated)"),
+            UserStatus::UpdatingDeprecated => write!(f, "updating (deprecated)"),
             UserStatus::Banned => write!(f, "banned"),
             UserStatus::OutOfCredits => write!(f, "out_of_credits"),
         }
@@ -355,12 +355,12 @@ impl Validate for User {
             return Err(DoubleZeroError::InvalidClientIp);
         }
         // dz_ip must be global unicast
-        if self.status != UserStatus::Pending && !is_global(self.dz_ip) {
+        if self.status != UserStatus::PendingDeprecated && !is_global(self.dz_ip) {
             msg!("dz_ip: {}", self.dz_ip);
             return Err(DoubleZeroError::InvalidDzIp);
         }
         // tunnel net must be private
-        if self.status != UserStatus::Pending && !self.tunnel_net.ip().is_link_local() {
+        if self.status != UserStatus::PendingDeprecated && !self.tunnel_net.ip().is_link_local() {
             msg!("tunnel_net: {}", self.tunnel_net);
             return Err(DoubleZeroError::InvalidTunnelNet);
         }
@@ -487,7 +487,7 @@ mod tests {
             val.tunnel_net,
             NetworkV4::new(Ipv4Addr::new(0, 0, 0, 0), 0).unwrap()
         );
-        assert_eq!(val.status, UserStatus::Pending);
+        assert_eq!(val.status, UserStatus::PendingDeprecated);
         assert_eq!(val.publishers, Vec::<Pubkey>::new());
         assert_eq!(val.subscribers, Vec::<Pubkey>::new());
         assert_eq!(val.validator_pubkey, Pubkey::default());
@@ -823,7 +823,7 @@ mod tests {
             dz_ip: [192, 168, 1, 1].into(),
             tunnel_id: 0,
             tunnel_net: NetworkV4::default(),
-            status: UserStatus::Pending,
+            status: UserStatus::PendingDeprecated,
             publishers: vec![],
             subscribers: vec![],
             validator_pubkey: Pubkey::default(),


### PR DESCRIPTION
## Summary

- Rename activator-only status variants to `*Deprecated` across `UserStatus`, `DeviceStatus`, `LinkStatus`, `MulticastGroupStatus`, `LocationStatus`, `ExchangeStatus`.
- `UserStatus` also renames `PendingBan` → `PendingBanDeprecated` and `Updating` → `UpdatingDeprecated`; both are only written/read by activator-driven flows (`requestban.rs`, `subscribe.rs` → `activate.rs`/`reject.rs`).
- **Numeric Borsh discriminants are preserved**, so legacy onchain accounts continue to decode (verified by the existing inline `test_state_compatibility_*` cases in each state file).
- `Display` appends ` (deprecated)` for renamed variants; `FromStr` (where it exists) accepts both old and new strings, so any CLI/external tooling that parses a status string keeps working.

## Audit outcomes

- **`UserStatus::Deleting` — kept.** `closeaccount.rs:328` (operator-driven) is the producer.
- **`UserStatus::PendingBan` — renamed.** Only read by activator-gated `ban.rs:66`.
- **`UserStatus::Updating` — renamed.** Only consumed by activator-driven `activate.rs:137`, `reject.rs:68`, `subscribe.rs:198`.
- **`MulticastGroupStatus::Suspended` / `Location::Suspended` / `Exchange::Suspended` — out of scope** for this phase. Defer to a follow-up.

## Controller `LinkStatusPending` sentinel

Option (b) from the issue: the rename here lands the variant change; the controller sentinel migration is in **PR 5.4** (Go SDK + controller), where a controller-local `linkStatusUnknown` replaces the in-memory sentinel use.

## Phase chain

This PR is the head of a 4-PR chain implementing tracker #3607 Phase 5. PRs 5.2/5.3/5.4 propagate the rename to Rust SDK + CLI, TS/Python SDKs, and Go SDK + Go consumers respectively. The workspace `cargo build` will not be green until **PR 5.2** lands — that is the explicit scope split called out in issue #3618.

## Testing Verification

- `cargo test -p doublezero-serviceability` — all unit + integration tests pass, including the inline `test_state_compatibility_*` Borsh-compat round-trips for `User`, `Device`, `Link`, `MulticastGroup`, `Location`, `Exchange`.
- `make rust-fmt` clean.
- Grep across the serviceability crate for old variant names (`UserStatus::Pending`, `…::Rejected`, `…::PendingBan`, `…::Updating`, `DeviceStatus::{Pending,Rejected}`, `LinkStatus::{Pending,Rejected}`, `MulticastGroupStatus::{Pending,Rejected}`, `LocationStatus::Pending`, `ExchangeStatus::Pending`) returns zero matches.

Part of #3607.
Closes #3617.