### PR TITLE
docs: scrub activator references (phase 6.1)

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -26,7 +26,7 @@ The CHANGELOG uses this format — entries are grouped by component with sub-bul
   - Description of change
 ```
 
-Common component names used in this project: CLI, Client, Onchain programs, Smartcontract, SDK, Telemetry, Activator, Device controller, Device agents, E2E tests, CI, Monitor, Funder, Tools, RFCs.
+Common component names used in this project: CLI, Client, Onchain programs, Smartcontract, SDK, Telemetry, Device controller, Device agents, E2E tests, CI, Monitor, Funder, Tools, RFCs.
 
 Guidelines:
 - Add entries under the existing `## Unreleased` / `### Changes` section, do not create a new section

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ DoubleZero is a decentralized high-performance network built on Solana. Contribu
 | Component        | Language                                            | Purpose                                                                                      |
 | ---------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `smartcontract/` | Rust                                                | Solana programs (serviceability, telemetry, revenue distribution) + CLI                      |
-| `activator/`     | Rust                                                | Offchain validator — approves/rejects entities, allocates resources (IPs, tunnel IDs)        |
 | `client/`        | Rust (`doublezero` CLI) + Go (`doublezerod` daemon) | End-user connectivity — GRE tunnels, BGP sessions                                            |
 | `controlplane/`  | Go                                                  | Controller pushes configs to devices; agent runs on Arista EOS; funder, monitor, admin tools |
 | `telemetry/`     | Go                                                  | Flow ingestion (NetFlow/IPFIX), gNMI writer, global monitor → ClickHouse/InfluxDB            |
@@ -19,7 +18,7 @@ DoubleZero is a decentralized high-performance network built on Solana. Contribu
 | `sdk/`           | Go, Python, TypeScript                              | Read-only account deserialization for serviceability, telemetry, revenue distribution        |
 | `e2e/`           | Go                                                  | End-to-end tests using testcontainers-go with Arista cEOS devices                            |
 
-**Onchain state lifecycle:** Pending → Activated/Rejected → Suspended/Deleting. The activator drives all transitions.
+**Onchain state lifecycle:** Created in `Activated`; admin/operator instructions drive subsequent transitions.
 
 **Serialization:** Borsh for onchain accounts, Protobuf for gRPC (controller↔agent), JSON for APIs.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-/activator/ @elitegreg

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,7 @@ The required image (`ghcr.io/malbeclabs/ceos:4.33.1F`) will be pulled automatica
 
 ### Running end-to-end tests
 
-End-to-end tests exercise the full DoubleZero stack — smartcontracts, controller, activator, client, and device agents — all running in isolated Docker containers.
+End-to-end tests exercise the full DoubleZero stack — smartcontracts, controller, client, and device agents — all running in isolated Docker containers.
 
 ```bash
 # Run a specific test
@@ -85,7 +85,7 @@ make e2e-test
 
 ### Running the local devnet
 
-This starts a full DoubleZero devnet in Docker, including the controller, activator, and DZ ledger with deployed Serviceability and Telemetry programs.
+This starts a full DoubleZero devnet in Docker, including the controller and DZ ledger with deployed Serviceability and Telemetry programs.
 
 The example below walks through creating a small two-device network with two clients and establishing connectivity between them:
 

--- a/client/doublezero/src/dzd_latency.rs
+++ b/client/doublezero/src/dzd_latency.rs
@@ -66,7 +66,7 @@ pub fn select_tunnel_endpoint(
         return device_public_ip;
     }
 
-    // No suitable endpoint found; let the activator pick one
+    // No suitable endpoint found; return UNSPECIFIED and let the caller decide.
     Ipv4Addr::UNSPECIFIED
 }
 

--- a/controlplane/doublezero-admin/src/cli/sentinel.rs
+++ b/controlplane/doublezero-admin/src/cli/sentinel.rs
@@ -683,7 +683,7 @@ impl CreateValidatorMulticastPublishersCommand {
                     nearest_device: nearest,
                     device_ip,
                     tunnel_endpoint: if tunnel_endpoint == Ipv4Addr::UNSPECIFIED {
-                        "(activator-assigned)".to_string()
+                        "(legacy-assigned)".to_string()
                     } else {
                         tunnel_endpoint.to_string()
                     },
@@ -851,9 +851,9 @@ impl CreateValidatorMulticastPublishersCommand {
 /// Build the set of tunnel endpoints already in use by users at `client_ip`.
 ///
 /// For users with an explicit `tunnel_endpoint` onchain, use that value.
-/// For legacy users where `tunnel_endpoint == UNSPECIFIED`, the activator
-/// implicitly routes their tunnel through the device's `public_ip`, so
-/// resolve it from `device_infos` rather than dropping the entry.
+/// For legacy users where `tunnel_endpoint == UNSPECIFIED`, the tunnel is
+/// implicitly routed through the device's `public_ip`, so resolve it from
+/// `device_infos` rather than dropping the entry.
 fn tunnel_exclude_ips(
     users: &[DzUser],
     client_ip: Ipv4Addr,

--- a/crates/sentinel/src/dz_ledger_writer.rs
+++ b/crates/sentinel/src/dz_ledger_writer.rs
@@ -88,8 +88,8 @@ pub fn build_create_multicast_publisher_instructions(
     //
     // When dz_prefix_count > 0 we append the ResourceExtension accounts so the contract takes
     // the atomic create+allocate+activate path. Without those accounts the user is created
-    // Pending and — with no activator — never reaches Activated, so the next poll cycle would
-    // re-attempt creation and trip AccountAlreadyInitialized.
+    // Pending and never reaches Activated, so the next poll cycle would re-attempt creation
+    // and trip AccountAlreadyInitialized.
     let (user_pda, _) = get_user_pda(program_id, &user.client_ip, SvcUserType::Multicast);
     let mut create_user_accounts = vec![
         AccountMeta::new(user_pda, false),

--- a/crates/sentinel/src/multicast_publisher.rs
+++ b/crates/sentinel/src/multicast_publisher.rs
@@ -1252,7 +1252,7 @@ mod tests {
         // Device has one UTE; the IBRL user already occupies it AND the
         // device's public_ip is also excluded (via a second user with matching
         // client_ip). No endpoint left — sentinel should skip rather than
-        // send UNSPECIFIED for a guaranteed activator rejection.
+        // send UNSPECIFIED for a guaranteed rejection.
         let group = Pubkey::new_unique();
         let ip = [10, 0, 0, 1];
         let device = Pubkey::new_unique();
@@ -1300,9 +1300,9 @@ mod tests {
     #[tokio::test]
     async fn legacy_unspecified_tunnel_endpoint_excludes_device_public_ip() {
         // An IBRL user predating the tunnel_endpoint field stores UNSPECIFIED
-        // onchain; the activator implicitly put its tunnel on the device's
-        // public_ip. The multicast publisher must therefore skip the public_ip
-        // and land on a UTE.
+        // onchain; its tunnel was implicitly placed on the device's public_ip.
+        // The multicast publisher must therefore skip the public_ip and land
+        // on a UTE.
         let group = Pubkey::new_unique();
         let ip = [10, 0, 0, 1];
         let device = Pubkey::new_unique();

--- a/crates/sentinel/src/tunnel_endpoint.rs
+++ b/crates/sentinel/src/tunnel_endpoint.rs
@@ -29,8 +29,8 @@ impl Default for DeviceEndpoints {
 /// `exclude_ips` is skipped — these are the endpoints already used by other
 /// user accounts at the same `client_ip`.
 ///
-/// Returns `Ipv4Addr::UNSPECIFIED` when no endpoint is available; the activator
-/// will then reject the create.
+/// Returns `Ipv4Addr::UNSPECIFIED` when no endpoint is available; the caller
+/// is expected to abort the create.
 pub fn select_tunnel_endpoint(
     public_ip: Ipv4Addr,
     user_tunnel_endpoints: &[Ipv4Addr],
@@ -53,9 +53,9 @@ pub fn select_tunnel_endpoint(
 /// at the same `client_ip`.
 ///
 /// A user with `tunnel_endpoint == UNSPECIFIED` is a legacy account from
-/// before the field was populated onchain; the activator implicitly routes
-/// its tunnel through the device's `public_ip`, so resolve it from
-/// `device_endpoints` rather than dropping the user.
+/// before the field was populated onchain; its tunnel is implicitly routed
+/// through the device's `public_ip`, so resolve it from `device_endpoints`
+/// rather than dropping the user.
 pub fn in_use_tunnel_endpoints<'a, I>(
     users: I,
     client_ip: Ipv4Addr,
@@ -193,8 +193,8 @@ mod tests {
     #[test]
     fn in_use_tunnel_endpoints_resolves_legacy_unspecified_via_device_public_ip() {
         // A legacy user predating the tunnel_endpoint field stores UNSPECIFIED
-        // onchain; the activator implicitly routes its tunnel through the
-        // device's public_ip, so we must add that to the in-use set.
+        // onchain; its tunnel is implicitly routed through the device's
+        // public_ip, so we must add that to the in-use set.
         let ip_a = [10, 0, 0, 1];
         let device_a = Pubkey::new_unique();
         let public_ip_a = Ipv4Addr::new(1, 1, 1, 1);

--- a/e2e/docker/ledger/fork-accounts/src/main.rs
+++ b/e2e/docker/ledger/fork-accounts/src/main.rs
@@ -126,7 +126,7 @@ fn cmd_fetch(args: &[String]) {
     }
 }
 
-/// Patch a GlobalState account's foundation_allowlist and activator_authority_pk.
+/// Patch a GlobalState account's foundation_allowlist and legacy authority key.
 fn cmd_patch_globalstate(args: &[String]) {
     if args.len() < 2 {
         eprintln!("Usage: fork-accounts patch-globalstate <accounts-dir> <authority-pubkey>");
@@ -177,7 +177,7 @@ fn cmd_patch_globalstate(args: &[String]) {
         let prev_len = global_state.foundation_allowlist.len();
         global_state.foundation_allowlist.push(authority);
 
-        // Set activator_authority_pk to the same authority.
+        // Set the legacy authority key to the same authority.
         global_state.activator_authority_pk = authority;
 
         // Re-serialize and write back.
@@ -193,7 +193,7 @@ fn cmd_patch_globalstate(args: &[String]) {
         fs::write(&path, json).expect("failed to write account file");
 
         eprintln!(
-            "Patched GlobalState account {}: added authority to foundation_allowlist (now {} entries) and set activator_authority_pk",
+            "Patched GlobalState account {}: added authority to foundation_allowlist (now {} entries) and set legacy authority key",
             path.file_stem().unwrap().to_str().unwrap(),
             prev_len + 1
         );

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -5,9 +5,7 @@ else
 	COMMIT_ID=$(git rev-parse HEAD)
 fi
 for tag in $(git tag --contains $COMMIT_ID) ; do
-	if [[ $tag == activator/* ]] ; then
-		ACTIVATOR_VERSION=$(echo $tag | cut -f2 -d/)
-	elif [[ $tag == controller/* ]] ; then
+	if [[ $tag == controller/* ]] ; then
 		CONTROLLER_VERSION=$(echo $tag | cut -f2 -d/)
 	elif [[ $tag == agent/* ]] ; then
 		AGENT_VERSION=$(echo $tag | cut -f2 -d/)
@@ -18,7 +16,6 @@ for tag in $(git tag --contains $COMMIT_ID) ; do
 	fi
 done
 
-echo ACTIVATOR_VERSION=$ACTIVATOR_VERSION
 echo CONTROLLER_VERSION=$CONTROLLER_VERSION
 echo AGENT_VERSION=$AGENT_VERSION
 echo DEVICE_TELEMETRY_AGENT_VERSION=$DEVICE_TELEMETRY_AGENT_VERSION

--- a/sdk/serviceability/python/serviceability/state.py
+++ b/sdk/serviceability/python/serviceability/state.py
@@ -51,7 +51,7 @@ class AccountTypeEnum(IntEnum):
 
 
 class LocationStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     SUSPENDED = 2
 
@@ -61,7 +61,7 @@ class LocationStatus(IntEnum):
 
 
 class ExchangeStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     SUSPENDED = 2
 
@@ -81,10 +81,10 @@ class DeviceDeviceType(IntEnum):
 
 
 class DeviceStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     DELETING = 2
-    REJECTED_DEPRECATED = 3  # activator-only; unreachable for new accounts
+    REJECTED_DEPRECATED = 3  # deprecated; unreachable for new accounts
     DRAINED = 4
     DEVICE_PROVISIONING = 5
     LINK_PROVISIONING = 6
@@ -222,10 +222,10 @@ class LinkLinkType(IntEnum):
 
 
 class LinkStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     DELETING = 3
-    REJECTED_DEPRECATED = 4  # activator-only; unreachable for new accounts
+    REJECTED_DEPRECATED = 4  # deprecated; unreachable for new accounts
     REQUESTED = 5
     HARD_DRAINED = 6
     SOFT_DRAINED = 7
@@ -315,13 +315,13 @@ class CyoaType(IntEnum):
 
 
 class UserStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     DELETING = 3
-    REJECTED_DEPRECATED = 4  # activator-only; unreachable for new accounts
-    PENDING_BAN_DEPRECATED = 5  # activator-only
+    REJECTED_DEPRECATED = 4  # deprecated; unreachable for new accounts
+    PENDING_BAN_DEPRECATED = 5  # deprecated
     BANNED = 6
-    UPDATING_DEPRECATED = 7  # activator-only intermediate state
+    UPDATING_DEPRECATED = 7  # deprecated intermediate state
     OUT_OF_CREDITS = 8
 
     def __str__(self) -> str:
@@ -349,11 +349,11 @@ class BGPStatus(IntEnum):
 
 
 class MulticastGroupStatus(IntEnum):
-    PENDING_DEPRECATED = 0  # activator-only; unreachable for new accounts
+    PENDING_DEPRECATED = 0  # deprecated; unreachable for new accounts
     ACTIVATED = 1
     SUSPENDED = 2
     DELETING = 3
-    REJECTED_DEPRECATED = 4  # activator-only; unreachable for new accounts
+    REJECTED_DEPRECATED = 4  # deprecated; unreachable for new accounts
 
     def __str__(self) -> str:
         _names = {

--- a/smartcontract/README.md
+++ b/smartcontract/README.md
@@ -85,7 +85,7 @@ Users access the DoubleZero network by establishing a GRE (Generic Routing Encap
 
 ## Contributor Automation Process
 
-DoubleZero is composed of six main components, each playing a specific role in enabling the operation of a decentralized, performance-aware network. Together, they provide the interface, control logic, automation, and monitoring required for contributors and users to participate in the system.
+DoubleZero is composed of five main components, each playing a specific role in enabling the operation of a decentralized, performance-aware network. Together, they provide the interface, control logic, automation, and monitoring required for contributors and users to participate in the system.
 
 ```mermaid
 flowchart TD
@@ -99,7 +99,6 @@ flowchart TD
     end
 
     subgraph Off-chain
-        ACT[Activator]
         CTRL[Controller]
     end
 
@@ -112,8 +111,6 @@ flowchart TD
     end
 
     CLI -->|Submit signed requests| SC
-    SC -->|Trigger validation| ACT
-    ACT -->|Allocate resources| SC
     SC -->|Resources| CTRL
     CTRL -->|Push config| AGENT
     AGENT -->|Submit signed metrics| LAT
@@ -121,7 +118,7 @@ flowchart TD
     LAT--> REWARDS[Rewards Process]
 
     classDef component fill:#f8fafc,stroke:#334155,stroke-width:1px;
-    class CLI,SC,LAT,ACT,CTRL,AGENT,THIRD component;
+    class CLI,SC,LAT,CTRL,AGENT,THIRD component;
 ```
 
 ### 1. **CLI (Command Line Interface)**
@@ -130,21 +127,17 @@ The CLI is the main user-facing tool for interacting with the DoubleZero network
 
 ### 2. **Serviceability Smart Contract**
 
-The Serviceability smart contract acts as the on-chain source of truth for the DoubleZero network. It securely stores all relevant metadata, including contributors, devices, and links, as well as state transitions such as pending, activated, or suspended. It also holds governance-related configurations. This contract enforces protocol-level rules, validates signatures from network participants, and ensures that all changes are transparent and auditable.
+The Serviceability smart contract acts as the on-chain source of truth for the DoubleZero network. It securely stores all relevant metadata, including contributors, devices, and links, as well as state transitions such as activated or suspended. It also holds governance-related configurations and is responsible for allocating resources (IP blocks, tunnel indices, GRE segments) at entity-creation time. This contract enforces protocol-level rules, validates signatures from network participants, and ensures that all changes are transparent and auditable.
 
-### 3. **Activator**
-
-The Activator is an off-chain guardian process responsible for validating and activating the various entities submitted by contributors. It plays a central role in approving Devices, Links, and Users after performing validation checks, and in allocating critical resources such as IP blocks, tunnel indices, and GRE segments. By bridging operational requirements with on-chain governance, the Activator ensures that only properly configured and compliant participants are allowed to operate within the network.
-
-### 4. **Controller**
+### 3. **Controller**
 
 The Controller is responsible for generating and applying network configuration to the physical or devices registered in the DoubleZero system. It uses the declarations stored on-chain to push routing rules, GRE tunnel definitions, and peering configurations to the appropriate devices. Its role is to ensure that all devices are provisioned correctly and are ready to forward traffic securely and efficiently. The Controller relies on the Agent to execute these actions on the hardware itself.
 
-### 5. **Agent**
+### 4. **Agent**
 
 The Agent runs on or near each physical device and serves as the telemetry and operations interface at the edge of the network. It is responsible for collecting performance metrics such as latency, availability, and throughput, and for signing and submitting this telemetry data back to the network. By providing accurate, real-time measurements, the Agent plays a critical role in supporting DoubleZero’s performance-based reward model and in maintaining the health and accountability of the infrastructure.
 
-### 6. Telemetry **Smart Contract**
+### 5. Telemetry **Smart Contract**
 
 The Latency Smart Contract functions as the on-chain registry for all network latency and performance metrics. It accepts signed reports from both internal agents and authorized third-party measurement providers, and supports measurements between DoubleZero devices as well as from external observation points. By storing this data immutably and transparently, the contract enables precise performance auditing and ensures that contributors are rewarded based on the actual quality of service they provide.
 
@@ -186,25 +179,18 @@ Additionally, the public key `metrics-publisher` is authorized to sign and submi
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending
-    Pending --> Activated: approve
-    Pending --> Rejected: reject
+    [*] --> Activated
     Activated --> Suspended: suspend
-    Activated --> Deleting: delete
     Suspended --> Activated: resume
-    Suspended --> Deleting: delete
-    Rejected --> [*]
-    Deleting --> [*]
+    Activated --> [*]: close
+    Suspended --> [*]: close
 
 ```
 
-In the DoubleZero system, each Device follows a defined lifecycle that ensures it is properly validated and provisioned before it becomes active in the network. The diagram above illustrates the possible states a Device can transition through:
+In the DoubleZero system, each Device follows a defined lifecycle. The diagram above illustrates the possible states a Device can transition through:
 
-- **Pending**: This is the initial state when a contributor creates a device. At this stage, the device's information is registered on-chain but it is not yet active or usable. It is awaiting review and approval by the activator process to change it to Activated. But if it fails the approval process, the Activator can change the state to Rejected.
-- **Activated**: Once a Device is approved—by an off-chain oracle process known as the *Activator*—it transitions to the `Activated` state. During this step, the Activator allocates the necessary resources (such as GRE configurations, IP allocations, and controller settings) and registers the device so it can begin serving users. While in this state, an actor can change the device's state to Suspended or Deleting.
-- **Rejected**: If the device fails validation or is not approved, the Activator transitions the device to the `Rejected` state. This state indicates that the device will not be used in the network and will not proceed further. The device can only be deleted once in this state.
-- **Suspended**: A contributor can suspend an activated device temporarily due to performance issues. In this state, the device is effectively paused and does not participate in routing. The contributor can then call the resume instruction to change the device state back to Activated.
-- **Deleting**: A network contributor can delete his own device. Devices that are no longer needed or have been decommissioned enter the `Deleting` state. This is a terminal phase that leads to complete removal from the network. The Activator will close the device account and lamports will be sent back to the contributor.
+- **Activated**: Devices are created directly in the `Activated` state. The Serviceability program allocates the necessary resources (GRE configurations, IP allocations, controller settings) at create time so the device can begin serving users immediately. While in this state, an admin/operator can move the device to Suspended or close the account.
+- **Suspended**: A contributor can suspend an activated device temporarily due to performance issues. In this state, the device is effectively paused and does not participate in routing. The contributor can then call the resume instruction to change the device state back to Activated, or close the account to remove the device from the network.
 
 We can retrieve a list of all devices that have been created and inspect the details of each, including the unique public key (Pubkey) that was generated during their registration. This Pubkey serves as the definitive on-chain identifier for the device and is used internally by the network to validate actions and ownership.
 
@@ -251,25 +237,18 @@ When the command is executed, DoubleZero records the link on‑chain, validates 
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending
-    Pending --> Activated: approve
-    Pending --> Rejected: reject
+    [*] --> Activated
     Activated --> Suspended: suspend
-    Activated --> Deleting: delete
     Suspended --> Activated: resume
-    Suspended --> Deleting: delete
-    Rejected --> [*]
-    Deleting --> [*]
+    Activated --> [*]: close
+    Suspended --> [*]: close
 
 ```
 
-In the DoubleZero system, each Link follows a defined lifecycle that ensures it is properly validated and provisioned before it becomes active in the network. The diagram above illustrates the possible states a Link can transition through:
+In the DoubleZero system, each Link follows a defined lifecycle. The diagram above illustrates the possible states a Link can transition through:
 
-- **Pending**: This is the initial state when a contributor creates a link. At this stage, the link information is registered on-chain but it is not yet active or usable. It is awaiting review and approval by the activator process to change it to Activated. But if it fails the approval process, the Activator can change the state to Rejected.
-- **Activated**: Once a Link is approved—by an off-chain oracle process known as the *Activator*—it transitions to the `Activated` state. During this step, the Activator allocates the necessary resources (such as GRE configurations, IP allocations, and controller settings) and registers the device so it can begin serving users. While in this state, an actor can change the link’s state to Suspended or Deleting.
-- **Rejected**: If the link fails validation or is not approved, the Activator transitions the device to the `Rejected` state. This state indicates that the link will not be used in the network and will not proceed further. The link can only be deleted once in this state.
-- **Suspended**: **This link state is not used for anything currently.** A contributor can suspend an activated link temporarily due to performance issues. In this state, the device is effectively paused and does not participate in routing. The contributor can then call the resume instruction to change the device state back to Activated.
-- **Deleting**: A network contributor can delete his own link. Links that are no longer needed or have been decommissioned enter the `Deleting` state. This is a terminal phase that leads to complete removal from the network. The Activator will close the device account and lamports will be sent back to the contributor.
+- **Activated**: Links are created directly in the `Activated` state. The Serviceability program allocates the necessary resources (GRE configurations, IP allocations, controller settings) at create time. While in this state, an admin/operator can move the link to Suspended or close the account.
+- **Suspended**: **This link state is not used for anything currently.** A contributor can suspend an activated link temporarily due to performance issues. In this state, the link is effectively paused and does not participate in routing. The contributor can then call the resume instruction to change the link state back to Activated, or close the account to remove the link from the network.
 
 ### As a contributor, I want to suspend a Device so that I can perform maintenance without allowing users to connect to it.
 
@@ -291,7 +270,7 @@ In the **Suspended** state:
 - The Agent may continue collecting telemetry, but the data is not used for active performance evaluation.
 - Links associated with the Device may also be disabled or marked as inactive depending on network policy.
 
-The suspension is processed as an on-chain transaction, ensuring transparency and accountability. Once the maintenance is completed, the contributor or the Activator can resume the Device using a similar command, triggering a transition back to the **Activated** state. This allows the Device to safely rejoin the network without requiring a full reinitialization.
+The suspension is processed as an on-chain transaction, ensuring transparency and accountability. Once the maintenance is completed, the contributor can resume the Device using a similar command, triggering a transition back to the **Activated** state. This allows the Device to safely rejoin the network without requiring a full reinitialization.
 
 To bring a previously suspended device back into service, the contributor can use the `doublezero device resume` command. This operation signals to the network that the device is once again ready to operate, and should be returned to the **Activated** state.
 
@@ -357,58 +336,44 @@ This process ensures that once DoubleZero is connected, traffic to validators th
 
 Additionally, this setup provides an automatic fallback mechanism: if the BGP session is disconnected, the daemon removes the static routes from the kernel’s routing table, allowing traffic to seamlessly continue flowing over the internet without interruption.
 
-To orchestrate this entire flow, the CLI is responsible for creating the user account on the smart contract, waiting for the Activator to validate and assign the necessary resources, and then initiating the connection process through the DoubleZero Daemon, which handles the tunnel setup and route provisioning.
+To orchestrate this entire flow, the CLI is responsible for creating the user account on the smart contract — which allocates network resources (such as a dedicated IP address) on-chain at create time — and then initiating the connection process through the DoubleZero Daemon, which handles the tunnel setup and route provisioning.
 
 ## User account lifecycle
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending
-    Pending --> Activated: approve
-    Pending --> Rejected: reject
+    [*] --> Activated
     Activated --> Suspended: suspend
-    Activated --> PendingBan: request_ban
-    Activated --> Deleting: delete
     Suspended --> Activated: resume
-    Suspended --> Deleting: delete
-    PendingBan --> Banned: ban
-    PendingBan --> Activated: reject_ban
+    Activated --> Banned: ban
+    Activated --> [*]: close
+    Suspended --> [*]: close
     Banned --> [*]
-    Deleting --> [*]
-    Rejected --> [*]
 ```
 
-The user account lifecycle in DoubleZero follows a stateful process that ensures all user registrations and terminations are validated, controlled, and auditable. The transitions between states are governed by a combination of user actions and decisions made by the network's Activator or governance entities.
+The user account lifecycle in DoubleZero follows a stateful process that ensures all user registrations and terminations are auditable.
 
 ### **User Account Flow Description**
 
-1. **Pending**
-    
-    When a user runs the `doublezero connect` command, a new user account is created on the smart contract in the **Pending** state. At this stage, the user is not yet active in the network. The request awaits validation and approval by the **Activator**, which checks the configuration and assigns necessary network resources (like IP addresses).
-    
-2. **Activated**
-    
-    If the Activator approves the user, the account transitions to the **Activated** state. The user is now officially part of the DoubleZero network, and GRE tunneling and BGP sessions. The user’s validator benefits from improved network connectivity at this point.
-    
-3. **Rejected**
-    
-    If the Activator finds the request invalid or non-compliant, the user is moved to the **Rejected** state. The account is discarded and cannot be used unless re-created.
-    
-4. **Suspended**
-    
+1. **Activated**
+
+    When a user runs the `doublezero connect` command, a new user account is created directly in the **Activated** state. The Serviceability program allocates the necessary network resources (such as a dedicated IP address from the contributor’s IP block) at create time, and the user is officially part of the DoubleZero network. The user’s validator benefits from improved network connectivity at this point.
+
+2. **Suspended**
+
     A user in the Activated state can temporarily **suspend** their connection, for instance, to perform maintenance or stop routing traffic through DoubleZero. This can be initiated by the user themselves. Suspended users are not eligible for routing or performance rewards until they resume.
-    
-5. **Resume**
-    
+
+3. **Resume**
+
     A previously suspended user can transition back to the Activated state by using the `doublezero resume` command, which restores routing and re-establishes connectivity.
-    
-6. **Deleting**
-    
-    When a user decides to permanently leave the network, they can initiate a **delete** operation. This sets the account to the **Deleting** state. The **Activator** then performs the cleanup (revoking resources, tearing down tunnels) and finalizes the deletion by removing the user account from the smart contract.
-    
-7. **Banning**
-    
-    In certain cases, such as policy violations or abuse, someone from the **DoubleZero Foundation** can initiate a **ban request**. This moves the user to the **PendingBan** state. After review, if the ban is confirmed, the account transitions to **Banned**, and the user is forcibly disconnected from the network. Banned users are considered permanently disallowed from rejoining.
+
+4. **Close**
+
+    When a user decides to permanently leave the network, they can close the account. This revokes resources and removes the user account from the smart contract.
+
+5. **Banning**
+
+    In certain cases, such as policy violations or abuse, someone from the **DoubleZero Foundation** can ban a user. This moves the user to the **Banned** state, where the user is forcibly disconnected from the network. Banned users are considered permanently disallowed from rejoining.
     
 
 ## As a user, I want to be able to connect to the DoubleZero network from my server so that I can improve the connectivity of my Solana validator.
@@ -423,11 +388,9 @@ This command initiates a full connection workflow managed by the CLI and the Dou
 
 When the `connect` command is executed, the CLI queries the list of Devices along with the latest latency results. It then **automatically selects the optimal Device** based on the lowest measured latency, ensuring that the user is connected through the most performant entry point in the network.
 
-Once the best Device is selected, the CLI proceeds to **create a new User account** on the **Serviceability smart contract**, which includes the identity of the server and its selected Device. This request is signed and submitted on-chain.
+Once the best Device is selected, the CLI proceeds to **create a new User account** on the **Serviceability smart contract**, which includes the identity of the server and its selected Device. This request is signed and submitted on-chain. The Serviceability program assigns the necessary network resources (such as a dedicated IP address from the contributor’s IP block, if required) at create time.
 
-The **Activator** then picks up this pending User, validates the request, and—if all conditions are met—**approves the user and assigns a network resource**, such as a dedicated IP address from the contributor’s IP block, if required.
-
-Once the account is approved and provisioned, the **daemon finalizes the connection**, establishing a GRE tunnel to the selected Device and exchanging BGP routes. From this point forward, the user’s server routes traffic to known Solana validators through the optimized DoubleZero mesh, significantly improving latency, packet delivery, and overall validator performance—without requiring manual network reconfiguration or restarts.
+Once the account is provisioned, the **daemon finalizes the connection**, establishing a GRE tunnel to the selected Device and exchanging BGP routes. From this point forward, the user’s server routes traffic to known Solana validators through the optimized DoubleZero mesh, significantly improving latency, packet delivery, and overall validator performance—without requiring manual network reconfiguration or restarts.
 
 ### **Usage**
 
@@ -458,7 +421,7 @@ doublezero connect [OPTIONS] <COMMAND>
     
     (Optional) Specifies the **IPv4 address** of the user's server.
     
-    If not provided, the client attempts to detect the IP automatically. This IP is used for tunnel source validation and helps the Activator assign the appropriate GRE configuration.
+    If not provided, the client attempts to detect the IP automatically. This IP is used for tunnel source validation and is recorded on-chain when the GRE configuration is assigned.
     
 - `--device <DEVICE>`
     

--- a/smartcontract/cli/src/tenant/delete.rs
+++ b/smartcontract/cli/src/tenant/delete.rs
@@ -112,7 +112,7 @@ impl DeleteTenantCliCommand {
                 spinner.finish_with_message("Done cleaning up access passes");
             }
 
-            // 3. Wait for activator to process close accounts (reference_count reaches 0)
+            // 3. Wait for account closures to be processed (reference_count reaches 0)
             if !tenant_users.is_empty() {
                 let spinner = ProgressBar::new_spinner();
                 spinner.set_style(
@@ -122,7 +122,7 @@ impl DeleteTenantCliCommand {
                         .tick_strings(&["-", "\\", "|", "/"]),
                 );
                 spinner.enable_steady_tick(Duration::from_millis(100));
-                spinner.set_message("Waiting for activator to process account closures...");
+                spinner.set_message("Waiting for account closures to be processed...");
 
                 // Poll tenant reference_count with exponential backoff
                 let max_attempts = 8; // 1+2+4+8+16+32+32+32 = 127 seconds max
@@ -152,7 +152,7 @@ impl DeleteTenantCliCommand {
                     delay = (delay * 2).min(max_delay);
                 }
 
-                spinner.finish_with_message("Activator processing complete");
+                spinner.finish_with_message("Account closure processing complete");
             }
         } else {
             // When not cascading user deletion, still clean up access passes

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
@@ -49,7 +49,7 @@ pub struct SubscribeUserResult {
     pub mgroup: MulticastGroup,
     /// True if the publisher list transitioned between empty and non-empty
     /// (gained first publisher or lost last publisher). Callers that need to
-    /// trigger activator reprocessing should check this flag.
+    /// trigger downstream reprocessing should check this flag.
     pub publisher_list_transitioned: bool,
 }
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -62,12 +62,12 @@ impl FromStr for DeviceType {
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     //Suspended = 2, // The suspended status is no longer used
     Deleting = 3,
-    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
+    RejectedDeprecated = 4, // deprecated; unreachable for new accounts
     Drained = 5,
     DeviceProvisioning = 6,
     LinkProvisioning = 7,

--- a/smartcontract/programs/doublezero-serviceability/src/state/exchange.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/exchange.rs
@@ -12,7 +12,7 @@ pub const BGP_COMMUNITY_MAX: u16 = 10999;
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExchangeStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     Suspended = 2,

--- a/smartcontract/programs/doublezero-serviceability/src/state/link.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/link.rs
@@ -53,12 +53,12 @@ impl fmt::Display for LinkLinkType {
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LinkStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     //Suspended = 2, // The suspended status is no longer used
     Deleting = 3,
-    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
+    RejectedDeprecated = 4, // deprecated; unreachable for new accounts
     Requested = 5,
     HardDrained = 6,
     SoftDrained = 7,

--- a/smartcontract/programs/doublezero-serviceability/src/state/location.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/location.rs
@@ -11,7 +11,7 @@ use std::fmt;
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LocationStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     Suspended = 2,

--- a/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/multicastgroup.rs
@@ -11,12 +11,12 @@ use std::{fmt, net::Ipv4Addr};
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MulticastGroupStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     Suspended = 2,
     Deleting = 3,
-    RejectedDeprecated = 4, // activator-only; unreachable for new accounts
+    RejectedDeprecated = 4, // deprecated; unreachable for new accounts
 }
 
 impl From<u8> for MulticastGroupStatus {

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -95,15 +95,15 @@ impl fmt::Display for UserCYOA {
 #[borsh(use_discriminant = true)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UserStatus {
-    PendingDeprecated = 0, // activator-only; unreachable for new accounts
+    PendingDeprecated = 0, // deprecated; unreachable for new accounts
     #[default]
     Activated = 1,
     SuspendedDeprecated = 2,
     Deleting = 3,
-    RejectedDeprecated = 4,   // activator-only; unreachable for new accounts
-    PendingBanDeprecated = 5, // activator-only
+    RejectedDeprecated = 4,   // deprecated; unreachable for new accounts
+    PendingBanDeprecated = 5, // deprecated
     Banned = 6,
-    UpdatingDeprecated = 7, // activator-only intermediate state
+    UpdatingDeprecated = 7, // deprecated intermediate state
     OutOfCredits = 8,
 }
 

--- a/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
@@ -747,8 +747,8 @@ async fn test_create_subscribe_user_ignores_expired_epoch() {
 
 /// CheckUserAccessPass keeps multicast users Activated when the access-pass is Expired.
 ///
-/// Regression test: the activator's periodic re-check must not transition multicast users
-/// to OutOfCredits based on `last_access_epoch`, since multicast access is gated by
+/// Regression test: the periodic CheckUserAccessPass re-check must not transition multicast
+/// users to OutOfCredits based on `last_access_epoch`, since multicast access is gated by
 /// mgroup_*_allowlist, not by epoch.
 #[tokio::test]
 async fn test_check_access_pass_multicast_stays_activated() {

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -33,7 +33,7 @@ const (
 type LocationStatus uint8
 
 const (
-	LocationStatusPendingDeprecated LocationStatus = 0 // activator-only; unreachable for new accounts
+	LocationStatusPendingDeprecated LocationStatus = 0 // deprecated; unreachable for new accounts
 	LocationStatusActivated         LocationStatus = 1
 	LocationStatusSuspended         LocationStatus = 2
 )
@@ -105,7 +105,7 @@ type Location struct {
 type ExchangeStatus uint8
 
 const (
-	ExchangeStatusPendingDeprecated ExchangeStatus = 0 // activator-only; unreachable for new accounts
+	ExchangeStatusPendingDeprecated ExchangeStatus = 0 // deprecated; unreachable for new accounts
 	ExchangeStatusActivated         ExchangeStatus = 1
 	ExchangeStatusSuspended         ExchangeStatus = 2
 )
@@ -159,10 +159,10 @@ func (d DeviceDeviceType) String() string {
 type DeviceStatus uint8
 
 const (
-	DeviceStatusPendingDeprecated  DeviceStatus = 0 // activator-only; unreachable for new accounts
+	DeviceStatusPendingDeprecated  DeviceStatus = 0 // deprecated; unreachable for new accounts
 	DeviceStatusActivated          DeviceStatus = 1
 	DeviceStatusDeleting           DeviceStatus = 3
-	DeviceStatusRejectedDeprecated DeviceStatus = 4 // activator-only; unreachable for new accounts
+	DeviceStatusRejectedDeprecated DeviceStatus = 4 // deprecated; unreachable for new accounts
 	DeviceStatusDrained            DeviceStatus = 5
 	DeviceStatusDeviceProvisioning DeviceStatus = 6
 	DeviceStatusLinkProvisioning   DeviceStatus = 7
@@ -553,10 +553,10 @@ func (l LinkLinkType) MarshalJSON() ([]byte, error) {
 type LinkStatus uint8
 
 const (
-	LinkStatusPendingDeprecated  LinkStatus = 0 // activator-only; unreachable for new accounts
+	LinkStatusPendingDeprecated  LinkStatus = 0 // deprecated; unreachable for new accounts
 	LinkStatusActivated          LinkStatus = 1
 	LinkStatusDeleting           LinkStatus = 3
-	LinkStatusRejectedDeprecated LinkStatus = 4 // activator-only; unreachable for new accounts
+	LinkStatusRejectedDeprecated LinkStatus = 4 // deprecated; unreachable for new accounts
 	LinkStatusRequested          LinkStatus = 5
 	LinkStatusHardDrained        LinkStatus = 6
 	LinkStatusSoftDrained        LinkStatus = 7
@@ -915,14 +915,14 @@ func (c CyoaType) MarshalJSON() ([]byte, error) {
 type UserStatus uint8
 
 const (
-	UserStatusPendingDeprecated    UserStatus = 0 // activator-only; unreachable for new accounts
+	UserStatusPendingDeprecated    UserStatus = 0 // deprecated; unreachable for new accounts
 	UserStatusActivated            UserStatus = 1
 	UserStatusSuspendedDeprecated  UserStatus = 2
 	UserStatusDeleted              UserStatus = 3
-	UserStatusRejectedDeprecated   UserStatus = 4 // activator-only; unreachable for new accounts
-	UserStatusPendingBanDeprecated UserStatus = 5 // activator-only
+	UserStatusRejectedDeprecated   UserStatus = 4 // deprecated; unreachable for new accounts
+	UserStatusPendingBanDeprecated UserStatus = 5 // deprecated
 	UserStatusBanned               UserStatus = 6
-	UserStatusUpdatingDeprecated   UserStatus = 7 // activator-only intermediate state
+	UserStatusUpdatingDeprecated   UserStatus = 7 // deprecated intermediate state
 	UserStatusOutOfCredits         UserStatus = 8
 )
 
@@ -1037,11 +1037,11 @@ func (u User) MarshalJSON() ([]byte, error) {
 type MulticastGroupStatus uint8
 
 const (
-	MulticastGroupStatusPendingDeprecated  MulticastGroupStatus = 0 // activator-only; unreachable for new accounts
+	MulticastGroupStatusPendingDeprecated  MulticastGroupStatus = 0 // deprecated; unreachable for new accounts
 	MulticastGroupStatusActivated          MulticastGroupStatus = 1
 	MulticastGroupStatusSuspended          MulticastGroupStatus = 2
 	MulticastGroupStatusDeleting           MulticastGroupStatus = 3
-	MulticastGroupStatusRejectedDeprecated MulticastGroupStatus = 4 // activator-only; unreachable for new accounts
+	MulticastGroupStatusRejectedDeprecated MulticastGroupStatus = 4 // deprecated; unreachable for new accounts
 )
 
 func (m MulticastGroupStatus) String() string {

--- a/smartcontract/sdk/rs/README.md
+++ b/smartcontract/sdk/rs/README.md
@@ -186,7 +186,7 @@ Creates a new exchange with the specified parameters. Returns the transaction si
 - `name: String` — Exchange name
 - `lat: f64` — Latitude
 - `lng: f64` — Longitude
-- `bgp_community: Option<u32>` — Optional BGP community (auto-assigned by activator)
+- `bgp_community: Option<u32>` — Optional BGP community (auto-assigned at create time)
 
 ### UpdateExchangeCommand
 Updates the parameters of an existing exchange. Returns the transaction signature.

--- a/smartcontract/sdk/rs/src/commands/tenant/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/tenant/delete.rs
@@ -57,7 +57,7 @@ impl DeleteTenantCommand {
                 .execute(client)?;
             }
 
-            // 3. Wait for activator to process close accounts (reference_count reaches 0)
+            // 3. Wait for account closures to be processed (reference_count reaches 0)
             if !tenant_users.is_empty() {
                 let tenant_pubkey = self.tenant_pubkey;
                 let builder = ExponentialBuilder::new()


### PR DESCRIPTION
## Summary

Phase 6.1 of the activator removal effort ([tracker #3607](https://github.com/malbeclabs/doublezero/issues/3607), [issue #3621](https://github.com/malbeclabs/doublezero/issues/3621)). Pure docs/comments scrub — no behavior change.

- **CLAUDE.md / DEVELOPMENT.md / smartcontract/README.md** — drop the activator from architecture descriptions and the contributor-automation diagram. Rewrite Device/Link/User lifecycle prose and mermaid state diagrams to reflect onchain allocation (`[*] → Activated`, no `Pending`/`Rejected`/`Updating`/`Deleting`).
- **`// activator-only` comments** on `*Deprecated` enum variants rewritten to `// deprecated` across the Rust program, Go SDK, and Python SDK state files. Numeric discriminants and field names unchanged.
- **Stale comments and one user-visible string** rewritten in `crates/sentinel/`, `controlplane/doublezero-admin/`, `client/doublezero/`, `smartcontract/cli/src/tenant/delete.rs` (+ SDK variant), `processors/user/activate.rs`, `processors/multicastgroup/subscribe.rs`, and `e2e/docker/ledger/fork-accounts/src/main.rs`.
- **Dead config/scripts**: remove the `/activator/` CODEOWNERS line (crate deleted in Phase 3), the activator-tag handling in `scripts/env.sh`, and the `Activator` component name in `.claude/commands/changelog.md`.

## Scope — what is intentionally NOT changed

Code identifiers that still exist as public API surface are preserved and will be cleaned up in a later code-rename PR (likely riding alongside the Phase 7 instruction removal):

- `activator_authority_pk` GlobalState field (and SDK mirrors)
- `Activator` variant in `PermissionName` / `ACTIVATOR` constant in `permission_flags`
- `--activator-authority` CLI flag
- Test-helper function names (`gs_with_activator`, `test_legacy_activator_*`)
- The `is_activator` local binding and `// Authorization: allow activator_authority_pk OR foundation_allowlist` comments in `authorize.rs` / processors — these describe the still-present legacy authorization path

The issue's strict acceptance grep (`grep -ri activator . | grep -v -E '(CHANGELOG|rfcs|target|node_modules)'` returns nothing) is therefore not satisfied by this PR — see the residual matches in code identifiers above. PERMISSION.md likewise keeps its "Legacy path" table referencing the `ACTIVATOR` flag and `activator_authority_pk` field as factually-accurate code documentation.

## Testing Verification

- `make rust-fmt`, `make rust-lint`, `make go-lint` clean.
- `cargo test` on `doublezero-serviceability` (257 passed), `doublezero-sentinel` (61 passed), `doublezero` (127 passed), `doublezero_sdk` (171 passed), `doublezero-admin` (8 passed).
- `go test ./smartcontract/sdk/go/... ./sdk/...` all packages pass.
- Python SDK pytest: 121 passed.

Part of #3607.
Closes #3621.