### PR TITLE
smartcontract/cli: reserve duplicated resource values during verify --fix

### DIFF
--- a/smartcontract/cli/src/resource/verify.rs
+++ b/smartcontract/cli/src/resource/verify.rs
@@ -365,13 +365,16 @@ impl VerifyResourceCliCommand {
                     }
                 }
 
-                // Step 2: Warn about duplicate usages but don't block
-                // Collect duplicate (resource_type, value) pairs to exclude from fixes
-                let mut duplicate_values: Vec<(ResourceType, IdOrIp)> = Vec::new();
+                // Step 2: Warn about duplicate usages. The duplicate itself must
+                // be resolved manually (by changing one of the conflicting
+                // accounts), but the underlying allocation state is still
+                // corrected below: the shared value stays reserved in the
+                // extension so it cannot be handed out to a third account
+                // before the conflict is resolved.
                 if !fix_duplicate_usages.is_empty() {
                     writeln!(
                         out,
-                        "Warning: skipping duplicate usages (must be resolved manually):"
+                        "Warning: duplicate usages detected (must be resolved manually):"
                     )?;
                     for d in &fix_duplicate_usages {
                         if let ResourceDiscrepancy::DuplicateUsage {
@@ -395,47 +398,16 @@ impl VerifyResourceCliCommand {
                                 accounts.len(),
                                 owners
                             )?;
-                            duplicate_values.push((*resource_type, value.clone()));
                         }
                     }
                     writeln!(out)?;
                 }
 
-                // Step 3: Fix allocate/deallocate discrepancies (excluding duplicates)
-                let fixable_allocated_not_used: Vec<_> = fix_allocated_not_used
-                    .iter()
-                    .filter(|d| {
-                        if let ResourceDiscrepancy::AllocatedButNotUsed {
-                            resource_type,
-                            value,
-                        } = d
-                        {
-                            !duplicate_values
-                                .iter()
-                                .any(|(rt, v)| rt == resource_type && v == value)
-                        } else {
-                            true
-                        }
-                    })
-                    .collect();
-
-                let fixable_used_not_allocated: Vec<_> = fix_used_not_allocated
-                    .iter()
-                    .filter(|d| {
-                        if let ResourceDiscrepancy::UsedButNotAllocated {
-                            resource_type,
-                            value,
-                            ..
-                        } = d
-                        {
-                            !duplicate_values
-                                .iter()
-                                .any(|(rt, v)| rt == resource_type && v == value)
-                        } else {
-                            true
-                        }
-                    })
-                    .collect();
+                // Step 3: Fix allocate/deallocate discrepancies. Values flagged
+                // as DuplicateUsage are not excluded — a shared value still
+                // belongs in the allocated set.
+                let fixable_allocated_not_used: Vec<_> = fix_allocated_not_used.iter().collect();
+                let fixable_used_not_allocated: Vec<_> = fix_used_not_allocated.iter().collect();
 
                 if !fixable_allocated_not_used.is_empty()
                     || !fixable_used_not_allocated.is_empty()


### PR DESCRIPTION
## Summary of Changes
- `verify --fix` now reserves a shared resource value (id or ip) in its `ResourceExtension` even when two accounts are using it. Previously the value was silently skipped because the duplicate was deferred for manual resolution, leaving the underlying allocation state wrong.
- The duplicate itself is still reported as a warning that must be resolved manually (one of the conflicting accounts has to change). Reserving the value prevents a third account from being assigned the same id/ip before that happens.
- Dropped the dead `AllocatedButNotUsed` half of the same filter: a duplicate implies the value is `in_use`, so it can never also be allocated-but-not-used.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Core logic |     1 | +12 / -40   | -28  |

Pure delete of the over-eager skip-filter plus a clarifying comment and warning-text tweak; no new behavior beyond what the existing allocate/deallocate path already does.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/resource/verify.rs` — removed the `duplicate_values` filter from `fixable_allocated_not_used` / `fixable_used_not_allocated` in the `--fix` path; updated the duplicate warning text from "skipping" to "detected".

</details>

## Testing Verification
- Existing 12 unit tests in `resource::verify::tests` still pass (`cargo test -p doublezero_cli --lib resource::verify`).
- Reasoned through the four state combinations for a duplicated value X used by accounts A and B:
  - X reserved, no other discrepancy → only `DuplicateUsage` reported, no fix proposed (unchanged).
  - X not reserved → `DuplicateUsage` + `UsedButNotAllocated`; `--fix` now proposes `ALLOCATE X` (previously skipped, the bug being fixed).
  - X reserved but unused (impossible when a duplicate exists, since it's in `in_use`) → no behavior change.