### PR TITLE
smartcontract/sdk: set max CU and heap frame on all serviceability transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - SDK (Rust)
   - Delete the now-dead `{Activate,Reject,CloseAccount}DeviceCommand`, `{Activate,Reject,CloseAccount}LinkCommand`, `{Activate,Reject,Deactivate}MulticastGroupCommand`, and `{Activate,Reject,Remove,Unlink}DeviceInterfaceCommand` wrappers and the corresponding orphaned trait methods on `DoubleZeroProgram` — none are reachable from any live caller ([#3623](https://github.com/malbeclabs/doublezero/issues/3623))
   - Delete the now-dead `ActivateUserCommand`, `RejectUserCommand`, `CloseAccountUserCommand`, and `BanUserCommand` wrappers — none are reachable from any live caller. `RequestBanUserCommand` (operator-driven, atomic) is unaffected ([#3622](https://github.com/malbeclabs/doublezero/issues/3622))
+  - Unconditionally request the protocol maximum compute (1,400,000 CU) and heap frame (256 KiB) on every serviceability transaction sent through `DZClient`. Removes `DoubleZeroClient::execute_transaction_with_compute_unit_limit` and the per-instruction `SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT` / `ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT` constants — serviceability runs on a dedicated private Solana cluster, so raising every transaction to the protocol max is free ([#3742](https://github.com/malbeclabs/doublezero/pull/3742))
 - SDK (Go/TS/Python)
   - Add the `bgp_rtt_ns` field to the `User` deserializer in all three SDKs; the Go executor builder accepts and serializes the new field via a 10-byte instruction payload.
 - Telemetry

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -53,6 +53,13 @@ use crate::{
     AccountData,
 };
 
+// Serviceability runs on a dedicated private Solana cluster, so every
+// transaction requests the protocol-max compute and heap budget. Values mirror
+// `solana-compute-budget`'s `MAX_COMPUTE_UNIT_LIMIT` and `MAX_HEAP_FRAME_BYTES`,
+// which are not re-exported through `solana-sdk`.
+const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
+
 pub struct DZClient {
     rpc_url: String,
     client: RpcClient,
@@ -138,7 +145,6 @@ impl DZClient {
         instruction: DoubleZeroInstruction,
         accounts: Vec<AccountMeta>,
         quiet: bool,
-        compute_unit_limit: Option<u32>,
     ) -> eyre::Result<Signature> {
         let payer = self
             .payer
@@ -159,13 +165,11 @@ impl DZClient {
             .concat(),
         );
 
-        let instructions: Vec<Instruction> = match compute_unit_limit {
-            Some(limit) => vec![
-                ComputeBudgetInstruction::set_compute_unit_limit(limit),
-                main_ix,
-            ],
-            None => vec![main_ix],
-        };
+        let instructions: Vec<Instruction> = vec![
+            ComputeBudgetInstruction::set_compute_unit_limit(MAX_COMPUTE_UNIT_LIMIT),
+            ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES),
+            main_ix,
+        ];
 
         let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
 
@@ -481,7 +485,7 @@ impl DoubleZeroClient for DZClient {
         instruction: DoubleZeroInstruction,
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature> {
-        self.execute_transaction_inner(instruction, accounts, false, None)
+        self.execute_transaction_inner(instruction, accounts, false)
     }
 
     fn execute_transaction_quiet(
@@ -489,16 +493,7 @@ impl DoubleZeroClient for DZClient {
         instruction: DoubleZeroInstruction,
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature> {
-        self.execute_transaction_inner(instruction, accounts, true, None)
-    }
-
-    fn execute_transaction_with_compute_unit_limit(
-        &self,
-        instruction: DoubleZeroInstruction,
-        accounts: Vec<AccountMeta>,
-        compute_unit_limit: u32,
-    ) -> eyre::Result<Signature> {
-        self.execute_transaction_inner(instruction, accounts, false, Some(compute_unit_limit))
+        self.execute_transaction_inner(instruction, accounts, true)
     }
 
     fn gets(&self, account_type: AccountType) -> eyre::Result<HashMap<Pubkey, AccountData>> {

--- a/smartcontract/sdk/rs/src/commands/globalconfig/set.rs
+++ b/smartcontract/sdk/rs/src/commands/globalconfig/set.rs
@@ -9,8 +9,6 @@ use doublezero_serviceability::{
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
-pub const SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct SetGlobalConfigCommand {
     pub local_asn: Option<u32>,
@@ -51,7 +49,7 @@ impl SetGlobalConfigCommand {
         let (admin_group_bits_pda, _, _) =
             get_resource_extension_pda(&client.get_program_id(), ResourceType::AdminGroupBits);
 
-        client.execute_transaction_with_compute_unit_limit(
+        client.execute_transaction(
             DoubleZeroInstruction::SetGlobalConfig(set_config_args),
             vec![
                 AccountMeta::new(pda_pubkey, false),
@@ -65,7 +63,6 @@ impl SetGlobalConfigCommand {
                 AccountMeta::new(vrf_ids_pda, false),
                 AccountMeta::new(admin_group_bits_pda, false),
             ],
-            SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT,
         )
     }
 
@@ -126,14 +123,14 @@ impl SetGlobalConfigCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::{SetGlobalConfigCommand, SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT};
+    use super::SetGlobalConfigCommand;
     use crate::{tests::utils::create_test_client, DoubleZeroClient};
     use doublezero_serviceability::pda::get_globalconfig_pda;
     use mockall::predicate;
     use solana_sdk::signature::Signature;
 
     #[test]
-    fn test_commands_setglobalconfig_uses_compute_unit_limit() {
+    fn test_commands_setglobalconfig_executes() {
         let mut client = create_test_client();
 
         // GetGlobalConfigCommand fetches the globalconfig PDA; return an error so
@@ -145,10 +142,9 @@ mod tests {
             .returning(|_| Err(eyre::eyre!("not initialized")));
 
         client
-            .expect_execute_transaction_with_compute_unit_limit()
-            .withf(|_, _, limit| *limit == SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT)
+            .expect_execute_transaction()
             .times(1)
-            .returning(|_, _, _| Ok(Signature::new_unique()));
+            .returning(|_, _| Ok(Signature::new_unique()));
 
         let res = SetGlobalConfigCommand {
             local_asn: Some(65000),

--- a/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/assign_node_segments.rs
@@ -12,8 +12,6 @@ use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature}
 /// appended by the client) we stay well under that limit at 4.
 pub const BACKFILL_BATCH_SIZE: usize = 4;
 
-pub const ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct AssignTopologyNodeSegmentsCommand {
     pub name: String,
@@ -43,12 +41,11 @@ impl AssignTopologyNodeSegmentsCommand {
                 accounts.push(AccountMeta::new(*device_pk, false));
             }
 
-            let sig = client.execute_transaction_with_compute_unit_limit(
+            let sig = client.execute_transaction(
                 DoubleZeroInstruction::AssignTopologyNodeSegments(AssignTopologyNodeSegmentsArgs {
                     name: self.name.clone(),
                 }),
                 accounts,
-                ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT,
             )?;
             signatures.push(sig);
         }
@@ -59,7 +56,6 @@ impl AssignTopologyNodeSegmentsCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT;
     use crate::{
         commands::topology::assign_node_segments::{
             AssignTopologyNodeSegmentsCommand, BACKFILL_BATCH_SIZE,
@@ -101,7 +97,7 @@ mod tests {
         let device2 = Pubkey::new_unique();
 
         client
-            .expect_execute_transaction_with_compute_unit_limit()
+            .expect_execute_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::AssignTopologyNodeSegments(
                     AssignTopologyNodeSegmentsArgs {
@@ -115,9 +111,8 @@ mod tests {
                     AccountMeta::new(device1, false),
                     AccountMeta::new(device2, false),
                 ]),
-                predicate::eq(ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT),
             )
-            .returning(|_, _, _| Ok(Signature::new_unique()));
+            .returning(|_, _| Ok(Signature::new_unique()));
 
         let res = AssignTopologyNodeSegmentsCommand {
             name: "algo128".to_string(),
@@ -157,15 +152,14 @@ mod tests {
                 expected_accounts.push(AccountMeta::new(*device_pk, false));
             }
             client
-                .expect_execute_transaction_with_compute_unit_limit()
+                .expect_execute_transaction()
                 .times(1)
                 .in_sequence(&mut seq)
                 .with(
                     predicate::eq(expected_args.clone()),
                     predicate::eq(expected_accounts),
-                    predicate::eq(ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT),
                 )
-                .returning(|_, _, _| Ok(Signature::new_unique()));
+                .returning(|_, _| Ok(Signature::new_unique()));
         }
 
         let res = AssignTopologyNodeSegmentsCommand {

--- a/smartcontract/sdk/rs/src/commands/topology/create.rs
+++ b/smartcontract/sdk/rs/src/commands/topology/create.rs
@@ -226,7 +226,7 @@ mod tests {
             });
 
         client
-            .expect_execute_transaction_with_compute_unit_limit()
+            .expect_execute_transaction()
             .times(1)
             .in_sequence(&mut seq)
             .with(
@@ -241,9 +241,8 @@ mod tests {
                     AccountMeta::new_readonly(globalstate_pubkey, false),
                     AccountMeta::new(vpnv4_device_pk, false),
                 ]),
-                predicate::eq(1_400_000),
             )
-            .returning(|_, _, _| Ok(Signature::new_unique()));
+            .returning(|_, _| Ok(Signature::new_unique()));
 
         let res = CreateTopologyCommand {
             name: "algo128".to_string(),

--- a/smartcontract/sdk/rs/src/doublezeroclient.rs
+++ b/smartcontract/sdk/rs/src/doublezeroclient.rs
@@ -51,15 +51,6 @@ pub trait DoubleZeroClient {
         accounts: Vec<AccountMeta>,
     ) -> eyre::Result<Signature>;
 
-    /// Like `execute_transaction`, but prepends a ComputeBudgetInstruction that sets a
-    /// custom per-transaction compute unit limit.
-    fn execute_transaction_with_compute_unit_limit(
-        &self,
-        instruction: DoubleZeroInstruction,
-        accounts: Vec<AccountMeta>,
-        compute_unit_limit: u32,
-    ) -> eyre::Result<Signature>;
-
     fn get_transactions(&self, pubkey: Pubkey) -> eyre::Result<Vec<DZTransaction>>;
 }
 


### PR DESCRIPTION
## Summary

- Every serviceability transaction sent through `DZClient` now prepends `set_compute_unit_limit(MAX_COMPUTE_UNIT_LIMIT = 1_400_000)` and `request_heap_frame(MAX_HEAP_FRAME_BYTES = 256 KiB)`, replacing the default 200K CU / 32 KiB heap.
- `DoubleZeroClient::execute_transaction_with_compute_unit_limit` is removed; the three per-instruction `SET_GLOBAL_CONFIG_COMPUTE_UNIT_LIMIT` / `ASSIGN_TOPOLOGY_NODE_SEGMENTS_COMPUTE_UNIT_LIMIT` constants that selectively opted into the higher CU limit are deleted along with it.
- Safe because the serviceability program runs on a dedicated private Solana cluster — there is no fee or resource-contention impact from raising every transaction to the protocol max.

## Testing Verification

- `cargo test -p doublezero_sdk --lib` (147 tests pass, including the rewritten globalconfig/set and topology backfill mock expectations).