### PR TITLE
agent: log config size in bytes and expose size metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - E2E
   - Switch geolocation invocations to `doublezero geolocation ...` and `doublezero init-geolocation-config`
 - Agent: log after Arista eapi commit
+- Agent: log received config size in bytes and expose `doublezero_agent_config_size_in_lines` and `doublezero_agent_config_size_in_bytes` Prometheus gauges ([#3741](https://github.com/malbeclabs/doublezero/issues/3741))
 
 ## [v0.23.0](https://github.com/malbeclabs/doublezero/compare/client/v0.22.0...client/v0.23.0) - 2026-05-15
 

--- a/controlplane/agent/cmd/agent/main.go
+++ b/controlplane/agent/cmd/agent/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -55,6 +56,13 @@ func pollControllerAndConfigureDevice(ctx context.Context, dzclient pb.Controlle
 		agent.ErrorsGetConfig.Inc()
 		return err
 	}
+
+	configLines := 0
+	if configText != "" {
+		configLines = strings.Count(configText, "\n") + 1
+	}
+	agent.ConfigSizeInLines.Set(float64(configLines))
+	agent.ConfigSizeInBytes.Set(float64(len(configText)))
 
 	if *verbose {
 		log.Printf("controller returned the following config: '%s'", configText)

--- a/controlplane/agent/internal/agent/metrics.go
+++ b/controlplane/agent/internal/agent/metrics.go
@@ -31,4 +31,16 @@ var (
 			Help: "Number of errors encountered while applying config to the device",
 		},
 	)
+	ConfigSizeInLines = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "doublezero_agent_config_size_in_lines",
+			Help: "Size in lines of the most recently received configuration from the controller",
+		},
+	)
+	ConfigSizeInBytes = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "doublezero_agent_config_size_in_bytes",
+			Help: "Size in bytes of the most recently received configuration from the controller",
+		},
+	)
 )

--- a/controlplane/agent/pkg/arista/eapi.go
+++ b/controlplane/agent/pkg/arista/eapi.go
@@ -215,6 +215,7 @@ func (e *EAPIClient) startLock(ctx context.Context, maxLockAge int) error {
 func (e *EAPIClient) startConfigSession(ctx context.Context, config string) ([]string, string, error) {
 	configSlice := strings.Split(config, "\n")
 	log.Printf("Received %d lines of configuration from controller", len(configSlice))
+	log.Printf("Received %d bytes of configuration from controller", len(config))
 	sessionName := fmt.Sprintf("doublezero-agent-%s", getEosConfigurationSessionDistinguisher())
 	configSlice = append([]string{fmt.Sprintf("configure session %s", sessionName)}, configSlice...)
 	cmd := &aristapb.RunConfigCmdsRequest{


### PR DESCRIPTION
## Summary of Changes
* Add a sibling log line in `EAPIClient.startConfigSession` reporting the received config payload size in bytes, alongside the existing line-count log. Operators asked for byte-size visibility on every config push.
* Expose two new Prometheus gauges on the agent — `doublezero_agent_config_size_in_bytes` and `doublezero_agent_config_size_in_lines` — set from `pollControllerAndConfigureDevice` after each successful pull from the controller. Gauges (not counters) because the size of the most-recently-received config can move up or down between polls.
* Empty controller responses set both gauges to `0`, so an empty-poll signal is consistent across both metrics.
* Fixes #3741

## Testing Verification
* `go build ./controlplane/agent/...` succeeds on the merged branch.
* `go test ./controlplane/agent/...` passes (`internal/agent` and `pkg/arista`).
* `gofmt -l controlplane/agent/` is clean.
* Diff is +22 / -0 lines, no test or behavior regressions touched.
