### PR TITLE
smartcontract/sdk: skip preflight simulation when submitting transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changes
+
+- SDK (Rust)
+  - Drop the pre-submit `simulate_transaction` call in `DZClient::execute_transaction_inner` and submit with `skip_preflight: true`, eliminating the redundant double-simulation (the explicit simulate plus `send_and_confirm_transaction`'s default preflight) on the happy path. Program logs are now recovered from `get_transaction` on the failure path so `SimulationError` / `SimulationTransactionError` and `DoubleZeroError` mapping in CLI output are unchanged. Trade-off: failing transactions now land onchain and burn fees instead of failing for free at simulation ([#3750](https://github.com/malbeclabs/doublezero/pull/3750))
 - e2e/qa: remove client-side capacity pre-filtering from `ValidDevices`, because the QA user pubkey bypasses capacity limits using the serviceability global-config qa-allowlist. Individual device failures no longer fail the test; instead, overall and per-host failure rates are evaluated after all batches and the test only fails if either exceeds `--failure-threshold` (default 10%) or `--per-host-failure-threshold` (default 20%).
 
 ## [v0.24.0](https://github.com/malbeclabs/doublezero/compare/client/v0.23.0...client/v0.24.0) - 2026-05-22

--- a/smartcontract/sdk/rs/src/client.rs
+++ b/smartcontract/sdk/rs/src/client.rs
@@ -14,7 +14,10 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
     pubsub_client::PubsubClient,
     rpc_client::RpcClient,
-    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    rpc_config::{
+        RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig,
+        RpcTransactionConfig,
+    },
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
 };
 use solana_rpc_client_api::client_error::{Error as ClientError, ErrorKind as ClientErrorKind};
@@ -176,30 +179,78 @@ impl DZClient {
         let blockhash = self.client.get_latest_blockhash().map_err(|e| eyre!(e))?;
         transaction.sign(&[&payer], blockhash);
 
-        debug!("Simulating transaction: {transaction:?}");
+        debug!("Sending transaction: {transaction:?}");
 
-        let result = self.client.simulate_transaction(&transaction)?;
-        let program_logs = result.value.logs.unwrap_or_default();
+        let signature = transaction.signatures[0];
+        let send_config = RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        };
 
-        if let Some(ref err) = result.value.err {
-            if quiet {
-                // Return structured errors with logs attached for the caller to handle
-                if let TransactionError::InstructionError(
-                    _index,
-                    InstructionError::Custom(number),
-                ) = err
-                {
-                    return Err(eyre!(SimulationError {
-                        source: DoubleZeroError::from(*number),
-                        program_logs,
-                    }));
-                } else {
+        match self
+            .client
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &transaction,
+                self.client.commitment(),
+                send_config,
+            ) {
+            Ok(sig) => Ok(sig),
+            Err(client_err) => {
+                let tx_err = match &client_err.kind {
+                    ClientErrorKind::TransactionError(e) => Some(e.clone()),
+                    ClientErrorKind::RpcError(
+                        solana_rpc_client_api::request::RpcError::RpcResponseError {
+                            data:
+                                solana_rpc_client_api::request::RpcResponseErrorData::SendTransactionPreflightFailure(
+                                    res,
+                                ),
+                            ..
+                        },
+                    ) => res.err.clone(),
+                    _ => None,
+                };
+
+                let Some(err) = tx_err else {
+                    return Err(eyre!(client_err));
+                };
+
+                // The tx may have landed onchain (skip_preflight=true means failing
+                // txs still land). Fetch logs from the confirmed tx if available.
+                let program_logs = self
+                    .client
+                    .get_transaction_with_config(
+                        &signature,
+                        RpcTransactionConfig {
+                            encoding: Some(UiTransactionEncoding::Base64),
+                            commitment: Some(self.client.commitment()),
+                            max_supported_transaction_version: Some(0),
+                        },
+                    )
+                    .ok()
+                    .and_then(|tx| tx.transaction.meta)
+                    .and_then(|meta| match meta.log_messages {
+                        OptionSerializer::Some(logs) => Some(logs),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+
+                if quiet {
+                    if let TransactionError::InstructionError(
+                        _index,
+                        InstructionError::Custom(number),
+                    ) = err
+                    {
+                        return Err(eyre!(SimulationError {
+                            source: DoubleZeroError::from(number),
+                            program_logs,
+                        }));
+                    }
                     return Err(eyre!(SimulationTransactionError {
-                        source: err.clone(),
+                        source: err,
                         program_logs,
                     }));
                 }
-            } else {
+
                 eprintln!("Program Logs:");
                 for log in &program_logs {
                     eprintln!("{log}");
@@ -210,16 +261,11 @@ impl DZClient {
                     InstructionError::Custom(number),
                 ) = err
                 {
-                    return Err(eyre!(DoubleZeroError::from(*number)));
-                } else {
-                    return Err(eyre!(err.clone()));
+                    return Err(eyre!(DoubleZeroError::from(number)));
                 }
+                Err(eyre!(err))
             }
         }
-
-        self.client
-            .send_and_confirm_transaction(&transaction)
-            .map_err(|e| eyre!(e))
     }
 
     /// Returns true for transient network errors that are worth retrying.


### PR DESCRIPTION
## Summary of Changes
- Drop the explicit `simulate_transaction` call in `DZClient::execute_transaction_inner`. Previously every successful tx was simulated twice (once here, then again by `send_and_confirm_transaction`'s default preflight); now it's submitted once.
- Submit with `RpcSendTransactionConfig { skip_preflight: true }` via `send_and_confirm_transaction_with_spinner_and_config`, eliminating preflight entirely.
- Preserve the existing error UX: on failure, extract the `TransactionError` from `ClientErrorKind::TransactionError` or `SendTransactionPreflightFailure`, fetch program logs via `get_transaction_with_config`, and surface them via the same `SimulationError` / `SimulationTransactionError` types so callers and CLI output are unchanged.
- Tradeoff: failing transactions now land onchain and burn fees instead of failing for free at simulation. The `get_transaction` fetch is only hit on the cold path.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +72 / -26   |  +46 |

Single-file refactor of the transaction submission path in the Rust SDK.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/sdk/rs/src/client.rs` — rewrites `execute_transaction_inner` to skip preflight and recover program logs from `get_transaction` on the failure path.

</details>

## Testing Verification
- `cargo test -p doublezero_sdk --lib` — all 147 unit tests pass.
- `cargo clippy -p doublezero_sdk -- -Dclippy::all -Dwarnings` clean.
- Failure-path behavior not exercised against a live cluster; recommend a manual run of a known-failing CLI command (e.g. duplicate-resource create) to confirm program logs still render and `DoubleZeroError` mapping is intact.