### PR TITLE
controller: make MaxUserTunnelSlots configurable via flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ All notable changes to this project will be documented in this file.
 - Agent: log after Arista eapi commit
 - Agent: log received config size in bytes and expose `doublezero_agent_config_size_in_lines` and `doublezero_agent_config_size_in_bytes` Prometheus gauges ([#3741](https://github.com/malbeclabs/doublezero/issues/3741))
 - Controller
-  - Add `--max-user-tunnel-slots` flag to override the per-device user-tunnel slot count at runtime (default `128`, validated `1 <= n <= 1024`). The Arista EOS hard cap is `1024`; the previous `MaxUserTunnelSlots` package constant is renamed `DefaultMaxUserTunnelSlots` and only supplies the default. Enables the GRE Tunnel Capacity Study stress controller without changing production defaults ([#3745](https://github.com/malbeclabs/doublezero/issues/3745))
+  - Add `--max-user-tunnel-slots` flag to override the per-device user-tunnel slot count of 128 at runtime.
 
 ## [v0.23.0](https://github.com/malbeclabs/doublezero/compare/client/v0.22.0...client/v0.23.0) - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ All notable changes to this project will be documented in this file.
   - Switch geolocation invocations to `doublezero geolocation ...` and `doublezero init-geolocation-config`
 - Agent: log after Arista eapi commit
 - Agent: log received config size in bytes and expose `doublezero_agent_config_size_in_lines` and `doublezero_agent_config_size_in_bytes` Prometheus gauges ([#3741](https://github.com/malbeclabs/doublezero/issues/3741))
+- Controller
+  - Add `--max-user-tunnel-slots` flag to override the per-device user-tunnel slot count at runtime (default `128`, validated `1 <= n <= 1024`). The Arista EOS hard cap is `1024`; the previous `MaxUserTunnelSlots` package constant is renamed `DefaultMaxUserTunnelSlots` and only supplies the default. Enables the GRE Tunnel Capacity Study stress controller without changing production defaults ([#3745](https://github.com/malbeclabs/doublezero/issues/3745))
 
 ## [v0.23.0](https://github.com/malbeclabs/doublezero/compare/client/v0.22.0...client/v0.23.0) - 2026-05-15
 

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/config"
+	controllerconfig "github.com/malbeclabs/doublezero/controlplane/controller/config"
 	"github.com/malbeclabs/doublezero/controlplane/controller/internal/controller"
 	pb "github.com/malbeclabs/doublezero/controlplane/proto/controller/gen/pb-go"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
@@ -129,24 +130,26 @@ func NewControllerCommand() *ControllerCommand {
 	c.fs.StringVar(&c.tlsKeyFile, "tls-key", "", "path to tls key file")
 	c.fs.BoolVar(&c.enablePprof, "enable-pprof", false, "enable pprof server")
 	c.fs.StringVar(&c.tlsListenPort, "tls-listen-port", "", "listening port for controller grpc server")
+	c.fs.IntVar(&c.maxUserTunnelSlots, "max-user-tunnel-slots", controllerconfig.DefaultMaxUserTunnelSlots, "per-device user tunnel slot count (1-1024)")
 	return c
 }
 
 type ControllerCommand struct {
-	fs             *flag.FlagSet
-	description    string
-	listenAddr     string
-	listenPort     string
-	env            string
-	programID      string
-	rpcEndpoint    string
-	deviceLocalASN uint64
-	noHardware     bool
-	showVersion    bool
-	tlsCertFile    string
-	tlsKeyFile     string
-	tlsListenPort  string
-	enablePprof    bool
+	fs                 *flag.FlagSet
+	description        string
+	listenAddr         string
+	listenPort         string
+	env                string
+	programID          string
+	rpcEndpoint        string
+	deviceLocalASN     uint64
+	noHardware         bool
+	showVersion        bool
+	tlsCertFile        string
+	tlsKeyFile         string
+	tlsListenPort      string
+	enablePprof        bool
+	maxUserTunnelSlots int
 }
 
 func (c *ControllerCommand) Fs() *flag.FlagSet {
@@ -226,6 +229,7 @@ func (c *ControllerCommand) Run() error {
 	defer ledgerRPCClient.Close()
 
 	options = append(options, controller.WithDeviceLocalASN(deviceLocalASN))
+	options = append(options, controller.WithMaxUserTunnelSlots(c.maxUserTunnelSlots))
 
 	const defaultFeaturesConfigPath = "/etc/doublezero-controller/features.yaml"
 	if f, err := os.Open(defaultFeaturesConfigPath); err == nil {

--- a/controlplane/controller/cmd/controller/main.go
+++ b/controlplane/controller/cmd/controller/main.go
@@ -130,7 +130,7 @@ func NewControllerCommand() *ControllerCommand {
 	c.fs.StringVar(&c.tlsKeyFile, "tls-key", "", "path to tls key file")
 	c.fs.BoolVar(&c.enablePprof, "enable-pprof", false, "enable pprof server")
 	c.fs.StringVar(&c.tlsListenPort, "tls-listen-port", "", "listening port for controller grpc server")
-	c.fs.IntVar(&c.maxUserTunnelSlots, "max-user-tunnel-slots", controllerconfig.DefaultMaxUserTunnelSlots, "per-device user tunnel slot count (1-1024)")
+	c.fs.IntVar(&c.maxUserTunnelSlots, "max-user-tunnel-slots", controllerconfig.DefaultMaxUserTunnelSlots, "per-device user tunnel slot count (must be positive)")
 	return c
 }
 

--- a/controlplane/controller/config/constants.go
+++ b/controlplane/controller/config/constants.go
@@ -4,6 +4,9 @@ const (
 	// StartUserTunnelNum is the starting tunnel number for user tunnels
 	StartUserTunnelNum = 500
 
-	// MaxUserTunnelSlots is the maximum number of user tunnel slots per device
-	MaxUserTunnelSlots = 128
+	// DefaultMaxUserTunnelSlots is the default maximum number of user tunnel slots
+	// per device. Controllers may override this at runtime via the
+	// --max-user-tunnel-slots flag (see cmd/controller). The Arista EOS hard cap
+	// is 1024.
+	DefaultMaxUserTunnelSlots = 128
 )

--- a/controlplane/controller/config/constants.go
+++ b/controlplane/controller/config/constants.go
@@ -6,7 +6,6 @@ const (
 
 	// DefaultMaxUserTunnelSlots is the default maximum number of user tunnel slots
 	// per device. Controllers may override this at runtime via the
-	// --max-user-tunnel-slots flag (see cmd/controller). The Arista EOS hard cap
-	// is 1024.
+	// --max-user-tunnel-slots flag (see cmd/controller).
 	DefaultMaxUserTunnelSlots = 128
 )

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -207,6 +207,10 @@ type Device struct {
 	LocationCode    string
 }
 
+// NewDevice constructs a Device with tunnelSlots user-tunnel entries pre-allocated.
+// Callers are expected to pass a positive tunnelSlots — the controller validates
+// the value through NewController before calling this; passing zero or negative
+// produces a Device with no usable tunnel slots.
 func NewDevice(ip net.IP, publicKey string, tunnelSlots int) *Device {
 	tunnels := make([]*Tunnel, 0, tunnelSlots)
 	devicePathologies := []string{}

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -207,10 +207,10 @@ type Device struct {
 	LocationCode    string
 }
 
-func NewDevice(ip net.IP, publicKey string) *Device {
-	tunnels := []*Tunnel{}
+func NewDevice(ip net.IP, publicKey string, tunnelSlots int) *Device {
+	tunnels := make([]*Tunnel, 0, tunnelSlots)
 	devicePathologies := []string{}
-	for i := 0; i < config.MaxUserTunnelSlots; i++ {
+	for i := 0; i < tunnelSlots; i++ {
 		id := config.StartUserTunnelNum + i
 		tunnel := &Tunnel{
 			Id:        id,
@@ -222,7 +222,7 @@ func NewDevice(ip net.IP, publicKey string) *Device {
 		PublicIP:          ip,
 		PubKey:            publicKey,
 		Tunnels:           tunnels,
-		TunnelSlots:       config.MaxUserTunnelSlots,
+		TunnelSlots:       tunnelSlots,
 		DevicePathologies: devicePathologies,
 	}
 }

--- a/controlplane/controller/internal/controller/models.go
+++ b/controlplane/controller/internal/controller/models.go
@@ -207,10 +207,6 @@ type Device struct {
 	LocationCode    string
 }
 
-// NewDevice constructs a Device with tunnelSlots user-tunnel entries pre-allocated.
-// Callers are expected to pass a positive tunnelSlots — the controller validates
-// the value through NewController before calling this; passing zero or negative
-// produces a Device with no usable tunnel slots.
 func NewDevice(ip net.IP, publicKey string, tunnelSlots int) *Device {
 	tunnels := make([]*Tunnel, 0, tunnelSlots)
 	devicePathologies := []string{}

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -949,7 +949,7 @@ func TestRenderConfig(t *testing.T) {
 			if strings.HasSuffix(test.Want, ".tmpl") {
 				templateData := map[string]int{
 					"StartTunnel": config.StartUserTunnelNum,
-					"EndTunnel":   config.StartUserTunnelNum + config.MaxUserTunnelSlots - 1,
+					"EndTunnel":   config.StartUserTunnelNum + config.DefaultMaxUserTunnelSlots - 1,
 				}
 				rendered, err := renderTemplateFile(test.Want, templateData)
 				if err != nil {

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -38,15 +38,12 @@ const (
 
 	bgpCommunityMinValid = 10000
 	bgpCommunityMaxValid = 10999
-
-	// maxUserTunnelSlotsHardCap is the Arista EOS hard cap on user tunnel slots.
-	maxUserTunnelSlotsHardCap = 1024
 )
 
 var (
 	ErrServiceabilityRequired    = errors.New("serviceability program client is required")
 	ErrLoggerRequired            = errors.New("logger is required")
-	ErrInvalidMaxUserTunnelSlots = errors.New("max user tunnel slots out of range")
+	ErrInvalidMaxUserTunnelSlots = errors.New("max user tunnel slots must be positive")
 )
 
 type ServiceabilityProgramClient interface {
@@ -93,8 +90,8 @@ func NewController(options ...Option) (*Controller, error) {
 	for _, o := range options {
 		o(controller)
 	}
-	if controller.maxUserTunnelSlots < 1 || controller.maxUserTunnelSlots > maxUserTunnelSlotsHardCap {
-		return nil, fmt.Errorf("%w: got %d, want 1..%d", ErrInvalidMaxUserTunnelSlots, controller.maxUserTunnelSlots, maxUserTunnelSlotsHardCap)
+	if controller.maxUserTunnelSlots < 1 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMaxUserTunnelSlots, controller.maxUserTunnelSlots)
 	}
 	if controller.listener == nil {
 		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", 443))
@@ -180,11 +177,6 @@ func WithFeaturesConfig(cfg *FeaturesConfig) Option {
 	}
 }
 
-// WithMaxUserTunnelSlots overrides the per-device user-tunnel slot count.
-// Validation happens once in NewController after all options are applied; the
-// value must be in [1, 1024] (Arista EOS hard cap) or NewController returns
-// ErrInvalidMaxUserTunnelSlots. Do not read this field during option
-// application — it is unvalidated until NewController completes.
 func WithMaxUserTunnelSlots(n int) Option {
 	return func(c *Controller) {
 		c.maxUserTunnelSlots = n

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/malbeclabs/doublezero/config"
+	controllerconfig "github.com/malbeclabs/doublezero/controlplane/controller/config"
 	pb "github.com/malbeclabs/doublezero/controlplane/proto/controller/gen/pb-go"
 	telemetryconfig "github.com/malbeclabs/doublezero/controlplane/telemetry/pkg/config"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
@@ -37,11 +38,15 @@ const (
 
 	bgpCommunityMinValid = 10000
 	bgpCommunityMaxValid = 10999
+
+	// maxUserTunnelSlotsHardCap is the Arista EOS hard cap on user tunnel slots.
+	maxUserTunnelSlotsHardCap = 1024
 )
 
 var (
-	ErrServiceabilityRequired = errors.New("serviceability program client is required")
-	ErrLoggerRequired         = errors.New("logger is required")
+	ErrServiceabilityRequired    = errors.New("serviceability program client is required")
+	ErrLoggerRequired            = errors.New("logger is required")
+	ErrInvalidMaxUserTunnelSlots = fmt.Errorf("max user tunnel slots must be between 1 and %d", maxUserTunnelSlotsHardCap)
 )
 
 type ServiceabilityProgramClient interface {
@@ -63,28 +68,33 @@ type stateCache struct {
 type Controller struct {
 	pb.UnimplementedControllerServer
 
-	log            *slog.Logger
-	cache          stateCache
-	mu             sync.RWMutex
-	serviceability ServiceabilityProgramClient
-	listener       net.Listener
-	noHardware     bool
-	updateDone     chan struct{}
-	tlsConfig      *tls.Config
-	environment    string
-	deviceLocalASN uint32
-	clickhouse     *ClickhouseWriter
-	featuresConfig *FeaturesConfig
+	log                *slog.Logger
+	cache              stateCache
+	mu                 sync.RWMutex
+	serviceability     ServiceabilityProgramClient
+	listener           net.Listener
+	noHardware         bool
+	updateDone         chan struct{}
+	tlsConfig          *tls.Config
+	environment        string
+	deviceLocalASN     uint32
+	clickhouse         *ClickhouseWriter
+	featuresConfig     *FeaturesConfig
+	maxUserTunnelSlots int
 }
 
 type Option func(*Controller)
 
 func NewController(options ...Option) (*Controller, error) {
 	controller := &Controller{
-		cache: stateCache{},
+		cache:              stateCache{},
+		maxUserTunnelSlots: controllerconfig.DefaultMaxUserTunnelSlots,
 	}
 	for _, o := range options {
 		o(controller)
+	}
+	if controller.maxUserTunnelSlots < 1 || controller.maxUserTunnelSlots > maxUserTunnelSlotsHardCap {
+		return nil, ErrInvalidMaxUserTunnelSlots
 	}
 	if controller.listener == nil {
 		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", 443))
@@ -167,6 +177,15 @@ func WithClickhouse(cw *ClickhouseWriter) Option {
 func WithFeaturesConfig(cfg *FeaturesConfig) Option {
 	return func(c *Controller) {
 		c.featuresConfig = cfg
+	}
+}
+
+// WithMaxUserTunnelSlots overrides the per-device user-tunnel slot count.
+// NewController validates the value is between 1 and the Arista EOS hard cap
+// of 1024, and returns ErrInvalidMaxUserTunnelSlots otherwise.
+func WithMaxUserTunnelSlots(n int) Option {
+	return func(c *Controller) {
+		c.maxUserTunnelSlots = n
 	}
 }
 
@@ -315,7 +334,7 @@ func (c *Controller) updateStateCache(ctx context.Context) error {
 		}
 
 		devicePubKey := base58.Encode(device.PubKey[:])
-		d := NewDevice(ip, devicePubKey)
+		d := NewDevice(ip, devicePubKey, c.maxUserTunnelSlots)
 
 		d.MgmtVrf = device.MgmtVrf
 		d.Code = device.Code

--- a/controlplane/controller/internal/controller/server.go
+++ b/controlplane/controller/internal/controller/server.go
@@ -46,7 +46,7 @@ const (
 var (
 	ErrServiceabilityRequired    = errors.New("serviceability program client is required")
 	ErrLoggerRequired            = errors.New("logger is required")
-	ErrInvalidMaxUserTunnelSlots = fmt.Errorf("max user tunnel slots must be between 1 and %d", maxUserTunnelSlotsHardCap)
+	ErrInvalidMaxUserTunnelSlots = errors.New("max user tunnel slots out of range")
 )
 
 type ServiceabilityProgramClient interface {
@@ -94,7 +94,7 @@ func NewController(options ...Option) (*Controller, error) {
 		o(controller)
 	}
 	if controller.maxUserTunnelSlots < 1 || controller.maxUserTunnelSlots > maxUserTunnelSlotsHardCap {
-		return nil, ErrInvalidMaxUserTunnelSlots
+		return nil, fmt.Errorf("%w: got %d, want 1..%d", ErrInvalidMaxUserTunnelSlots, controller.maxUserTunnelSlots, maxUserTunnelSlotsHardCap)
 	}
 	if controller.listener == nil {
 		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", 443))
@@ -181,8 +181,10 @@ func WithFeaturesConfig(cfg *FeaturesConfig) Option {
 }
 
 // WithMaxUserTunnelSlots overrides the per-device user-tunnel slot count.
-// NewController validates the value is between 1 and the Arista EOS hard cap
-// of 1024, and returns ErrInvalidMaxUserTunnelSlots otherwise.
+// Validation happens once in NewController after all options are applied; the
+// value must be in [1, 1024] (Arista EOS hard cap) or NewController returns
+// ErrInvalidMaxUserTunnelSlots. Do not read this field during option
+// application — it is unvalidated until NewController completes.
 func WithMaxUserTunnelSlots(n int) Option {
 	return func(c *Controller) {
 		c.maxUserTunnelSlots = n

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -1824,7 +1824,7 @@ func TestMaxUserTunnelSlotsOption(t *testing.T) {
 			wantSize: config.DefaultMaxUserTunnelSlots,
 		},
 		{
-			name:     "valid_max_eos_hard_cap",
+			name:     "valid_large",
 			opts:     []Option{WithMaxUserTunnelSlots(1024)},
 			wantErr:  nil,
 			wantSize: 1024,
@@ -1837,11 +1837,6 @@ func TestMaxUserTunnelSlotsOption(t *testing.T) {
 		{
 			name:    "invalid_negative",
 			opts:    []Option{WithMaxUserTunnelSlots(-1)},
-			wantErr: ErrInvalidMaxUserTunnelSlots,
-		},
-		{
-			name:    "invalid_above_hard_cap",
-			opts:    []Option{WithMaxUserTunnelSlots(1025)},
 			wantErr: ErrInvalidMaxUserTunnelSlots,
 		},
 	}

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // helper that creates a slice of Tunnel structs with sequential IDs. We can use this to populate
-// a list of tunnel slots so we don't have to update tests by hand when MaxUserTunnelSlots changes.
+// a list of tunnel slots so we don't have to update tests by hand when DefaultMaxUserTunnelSlots changes.
 func generateEmptyTunnelSlots(startID, count int) []*Tunnel {
 	tunnels := make([]*Tunnel, count)
 	for i := 0; i < count; i++ {
@@ -573,7 +573,7 @@ func TestGetConfig(t *testing.T) {
 			if strings.HasSuffix(test.Want, ".tmpl") {
 				templateData := map[string]int{
 					"StartTunnel": config.StartUserTunnelNum,
-					"EndTunnel":   config.StartUserTunnelNum + config.MaxUserTunnelSlots - 1,
+					"EndTunnel":   config.StartUserTunnelNum + config.DefaultMaxUserTunnelSlots - 1,
 				}
 				rendered, err := renderTemplateFile(test.Want, templateData)
 				if err != nil {
@@ -981,8 +981,8 @@ func TestStateCache(t *testing.T) {
 									{239, 0, 0, 1},
 								},
 							},
-						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+2, config.MaxUserTunnelSlots-2)...),
-						TunnelSlots: config.MaxUserTunnelSlots,
+						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+2, config.DefaultMaxUserTunnelSlots-2)...),
+						TunnelSlots: config.DefaultMaxUserTunnelSlots,
 						Interfaces: []Interface{
 							{
 								InterfaceType: InterfaceTypePhysical,
@@ -1117,8 +1117,8 @@ func TestStateCache(t *testing.T) {
 								MetroRouting:  true,
 								TenantPubKey:  "11111111111111111111111111111111",
 							},
-						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.MaxUserTunnelSlots-1)...),
-						TunnelSlots: config.MaxUserTunnelSlots,
+						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.DefaultMaxUserTunnelSlots-1)...),
+						TunnelSlots: config.DefaultMaxUserTunnelSlots,
 					},
 				},
 			},
@@ -1231,8 +1231,8 @@ func TestStateCache(t *testing.T) {
 								MetroRouting:  true,
 								TenantPubKey:  "11111111111111111111111111111111",
 							},
-						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.MaxUserTunnelSlots-1)...),
-						TunnelSlots: config.MaxUserTunnelSlots,
+						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+1, config.DefaultMaxUserTunnelSlots-1)...),
+						TunnelSlots: config.DefaultMaxUserTunnelSlots,
 					},
 				},
 			},
@@ -1384,8 +1384,8 @@ func TestStateCache(t *testing.T) {
 								MetroRouting:  true,
 								TenantPubKey:  "11111111111111111111111111111111",
 							},
-						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+2, config.MaxUserTunnelSlots-2)...),
-						TunnelSlots: config.MaxUserTunnelSlots,
+						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+2, config.DefaultMaxUserTunnelSlots-2)...),
+						TunnelSlots: config.DefaultMaxUserTunnelSlots,
 					},
 				},
 			},
@@ -1558,8 +1558,8 @@ func TestStateCache(t *testing.T) {
 								MetroRouting:  true,
 								TenantPubKey:  "7fTN12qMUn1gSUuTMxNCdjndcxwJu45kosXuqJiXMeT9",
 							},
-						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+3, config.MaxUserTunnelSlots-3)...),
-						TunnelSlots: config.MaxUserTunnelSlots,
+						}, generateEmptyTunnelSlots(config.StartUserTunnelNum+3, config.DefaultMaxUserTunnelSlots-3)...),
+						TunnelSlots: config.DefaultMaxUserTunnelSlots,
 						Interfaces: []Interface{
 							{
 								InterfaceType:  InterfaceTypeLoopback,
@@ -1786,6 +1786,95 @@ func TestServiceabilityProgramClientArg(t *testing.T) {
 			_, err := NewController(opts...)
 			if err != test.wantErr {
 				t.Fatalf("expected error %v, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestMaxUserTunnelSlotsOption(t *testing.T) {
+	mockClient := &mockServiceabilityProgramClient{
+		ProgramIDFunc: func() solana.PublicKey {
+			return solana.MustPublicKeyFromBase58("11111111111111111111111111111111")
+		},
+	}
+
+	tests := []struct {
+		name     string
+		opts     []Option
+		wantErr  error
+		wantSize int
+	}{
+		{
+			name:     "default_when_option_omitted",
+			opts:     nil,
+			wantErr:  nil,
+			wantSize: config.DefaultMaxUserTunnelSlots,
+		},
+		{
+			name:     "valid_min",
+			opts:     []Option{WithMaxUserTunnelSlots(1)},
+			wantErr:  nil,
+			wantSize: 1,
+		},
+		{
+			name:     "valid_default",
+			opts:     []Option{WithMaxUserTunnelSlots(config.DefaultMaxUserTunnelSlots)},
+			wantErr:  nil,
+			wantSize: config.DefaultMaxUserTunnelSlots,
+		},
+		{
+			name:     "valid_max_eos_hard_cap",
+			opts:     []Option{WithMaxUserTunnelSlots(1024)},
+			wantErr:  nil,
+			wantSize: 1024,
+		},
+		{
+			name:    "invalid_zero",
+			opts:    []Option{WithMaxUserTunnelSlots(0)},
+			wantErr: ErrInvalidMaxUserTunnelSlots,
+		},
+		{
+			name:    "invalid_negative",
+			opts:    []Option{WithMaxUserTunnelSlots(-1)},
+			wantErr: ErrInvalidMaxUserTunnelSlots,
+		},
+		{
+			name:    "invalid_above_hard_cap",
+			opts:    []Option{WithMaxUserTunnelSlots(1025)},
+			wantErr: ErrInvalidMaxUserTunnelSlots,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := []Option{
+				WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+				WithListener(bufconn.Listen(1024 * 1024)),
+				WithServiceabilityProgramClient(mockClient),
+			}
+			opts = append(opts, test.opts...)
+			c, err := NewController(opts...)
+			if err != test.wantErr {
+				t.Fatalf("expected error %v, got %v", test.wantErr, err)
+			}
+			if test.wantErr != nil {
+				return
+			}
+			if c.maxUserTunnelSlots != test.wantSize {
+				t.Errorf("expected maxUserTunnelSlots=%d, got %d", test.wantSize, c.maxUserTunnelSlots)
+			}
+			d := NewDevice(net.IPv4(1, 2, 3, 4), "pk", c.maxUserTunnelSlots)
+			if len(d.Tunnels) != test.wantSize {
+				t.Errorf("expected %d tunnel slots on device, got %d", test.wantSize, len(d.Tunnels))
+			}
+			if d.TunnelSlots != test.wantSize {
+				t.Errorf("expected device.TunnelSlots=%d, got %d", test.wantSize, d.TunnelSlots)
+			}
+			if d.Tunnels[0].Id != config.StartUserTunnelNum {
+				t.Errorf("expected first tunnel id=%d, got %d", config.StartUserTunnelNum, d.Tunnels[0].Id)
+			}
+			if d.Tunnels[test.wantSize-1].Id != config.StartUserTunnelNum+test.wantSize-1 {
+				t.Errorf("expected last tunnel id=%d, got %d", config.StartUserTunnelNum+test.wantSize-1, d.Tunnels[test.wantSize-1].Id)
 			}
 		})
 	}
@@ -2283,7 +2372,7 @@ func TestEndToEnd(t *testing.T) {
 			if strings.HasSuffix(test.Want, ".tmpl") {
 				templateData := map[string]int{
 					"StartTunnel": config.StartUserTunnelNum,
-					"EndTunnel":   config.StartUserTunnelNum + config.MaxUserTunnelSlots - 1,
+					"EndTunnel":   config.StartUserTunnelNum + config.DefaultMaxUserTunnelSlots - 1,
 				}
 				rendered, err := renderTemplateFile(test.Want, templateData)
 				if err != nil {

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log"
 	"log/slog"
@@ -1854,11 +1855,14 @@ func TestMaxUserTunnelSlotsOption(t *testing.T) {
 			}
 			opts = append(opts, test.opts...)
 			c, err := NewController(opts...)
-			if err != test.wantErr {
-				t.Fatalf("expected error %v, got %v", test.wantErr, err)
-			}
 			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("expected error %v, got %v", test.wantErr, err)
+				}
 				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
 			}
 			if c.maxUserTunnelSlots != test.wantSize {
 				t.Errorf("expected maxUserTunnelSlots=%d, got %d", test.wantSize, c.maxUserTunnelSlots)

--- a/e2e/ibrl_test.go
+++ b/e2e/ibrl_test.go
@@ -73,7 +73,7 @@ func checkIbgpMsdpPeerRemoved(t *testing.T, dn *TestDevnet, device *devnet.Devic
 			dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 				"DeviceIP":    device.CYOANetworkIP,
 				"StartTunnel": controllerconfig.StartUserTunnelNum,
-				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 			}))
 		require.NoError(t, err, "error reading agent configuration fixture for peer removal")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -101,7 +101,7 @@ func checkDeviceDrain(t *testing.T, dn *TestDevnet, device *devnet.Device) {
 			dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 				"DeviceIP":    device.CYOANetworkIP,
 				"StartTunnel": controllerconfig.StartUserTunnelNum,
-				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 			}))
 		require.NoError(t, err, "error reading drained config fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -131,7 +131,7 @@ func checkDeviceUndrain(t *testing.T, dn *TestDevnet, device *devnet.Device) {
 			dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 				"DeviceIP":    device.CYOANetworkIP,
 				"StartTunnel": controllerconfig.StartUserTunnelNum,
-				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 			}))
 		require.NoError(t, err, "error reading undrained config fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -157,7 +157,7 @@ func checkIBRLPostConnect(t *testing.T, dn *TestDevnet, device *devnet.Device, c
 					"ClientIP":    client.CYOANetworkIP,
 					"DeviceIP":    device.CYOANetworkIP,
 					"StartTunnel": controllerconfig.StartUserTunnelNum,
-					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 				}))
 			require.NoError(t, err, "error reading agent configuration fixture")
 			err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -327,7 +327,7 @@ func checkIBRLPostDisconnect(t *testing.T, dn *TestDevnet, device *devnet.Device
 				dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 					"DeviceIP":    device.CYOANetworkIP,
 					"StartTunnel": controllerconfig.StartUserTunnelNum,
-					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 				}))
 			require.NoError(t, err, "error reading agent configuration fixture")
 			err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))

--- a/e2e/ibrl_with_allocated_ip_test.go
+++ b/e2e/ibrl_with_allocated_ip_test.go
@@ -131,7 +131,7 @@ func checkIBRLWithAllocatedIPPostConnect(t *testing.T, dn *TestDevnet, device *d
 					"DeviceIP":                  device.CYOANetworkIP,
 					"ExpectedAllocatedClientIP": expectedAllocatedClientIP,
 					"StartTunnel":               controllerconfig.StartUserTunnelNum,
-					"EndTunnel":                 controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+					"EndTunnel":                 controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 				}))
 			require.NoError(t, err, "error reading agent configuration fixture")
 			err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -323,7 +323,7 @@ func checkIBRLWithAllocatedIPPostDisconnect(t *testing.T, dn *TestDevnet, device
 				dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 					"DeviceIP":    device.CYOANetworkIP,
 					"StartTunnel": controllerconfig.StartUserTunnelNum,
-					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+					"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 				}))
 			require.NoError(t, err, "error reading agent configuration fixture")
 			err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))

--- a/e2e/internal/devnet/device.go
+++ b/e2e/internal/devnet/device.go
@@ -367,8 +367,9 @@ func (d *Device) Start(ctx context.Context) error {
 	}
 	d.log.Debug("--> Created device onchain", "code", spec.Code, "cyoaNetworkIP", cyoaNetworkIP, "dzPrefix", dzPrefix, "devicePK", devicePK)
 
-	// MaxUserTunnelSlots is now a constant from config package
-	d.log.Debug("--> Using MaxUserTunnelSlots constant", "maxUsers", controllerconfig.MaxUserTunnelSlots)
+	// User tunnel slot count is a per-device default in the controller's config package
+	// and can be overridden at runtime via the controller's --max-user-tunnel-slots flag.
+	d.log.Debug("--> Using DefaultMaxUserTunnelSlots", "maxUsers", controllerconfig.DefaultMaxUserTunnelSlots)
 
 	// Create interfaces onchain.
 	for name, ifaceType := range spec.Interfaces {
@@ -868,8 +869,9 @@ func (d *Device) setState(ctx context.Context, containerID string) error {
 	d.ID = onchainID
 	d.CYOANetworkIP = ip
 
-	// MaxUserTunnelSlots is now a constant from config package
-	d.log.Debug("--> Using MaxUserTunnelSlots constant", "maxUsers", controllerconfig.MaxUserTunnelSlots)
+	// User tunnel slot count is a per-device default in the controller's config package
+	// and can be overridden at runtime via the controller's --max-user-tunnel-slots flag.
+	d.log.Debug("--> Using DefaultMaxUserTunnelSlots", "maxUsers", controllerconfig.DefaultMaxUserTunnelSlots)
 
 	return nil
 }

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -379,7 +379,7 @@ func checkMulticastBothUsersAgentConfig(t *testing.T, dn *TestDevnet, device *de
 				"PublisherTunnelBGPNeighbor":   pubTunnelBGPNeighbor,
 				"SubscriberTunnelBGPNeighbor":  subTunnelBGPNeighbor,
 				"StartTunnel":                  controllerconfig.StartUserTunnelNum,
-				"EndTunnel":                    controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+				"EndTunnel":                    controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 			}))
 		require.NoError(t, err, "error reading agent configuration fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))
@@ -395,7 +395,7 @@ func checkMulticastBothUsersRemovedAgentConfig(t *testing.T, dn *TestDevnet, dev
 			dn.BuildAgentConfigData(t, device.Spec.Code, map[string]any{
 				"DeviceIP":    device.CYOANetworkIP,
 				"StartTunnel": controllerconfig.StartUserTunnelNum,
-				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.MaxUserTunnelSlots - 1,
+				"EndTunnel":   controllerconfig.StartUserTunnelNum + controllerconfig.DefaultMaxUserTunnelSlots - 1,
 			}))
 		require.NoError(t, err, "error reading agent configuration fixture")
 		err = dn.WaitForAgentConfigMatchViaController(t, device.ID, string(config))


### PR DESCRIPTION
## Summary of Changes
- Add `--max-user-tunnel-slots` CLI flag on the controller to override the per-device user-tunnel slot count at runtime (default remains 128).
- Rename the package constant `MaxUserTunnelSlots` → `DefaultMaxUserTunnelSlots` to make the override path explicit; update all internal callers (controller, e2e tests).
Resolves: #3745

## Diff Breakdown
| Category     | Files | Lines (+/-)     | Net  |
|--------------|-------|-----------------|------|
| Tests        |     6 | +117 / -27      |  +90 |
| Core logic   |     2 |  +33 / -20      |  +13 |
| Scaffolding  |     2 |  +22 / -16      |   +6 |
| Docs         |     1 |   +2 / -0       |   +2 |
| **Total**    |    11 | +174 / -63      | +111 |


## Testing Verification
- New unit tests in `server_test.go`
