### PR TITLE
feat(e2e): fix flaky settlement test

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -484,6 +484,35 @@ func (c *Client) WaitForMulticastStatusDisconnected(ctx context.Context) error {
 	return c.waitForUserTypeStatusDisconnected(ctx, "Multicast", FindMulticastStatus)
 }
 
+// WaitForIBRLStatusDisconnected polls until no IBRL (or IBRLWithAllocatedIP)
+// status entry remains with a non-disconnected session. Non-IBRL tunnel types
+// (e.g. Multicast) are ignored. Prefer this over WaitForStatusDisconnected in
+// multi-tunnel contexts where a Multicast tunnel can persist independently of
+// the unicast lifecycle — e.g. when a stale shred-subscription seat cannot be
+// withdrawn and its multicast tunnel stays up. Walks the status list directly
+// rather than reusing FindIBRLStatus, which has a single-status fallback that
+// would misclassify a lone Multicast entry as IBRL.
+func (c *Client) WaitForIBRLStatusDisconnected(ctx context.Context) error {
+	c.log.Debug("Waiting for IBRL status to be disconnected", "host", c.Host)
+	err := poll.Until(ctx, func() (bool, error) {
+		resp, err := c.grpcClient.GetStatus(ctx, &emptypb.Empty{})
+		if err != nil {
+			return false, err
+		}
+		for _, s := range resp.Status {
+			if IsIBRLStatus(s) && s.SessionStatus != UserStatusDisconnected {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, waitForStatusDisconnectedTimeout, waitInterval)
+	if err != nil {
+		return fmt.Errorf("failed to wait for IBRL status to be disconnected on host %s: %w", c.Host, err)
+	}
+	c.log.Debug("Confirmed IBRL status is disconnected", "host", c.Host)
+	return nil
+}
+
 // waitForUserTypeStatusDisconnected polls until find returns nil or a status
 // whose session is disconnected. userType is used only for log context.
 func (c *Client) waitForUserTypeStatusDisconnected(ctx context.Context, userType string, find func([]*pb.Status) *pb.Status) error {

--- a/e2e/internal/qa/client_unicast.go
+++ b/e2e/internal/qa/client_unicast.go
@@ -47,9 +47,19 @@ func (c *Client) ConnectUserUnicast_NoWait(ctx context.Context, deviceCode strin
 func (c *Client) ConnectUserUnicast(ctx context.Context, deviceCode string, waitForStatus bool) error {
 	c.doubleZeroIP = nil // Clear stale IP before connecting
 
-	err := c.DisconnectUser(ctx, true, true)
+	// Submit the disconnect RPC without waiting for all-tunnel disconnected
+	// status or all-user-deletion onchain: a stale Multicast tunnel (e.g. from
+	// a shred-subscription seat that cannot be withdrawn) keeps an oracle-owned
+	// multicast user account alive that `doublezero disconnect` skips and the
+	// daemon's multicast tunnel stays BGP-up. Waiting on either condition would
+	// block the entire unicast suite. Wait only for the IBRL tunnel to be down
+	// before reconnecting.
+	err := c.DisconnectUser(ctx, false, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure disconnected on host %s: %w", c.Host, err)
+	}
+	if err := c.WaitForIBRLStatusDisconnected(ctx); err != nil {
+		return fmt.Errorf("failed to ensure IBRL disconnected on host %s: %w", c.Host, err)
 	}
 
 	c.log.Debug("Connecting unicast user", "host", c.Host, "device", deviceCode, "allocateAddr", c.AllocateAddr)

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -142,8 +142,14 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 			wg.Add(1)
 			go func(client *qa.Client) {
 				defer wg.Done()
-				err := client.DisconnectUser(context.Background(), true, true)
-				assert.NoError(t, err, "failed to disconnect user")
+				// Mirror ConnectUserUnicast: don't block on a stale Multicast
+				// tunnel left by a shred-subscription seat that won't withdraw.
+				cleanupCtx := context.Background()
+				if err := client.DisconnectUser(cleanupCtx, false, false); err != nil {
+					assert.NoError(t, err, "failed to disconnect user")
+					return
+				}
+				assert.NoError(t, client.WaitForIBRLStatusDisconnected(cleanupCtx), "failed to wait for IBRL disconnected")
 			}(client)
 		}
 		wg.Wait()

--- a/e2e/qa_unicast_test.go
+++ b/e2e/qa_unicast_test.go
@@ -33,8 +33,14 @@ func TestQA_UnicastConnectivity(t *testing.T) {
 			wg.Add(1)
 			go func(client *qa.Client) {
 				defer wg.Done()
-				err := client.DisconnectUser(context.Background(), true, true)
-				assert.NoError(t, err, "failed to disconnect user")
+				// Mirror ConnectUserUnicast: don't block on a stale Multicast
+				// tunnel left by a shred-subscription seat that won't withdraw.
+				cleanupCtx := context.Background()
+				if err := client.DisconnectUser(cleanupCtx, false, false); err != nil {
+					assert.NoError(t, err, "failed to disconnect user")
+					return
+				}
+				assert.NoError(t, client.WaitForIBRLStatusDisconnected(cleanupCtx), "failed to wait for IBRL disconnected")
 			}(client)
 		}
 		wg.Wait()


### PR DESCRIPTION
## Summary of Changes
Unicast QA tests will no longer hang on a stuck Multicast tunnel, regardless of what's causing the stuck state.
## Testing Verification
* Updated e2e tests
