### PR TITLE
ci(e2e): add trusted fork PR e2e dispatch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - doublezero-k8s-ci
+    - ubuntu-24.04-16c-64gb
+config-variables: null

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,17 @@ on:
   push:
     branches: [ main, 'hotfix/**' ]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to test
+        required: true
+      head_sha:
+        description: Expected PR head SHA
+        required: true
+      image_tag:
+        description: GHCR image tag for this trusted run
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -12,19 +23,19 @@ env:
   SHARD_COUNT: "4"
   # Use registry-qualified image names so we can push/pull between jobs
   DZ_IMAGE_REPO: ghcr.io/malbeclabs/dz-e2e
-  DZ_IMAGE_TAG: ${{ github.sha }}
+  DZ_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
   # Individual image refs for the e2e tests
-  DZ_BASE_IMAGE: ghcr.io/malbeclabs/dz-e2e/base:${{ github.sha }}
-  DZ_LEDGER_IMAGE: ghcr.io/malbeclabs/dz-e2e/ledger:${{ github.sha }}
-  DZ_CONTROLLER_IMAGE: ghcr.io/malbeclabs/dz-e2e/controller:${{ github.sha }}
-  DZ_MANAGER_IMAGE: ghcr.io/malbeclabs/dz-e2e/manager:${{ github.sha }}
-  DZ_FUNDER_IMAGE: ghcr.io/malbeclabs/dz-e2e/funder:${{ github.sha }}
-  DZ_DEVICE_IMAGE: ghcr.io/malbeclabs/dz-e2e/device:${{ github.sha }}
-  DZ_CLIENT_IMAGE: ghcr.io/malbeclabs/dz-e2e/client:${{ github.sha }}
-  DZ_DEVICE_HEALTH_ORACLE_IMAGE: ghcr.io/malbeclabs/dz-e2e/device-health-oracle:${{ github.sha }}
-  DZ_GEOPROBE_IMAGE: ghcr.io/malbeclabs/dz-e2e/geoprobe:${{ github.sha }}
-  DZ_SENTINEL_IMAGE: ghcr.io/malbeclabs/dz-e2e/sentinel:${{ github.sha }}
-  DZ_VALIDATOR_METADATA_SERVICE_MOCK_IMAGE: ghcr.io/malbeclabs/dz-e2e/validator-metadata-service-mock:${{ github.sha }}
+  DZ_BASE_IMAGE: ghcr.io/malbeclabs/dz-e2e/base:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_LEDGER_IMAGE: ghcr.io/malbeclabs/dz-e2e/ledger:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_CONTROLLER_IMAGE: ghcr.io/malbeclabs/dz-e2e/controller:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_MANAGER_IMAGE: ghcr.io/malbeclabs/dz-e2e/manager:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_FUNDER_IMAGE: ghcr.io/malbeclabs/dz-e2e/funder:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_DEVICE_IMAGE: ghcr.io/malbeclabs/dz-e2e/device:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_CLIENT_IMAGE: ghcr.io/malbeclabs/dz-e2e/client:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_DEVICE_HEALTH_ORACLE_IMAGE: ghcr.io/malbeclabs/dz-e2e/device-health-oracle:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_GEOPROBE_IMAGE: ghcr.io/malbeclabs/dz-e2e/geoprobe:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_SENTINEL_IMAGE: ghcr.io/malbeclabs/dz-e2e/sentinel:${{ github.event.inputs.image_tag || github.sha }}
+  DZ_VALIDATOR_METADATA_SERVICE_MOCK_IMAGE: ghcr.io/malbeclabs/dz-e2e/validator-metadata-service-mock:${{ github.event.inputs.image_tag || github.sha }}
 
 jobs:
   setup:
@@ -33,25 +44,60 @@ jobs:
       packages: write
       contents: read
     outputs:
+      run-e2e: ${{ steps.gate.outputs.run-e2e }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
+      - name: Decide whether privileged e2e can run
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping privileged e2e on an external fork PR. A maintainer can comment /run-e2e to start a trusted run."
+            {
+              echo "### Privileged e2e skipped"
+              echo
+              echo "This pull request comes from an external fork, so GitHub only grants a read-only token and no secrets."
+              echo "A maintainer can comment \`/run-e2e\` to dispatch trusted e2e for this PR head SHA."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "run-e2e=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.run-e2e == 'true' && github.event_name != 'workflow_dispatch'
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.run-e2e == 'true' && github.event_name == 'workflow_dispatch'
+        with:
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
+          fetch-depth: 2
+      - name: Validate trusted PR head
+        if: steps.gate.outputs.run-e2e == 'true' && github.event_name == 'workflow_dispatch'
+        run: |
+          actual_head="$(git rev-parse HEAD^2)"
+          if [ "$actual_head" != "${{ github.event.inputs.head_sha }}" ]; then
+            echo "::error::PR head SHA changed: expected ${{ github.event.inputs.head_sha }}, got $actual_head"
+            exit 1
+          fi
       - uses: actions/setup-go@v5
+        if: steps.gate.outputs.run-e2e == 'true'
         with:
           go-version-file: go.mod
           cache: true
       - name: Login to GHCR
+        if: steps.gate.outputs.run-e2e == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install make
+        if: steps.gate.outputs.run-e2e == 'true'
         run: sudo apt-get update && sudo apt-get install -y make
       - name: Build images
+        if: steps.gate.outputs.run-e2e == 'true'
         working-directory: e2e/
         run: go run ./cmd/dzctl/main.go build
       - name: Push images to registry
+        if: steps.gate.outputs.run-e2e == 'true'
         run: |
           docker push ${{ env.DZ_IMAGE_REPO }}/base:${{ env.DZ_IMAGE_TAG }}
           docker push ${{ env.DZ_IMAGE_REPO }}/ledger:${{ env.DZ_IMAGE_TAG }}
@@ -65,11 +111,12 @@ jobs:
           docker push ${{ env.DZ_IMAGE_REPO }}/sentinel:${{ env.DZ_IMAGE_TAG }}
           docker push ${{ env.DZ_IMAGE_REPO }}/validator-metadata-service-mock:${{ env.DZ_IMAGE_TAG }}
       - name: Discover tests and distribute across shards
+        if: steps.gate.outputs.run-e2e == 'true'
         id: shard
         working-directory: e2e/
         run: |
           # Find files with exactly the e2e build tag (excludes compound tags like "e2e && stress")
-          tests=$(grep -rl '^//go:build e2e$' *_test.go \
+          tests=$(grep -rl '^//go:build e2e$' ./*_test.go \
             | xargs grep -h '^func TestE2E_' \
             | sed 's/func \(TestE2E_[a-zA-Z0-9_]*\).*/\1/' \
             | sort)
@@ -87,16 +134,16 @@ jobs:
           # Distribute remaining tests round-robin across shards
           declare -a shards
           for ((i=0; i<SHARD_COUNT; i++)); do
-            shards[$i]=""
+            shards[i]=""
           done
 
           i=0
           while IFS= read -r test; do
             idx=$((i % SHARD_COUNT))
-            if [ -n "${shards[$idx]}" ]; then
-              shards[$idx]="${shards[$idx]}|${test}"
+            if [ -n "${shards[idx]}" ]; then
+              shards[idx]="${shards[idx]}|${test}"
             else
-              shards[$idx]="$test"
+              shards[idx]="$test"
             fi
             i=$((i + 1))
           done <<< "$remaining"
@@ -104,7 +151,7 @@ jobs:
           # Build JSON matrix: shard 1 = BackwardCompatibility, shards 2+ = round-robin
           matrix="[{\"shard\":1,\"run\":\"^(${dedicated})$\"}"
           for ((i=0; i<SHARD_COUNT; i++)); do
-            matrix="${matrix},{\"shard\":$((i + 2)),\"run\":\"^(${shards[$i]})$\"}"
+            matrix="${matrix},{\"shard\":$((i + 2)),\"run\":\"^(${shards[i]})$\"}"
           done
           matrix="${matrix}]"
 
@@ -114,6 +161,7 @@ jobs:
   e2e:
     name: e2e (shard ${{ matrix.shard }})
     needs: setup
+    if: needs.setup.outputs.run-e2e == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +176,20 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
+          fetch-depth: 2
+      - name: Validate trusted PR head
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          actual_head="$(git rev-parse HEAD^2)"
+          if [ "$actual_head" != "${{ github.event.inputs.head_sha }}" ]; then
+            echo "::error::PR head SHA changed: expected ${{ github.event.inputs.head_sha }}, got $actual_head"
+            exit 1
+          fi
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,20 @@ jobs:
           go-version-file: go.mod
           cache: true
       - uses: docker/setup-buildx-action@v3
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker Hub credentials are unavailable; continuing without Docker Hub login."
+          fi
       - name: Login to Docker Hub
+        if: steps.dockerhub.outputs.available == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -3,20 +3,31 @@ on:
   push:
     branches: [main, 'hotfix/**']
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to test
+        required: true
+      head_sha:
+        description: Expected PR head SHA
+        required: true
+      image_tag:
+        description: GHCR image tag for this trusted run
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DZ_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  DZ_SHA: ${{ github.event.inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
   SHRED_IMAGE_REPO: ghcr.io/malbeclabs/dz-shreds-e2e
-  SHRED_IMAGE_TAG: ${{ github.event.pull_request.head.sha || github.sha }}
-  SHRED_BASE_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/base:${{ github.event.pull_request.head.sha || github.sha }}
-  SHRED_LEDGER_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/ledger:${{ github.event.pull_request.head.sha || github.sha }}
-  SHRED_MANAGER_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/manager:${{ github.event.pull_request.head.sha || github.sha }}
-  SHRED_ORACLE_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/oracle:${{ github.event.pull_request.head.sha || github.sha }}
-  SHRED_CLIENT_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/client:${{ github.event.pull_request.head.sha || github.sha }}
+  SHRED_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
+  SHRED_BASE_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/base:${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
+  SHRED_LEDGER_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/ledger:${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
+  SHRED_MANAGER_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/manager:${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
+  SHRED_ORACLE_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/oracle:${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
+  SHRED_CLIENT_IMAGE: ghcr.io/malbeclabs/dz-shreds-e2e/client:${{ github.event.inputs.image_tag || github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   setup:
@@ -26,35 +37,57 @@ jobs:
       packages: write
       contents: read
     outputs:
+      run-e2e: ${{ steps.gate.outputs.run-e2e }}
       shreds-sha: ${{ steps.checkout-shreds.outputs.commit }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
+      - name: Decide whether privileged shreds e2e can run
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping privileged shreds e2e on an external fork PR. A maintainer can comment /run-e2e to start a trusted run."
+            {
+              echo "### Privileged shreds e2e skipped"
+              echo
+              echo "This pull request comes from an external fork, so GitHub withholds repository secrets."
+              echo "A maintainer can comment \`/run-e2e\` to dispatch trusted shreds e2e for this PR head SHA."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "run-e2e=true" >> "$GITHUB_OUTPUT"
       - name: Checkout doublezero-shreds
+        if: steps.gate.outputs.run-e2e == 'true'
         id: checkout-shreds
         uses: actions/checkout@v4
         with:
           repository: malbeclabs/doublezero-shreds
           token: ${{ secrets.MALBEC_INFRA_RO }}
       - uses: actions/setup-go@v5
+        if: steps.gate.outputs.run-e2e == 'true'
         with:
           go-version-file: go.mod
           cache: true
       - name: Login to GHCR
+        if: steps.gate.outputs.run-e2e == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Override doublezero SHA
+        if: steps.gate.outputs.run-e2e == 'true'
         run: |
           echo "Using doublezero SHA: $DZ_SHA"
           jq --arg sha "$DZ_SHA" '.doublezero = $sha' e2e/.dep-shas.json > e2e/.dep-shas.json.tmp
           mv e2e/.dep-shas.json.tmp e2e/.dep-shas.json
           cat e2e/.dep-shas.json
       - name: Build images
+        if: steps.gate.outputs.run-e2e == 'true'
         working-directory: e2e/
         run: go run -tags=e2e ./cmd/devnet build -v
       - name: Push images to registry
+        if: steps.gate.outputs.run-e2e == 'true'
         run: |
           docker push ${{ env.SHRED_IMAGE_REPO }}/base:${{ env.SHRED_IMAGE_TAG }}
           docker push ${{ env.SHRED_IMAGE_REPO }}/ledger:${{ env.SHRED_IMAGE_TAG }}
@@ -62,11 +95,12 @@ jobs:
           docker push ${{ env.SHRED_IMAGE_REPO }}/oracle:${{ env.SHRED_IMAGE_TAG }}
           docker push ${{ env.SHRED_IMAGE_REPO }}/client:${{ env.SHRED_IMAGE_TAG }}
       - name: Discover tests and distribute across shards
+        if: steps.gate.outputs.run-e2e == 'true'
         id: shard
         working-directory: e2e/
         run: |
           # Find all TestE2E_* functions in files with the e2e build tag.
-          tests=$(grep -rl '^//go:build e2e$' *_test.go \
+          tests=$(grep -rl '^//go:build e2e$' ./*_test.go \
             | xargs grep -h '^func TestE2E_' \
             | sed 's/func \(TestE2E_[a-zA-Z0-9_]*\).*/\1/' \
             | sort)
@@ -96,14 +130,14 @@ jobs:
 
           ROUND_ROBIN_SHARDS=2
           declare -a shards
-          for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do shards[$i]=""; done
+          for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do shards[i]=""; done
           i=0
           while IFS= read -r test; do
             idx=$((i % ROUND_ROBIN_SHARDS))
-            if [ -n "${shards[$idx]}" ]; then
-              shards[$idx]="${shards[$idx]}|${test}"
+            if [ -n "${shards[idx]}" ]; then
+              shards[idx]="${shards[idx]}|${test}"
             else
-              shards[$idx]="$test"
+              shards[idx]="$test"
             fi
             i=$((i + 1))
           done <<< "$remaining"
@@ -112,7 +146,7 @@ jobs:
           matrix="[{\"shard\":1,\"run\":\"^(${pinned_1})$\"}"
           matrix="${matrix},{\"shard\":2,\"run\":\"^(${pinned_2})$\"}"
           for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do
-            matrix="${matrix},{\"shard\":$((i + 3)),\"run\":\"^(${shards[$i]})$\"}"
+            matrix="${matrix},{\"shard\":$((i + 3)),\"run\":\"^(${shards[i]})$\"}"
           done
           matrix="${matrix}]"
 
@@ -122,6 +156,7 @@ jobs:
   shard-e2e:
     name: shard-e2e (shard ${{ matrix.shard }})
     needs: setup
+    if: needs.setup.outputs.run-e2e == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/trusted-fork-e2e.yml
+++ b/.github/workflows/trusted-fork-e2e.yml
@@ -1,0 +1,122 @@
+name: trusted-fork-e2e
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to test
+        required: true
+      suites:
+        description: 'Which suite to run: all, e2e, or shreds-e2e'
+        required: false
+        default: all
+
+concurrency:
+  group: trusted-fork-e2e-${{ github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    # Keep this workflow gated: only /run-e2e comments on PRs, or manual runs.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       (github.event.comment.body == '/run-e2e' || startsWith(github.event.comment.body, '/run-e2e ')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch trusted e2e workflows
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allowedPermissions = new Set(['admin', 'maintain', 'write']);
+            const { owner, repo } = context.repo;
+            const isManual = context.eventName === 'workflow_dispatch';
+            const inputs = context.payload.inputs || {};
+            const prNumber = Number(isManual ? inputs.pr_number : context.payload.issue.number);
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`Invalid pull request number: ${isManual ? inputs.pr_number : context.payload.issue.number}`);
+            }
+
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: context.actor,
+            });
+
+            if (!allowedPermissions.has(permission.permission)) {
+              throw new Error(`@${context.actor} has ${permission.permission} permission; trusted e2e requires write, maintain, or admin.`);
+            }
+
+            const suiteToken = (isManual
+              ? (inputs.suites || 'all')
+              : (context.payload.comment.body.trim().split(/\s+/)[1] || 'all'))
+              .toLowerCase();
+
+            const suites = new Map([
+              ['all', ['e2e.yml', 'shreds-e2e.yml']],
+              ['e2e', ['e2e.yml']],
+              ['core', ['e2e.yml']],
+              ['shreds', ['shreds-e2e.yml']],
+              ['shreds-e2e', ['shreds-e2e.yml']],
+            ]);
+
+            const workflows = suites.get(suiteToken);
+            if (!workflows) {
+              throw new Error(`Unknown suite '${suiteToken}'. Use one of: all, e2e, shreds-e2e.`);
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.state !== 'open') {
+              throw new Error(`Pull request #${prNumber} is ${pr.state}; trusted e2e only runs for open PRs.`);
+            }
+
+            const headSha = pr.head.sha;
+            const imageTag = `trusted-pr-${prNumber}-${headSha}`;
+            const dispatched = [];
+
+            for (const workflow_id of workflows) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id,
+                ref: pr.base.ref,
+                inputs: {
+                  pr_number: String(prNumber),
+                  head_sha: headSha,
+                  image_tag: imageTag,
+                },
+              });
+              dispatched.push(workflow_id);
+            }
+
+            const links = dispatched
+              .map((workflow) => `- [${workflow}](https://github.com/${owner}/${repo}/actions/workflows/${workflow})`)
+              .join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: [
+                `Trusted e2e requested by @${context.actor} for \`${headSha}\`.`,
+                '',
+                `Image tag: \`${imageTag}\``,
+                '',
+                'Dispatched workflows:',
+                links,
+              ].join('\n'),
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- ci(e2e): add trusted fork PR e2e dispatch ([#3777](https://github.com/malbeclabs/doublezero/pull/3777))
 - SDK (Rust)
   - Drop the pre-submit `simulate_transaction` call in `DZClient::execute_transaction_inner` and submit with `skip_preflight: true`, eliminating the redundant double-simulation (the explicit simulate plus `send_and_confirm_transaction`'s default preflight) on the happy path. Program logs are now recovered from `get_transaction` on the failure path so `SimulationError` / `SimulationTransactionError` and `DoubleZeroError` mapping in CLI output are unchanged. Trade-off: failing transactions now land onchain and burn fees instead of failing for free at simulation ([#3750](https://github.com/malbeclabs/doublezero/pull/3750))
 - e2e/qa: remove client-side capacity pre-filtering from `ValidDevices`, because the QA user pubkey bypasses capacity limits using the serviceability global-config qa-allowlist. Individual device failures no longer fail the test; instead, overall and per-host failure rates are evaluated after all batches and the test only fails if either exceeds `--failure-threshold` (default 10%) or `--per-host-failure-threshold` (default 20%).
@@ -22,7 +23,6 @@ All notable changes to this project will be documented in this file.
 ### Breaking
 
 ### Changes
-
 
 - Smartcontract
   - Deprecate the 13 contributor-side program instructions whose only client was the now-deleted activator: `ActivateDevice` (21), `RejectDevice` (22), `CloseAccountDevice` (27), `ActivateLink` (29), `RejectLink` (30), `CloseAccountLink` (35), `ActivateMulticastGroup` (47), `RejectMulticastGroup` (48), `DeactivateMulticastGroup` (53), `ActivateDeviceInterface` (72), `RemoveDeviceInterface` (75), `UnlinkDeviceInterface` (77), and `RejectDeviceInterface` (78). Dispatch arms now short-circuit to `DoubleZeroError::Deprecated` (custom code 67); processor files and argument structs are removed. Borsh variant tags are preserved (unit variants) so the wire format is unchanged — old clients receive a deterministic deprecation error rather than an unknown-instruction decode failure. Bumps `MIN_COMPATIBLE_VERSION` to `0.15.0` (the `client/v0.14.1` git tag was a patch release built from a commit whose workspace Cargo version was still `0.14.0`, so the v0.14.1 binary self-reports as 0.14.0 in its startup version check; v0.15.0 is the first release whose embedded version actually satisfies the intended ≥ 0.14.1 gate). Gated on onchain `ProgramConfig.min_compatible_version ≥ 0.15.0` ([#3623](https://github.com/malbeclabs/doublezero/issues/3623))
@@ -79,7 +79,7 @@ All notable changes to this project will be documented in this file.
 - SDK
   - Drop V3 handling from the Go, Python, and TypeScript serviceability readers: remove `DeserializeInterfaceV3` (Go) and the `version === 3` / `version == 3` legacy-slot branches (Python/TS); remove the `TestDeserializeInterfaceV3CrossLanguage` Go test. The forward-compat trailing `interfaces` vec continues to carry `flex_algo_node_segments` via the size-prefixed body — that path is unchanged ([#3664](https://github.com/malbeclabs/doublezero/issues/3664))
   - Let side-Z contributors update a link's `status` / `desired_status` / `delay_override_ns` via `UpdateLinkCommand`; the Rust SDK now auto-detects the signer's side and builds the 4-account side-Z preamble the on-chain processor expects, instead of always sending the side-A layout ([#3702](https://github.com/malbeclabs/doublezero/issues/3702))
-- Controller: 
+- Controller:
   - Enforce interface MTU during config render from interface role (CYOA/DIA → 1500, fabric → 9000) instead of trusting onchain `Interface.Mtu` / `Link.Mtu`; render each parent interface exactly once with `max` of its subinterface MTUs; change the `tunnel.tmpl` fallback from `2048` to `9000`. Guards against stale V1 onchain interfaces (`Mtu = 0`) and duplicate parent blocks that previously caused silent IS-IS adjacency failures ([#3696](https://github.com/malbeclabs/doublezero/pull/3696))
 - E2E tests
   - Make multicast QA failures self-explanatory: require a `Multicast`-typed status entry after multicast connect (instead of accepting a stale IBRL one), retry `MulticastJoin` briefly on "interface not found" to absorb the daemon/kernel race, snapshot host state once after 30s of zero packets, and heartbeat the publisher's tunnel status during send windows to catch silent regressions


### PR DESCRIPTION
# Summary

Adds maintainer-gated trusted e2e automation for external fork PRs, so default fork PR CI no longer fails on unavailable GHCR write permissions or repository secrets.

## Changes

- Add `trusted-fork-e2e` workflow for `/run-e2e` PR comments and manual dispatch.
- Require the requester to have `write`, `maintain`, or `admin` repo permission.
- Dispatch trusted `e2e.yml` and/or `shreds-e2e.yml` runs with the exact PR head SHA.
- Add `workflow_dispatch` support to `e2e.yml` and `shreds-e2e.yml`.
- Skip privileged e2e setup on external fork `pull_request` runs with a clear notice.
- Validate trusted workflow checkouts still match the requested PR head SHA.
- Skip Docker Hub login in Go container tests when fork PR secrets are unavailable.
- Add `actionlint` config for existing custom runner labels.