### PR TITLE
tools/stress: agent SSH + log parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Tools
+  - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.
+
 ## [v0.25.1](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.1) - 2026-06-01
 
 ### Breaking

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.17.1
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
+	golang.org/x/crypto v0.49.0
 	golang.org/x/mod v0.33.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
@@ -193,7 +194,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
 	golang.org/x/term v0.41.0 // indirect

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -137,12 +137,20 @@ func run() error {
 	// doesn't leave a config file behind. A dry-run is exempt: its whole job is
 	// to dump the resolved config without needing the live-RPC flags.
 	if !*dryRun {
-		if err := requireFlags(map[string]string{
+		required := map[string]string{
 			"--dut-pubkey": *dutPubkey,
 			"--rpc-url":    *rpcURL,
 			"--program-id": *programID,
 			"--keypair":    *keypairPath,
-		}); err != nil {
+		}
+		if !*noAgent {
+			// Agent telemetry is required unless explicitly disabled; don't
+			// silently degrade to a no-op run that records no pre_commit_log /
+			// applied rows.
+			required["--dut-ssh-host"] = *dutSSHHost
+			required["--dut-ssh-key"] = *dutSSHKey
+		}
+		if err := requireFlags(required); err != nil {
 			return err
 		}
 	}
@@ -288,19 +296,17 @@ func requireFlags(required map[string]string) error {
 // selectAgentRunner picks between the SSH-backed runner and the no-op, based
 // on the CLI flags:
 //
-//   - --no-agent → noop (operator opted out)
-//   - --dut-ssh-host + --dut-ssh-key set → SSH runner (default for live runs)
-//   - otherwise → noop with a warning (operator forgot the flags)
+//   - --no-agent → noop (operator explicitly opted out, e.g. offline testing)
+//   - otherwise → SSH runner
+//
+// The SSH flags are validated as required upstream when --no-agent is unset, so
+// this never silently falls back to the no-op runner.
 //
 // The SSH runner tees remote stdout/stderr into <working-dir>/orchestrator.agent.log.
 // The exec'd command appends --controller iff the operator passed --controller.
 func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir string, logger *slog.Logger) agent.Runner {
 	if noAgent {
 		logger.Info("agent: --no-agent set; using no-op runner")
-		return agent.NewNoop(logger)
-	}
-	if sshHost == "" || sshKey == "" {
-		logger.Warn("agent: --dut-ssh-host and --dut-ssh-key not both set; falling back to no-op runner (pre_commit_log / applied events will not be recorded)")
 		return agent.NewNoop(logger)
 	}
 

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -44,6 +44,7 @@ type orchestratorConfig struct {
 	DUTPubkey       string `json:"dut_pubkey"`
 	DUTSSHHost      string `json:"dut_ssh_host"`
 	DUTSSHKey       string `json:"dut_ssh_key"`
+	DUTSSHUser      string `json:"dut_ssh_user"`
 	RPCURL          string `json:"rpc_url"`
 	ProgramID       string `json:"program_id"`
 	KeypairPath     string `json:"keypair"`
@@ -53,6 +54,7 @@ type orchestratorConfig struct {
 	ClientIPBase    string `json:"client_ip_base"`
 	TunnelEndpoint  string `json:"tunnel_endpoint"`
 	TenantPubkey    string `json:"tenant_pubkey,omitempty"`
+	NoAgent         bool   `json:"no_agent"`
 }
 
 func main() {
@@ -82,6 +84,8 @@ func run() error {
 		runID           = flag.String("run-id", "", "Run identifier written into every runlog row; auto-generated if empty.")
 		logLevel        = flag.String("log-level", "info", "slog level: debug|info|warn|error.")
 		dryRun          = flag.Bool("dry-run", false, "Validate flags and dump orchestrator-config.json without contacting the RPC.")
+		dutSSHUser      = flag.String("dut-ssh-user", "admin", "SSH user for the DUT.")
+		noAgent         = flag.Bool("no-agent", false, "Use the no-op AgentRunner even when SSH flags are set (offline testing).")
 	)
 	flag.Parse()
 
@@ -117,6 +121,7 @@ func run() error {
 		DUTPubkey:       *dutPubkey,
 		DUTSSHHost:      *dutSSHHost,
 		DUTSSHKey:       *dutSSHKey,
+		DUTSSHUser:      *dutSSHUser,
 		RPCURL:          *rpcURL,
 		ProgramID:       *programID,
 		KeypairPath:     *keypairPath,
@@ -126,6 +131,7 @@ func run() error {
 		ClientIPBase:    *clientIPBase,
 		TunnelEndpoint:  *tunnelEndpoint,
 		TenantPubkey:    *tenantPubkey,
+		NoAgent:         *noAgent,
 	}
 	// Validate required flags before writing anything, so a bad invocation
 	// doesn't leave a config file behind. A dry-run is exempt: its whole job is
@@ -180,6 +186,7 @@ func run() error {
 	liveExec, err := exec.New(exec.Config{
 		Client:         client,
 		Executor:       executor,
+		RPC:            rpc,
 		DevicePubkey:   dutPK,
 		TenantPubkey:   tenantPK,
 		ClientIPBase:   baseIP,
@@ -206,6 +213,8 @@ func run() error {
 	ctx, abortCancel := abort.Watch(rootCtx, *abortFile, abort.DefaultPollInterval, logger)
 	defer abortCancel()
 
+	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, logger)
+
 	cfg := sweep.Config{
 		RunID:         *runID,
 		Target:        *targetUserCount,
@@ -213,7 +222,7 @@ func run() error {
 		Hold:          time.Duration(*holdSeconds) * time.Second,
 		OwnerFilter:   signer.PublicKey(),
 		Executor:      liveExec,
-		Agent:         agent.NewNoop(logger),
+		Agent:         agentRunner,
 		Runlog:        rlw,
 		Clock:         sweep.RealClock{},
 		Logger:        logger,
@@ -274,6 +283,39 @@ func requireFlags(required map[string]string) error {
 		return fmt.Errorf("missing required flag(s): %v", missing)
 	}
 	return nil
+}
+
+// selectAgentRunner picks between the SSH-backed runner and the no-op, based
+// on the CLI flags:
+//
+//   - --no-agent → noop (operator opted out)
+//   - --dut-ssh-host + --dut-ssh-key set → SSH runner (default for live runs)
+//   - otherwise → noop with a warning (operator forgot the flags)
+//
+// The SSH runner tees remote stdout/stderr into <working-dir>/orchestrator.agent.log.
+// The exec'd command appends --controller iff the operator passed --controller.
+func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir string, logger *slog.Logger) agent.Runner {
+	if noAgent {
+		logger.Info("agent: --no-agent set; using no-op runner")
+		return agent.NewNoop(logger)
+	}
+	if sshHost == "" || sshKey == "" {
+		logger.Warn("agent: --dut-ssh-host and --dut-ssh-key not both set; falling back to no-op runner (pre_commit_log / applied events will not be recorded)")
+		return agent.NewNoop(logger)
+	}
+
+	cmd := "doublezero-agent -verbose"
+	if controllerAddr != "" {
+		cmd = fmt.Sprintf("doublezero-agent -verbose -controller %s", controllerAddr)
+	}
+	return agent.NewSSH(agent.SSHConfig{
+		Host:    sshHost,
+		User:    sshUser,
+		KeyPath: sshKey,
+		Command: cmd,
+		LogPath: filepath.Join(workingDir, "orchestrator.agent.log"),
+		Logger:  logger,
+	})
 }
 
 func parseIPv4(s string) ([4]byte, error) {

--- a/tools/stress/device-orchestrator/pkg/agent/agent.go
+++ b/tools/stress/device-orchestrator/pkg/agent/agent.go
@@ -40,12 +40,16 @@ type Event struct {
 //   - Start(ctx) blocks until the agent stream is healthy enough to emit
 //     events (or returns an error). It returns immediately for the no-op impl.
 //   - Events() returns a channel that closes when the runner exits.
+//   - Err() reports the terminal error after Events() has closed: non-nil if
+//     the runner stopped because its stream failed, nil if it shut down because
+//     its context was cancelled. Only valid to read once Events() is closed.
 //
 // The SSH-backed implementation will manage an ssh.Session and parse stdout
 // for the two log lines listed under EventKind.
 type Runner interface {
 	Start(ctx context.Context) error
 	Events() <-chan Event
+	Err() error
 }
 
 // NewNoop returns a Runner that never starts a process and never emits events.
@@ -77,3 +81,6 @@ func (n *noop) Start(ctx context.Context) error {
 }
 
 func (n *noop) Events() <-chan Event { return n.events }
+
+// Err always returns nil: the no-op runner has no stream to fail.
+func (n *noop) Err() error { return nil }

--- a/tools/stress/device-orchestrator/pkg/agent/parser.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser.go
@@ -11,17 +11,23 @@ import (
 // It tracks two log lines from controlplane/agent/pkg/arista/eapi.go:
 //
 //   - "Committing config session due to diffs detected: <diff>"
-//     → emit one EventPreCommitLog per `+ interface Tunnel<ID>` in the diff,
-//     and remember those IDs as "pending".
+//     opens a diff block. The agent logs the diff with a single log.Printf, but
+//     Go's log package only prefixes the first line, so the body of the diff —
+//     the "+ interface Tunnel<ID>" lines — arrives on the lines that *follow*
+//     the marker. The parser therefore stays in the block and scans every
+//     subsequent line, emitting one EventPreCommitLog per added tunnel and
+//     remembering those IDs as "pending".
 //   - "Configuration session finalized with command '... commit'"
-//     → emit one EventApplied per pending ID, then clear the buffer.
+//     → emit one EventApplied per pending ID, then close the block and clear
+//     the buffer.
 //   - "Configuration session finalized with command '... abort'"
-//     → clear the buffer with no Applied events.
+//     → close the block and clear the buffer with no Applied events.
 //
 // A single Parser is goroutine-safe only against the calling Parse goroutine;
 // callers should funnel all lines through one Parse loop.
 type Parser struct {
 	pending []uint16
+	inDiff  bool             // open between a "Committing..." marker and its finalize line
 	now     func() time.Time // injectable for tests
 }
 
@@ -48,19 +54,13 @@ func WithClock(now func() time.Time) ParserOption {
 // retain.
 func (p *Parser) Parse(line string) []Event {
 	if m := committingRE.FindStringSubmatch(line); m != nil {
-		ids := extractAddedTunnelIDs(m[1])
-		if len(ids) == 0 {
-			return nil
-		}
-		p.pending = append(p.pending, ids...)
-		now := p.now()
-		out := make([]Event, 0, len(ids))
-		for _, id := range ids {
-			out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
-		}
-		return out
+		// Open the diff block and scan the inline remainder of the marker line
+		// (the agent appends the first diff line after the colon).
+		p.inDiff = true
+		return p.scanAddedTunnels(m[1])
 	}
 	if finalizedCommitRE.MatchString(line) {
+		p.inDiff = false
 		if len(p.pending) == 0 {
 			return nil
 		}
@@ -74,10 +74,33 @@ func (p *Parser) Parse(line string) []Event {
 	}
 	if finalizedAbortRE.MatchString(line) {
 		// Abort cleared the session — drop pending without emitting Applied.
+		p.inDiff = false
 		p.pending = p.pending[:0]
 		return nil
 	}
+	if p.inDiff {
+		// A diff-body line inside an open commit block: the "+ interface
+		// Tunnel<ID>" additions arrive here, one (or more) per line.
+		return p.scanAddedTunnels(line)
+	}
 	return nil
+}
+
+// scanAddedTunnels emits one EventPreCommitLog per "+ interface Tunnel<ID>"
+// found in s, recording the IDs as pending. Returns nil when s adds no tunnels
+// (context lines, "- interface" deletions, or unrelated diff text).
+func (p *Parser) scanAddedTunnels(s string) []Event {
+	ids := extractAddedTunnelIDs(s)
+	if len(ids) == 0 {
+		return nil
+	}
+	p.pending = append(p.pending, ids...)
+	now := p.now()
+	out := make([]Event, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
+	}
+	return out
 }
 
 // Pending exposes the in-flight tunnel IDs awaiting an Applied event; tests
@@ -89,9 +112,10 @@ func (p *Parser) Pending() []uint16 {
 }
 
 var (
-	// committingRE captures the diff payload from the agent's pre-commit log.
-	// The diff is everything after the colon-space and runs to end of line —
-	// agents emit the diff inline (often multi-section but single-line).
+	// committingRE matches the agent's pre-commit marker and captures whatever
+	// trails the colon on that same line. Only the first diff line lands here:
+	// Go's log package prefixes a timestamp to the marker line, and the rest of
+	// the multi-line diff arrives on subsequent lines (handled via inDiff).
 	committingRE = regexp.MustCompile(`Committing config session due to diffs detected:\s*(.*)$`)
 
 	// addedTunnelRE matches an additive interface-Tunnel diff line; the `\b` on

--- a/tools/stress/device-orchestrator/pkg/agent/parser.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// Parser turns lines from a doublezero-agent log stream into AgentEvents.
+//
+// It tracks two log lines from controlplane/agent/pkg/arista/eapi.go:
+//
+//   - "Committing config session due to diffs detected: <diff>"
+//     → emit one EventPreCommitLog per `+ interface Tunnel<ID>` in the diff,
+//     and remember those IDs as "pending".
+//   - "Configuration session finalized with command '... commit'"
+//     → emit one EventApplied per pending ID, then clear the buffer.
+//   - "Configuration session finalized with command '... abort'"
+//     → clear the buffer with no Applied events.
+//
+// A single Parser is goroutine-safe only against the calling Parse goroutine;
+// callers should funnel all lines through one Parse loop.
+type Parser struct {
+	pending []uint16
+	now     func() time.Time // injectable for tests
+}
+
+// NewParser returns a Parser that stamps events with the current wallclock.
+// Pass WithClock to override (testing).
+func NewParser(opts ...ParserOption) *Parser {
+	p := &Parser{now: time.Now}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// ParserOption configures NewParser.
+type ParserOption func(*Parser)
+
+// WithClock overrides time.Now for the parser; used by tests.
+func WithClock(now func() time.Time) ParserOption {
+	return func(p *Parser) { p.now = now }
+}
+
+// Parse advances the parser by one log line and returns any events produced.
+// The returned slice is freshly allocated per call and safe for the caller to
+// retain.
+func (p *Parser) Parse(line string) []Event {
+	if m := committingRE.FindStringSubmatch(line); m != nil {
+		ids := extractAddedTunnelIDs(m[1])
+		if len(ids) == 0 {
+			return nil
+		}
+		p.pending = append(p.pending, ids...)
+		now := p.now()
+		out := make([]Event, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
+		}
+		return out
+	}
+	if finalizedCommitRE.MatchString(line) {
+		if len(p.pending) == 0 {
+			return nil
+		}
+		now := p.now()
+		out := make([]Event, 0, len(p.pending))
+		for _, id := range p.pending {
+			out = append(out, Event{Kind: EventApplied, TunnelID: id, At: now})
+		}
+		p.pending = p.pending[:0]
+		return out
+	}
+	if finalizedAbortRE.MatchString(line) {
+		// Abort cleared the session — drop pending without emitting Applied.
+		p.pending = p.pending[:0]
+		return nil
+	}
+	return nil
+}
+
+// Pending exposes the in-flight tunnel IDs awaiting an Applied event; tests
+// inspect this to assert state transitions.
+func (p *Parser) Pending() []uint16 {
+	out := make([]uint16, len(p.pending))
+	copy(out, p.pending)
+	return out
+}
+
+var (
+	// committingRE captures the diff payload from the agent's pre-commit log.
+	// The diff is everything after the colon-space and runs to end of line —
+	// agents emit the diff inline (often multi-section but single-line).
+	committingRE = regexp.MustCompile(`Committing config session due to diffs detected:\s*(.*)$`)
+
+	// addedTunnelRE matches an additive interface-Tunnel diff line; the `\b` on
+	// the right keeps "Tunnel50001" out of a "Tunnel500" match.
+	addedTunnelRE = regexp.MustCompile(`\+\s*interface Tunnel(\d+)\b`)
+
+	// finalizedCommitRE matches the post-commit log line on a successful
+	// commit. The quoted command always ends in "...commit" for actual commits
+	// and "...abort" for no-op sessions.
+	finalizedCommitRE = regexp.MustCompile(`Configuration session finalized with command '.*\s+commit'`)
+	finalizedAbortRE  = regexp.MustCompile(`Configuration session finalized with command '.*\s+abort'`)
+)
+
+// extractAddedTunnelIDs pulls every "+ interface Tunnel<ID>" out of a diff
+// payload. Returns nil when no additive lines are present (e.g., pure
+// deprovision diffs).
+func extractAddedTunnelIDs(diff string) []uint16 {
+	matches := addedTunnelRE.FindAllStringSubmatch(diff, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]uint16, 0, len(matches))
+	for _, m := range matches {
+		id, err := strconv.ParseUint(m[1], 10, 16)
+		if err != nil {
+			continue
+		}
+		out = append(out, uint16(id))
+	}
+	return out
+}

--- a/tools/stress/device-orchestrator/pkg/agent/parser_test.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser_test.go
@@ -1,0 +1,134 @@
+package agent_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-orchestrator/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedClock returns a constant time for deterministic event timestamps.
+func fixedClock(at time.Time) func() time.Time {
+	return func() time.Time { return at }
+}
+
+func TestParser_SingleTunnelDiffThenCommit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	p := agent.NewParser(agent.WithClock(fixedClock(now)))
+
+	events := p.Parse(`2026/05/27 12:00:01 Committing config session due to diffs detected: + interface Tunnel500   ip address 169.254.0.1/30`)
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventPreCommitLog, events[0].Kind)
+	assert.Equal(t, uint16(500), events[0].TunnelID)
+	assert.Equal(t, now, events[0].At)
+	assert.Equal(t, []uint16{500}, p.Pending())
+
+	events = p.Parse(`2026/05/27 12:00:02 Configuration session finalized with command 'configure session doublezero-agent-abc123 commit'`)
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventApplied, events[0].Kind)
+	assert.Equal(t, uint16(500), events[0].TunnelID)
+	assert.Empty(t, p.Pending(), "pending should clear after commit-success")
+}
+
+func TestParser_MultiTunnelDiffEmitsOneEventPerTunnel(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	diff := `Committing config session due to diffs detected: + interface Tunnel500 + interface Tunnel501 - interface Tunnel499 + interface Tunnel502`
+	events := p.Parse(diff)
+	require.Len(t, events, 3, "only + lines, not - lines, produce events")
+	assert.Equal(t, []uint16{500, 501, 502}, []uint16{events[0].TunnelID, events[1].TunnelID, events[2].TunnelID})
+	for _, e := range events {
+		assert.Equal(t, agent.EventPreCommitLog, e.Kind)
+	}
+
+	applied := p.Parse(`Configuration session finalized with command 'configure session foo commit'`)
+	require.Len(t, applied, 3, "Applied fires once per pending tunnel")
+	assert.Equal(t, []uint16{500, 501, 502}, []uint16{applied[0].TunnelID, applied[1].TunnelID, applied[2].TunnelID})
+}
+
+func TestParser_DeprovisionOnlyDiffEmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	events := p.Parse(`Committing config session due to diffs detected: - interface Tunnel500 - interface Tunnel501`)
+	assert.Empty(t, events)
+	assert.Empty(t, p.Pending())
+}
+
+func TestParser_AbortClearsBufferWithoutAppliedEvents(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	events := p.Parse(`Committing config session due to diffs detected: + interface Tunnel500`)
+	require.Len(t, events, 1)
+	require.Equal(t, []uint16{500}, p.Pending())
+
+	events = p.Parse(`Configuration session finalized with command 'configure session foo abort'`)
+	assert.Empty(t, events, "abort emits no events")
+	assert.Empty(t, p.Pending(), "abort still clears pending")
+}
+
+func TestParser_CommitWithoutPendingDiffIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	events := p.Parse(`Configuration session finalized with command 'configure session foo commit'`)
+	assert.Empty(t, events)
+}
+
+func TestParser_TwoConsecutiveProvisionCycles(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+
+	// Cycle 1
+	require.Len(t, p.Parse(`Committing config session due to diffs detected: + interface Tunnel500`), 1)
+	require.Len(t, p.Parse(`Configuration session finalized with command 'configure session foo commit'`), 1)
+	assert.Empty(t, p.Pending())
+
+	// Cycle 2
+	require.Len(t, p.Parse(`Committing config session due to diffs detected: + interface Tunnel501`), 1)
+	applied := p.Parse(`Configuration session finalized with command 'configure session bar commit'`)
+	require.Len(t, applied, 1)
+	assert.Equal(t, uint16(501), applied[0].TunnelID, "cycle 2 must not replay tunnel 500")
+}
+
+func TestParser_UnrelatedLinesIgnored(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	for _, line := range []string{
+		``,
+		`Received 42 lines of configuration from controller`,
+		`forced unlock of configuration lock (xyz)`,
+		`some random log noise`,
+	} {
+		assert.Empty(t, p.Parse(line), "line=%q", line)
+	}
+}
+
+func TestParser_RejectsOversizedTunnelID(t *testing.T) {
+	t.Parallel()
+
+	// uint16 max is 65535; 70000 should be silently skipped, not panic.
+	p := agent.NewParser()
+	events := p.Parse(`Committing config session due to diffs detected: + interface Tunnel70000 + interface Tunnel500`)
+	require.Len(t, events, 1)
+	assert.Equal(t, uint16(500), events[0].TunnelID)
+}
+
+func TestParser_DoesNotConfuseInterfaceNamePrefixes(t *testing.T) {
+	t.Parallel()
+
+	// "Tunnel5000" must not match a regex that's been fooled by "Tunnel500"
+	// being a prefix. Use a `\b` boundary in the regex.
+	p := agent.NewParser()
+	events := p.Parse(`Committing config session due to diffs detected: + interface Tunnel5000`)
+	require.Len(t, events, 1)
+	assert.Equal(t, uint16(5000), events[0].TunnelID)
+}

--- a/tools/stress/device-orchestrator/pkg/agent/parser_test.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser_test.go
@@ -38,8 +38,21 @@ func TestParser_MultiTunnelDiffEmitsOneEventPerTunnel(t *testing.T) {
 	t.Parallel()
 
 	p := agent.NewParser()
-	diff := `Committing config session due to diffs detected: + interface Tunnel500 + interface Tunnel501 - interface Tunnel499 + interface Tunnel502`
-	events := p.Parse(diff)
+	// streamLines feeds one line per Parse call. The agent logs the diff with a
+	// single log.Printf, so only the marker line carries the timestamp prefix
+	// and every "+ interface Tunnel<ID>" lands on its own subsequent line.
+	lines := []string{
+		`2026/05/27 12:00:01 Committing config session due to diffs detected: `,
+		`+ interface Tunnel500`,
+		`    ip address 169.254.0.1/30`,
+		`+ interface Tunnel501`,
+		`- interface Tunnel499`,
+		`+ interface Tunnel502`,
+	}
+	var events []agent.Event
+	for _, l := range lines {
+		events = append(events, p.Parse(l)...)
+	}
 	require.Len(t, events, 3, "only + lines, not - lines, produce events")
 	assert.Equal(t, []uint16{500, 501, 502}, []uint16{events[0].TunnelID, events[1].TunnelID, events[2].TunnelID})
 	for _, e := range events {
@@ -49,6 +62,23 @@ func TestParser_MultiTunnelDiffEmitsOneEventPerTunnel(t *testing.T) {
 	applied := p.Parse(`Configuration session finalized with command 'configure session foo commit'`)
 	require.Len(t, applied, 3, "Applied fires once per pending tunnel")
 	assert.Equal(t, []uint16{500, 501, 502}, []uint16{applied[0].TunnelID, applied[1].TunnelID, applied[2].TunnelID})
+}
+
+func TestParser_AddedInterfaceOutsideDiffBlockIgnored(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	// A "+ interface Tunnel" line with no preceding "Committing..." marker is
+	// not part of a commit diff and must not produce events.
+	assert.Empty(t, p.Parse(`+ interface Tunnel500`))
+	assert.Empty(t, p.Pending())
+
+	// Once a commit closes the block, later diff-shaped lines are ignored again
+	// until the next marker opens a new block.
+	require.Len(t, p.Parse(`Committing config session due to diffs detected: + interface Tunnel600`), 1)
+	require.Len(t, p.Parse(`Configuration session finalized with command 'configure session foo commit'`), 1)
+	assert.Empty(t, p.Parse(`+ interface Tunnel601`), "diff-shaped line after block close is ignored")
+	assert.Empty(t, p.Pending())
 }
 
 func TestParser_DeprovisionOnlyDiffEmitsNothing(t *testing.T) {

--- a/tools/stress/device-orchestrator/pkg/agent/ssh.go
+++ b/tools/stress/device-orchestrator/pkg/agent/ssh.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHConfig describes how to reach the DUT and what to run on it.
+type SSHConfig struct {
+	// Host is the dial target, e.g. "10.0.0.1:22". The dialer expects a
+	// host:port; callers should resolve hostnames upstream.
+	Host string
+	// User to authenticate as. Defaults to "admin" if empty.
+	User string
+	// KeyPath is the path to a PEM-encoded private key for public-key auth.
+	KeyPath string
+	// Command is the remote command to exec. Defaults to
+	// "doublezero-agent -verbose" if empty; callers can override with
+	// additional flags such as the controller address.
+	Command string
+	// LogPath, when non-empty, is the local file the SSH runner tees remote
+	// stdout/stderr into. The file is truncated on Start.
+	LogPath string
+	// Logger is used for diagnostic logs from the runner; pass nil for silent.
+	Logger *slog.Logger
+}
+
+// SSH is a Runner that dials the DUT over SSH, executes doublezero-agent in
+// verbose mode, and emits AgentEvents parsed from the remote log stream.
+//
+// Host key verification uses ssh.InsecureIgnoreHostKey because the
+// orchestrator targets ephemeral cEOS containers whose host keys regenerate
+// on every restart; the threat model is "operator on the same subnet" and
+// the SSH session carries no privileged credentials beyond what the keypair
+// already grants. Do not reuse this dialer for production workloads.
+type SSH struct {
+	cfg SSHConfig
+
+	events chan Event
+
+	mu      sync.Mutex
+	started bool
+	client  *ssh.Client
+	session *ssh.Session
+	logFile *os.File
+}
+
+// NewSSH returns an unstarted SSH runner. Call Start to dial.
+func NewSSH(cfg SSHConfig) *SSH {
+	if cfg.User == "" {
+		cfg.User = "admin"
+	}
+	if cfg.Command == "" {
+		cfg.Command = "doublezero-agent -verbose"
+	}
+	return &SSH{
+		cfg:    cfg,
+		events: make(chan Event, 64),
+	}
+}
+
+// Events returns the channel the runner emits AgentEvents on. It closes
+// when the runner exits (ctx cancel, process exit, or session error).
+func (s *SSH) Events() <-chan Event { return s.events }
+
+// Start dials the DUT, opens a session, executes the configured command, and
+// streams its stdout/stderr through the parser. Start returns once the
+// session has been opened; the read loop runs in a goroutine until ctx is
+// cancelled or the remote command exits.
+func (s *SSH) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return fmt.Errorf("ssh agent: already started")
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	signer, err := loadSigner(s.cfg.KeyPath)
+	if err != nil {
+		return fmt.Errorf("ssh agent: load key %s: %w", s.cfg.KeyPath, err)
+	}
+
+	clientCfg := &ssh.ClientConfig{
+		User:            s.cfg.User,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	client, err := ssh.Dial("tcp", s.cfg.Host, clientCfg)
+	if err != nil {
+		return fmt.Errorf("ssh agent: dial %s: %w", s.cfg.Host, err)
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		_ = client.Close()
+		return fmt.Errorf("ssh agent: new session: %w", err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		_ = session.Close()
+		_ = client.Close()
+		return fmt.Errorf("ssh agent: stdout pipe: %w", err)
+	}
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		_ = session.Close()
+		_ = client.Close()
+		return fmt.Errorf("ssh agent: stderr pipe: %w", err)
+	}
+
+	var logFile *os.File
+	if s.cfg.LogPath != "" {
+		logFile, err = os.Create(s.cfg.LogPath)
+		if err != nil {
+			_ = session.Close()
+			_ = client.Close()
+			return fmt.Errorf("ssh agent: open log %s: %w", s.cfg.LogPath, err)
+		}
+	}
+
+	s.mu.Lock()
+	s.client = client
+	s.session = session
+	s.logFile = logFile
+	s.mu.Unlock()
+
+	if err := session.Start(s.cfg.Command); err != nil {
+		s.shutdown()
+		return fmt.Errorf("ssh agent: start %q: %w", s.cfg.Command, err)
+	}
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("ssh agent started", "host", s.cfg.Host, "command", s.cfg.Command, "log_path", s.cfg.LogPath)
+	}
+
+	parser := NewParser()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		streamLines(ctx, stdout, logFile, parser, s.events, s.cfg.Logger, "stdout")
+	}()
+	go func() {
+		defer wg.Done()
+		streamLines(ctx, stderr, logFile, parser, s.events, s.cfg.Logger, "stderr")
+	}()
+
+	go func() {
+		// Close session and channel when ctx cancels OR all reader goroutines exit.
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-ctx.Done():
+		case <-done:
+		}
+		// Closing the session causes the read loops to return EOF; the wait
+		// below blocks until both have returned before closing the events
+		// channel, so consumers never see a half-emitted event.
+		s.shutdown()
+		<-done
+		close(s.events)
+	}()
+
+	return nil
+}
+
+// shutdown is idempotent; safe to call from Start error paths and from the
+// supervising goroutine.
+func (s *SSH) shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session != nil {
+		_ = s.session.Close()
+		s.session = nil
+	}
+	if s.client != nil {
+		_ = s.client.Close()
+		s.client = nil
+	}
+	if s.logFile != nil {
+		_ = s.logFile.Close()
+		s.logFile = nil
+	}
+}
+
+// streamLines reads `src` line-by-line, optionally tees raw lines to `tee`,
+// runs each through `parser`, and pushes resulting events onto `events`.
+// Returns early when ctx cancels so a slow consumer can't deadlock shutdown.
+func streamLines(ctx context.Context, src io.Reader, tee io.Writer, parser *Parser, events chan<- Event, log *slog.Logger, label string) {
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024) // large diffs can exceed default
+	for scanner.Scan() {
+		line := scanner.Text()
+		if tee != nil {
+			if _, err := tee.Write([]byte(line + "\n")); err != nil && log != nil {
+				log.Warn("ssh agent: log tee write failed", "err", err, "stream", label)
+			}
+		}
+		for _, ev := range parser.Parse(line) {
+			select {
+			case events <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil && log != nil {
+		log.Warn("ssh agent: stream ended with error", "err", err, "stream", label)
+	}
+}
+
+// loadSigner reads a PEM-encoded private key from disk and returns an ssh.Signer.
+func loadSigner(path string) (ssh.Signer, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.ParsePrivateKey(buf)
+}

--- a/tools/stress/device-orchestrator/pkg/agent/ssh.go
+++ b/tools/stress/device-orchestrator/pkg/agent/ssh.go
@@ -139,34 +139,60 @@ func (s *SSH) Start(ctx context.Context) error {
 		s.cfg.Logger.Info("ssh agent started", "host", s.cfg.Host, "command", s.cfg.Command, "log_path", s.cfg.LogPath)
 	}
 
+	// Funnel both streams through a single consumer. The two reader goroutines
+	// only scan raw lines and forward them on `lines`; one consumer tees to the
+	// log and runs the parser. This keeps the parser (which is not
+	// goroutine-safe) and the log file touched by exactly one goroutine, while
+	// still interleaving stdout/stderr in arrival order so a "Committing..."
+	// marker and its multi-line diff body are parsed as one ordered sequence.
 	parser := NewParser()
-	var wg sync.WaitGroup
-	wg.Add(2)
+	lines := make(chan string, 256)
+
+	var readWG sync.WaitGroup
+	readWG.Add(2)
 	go func() {
-		defer wg.Done()
-		streamLines(ctx, stdout, logFile, parser, s.events, s.cfg.Logger, "stdout")
+		defer readWG.Done()
+		scanLines(ctx, stdout, lines, s.cfg.Logger, "stdout")
 	}()
 	go func() {
-		defer wg.Done()
-		streamLines(ctx, stderr, logFile, parser, s.events, s.cfg.Logger, "stderr")
+		defer readWG.Done()
+		scanLines(ctx, stderr, lines, s.cfg.Logger, "stderr")
+	}()
+	go func() {
+		readWG.Wait()
+		close(lines)
+	}()
+
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		for line := range lines {
+			if logFile != nil {
+				if _, err := logFile.WriteString(line + "\n"); err != nil && s.cfg.Logger != nil {
+					s.cfg.Logger.Warn("ssh agent: log tee write failed", "err", err)
+				}
+			}
+			for _, ev := range parser.Parse(line) {
+				select {
+				case s.events <- ev:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
 	}()
 
 	go func() {
-		// Close session and channel when ctx cancels OR all reader goroutines exit.
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
+		// Close session and channel when ctx cancels OR the streams end.
 		select {
 		case <-ctx.Done():
-		case <-done:
+		case <-consumerDone:
 		}
 		// Closing the session causes the read loops to return EOF; the wait
-		// below blocks until both have returned before closing the events
+		// below blocks until the consumer has drained before closing the events
 		// channel, so consumers never see a half-emitted event.
 		s.shutdown()
-		<-done
+		<-consumerDone
 		close(s.events)
 	}()
 
@@ -192,25 +218,18 @@ func (s *SSH) shutdown() {
 	}
 }
 
-// streamLines reads `src` line-by-line, optionally tees raw lines to `tee`,
-// runs each through `parser`, and pushes resulting events onto `events`.
-// Returns early when ctx cancels so a slow consumer can't deadlock shutdown.
-func streamLines(ctx context.Context, src io.Reader, tee io.Writer, parser *Parser, events chan<- Event, log *slog.Logger, label string) {
+// scanLines reads `src` line-by-line and forwards each raw line on `lines`.
+// It returns early when ctx cancels so a slow consumer can't deadlock
+// shutdown. Tee-to-log and parsing happen in the single consumer that drains
+// `lines`, so this reader never touches the parser or the log file.
+func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slog.Logger, label string) {
 	scanner := bufio.NewScanner(src)
 	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024) // large diffs can exceed default
 	for scanner.Scan() {
-		line := scanner.Text()
-		if tee != nil {
-			if _, err := tee.Write([]byte(line + "\n")); err != nil && log != nil {
-				log.Warn("ssh agent: log tee write failed", "err", err, "stream", label)
-			}
-		}
-		for _, ev := range parser.Parse(line) {
-			select {
-			case events <- ev:
-			case <-ctx.Done():
-				return
-			}
+		select {
+		case lines <- scanner.Text():
+		case <-ctx.Done():
+			return
 		}
 	}
 	if err := scanner.Err(); err != nil && log != nil {

--- a/tools/stress/device-orchestrator/pkg/agent/ssh.go
+++ b/tools/stress/device-orchestrator/pkg/agent/ssh.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -28,6 +29,9 @@ type SSHConfig struct {
 	// LogPath, when non-empty, is the local file the SSH runner tees remote
 	// stdout/stderr into. The file is truncated on Start.
 	LogPath string
+	// DialTimeout bounds the TCP connect + SSH handshake so an unresponsive
+	// device fails fast with a dial error instead of hanging. Defaults to 10s.
+	DialTimeout time.Duration
 	// Logger is used for diagnostic logs from the runner; pass nil for silent.
 	Logger *slog.Logger
 }
@@ -45,11 +49,12 @@ type SSH struct {
 
 	events chan Event
 
-	mu      sync.Mutex
-	started bool
-	client  *ssh.Client
-	session *ssh.Session
-	logFile *os.File
+	mu        sync.Mutex
+	started   bool
+	client    *ssh.Client
+	session   *ssh.Session
+	logFile   *os.File
+	streamErr error
 }
 
 // NewSSH returns an unstarted SSH runner. Call Start to dial.
@@ -59,6 +64,9 @@ func NewSSH(cfg SSHConfig) *SSH {
 	}
 	if cfg.Command == "" {
 		cfg.Command = "doublezero-agent -verbose"
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = 10 * time.Second
 	}
 	return &SSH{
 		cfg:    cfg,
@@ -92,6 +100,7 @@ func (s *SSH) Start(ctx context.Context) error {
 		User:            s.cfg.User,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         s.cfg.DialTimeout,
 	}
 	client, err := ssh.Dial("tcp", s.cfg.Host, clientCfg)
 	if err != nil {
@@ -152,11 +161,17 @@ func (s *SSH) Start(ctx context.Context) error {
 	readWG.Add(2)
 	go func() {
 		defer readWG.Done()
-		scanLines(ctx, stdout, lines, s.cfg.Logger, "stdout")
+		// Record a read error only if it wasn't provoked by our own teardown
+		// (ctx cancel closes the session, which surfaces as a read error here).
+		if err := scanLines(ctx, stdout, lines, s.cfg.Logger, "stdout"); err != nil && ctx.Err() == nil {
+			s.setStreamErr(err)
+		}
 	}()
 	go func() {
 		defer readWG.Done()
-		scanLines(ctx, stderr, lines, s.cfg.Logger, "stderr")
+		if err := scanLines(ctx, stderr, lines, s.cfg.Logger, "stderr"); err != nil && ctx.Err() == nil {
+			s.setStreamErr(err)
+		}
 	}()
 	go func() {
 		readWG.Wait()
@@ -199,6 +214,24 @@ func (s *SSH) Start(ctx context.Context) error {
 	return nil
 }
 
+// Err returns the terminal stream error after Events() has closed: non-nil if
+// a stdout/stderr read failed for a reason other than our own ctx-driven
+// shutdown, nil otherwise.
+func (s *SSH) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streamErr
+}
+
+// setStreamErr records the first stream read error.
+func (s *SSH) setStreamErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.streamErr == nil {
+		s.streamErr = err
+	}
+}
+
 // shutdown is idempotent; safe to call from Start error paths and from the
 // supervising goroutine.
 func (s *SSH) shutdown() {
@@ -219,22 +252,27 @@ func (s *SSH) shutdown() {
 }
 
 // scanLines reads `src` line-by-line and forwards each raw line on `lines`.
-// It returns early when ctx cancels so a slow consumer can't deadlock
+// It returns early (nil) when ctx cancels so a slow consumer can't deadlock
 // shutdown. Tee-to-log and parsing happen in the single consumer that drains
-// `lines`, so this reader never touches the parser or the log file.
-func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slog.Logger, label string) {
+// `lines`, so this reader never touches the parser or the log file. It returns
+// the scanner error, if any, so the caller can fail the run on a broken stream.
+func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slog.Logger, label string) error {
 	scanner := bufio.NewScanner(src)
 	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024) // large diffs can exceed default
 	for scanner.Scan() {
 		select {
 		case lines <- scanner.Text():
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
-	if err := scanner.Err(); err != nil && log != nil {
-		log.Warn("ssh agent: stream ended with error", "err", err, "stream", label)
+	if err := scanner.Err(); err != nil {
+		if log != nil {
+			log.Error("ssh agent: stream ended with error", "err", err, "stream", label)
+		}
+		return err
 	}
+	return nil
 }
 
 // loadSigner reads a PEM-encoded private key from disk and returns an ssh.Signer.

--- a/tools/stress/device-orchestrator/pkg/exec/exec.go
+++ b/tools/stress/device-orchestrator/pkg/exec/exec.go
@@ -142,6 +142,9 @@ func (l *Live) fetchTunnelID(ctx context.Context, userPDA solana.PublicKey) (uin
 	}
 	var u serviceability.User
 	serviceability.DeserializeUser(serviceability.NewByteReader(data), &u)
+	if u.AccountType != serviceability.UserType {
+		return 0, fmt.Errorf("account %s is not a user account (got account type %d)", userPDA, u.AccountType)
+	}
 	return u.TunnelId, nil
 }
 

--- a/tools/stress/device-orchestrator/pkg/exec/exec.go
+++ b/tools/stress/device-orchestrator/pkg/exec/exec.go
@@ -18,6 +18,11 @@ import (
 type Config struct {
 	Client   *serviceability.Client
 	Executor *serviceability.Executor
+	// RPC is used to fetch individual User accounts post-create so the
+	// orchestrator can record the assigned TunnelId in the runlog. In
+	// production this is the same *solanarpc.Client the Client/Executor
+	// were built from.
+	RPC serviceability.RPCClient
 
 	DevicePubkey solana.PublicKey
 	TenantPubkey solana.PublicKey // zero pubkey = no tenant
@@ -42,13 +47,16 @@ type Live struct {
 }
 
 // New returns a Live executor with the given configuration. Callers must
-// supply a non-nil Client and Executor.
+// supply a non-nil Client, Executor, and RPC.
 func New(cfg Config) (*Live, error) {
 	if cfg.Client == nil {
 		return nil, fmt.Errorf("exec.New: Client is required")
 	}
 	if cfg.Executor == nil {
 		return nil, fmt.Errorf("exec.New: Executor is required")
+	}
+	if cfg.RPC == nil {
+		return nil, fmt.Errorf("exec.New: RPC is required")
 	}
 	if cfg.DzPrefixCount == 0 {
 		cfg.DzPrefixCount = 1
@@ -89,12 +97,17 @@ func (l *Live) CreateUser(ctx context.Context, idx int) (sweep.CreateResult, err
 	// confirm and activate both anchor at the post-call wallclock. A future
 	// SDK refactor can split these.
 	//
-	// TunnelID is recorded as 0 for now: the SDK's CreateUser doesn't surface
-	// the assigned tunnel_id, and reading it back needs the User account bytes.
-	// Part 3 wires the per-account fetch here.
+	// Read the assigned tunnel_id back from the on-chain User account so the
+	// runlog and the agent-event consumer can key on it. A failure here is
+	// non-fatal: the create itself succeeded (the User exists onchain), so we
+	// record TunnelID 0 and continue.
+	tunnelID, err := l.fetchTunnelID(ctx, userPDA)
+	if err != nil {
+		tunnelID = 0
+	}
 	return sweep.CreateResult{
 		UserPDA:     userPDA,
-		TunnelID:    0,
+		TunnelID:    tunnelID,
 		ConfirmedAt: now,
 		ActivatedAt: now,
 	}, nil
@@ -110,6 +123,26 @@ func (l *Live) DeleteUser(ctx context.Context, userPDA solana.PublicKey) (sweep.
 		ConfirmedAt: now,
 		ActivatedAt: now,
 	}, nil
+}
+
+// fetchTunnelID reads the user account by PDA and returns the assigned
+// TunnelId. The sweep loop logs this in the runlog so the agent-event
+// consumer can attribute `+ interface Tunnel<ID>` log lines back to a user.
+func (l *Live) fetchTunnelID(ctx context.Context, userPDA solana.PublicKey) (uint16, error) {
+	info, err := l.cfg.RPC.GetAccountInfo(ctx, userPDA)
+	if err != nil {
+		return 0, fmt.Errorf("get user account info: %w", err)
+	}
+	if info == nil || info.Value == nil {
+		return 0, fmt.Errorf("user account %s not found", userPDA)
+	}
+	data := info.Value.Data.GetBinary()
+	if len(data) == 0 {
+		return 0, fmt.Errorf("user account %s empty", userPDA)
+	}
+	var u serviceability.User
+	serviceability.DeserializeUser(serviceability.NewByteReader(data), &u)
+	return u.TunnelId, nil
 }
 
 // ipForIndex returns base shifted by idx, wrapping at the /16 boundary so the

--- a/tools/stress/device-orchestrator/pkg/exec/exec_test.go
+++ b/tools/stress/device-orchestrator/pkg/exec/exec_test.go
@@ -1,9 +1,15 @@
 package exec
 
 import (
+	"context"
+	"encoding/binary"
 	"testing"
 
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIPForIndex(t *testing.T) {
@@ -24,4 +30,83 @@ func TestIPForIndex(t *testing.T) {
 		got := ipForIndex(base, tc.idx)
 		assert.Equal(t, tc.want, got, "idx=%d", tc.idx)
 	}
+}
+
+// stubRPC implements serviceability.RPCClient for fetchTunnelID tests.
+type stubRPC struct {
+	accountInfo *solanarpc.GetAccountInfoResult
+	err         error
+}
+
+func (s *stubRPC) GetProgramAccounts(context.Context, solana.PublicKey) (solanarpc.GetProgramAccountsResult, error) {
+	return nil, nil
+}
+
+func (s *stubRPC) GetAccountInfo(context.Context, solana.PublicKey) (*solanarpc.GetAccountInfoResult, error) {
+	return s.accountInfo, s.err
+}
+
+func TestFetchTunnelID_ReadsFromUserAccount(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	device := solana.NewWallet().PublicKey()
+
+	// Hand-encode a User account body matching DeserializeUser's field order.
+	// All fields zero except TunnelId so the test pin-points that read path.
+	const tunnelID uint16 = 4242
+	body := makeUserAccountBytes(owner, device, [4]byte{10, 0, 0, 5}, tunnelID)
+
+	stub := &stubRPC{
+		accountInfo: &solanarpc.GetAccountInfoResult{
+			Value: &solanarpc.Account{
+				Data: solanarpc.DataBytesOrJSONFromBytes(body),
+			},
+		},
+	}
+	live := &Live{cfg: Config{RPC: stub}}
+
+	got, err := live.fetchTunnelID(context.Background(), solana.NewWallet().PublicKey())
+	require.NoError(t, err)
+	assert.Equal(t, tunnelID, got)
+}
+
+func TestFetchTunnelID_AccountMissing(t *testing.T) {
+	t.Parallel()
+
+	live := &Live{cfg: Config{RPC: &stubRPC{accountInfo: &solanarpc.GetAccountInfoResult{Value: nil}}}}
+	_, err := live.fetchTunnelID(context.Background(), solana.NewWallet().PublicKey())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// makeUserAccountBytes serializes a User account body with the minimum fields
+// the test needs. Matches the field order in serviceability.DeserializeUser.
+func makeUserAccountBytes(owner, device solana.PublicKey, clientIP [4]byte, tunnelID uint16) []byte {
+	b := make([]byte, 0, 256)
+	b = append(b, byte(serviceability.UserType)) // AccountType
+	b = append(b, owner[:]...)                   // Owner [32]
+	b = append(b, make([]byte, 16)...)           // Index u128
+	b = append(b, 0)                             // BumpSeed
+	b = append(b, byte(serviceability.UserTypeIBRL))
+	b = append(b, make([]byte, 32)...) // TenantPubKey (zero)
+	b = append(b, device[:]...)        // DevicePubKey
+	b = append(b, byte(serviceability.CyoaTypeGREOverDIA))
+	b = append(b, clientIP[:]...)     // ClientIp [4]
+	b = append(b, make([]byte, 4)...) // DzIp [4]
+	var tidBuf [2]byte
+	binary.LittleEndian.PutUint16(tidBuf[:], tunnelID)
+	b = append(b, tidBuf[:]...)       // TunnelId u16 LE
+	b = append(b, make([]byte, 5)...) // TunnelNet
+	b = append(b, byte(serviceability.UserStatusActivated))
+	b = append(b, 0, 0, 0, 0)          // Publishers len
+	b = append(b, 0, 0, 0, 0)          // Subscribers len
+	b = append(b, make([]byte, 32)...) // ValidatorPubKey
+	b = append(b, make([]byte, 4)...)  // TunnelEndpoint
+	b = append(b, 0)                   // TunnelFlags
+	b = append(b, 0)                   // BgpStatus
+	b = append(b, make([]byte, 8)...)  // LastBgpUpAt
+	b = append(b, make([]byte, 8)...)  // LastBgpReportedAt
+	b = append(b, make([]byte, 8)...)  // BgpRttNs
+	return b
 }

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -172,33 +172,45 @@ func Run(ctx context.Context, cfg Config) error {
 	cfg.Logger = cfg.Logger.With("run_id", cfg.RunID)
 
 	registry := newTunnelRegistry()
-	agentCtx, agentCancel := context.WithCancel(ctx)
+
+	// runCtx lets the agent-event consumer abort the provisioning loop if the
+	// agent stream dies. The agent is required telemetry for a run, so a broken
+	// stream fails the run rather than silently degrading to missing runlog
+	// rows. deprovision below still runs (it derives from the original ctx).
+	runCtx, runCancel := context.WithCancelCause(ctx)
+	defer runCancel(nil)
+
+	agentCtx, agentCancel := context.WithCancel(runCtx)
 	defer agentCancel()
 	if err := cfg.Agent.Start(agentCtx); err != nil {
 		return fmt.Errorf("start agent runner: %w", err)
 	}
 
+	var agentErr error
 	var consumerWG sync.WaitGroup
 	consumerWG.Add(1)
 	go func() {
 		defer consumerWG.Done()
 		consumeAgentEvents(&cfg, registry)
+		// Events() has closed. If it closed because the stream errored (rather
+		// than our own agentCancel during teardown), abort the run so the
+		// provisioning loop stops and Run reports the failure.
+		if e := cfg.Agent.Err(); e != nil {
+			agentErr = fmt.Errorf("agent stream: %w", e)
+			runCancel(agentErr)
+		}
 	}()
 
-	created, err := provision(ctx, &cfg, registry)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		// On a non-cancel error from provision we still want deprovision to
-		// run (clean up what was created); the consumer keeps draining in
-		// parallel so any straggling agent events for already-created users
-		// still land in the runlog.
-		_ = err
-	}
-	// Always attempt deprovision so an abort during provision still cleans up
-	// what the sweep created. Teardown runs under a context derived with
-	// WithoutCancel: an abort/signal that cancelled ctx must not also abandon
-	// the users we already created, so deprovision ignores that cancellation
-	// (it still inherits ctx's values). Callers wanting a hard stop on teardown
-	// must enforce it out of band.
+	created, err := provision(runCtx, &cfg, registry)
+
+	// Always attempt deprovision so a provision error (or an abort during
+	// provision) still cleans up what the sweep created; the consumer keeps
+	// draining in parallel so any straggling agent events for already-created
+	// users still land in the runlog. Teardown runs under a context derived
+	// with WithoutCancel: an abort/signal that cancelled ctx must not also
+	// abandon the users we already created, so deprovision ignores that
+	// cancellation (it still inherits ctx's values). Callers wanting a hard
+	// stop on teardown must enforce it out of band.
 	depErr := deprovision(context.WithoutCancel(ctx), &cfg, created)
 
 	// Tell the agent to stop and wait for the consumer goroutine to drain so
@@ -206,6 +218,11 @@ func Run(ctx context.Context, cfg Config) error {
 	agentCancel()
 	consumerWG.Wait()
 
+	// An agent stream failure takes precedence: it aborted the run, so report
+	// it even though provision likely returned context.Canceled as a result.
+	if agentErr != nil {
+		return agentErr
+	}
 	if err != nil {
 		return err
 	}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
@@ -122,9 +123,46 @@ type createdUser struct {
 	tunnelID uint16
 }
 
+// tunnelRegistry holds the orchestrator's tunnelID → user metadata mapping,
+// shared between the provision goroutine (which writes) and the agent-event
+// consumer goroutine (which reads). Lookups for unknown tunnel IDs return
+// `ok=false` so the consumer can warn-log and drop the event.
+type tunnelRegistry struct {
+	mu  sync.RWMutex
+	idx map[uint16]createdUser
+}
+
+func newTunnelRegistry() *tunnelRegistry {
+	return &tunnelRegistry{idx: make(map[uint16]createdUser)}
+}
+
+func (r *tunnelRegistry) register(u createdUser) {
+	if u.tunnelID == 0 {
+		// TunnelId == 0 means the executor didn't surface a real ID; nothing
+		// in the agent log can match it, so don't take a map slot.
+		return
+	}
+	r.mu.Lock()
+	r.idx[u.tunnelID] = u
+	r.mu.Unlock()
+}
+
+func (r *tunnelRegistry) lookup(tunnelID uint16) (createdUser, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	u, ok := r.idx[tunnelID]
+	return u, ok
+}
+
 // Run drives the provision-then-deprovision sweep to completion. Returns the
 // number of users actually created/deleted alongside the error (if any), so
 // callers can report partial progress on abort.
+//
+// Run additionally starts a goroutine that consumes events from cfg.Agent and
+// writes pre_commit_log / applied runlog rows for tunnel IDs the sweep
+// registered. The consumer exits when the agent's Events channel closes; we
+// derive an agentCtx from ctx and cancel it after deprovision so the agent
+// stops cleanly even on a successful run.
 func Run(ctx context.Context, cfg Config) error {
 	cfg.applyDefaults()
 	if err := cfg.validate(); err != nil {
@@ -133,13 +171,27 @@ func Run(ctx context.Context, cfg Config) error {
 	// Tag every sweep log line with the run ID.
 	cfg.Logger = cfg.Logger.With("run_id", cfg.RunID)
 
-	if err := cfg.Agent.Start(ctx); err != nil {
+	registry := newTunnelRegistry()
+	agentCtx, agentCancel := context.WithCancel(ctx)
+	defer agentCancel()
+	if err := cfg.Agent.Start(agentCtx); err != nil {
 		return fmt.Errorf("start agent runner: %w", err)
 	}
 
-	created, err := provision(ctx, &cfg)
+	var consumerWG sync.WaitGroup
+	consumerWG.Add(1)
+	go func() {
+		defer consumerWG.Done()
+		consumeAgentEvents(&cfg, registry)
+	}()
+
+	created, err := provision(ctx, &cfg, registry)
 	if err != nil && !errors.Is(err, context.Canceled) {
-		return err
+		// On a non-cancel error from provision we still want deprovision to
+		// run (clean up what was created); the consumer keeps draining in
+		// parallel so any straggling agent events for already-created users
+		// still land in the runlog.
+		_ = err
 	}
 	// Always attempt deprovision so an abort during provision still cleans up
 	// what the sweep created. Teardown runs under a context derived with
@@ -148,16 +200,61 @@ func Run(ctx context.Context, cfg Config) error {
 	// (it still inherits ctx's values). Callers wanting a hard stop on teardown
 	// must enforce it out of band.
 	depErr := deprovision(context.WithoutCancel(ctx), &cfg, created)
+
+	// Tell the agent to stop and wait for the consumer goroutine to drain so
+	// no events are dropped between deprovision-end and consumer-exit.
+	agentCancel()
+	consumerWG.Wait()
+
 	if err != nil {
 		return err
 	}
 	return depErr
 }
 
+// consumeAgentEvents reads from cfg.Agent.Events() until the channel closes
+// and writes pre_commit_log / applied rows for tunnel IDs the sweep has
+// registered. Events for unknown tunnel IDs are warn-logged and dropped — the
+// most likely cause is a tunnel that belongs to a non-orchestrator user.
+func consumeAgentEvents(cfg *Config, registry *tunnelRegistry) {
+	for ev := range cfg.Agent.Events() {
+		u, ok := registry.lookup(ev.TunnelID)
+		if !ok {
+			cfg.Logger.Debug("sweep: agent event for unregistered tunnel; dropping",
+				"tunnel_id", ev.TunnelID, "kind", ev.Kind)
+			continue
+		}
+		var runlogEvent runlog.Event
+		switch ev.Kind {
+		case agent.EventPreCommitLog:
+			runlogEvent = runlog.EventPreCommitLog
+		case agent.EventApplied:
+			runlogEvent = runlog.EventApplied
+		default:
+			continue
+		}
+		row := runlog.Row{
+			RunID:       cfg.RunID,
+			UserIndex:   u.idx,
+			UserPubkey:  u.pubkey.String(),
+			TunnelID:    u.tunnelID,
+			Event:       runlogEvent,
+			TNs:         ev.At.UnixNano(),
+			NAfterEvent: 0, // active-count state is owned by the sweep goroutine and not safe to read here
+		}
+		if err := cfg.Runlog.Append(row); err != nil {
+			cfg.Logger.Warn("sweep: runlog append failed for agent event",
+				"err", err, "kind", runlogEvent, "tunnel_id", ev.TunnelID)
+		}
+	}
+}
+
 // provision walks 0 → Target in batches, returning the slice of created users
 // so deprovision can iterate in reverse. Returns ctx.Err() if cancelled
-// between users.
-func provision(ctx context.Context, cfg *Config) ([]createdUser, error) {
+// between users. Each created user is also registered with the tunnel
+// registry so the agent-event consumer can attribute pre_commit_log /
+// applied events back to a user_index.
+func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry) ([]createdUser, error) {
 	if cfg.Target == 0 {
 		return nil, nil
 	}
@@ -207,7 +304,9 @@ func provision(ctx context.Context, cfg *Config) ([]createdUser, error) {
 			if err := emit(cfg, idx, pkStr, res.TunnelID, runlog.EventConfirm, res.ConfirmedAt, activeCount); err != nil {
 				return created, err
 			}
-			created = append(created, createdUser{idx: idx, pubkey: res.UserPDA, tunnelID: res.TunnelID})
+			cu := createdUser{idx: idx, pubkey: res.UserPDA, tunnelID: res.TunnelID}
+			created = append(created, cu)
+			registry.register(cu)
 			activeCount++
 			if err := emit(cfg, idx, pkStr, res.TunnelID, runlog.EventActivate, res.ActivatedAt, activeCount); err != nil {
 				return created, err

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -67,6 +67,11 @@ type fakeExecutor struct {
 	// Optional hook invoked after the Nth create completes (1-based), with the
 	// created count. The abort test uses it to cancel the sweep context.
 	afterCreate func(calls int)
+
+	// Optional gate: when non-nil, DeleteUser blocks on it after incrementing
+	// deleteN. Tests use this to interleave work between provision and
+	// deprovision (e.g., emitting agent events).
+	deleteGate <-chan struct{}
 }
 
 func newFakeExecutor(owner solana.PublicKey) *fakeExecutor {
@@ -115,6 +120,9 @@ func (f *fakeExecutor) CreateUser(ctx context.Context, idx int) (sweep.CreateRes
 
 func (f *fakeExecutor) DeleteUser(ctx context.Context, userPDA solana.PublicKey) (sweep.DeleteResult, error) {
 	calls := int(f.deleteN.Add(1))
+	if f.deleteGate != nil {
+		<-f.deleteGate
+	}
 	f.mu.Lock()
 	// Remove the matching user from the active set.
 	for i, u := range f.created {
@@ -308,6 +316,114 @@ func TestRun_RejectsInvalidConfig(t *testing.T) {
 			err := sweep.Run(context.Background(), tc.cfg)
 			require.Error(t, err)
 		})
+	}
+}
+
+// scriptedAgent is an agent.Runner used to drive the sweep's agent-event
+// consumer from a test. Events are emitted via Emit() so the test can
+// control timing — in production the agent log lags the on-chain CreateUser
+// by far longer than registry registration takes, but in tests the executor
+// is instantaneous and we need to emit AFTER provision has registered the
+// tunnels.
+type scriptedAgent struct {
+	out chan agent.Event
+}
+
+func newScriptedAgent() *scriptedAgent {
+	return &scriptedAgent{out: make(chan agent.Event, 16)}
+}
+
+func (s *scriptedAgent) Start(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		close(s.out)
+	}()
+	return nil
+}
+
+func (s *scriptedAgent) Events() <-chan agent.Event { return s.out }
+
+func (s *scriptedAgent) Emit(e agent.Event) { s.out <- e }
+
+func TestRun_ConsumesAgentEventsForRegisteredTunnels(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	// Block deprovision so the test can emit agent events while all created
+	// tunnels are registered but before agentCancel() shuts the consumer down.
+	gate := make(chan struct{})
+	exec.deleteGate = gate
+
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:         "run-events",
+		Target:        2,
+		UsersPerBatch: 2,
+		Hold:          0,
+		OwnerFilter:   owner,
+		Executor:      exec,
+		Agent:         ag,
+		Runlog:        w,
+		Clock:         &fakeClock{now: time.Unix(1_700_000_000, 0)},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	// Wait for deprovision to begin (deleteN >= 1) — this means provision is
+	// fully complete AND both tunnel registrations are in the registry.
+	deadline := time.Now().Add(time.Second)
+	for exec.deleteN.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("sweep did not reach deprovision within 1s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Emit events for both registered tunnels plus one unregistered one.
+	ag.Emit(agent.Event{Kind: agent.EventPreCommitLog, TunnelID: 500, At: time.Unix(1, 100)})
+	ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: 500, At: time.Unix(1, 200)})
+	ag.Emit(agent.Event{Kind: agent.EventPreCommitLog, TunnelID: 999, At: time.Unix(1, 300)}) // unregistered; dropped
+	ag.Emit(agent.Event{Kind: agent.EventPreCommitLog, TunnelID: 501, At: time.Unix(1, 400)})
+	ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: 501, At: time.Unix(1, 500)})
+
+	close(gate) // unblock deprovision
+
+	require.NoError(t, <-done)
+	require.NoError(t, w.Close())
+
+	rows := readRows(t, path)
+
+	// Filter for the agent-driven rows so we don't depend on exact interleaving
+	// with the submit/confirm/activate stream emitted by provision.
+	var preCommit, applied []runlog.Row
+	for _, r := range rows {
+		switch r.Event {
+		case runlog.EventPreCommitLog:
+			preCommit = append(preCommit, r)
+		case runlog.EventApplied:
+			applied = append(applied, r)
+		}
+	}
+	require.Len(t, preCommit, 2, "two registered tunnels → two pre_commit_log rows; the unregistered tunnel 999 is dropped")
+	require.Len(t, applied, 2)
+
+	// Tunnel 500 → user_index 0, Tunnel 501 → user_index 1 (fake executor assigns 500+idx).
+	for _, r := range preCommit {
+		switch r.TunnelID {
+		case 500:
+			assert.Equal(t, 0, r.UserIndex)
+		case 501:
+			assert.Equal(t, 1, r.UserIndex)
+		default:
+			t.Fatalf("unexpected tunnel id %d in pre_commit_log", r.TunnelID)
+		}
 	}
 }
 

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -326,7 +326,9 @@ func TestRun_RejectsInvalidConfig(t *testing.T) {
 // is instantaneous and we need to emit AFTER provision has registered the
 // tunnels.
 type scriptedAgent struct {
-	out chan agent.Event
+	out      chan agent.Event
+	err      error
+	closeOut sync.Once
 }
 
 func newScriptedAgent() *scriptedAgent {
@@ -336,14 +338,25 @@ func newScriptedAgent() *scriptedAgent {
 func (s *scriptedAgent) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
-		close(s.out)
+		s.closeOut.Do(func() { close(s.out) })
 	}()
 	return nil
 }
 
 func (s *scriptedAgent) Events() <-chan agent.Event { return s.out }
 
+func (s *scriptedAgent) Err() error { return s.err }
+
 func (s *scriptedAgent) Emit(e agent.Event) { s.out <- e }
+
+// Fail simulates a stream error: it records the terminal error and closes the
+// events channel so the consumer observes the failure (as the SSH runner does
+// when a read fails). The error is set before the close so the consumer, which
+// reads Err() only after the channel drains, sees it.
+func (s *scriptedAgent) Fail(err error) {
+	s.err = err
+	s.closeOut.Do(func() { close(s.out) })
+}
 
 func TestRun_ConsumesAgentEventsForRegisteredTunnels(t *testing.T) {
 	t.Parallel()
@@ -425,6 +438,52 @@ func TestRun_ConsumesAgentEventsForRegisteredTunnels(t *testing.T) {
 			t.Fatalf("unexpected tunnel id %d in pre_commit_log", r.TunnelID)
 		}
 	}
+}
+
+// An agent stream error aborts the run: provision stops, deprovision still
+// cleans up what was created, and Run returns the agent error.
+func TestRun_AgentStreamErrorFailsRun(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+	streamErr := errors.New("connection reset")
+
+	// Fail the agent stream after the first create so provision is still in
+	// flight when the abort lands.
+	exec.afterCreate = func(calls int) {
+		if calls == 1 {
+			ag.Fail(streamErr)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:         "run-agent-fail",
+		Target:        4,
+		UsersPerBatch: 1,
+		Hold:          0,
+		OwnerFilter:   owner,
+		Executor:      exec,
+		Agent:         ag,
+		Runlog:        w,
+		Clock:         &fakeClock{now: time.Unix(1_700_000_000, 0)},
+	}
+
+	runErr := sweep.Run(context.Background(), cfg)
+	require.Error(t, runErr)
+	require.ErrorIs(t, runErr, streamErr, "Run should surface the agent stream error")
+
+	// Deprovision still ran: every created user was deleted.
+	assert.Equal(t, exec.createN.Load(), exec.deleteN.Load(), "all created users are deprovisioned")
+	exec.mu.Lock()
+	assert.Empty(t, exec.created, "no users left active after teardown")
+	exec.mu.Unlock()
 }
 
 // Sanity: ctx cancellation between users is observed at the next iteration boundary.


### PR DESCRIPTION
## Summary

Completes the device-stress orchestrator (#3746) by replacing the no-op `AgentRunner` with the live SSH-driven runner and the log parser that turns agent diff/commit lines into `pre_commit_log` / `applied` runlog rows. Stacked on top of #3776 (part 2, orchestrator skeleton). Part 3 of #3746. Fixes #3772.

- **`pkg/agent/parser.go`** — `Parser.Parse(line) []Event` tracks two log lines from `controlplane/agent/pkg/arista/eapi.go`:
  - `Committing config session due to diffs detected: <diff>` → extracts every `+ interface Tunnel<ID>` and emits one `pre_commit_log` event per ID; the diff's `-` lines (deprovisions) are ignored.
  - `Configuration session finalized with command '... commit'` → emits one `applied` event per pending tunnel; the `... abort` variant clears the buffer without emitting.
- **`pkg/agent/ssh.go`** — `NewSSH(cfg) Runner` dials `--dut-ssh-host` with `--dut-ssh-key`, execs `doublezero-agent -verbose` (appending `-controller <addr>` when `--controller` is set), and tees remote stdout/stderr into `<working-dir>/orchestrator.agent.log` while running every line through `Parser`. The session is closed on ctx cancel; the events channel closes after both stream readers exit so consumers never see a half-emitted event. Host-key verification uses `ssh.InsecureIgnoreHostKey` (documented; targets are ephemeral cEOS containers).
- **`pkg/sweep`** — gained an agent-event consumer goroutine and a `tunnelRegistry` populated as users are created; consumer attributes each `agent.Event` back to a `user_index` via tunnel ID lookup and appends `pre_commit_log` / `applied` rows. Unknown tunnels are debug-logged and dropped. The agent is started under a derived context that the sweep cancels after deprovision, so a clean run still shuts the agent down rather than leaking goroutines.
- **`pkg/exec.fetchTunnelID`** — now implemented: `GetAccountInfo` on the user PDA + `DeserializeUser` + return `TunnelId`. `exec.Config` gains an `RPC` field; the cmd binary passes the same `*solanarpc.Client` used by `Client`/`Executor`.
- **`cmd/device-orchestrator`** — new flags `--dut-ssh-user` (default `admin`) and `--no-agent` (offline testing). SSH runner is the default when `--dut-ssh-host` and `--dut-ssh-key` are both set; with either missing, the cmd falls back to the no-op runner and warns.

## Testing Verification

- `pkg/agent/parser_test.go`: golden line fixtures for single-tunnel diff, multi-tunnel diff (mixed +/-), deprovision-only diff, commit-success after multi-tunnel diff, abort-clears-buffer, stray commit-with-no-pending, two consecutive provision cycles, oversized tunnel ID skipped, `Tunnel5000` vs `Tunnel500` boundary.
- `pkg/sweep/sweep_test.go`: new `scriptedAgent` + a `deleteGate` on the fake executor lets the test emit agent events while deprovision is blocked; asserts `pre_commit_log` / `applied` rows are written for the two registered tunnels and the unregistered tunnel 999 is dropped. Tests pass under `-race`.
- `pkg/exec/exec_test.go`: stub RPC returns a hand-encoded `User` body with `TunnelId = 4242`; `fetchTunnelID` reads it correctly. Missing-account path returns an error containing `not found`.
- Smoke test: `make build` produces `bin/device-orchestrator`; `--dry-run` writes `orchestrator-config.json` containing `dut_ssh_user`, `no_agent`, and the rest of the flag set.
- `make go-build go-lint go-test` all green.

## Out of scope

- Integration test that actually SSH-dials a container. The SSH client is deterministic plumbing over `golang.org/x/crypto/ssh`; CI never opens an SSH session. Acceptance is via the manual devnet run per #3746.