### PR TITLE
feat(controller): enable eos-native gnmi provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- feat(controller): enable eos-native gnmi provider ([#3781](https://github.com/malbeclabs/doublezero/pull/3781))
 - CLI
   - Migrate `doublezero geolocation` subcommands into the new `doublezero-geolocation-cli` module crate per RFC-20. The `probe` and `user` subtrees and the hidden `init` verb are now owned by the crate; the binary mounts them via `GeolocationArgs` from `doublezero-geolocation-cli`. The hidden top-level `doublezero init-geolocation-config` alias is removed; use `doublezero geolocation init` instead.
 - ci(e2e): add trusted fork PR e2e dispatch ([#3777](https://github.com/malbeclabs/doublezero/pull/3777))

--- a/controlplane/controller/internal/controller/fixtures/base.config.drained.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.drained.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 15

--- a/controlplane/controller/internal/controller/fixtures/base.config.flex-algo-disabled.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.flex-algo-disabled.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet1/1
    mtu 9000
    no switchport

--- a/controlplane/controller/internal/controller/fixtures/base.config.flex-algo.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.flex-algo.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet1/1
    mtu 9000
    no switchport

--- a/controlplane/controller/internal/controller/fixtures/base.config.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 15

--- a/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.with.mgmt.vrf.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
+++ b/controlplane/controller/internal/controller/fixtures/base.config.without.interfaces.peers.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 101

--- a/controlplane/controller/internal/controller/fixtures/e2e.multi.vrf.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.multi.vrf.tmpl
@@ -66,6 +66,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 101

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 101

--- a/controlplane/controller/internal/controller/fixtures/e2e.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 14.14.14.14/32
    node-segment ipv4 index 101

--- a/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.without.interfaces.peers.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/interfaces.txt
+++ b/controlplane/controller/internal/controller/fixtures/interfaces.txt
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback255
    ip address 172.31.1.255/32
    node-segment ipv4 index 101

--- a/controlplane/controller/internal/controller/fixtures/metro.routing.disabled.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/metro.routing.disabled.tunnel.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/mixed.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/mixed.tunnel.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/multi.vrf.mixed.metro.routing.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/multi.vrf.mixed.metro.routing.tunnel.tmpl
@@ -66,6 +66,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/multi.vrf.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/multi.vrf.tunnel.tmpl
@@ -66,6 +66,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/multicast.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/multicast.tunnel.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/nohardware.tunnel.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/unicast.tunnel.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unicast.tunnel.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/unknown.peer.removal.tmpl
@@ -64,6 +64,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Loopback1000
    description RP Address
    ip address 10.0.0.0/32

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -12,6 +12,49 @@ import (
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 )
 
+func TestRenderGNMIManagementProvider(t *testing.T) {
+	data := templateData{
+		Strings:                  StringsHelper{},
+		MulticastGroupBlock:      "239.0.0.0/24",
+		TelemetryTWAMPListenPort: 862,
+		LocalASN:                 65342,
+		UnicastVrfs:              []uint16{1},
+		Device: &Device{
+			PublicIP:        net.IP{7, 7, 7, 7},
+			Vpn4vLoopbackIP: net.IP{14, 14, 14, 14},
+			IsisNet:         "49.0000.0e0e.0e0e.0000.00",
+			ExchangeCode:    "tst",
+			BgpCommunity:    10050,
+			Interfaces:      []Interface{},
+		},
+	}
+
+	got, err := renderConfig(data)
+	if err != nil {
+		t.Fatalf("renderConfig() error: %v", err)
+	}
+
+	want := `management api gnmi
+   provider eos-native
+!`
+	if count := strings.Count(got, "management api gnmi"); count != 1 {
+		t.Fatalf("rendered %d gNMI management blocks; want 1\nconfig:\n%s", count, got)
+	}
+	if !strings.Contains(got, want) {
+		t.Fatalf("rendered config missing gNMI provider block %q\nconfig:\n%s", want, got)
+	}
+	for _, forbidden := range []string{
+		"   85 permit tcp any any eq 57400",
+		"transport grpc",
+		"port 57400",
+		"listen-addresses",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("rendered remote gNMI server config %q; want only local eos-native provider\nconfig:\n%s", forbidden, got)
+		}
+	}
+}
+
 func TestRenderConfig(t *testing.T) {
 	tests := []struct {
 		Name        string

--- a/controlplane/controller/internal/controller/templates/tunnel.tmpl
+++ b/controlplane/controller/internal/controller/templates/tunnel.tmpl
@@ -84,6 +84,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 {{- range .Device.Interfaces }}
 interface {{ .Name }}
    {{- if .IsPhysical }}

--- a/e2e/fixtures/ibrl/doublezero_agent_config_drained.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_drained.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_peer_removed.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_removed.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_removed.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
+++ b/e2e/fixtures/multicast/doublezero_agent_config_both_users_added.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport

--- a/e2e/fixtures/multicast/doublezero_agent_config_both_users_removed.tmpl
+++ b/e2e/fixtures/multicast/doublezero_agent_config_both_users_removed.tmpl
@@ -57,6 +57,9 @@ ip access-list MAIN-CONTROL-PLANE-ACL
 system control-plane
    ip access-group MAIN-CONTROL-PLANE-ACL in
 !
+management api gnmi
+   provider eos-native
+!
 interface Ethernet2
    mtu 9000
    no switchport


### PR DESCRIPTION
# Summary

- Enables the Arista `eos-native` gNMI provider in the controller EOS config template
- Renders only the local `management api gnmi` provider block needed by the telemetry agent tunnel path
- Avoids opening remote gRPC access on DIA interfaces
- Updates controller render fixtures, e2e expected config fixtures, and focused render coverage

## Testing

Validated controller rendering behavior for:

- the gNMI management block is rendered with `provider eos-native`
- no remote gNMI listener config is rendered (`transport grpc`, `port 57400`, `listen-addresses`)
- no explicit TCP/57400 control-plane ACL permit is added
- controller render fixtures match the simplified config

Closes malbeclabs/infra#1414