### PR TITLE
cli/geolocation: convert probe verbs to RFC-20 (async + ctx)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ dependencies = [
  "serde_json",
  "solana-sdk",
  "tabled",
+ "tokio",
  "tracing",
 ]
 

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -272,7 +272,7 @@ async fn main() -> eyre::Result<()> {
             let svc_program_id = *dzclient.get_program_id();
             let (globalstate_pk, _) = get_globalstate_pda(&svc_program_id);
             let geo_cli = GeoCliCommandImpl::new(&geo_client, &dzclient, globalstate_pk);
-            args.command.execute(&geo_cli, &mut handle)
+            args.command.execute(&ctx, &geo_cli, &mut handle).await
         }
 
         // Multicast: the `Group` subtree is module-crate business and dispatched by

--- a/crates/doublezero-geolocation-cli/Cargo.toml
+++ b/crates/doublezero-geolocation-cli/Cargo.toml
@@ -29,4 +29,4 @@ doublezero-program-common.workspace = true
 doublezero_sdk.workspace = true
 
 [dev-dependencies]
-tokio.workspace = true
+doublezero-cli-core = { workspace = true, features = ["testing"] }

--- a/crates/doublezero-geolocation-cli/Cargo.toml
+++ b/crates/doublezero-geolocation-cli/Cargo.toml
@@ -27,3 +27,6 @@ doublezero-cli-core.workspace = true
 doublezero-geolocation = { workspace = true, features = ["no-entrypoint"] }
 doublezero-program-common.workspace = true
 doublezero_sdk.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -47,13 +47,13 @@ impl GeolocationCommand {
         match self {
             Self::Init(args) => args.execute(client, out),
             Self::Probe(cmd) => match cmd.command {
-                ProbeCommands::Create(args) => args.execute(client, out),
-                ProbeCommands::Update(args) => args.execute(client, out),
-                ProbeCommands::Delete(args) => args.execute(client, out),
+                ProbeCommands::Create(args) => args.execute(ctx, client, out).await,
+                ProbeCommands::Update(args) => args.execute(ctx, client, out).await,
+                ProbeCommands::Delete(args) => args.execute(ctx, client, out).await,
                 ProbeCommands::Get(args) => args.execute(ctx, client, out).await,
-                ProbeCommands::List(args) => args.execute(client, out),
-                ProbeCommands::AddParent(args) => args.execute(client, out),
-                ProbeCommands::RemoveParent(args) => args.execute(client, out),
+                ProbeCommands::List(args) => args.execute(ctx, client, out).await,
+                ProbeCommands::AddParent(args) => args.execute(ctx, client, out).await,
+                ProbeCommands::RemoveParent(args) => args.execute(ctx, client, out).await,
             },
             Self::User(cmd) => match cmd.command {
                 UserCommands::Create(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -5,6 +5,7 @@
 //! `doublezero geolocation <subcommand>`.
 
 use clap::{Args, Subcommand};
+use doublezero_cli_core::CliContext;
 use std::io::Write;
 
 use crate::{
@@ -37,14 +38,19 @@ pub struct GeolocationArgs {
 }
 
 impl GeolocationCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
         match self {
             Self::Init(args) => args.execute(client, out),
             Self::Probe(cmd) => match cmd.command {
                 ProbeCommands::Create(args) => args.execute(client, out),
                 ProbeCommands::Update(args) => args.execute(client, out),
                 ProbeCommands::Delete(args) => args.execute(client, out),
-                ProbeCommands::Get(args) => args.execute(client, out),
+                ProbeCommands::Get(args) => args.execute(ctx, client, out).await,
                 ProbeCommands::List(args) => args.execute(client, out),
                 ProbeCommands::AddParent(args) => args.execute(client, out),
                 ProbeCommands::RemoveParent(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/probe/add_parent.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/add_parent.rs
@@ -49,20 +49,11 @@ impl AddParentGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geo_probe_add_parent() {

--- a/crates/doublezero-geolocation-cli/src/probe/add_parent.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/add_parent.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geo_probe::{
     add_parent_device::AddParentDeviceCommand, get::GetGeoProbeCommand,
 };
@@ -17,7 +17,14 @@ pub struct AddParentGeoProbeCliCommand {
 }
 
 impl AddParentGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, probe = %self.probe, device = %self.device, "geolocation probe add-parent");
+
         let (_, resolved_probe) = client.get_geo_probe(GetGeoProbeCommand {
             pubkey_or_code: self.probe,
         })?;
@@ -42,10 +49,20 @@ impl AddParentGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geo_probe_add_parent() {
@@ -101,12 +118,15 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddParentGeoProbeCliCommand {
-            probe: "ams-probe-01".to_string(),
-            device: device_pk.to_string(),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddParentGeoProbeCliCommand {
+                probe: "ams-probe-01".to_string(),
+                device: device_pk.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/probe/create.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/create.rs
@@ -1,6 +1,9 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::{validate_code, validate_pubkey, validate_pubkey_or_code};
+use doublezero_cli_core::{
+    validators::{validate_code, validate_pubkey, validate_pubkey_or_code},
+    CliContext,
+};
 use doublezero_sdk::geolocation::geo_probe::create::CreateGeoProbeCommand;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr};
@@ -25,7 +28,14 @@ pub struct CreateGeoProbeCliCommand {
 }
 
 impl CreateGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, code = %self.code, "geolocation probe create");
+
         let exchange_pk = client.resolve_exchange_pk(self.exchange)?;
         let metrics_publisher_pk: Pubkey = self.signing_pubkey.parse().expect("validated by clap");
 
@@ -50,8 +60,18 @@ impl CreateGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geo_probe_create() {
@@ -89,15 +109,18 @@ mod tests {
             }))
             .returning(move |_| Ok((signature, probe_pda)));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = CreateGeoProbeCliCommand {
-            code: "ams-probe-01".to_string(),
-            exchange: exchange_pk.to_string(),
-            public_ip: Ipv4Addr::new(10, 0, 0, 1),
-            port: 8923,
-            signing_pubkey: metrics_pk.to_string(),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            CreateGeoProbeCliCommand {
+                code: "ams-probe-01".to_string(),
+                exchange: exchange_pk.to_string(),
+                public_ip: Ipv4Addr::new(10, 0, 0, 1),
+                port: 8923,
+                signing_pubkey: metrics_pk.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/probe/create.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/create.rs
@@ -60,18 +60,9 @@ impl CreateGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geo_probe_create() {

--- a/crates/doublezero-geolocation-cli/src/probe/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/delete.rs
@@ -57,20 +57,11 @@ impl DeleteGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geo_probe_delete() {

--- a/crates/doublezero-geolocation-cli/src/probe/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/delete.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geo_probe::{
     delete::DeleteGeoProbeCommand, get::GetGeoProbeCommand,
 };
@@ -17,7 +17,14 @@ pub struct DeleteGeoProbeCliCommand {
 }
 
 impl DeleteGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, probe = %self.probe, "geolocation probe delete");
+
         let (_, resolved_probe) = client.get_geo_probe(GetGeoProbeCommand {
             pubkey_or_code: self.probe,
         })?;
@@ -50,10 +57,20 @@ impl DeleteGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geo_probe_delete() {
@@ -102,12 +119,15 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = DeleteGeoProbeCliCommand {
-            probe: "ams-probe-01".to_string(),
-            yes: true,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            DeleteGeoProbeCliCommand {
+                probe: "ams-probe-01".to_string(),
+                yes: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/probe/get.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/get.rs
@@ -110,20 +110,11 @@ impl GetGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn setup_client() -> (MockGeoCliCommand, Pubkey, Pubkey, Pubkey, Pubkey) {
         let client = MockGeoCliCommand::new();

--- a/crates/doublezero-geolocation-cli/src/probe/get.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/get.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_program_common::serializer;
 use doublezero_sdk::geolocation::geo_probe::get::GetGeoProbeCommand;
 use serde::{Serialize, Serializer};
@@ -52,7 +52,14 @@ struct GeoProbeGetDisplay {
 }
 
 impl GetGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, probe = %self.probe, "geolocation probe get");
+
         let (pubkey, probe) = client.get_geo_probe(GetGeoProbeCommand {
             pubkey_or_code: self.probe,
         })?;
@@ -103,10 +110,20 @@ impl GetGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn setup_client() -> (MockGeoCliCommand, Pubkey, Pubkey, Pubkey, Pubkey) {
         let client = MockGeoCliCommand::new();
@@ -153,22 +170,27 @@ mod tests {
             .expect_get_geo_probe()
             .returning(move |_| Err(eyre::eyre!("not found")));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeoProbeCliCommand {
-            probe: Pubkey::new_unique().to_string(),
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: Pubkey::new_unique().to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
 
         let mut output = Vec::new();
-        let res = GetGeoProbeCliCommand {
-            probe: probe_pk.to_string(),
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: probe_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let has_row = |header: &str, value: &str| {
@@ -199,13 +221,16 @@ mod tests {
             }))
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeoProbeCliCommand {
-            probe: probe_pk.to_string(),
-            json: true,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: probe_pk.to_string(),
+                json: true,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let json: serde_json::Value =
             serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
@@ -238,13 +263,16 @@ mod tests {
             }))
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeoProbeCliCommand {
-            probe: probe_pk.to_string(),
-            json: false,
-            json_compact: true,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: probe_pk.to_string(),
+                json: false,
+                json_compact: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let trimmed = output_str.trim();

--- a/crates/doublezero-geolocation-cli/src/probe/list.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/list.rs
@@ -99,20 +99,11 @@ impl ListGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use doublezero_sdk::{AccountType as SvcAccountType, Exchange, ExchangeStatus};
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn make_exchange(pk: Pubkey, code: &str) -> Exchange {
         Exchange {

--- a/crates/doublezero-geolocation-cli/src/probe/list.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/list.rs
@@ -1,5 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
+use doublezero_cli_core::CliContext;
 use doublezero_program_common::serializer;
 use doublezero_sdk::geolocation::geo_probe::list::ListGeoProbeCommand;
 use serde::{Serialize, Serializer};
@@ -43,7 +44,14 @@ pub struct GeoProbeDisplay {
 }
 
 impl ListGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, "geolocation probe list");
+
         let probes = client.list_geo_probes(ListGeoProbeCommand)?;
         let exchanges = client.list_exchanges()?;
 
@@ -91,10 +99,20 @@ impl ListGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use doublezero_sdk::{AccountType as SvcAccountType, Exchange, ExchangeStatus};
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn make_exchange(pk: Pubkey, code: &str) -> Exchange {
         Exchange {
@@ -149,12 +167,15 @@ mod tests {
             .expect_list_exchanges()
             .returning(move || Ok(exchanges.clone()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeoProbeCliCommand {
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeoProbeCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("ams-probe-01"));
@@ -194,12 +215,15 @@ mod tests {
             .expect_list_exchanges()
             .returning(|| Ok(HashMap::new()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeoProbeCliCommand {
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeoProbeCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains(&exchange_pk.to_string()));
@@ -240,12 +264,15 @@ mod tests {
             .expect_list_exchanges()
             .returning(move || Ok(exchanges.clone()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeoProbeCliCommand {
-            json: true,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeoProbeCliCommand {
+                json: true,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let parsed: Vec<serde_json::Value> = serde_json::from_str(output_str.trim()).unwrap();
@@ -270,12 +297,15 @@ mod tests {
             .expect_list_exchanges()
             .returning(|| Ok(HashMap::new()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeoProbeCliCommand {
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeoProbeCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
     }
 }

--- a/crates/doublezero-geolocation-cli/src/probe/remove_parent.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/remove_parent.rs
@@ -49,20 +49,11 @@ impl RemoveParentGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geo_probe_remove_parent() {

--- a/crates/doublezero-geolocation-cli/src/probe/remove_parent.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/remove_parent.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geo_probe::{
     get::GetGeoProbeCommand, remove_parent_device::RemoveParentDeviceCommand,
 };
@@ -17,7 +17,14 @@ pub struct RemoveParentGeoProbeCliCommand {
 }
 
 impl RemoveParentGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, probe = %self.probe, device = %self.device, "geolocation probe remove-parent");
+
         let (_, resolved_probe) = client.get_geo_probe(GetGeoProbeCommand {
             pubkey_or_code: self.probe,
         })?;
@@ -42,10 +49,20 @@ impl RemoveParentGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geo_probe_remove_parent() {
@@ -101,12 +118,15 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = RemoveParentGeoProbeCliCommand {
-            probe: "ams-probe-01".to_string(),
-            device: device_pk.to_string(),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            RemoveParentGeoProbeCliCommand {
+                probe: "ams-probe-01".to_string(),
+                device: device_pk.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/probe/update.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/update.rs
@@ -74,19 +74,10 @@ impl UpdateGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geo_probe_update() {

--- a/crates/doublezero-geolocation-cli/src/probe/update.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/update.rs
@@ -1,6 +1,9 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::{validate_pubkey, validate_pubkey_or_code};
+use doublezero_cli_core::{
+    validators::{validate_pubkey, validate_pubkey_or_code},
+    CliContext,
+};
 use doublezero_sdk::geolocation::geo_probe::{
     get::GetGeoProbeCommand, update::UpdateGeoProbeCommand,
 };
@@ -24,7 +27,14 @@ pub struct UpdateGeoProbeCliCommand {
 }
 
 impl UpdateGeoProbeCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, probe = %self.probe, "geolocation probe update");
+
         if self.public_ip.is_none() && self.port.is_none() && self.signing_pubkey.is_none() {
             return Err(eyre::eyre!(
                 "At least one of --public-ip, --port, or --signing-pubkey is required"
@@ -64,9 +74,19 @@ impl UpdateGeoProbeCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geo_probe_update() {
@@ -118,14 +138,17 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = UpdateGeoProbeCliCommand {
-            probe: "ams-probe-01".to_string(),
-            public_ip: Some(Ipv4Addr::new(192, 168, 1, 1)),
-            port: None,
-            signing_pubkey: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            UpdateGeoProbeCliCommand {
+                probe: "ams-probe-01".to_string(),
+                public_ip: Some(Ipv4Addr::new(192, 168, 1, 1)),
+                port: None,
+                signing_pubkey: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));


### PR DESCRIPTION
## Summary

Convert all 7 `doublezero geolocation probe ...` verbs to the RFC-20 `async fn execute(ctx, client, out)` form. Per [RFC-20 §3](../blob/main/rfcs/rfc20-cli-standardization.md), every verb in a module crate must be `async fn` and receive environment-derived configuration through `CliContext`.

This is PR 2 of a stack. Stacked on #3792 (move-as-is). After #3792 lands, this rebases onto main.

## What changes

- Each of the 7 probe verb files (`create`, `update`, `delete`, `get`, `list`, `add_parent`, `remove_parent`) now exposes `pub async fn execute<C: GeoCliCommand, W: Write>(self, ctx: &CliContext, client: &C, out: &mut W) -> eyre::Result<()>`.
- A `tracing::debug!(env = %ctx.env, ..., "geolocation probe <verb>")` breadcrumb is the first statement of each verb body.
- Verb tests use the existing `block_on` helper (mirroring `smartcontract/cli/src/location/get.rs`) and build a `CliContext` via `doublezero_cli_core::testing::cli_context_default_for_tests()`.
- `GeolocationCommand::execute` in `cli.rs` is `async fn`; all 7 Probe arms now `.await`.
- The binary's call site `args.command.execute(&ctx, &geo_cli, &mut handle).await`.

## What stays the same

- All verb arguments, output, JSON schemas, exit codes unchanged.
- `Init` and all 9 `User::*` dispatcher arms stay sync — PRs 3 and 4 convert those.
- No new flags, no validator changes, no new public API.

## RFC reference

[RFC-20: CLI Standardization §3, §5](../blob/main/rfcs/rfc20-cli-standardization.md)

## Testing Verification

- [x] `make rust-lint` clean in dev container (rustfmt nightly + clippy)
- [x] `cargo test -p doublezero-geolocation-cli`: 41/41
- [x] `cargo test -p doublezero`: 133/133