### PR TITLE
cli/geolocation: convert user verbs to RFC-20 (async + ctx)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,6 @@ dependencies = [
  "serde_json",
  "solana-sdk",
  "tabled",
- "tokio",
  "tracing",
 ]
 

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -56,7 +56,7 @@ impl GeolocationCommand {
                 ProbeCommands::RemoveParent(args) => args.execute(ctx, client, out).await,
             },
             Self::User(cmd) => match cmd.command {
-                UserCommands::Create(args) => args.execute(client, out),
+                UserCommands::Create(args) => args.execute(ctx, client, out).await,
                 UserCommands::Update(args) => args.execute(client, out),
                 UserCommands::Delete(args) => args.execute(client, out),
                 UserCommands::Get(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -57,7 +57,7 @@ impl GeolocationCommand {
             },
             Self::User(cmd) => match cmd.command {
                 UserCommands::Create(args) => args.execute(ctx, client, out).await,
-                UserCommands::Update(args) => args.execute(client, out),
+                UserCommands::Update(args) => args.execute(ctx, client, out).await,
                 UserCommands::Delete(args) => args.execute(client, out),
                 UserCommands::Get(args) => args.execute(client, out),
                 UserCommands::List(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -63,7 +63,7 @@ impl GeolocationCommand {
                 UserCommands::List(args) => args.execute(ctx, client, out).await,
                 UserCommands::AddTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::RemoveTarget(args) => args.execute(ctx, client, out).await,
-                UserCommands::SetResultDestination(args) => args.execute(client, out),
+                UserCommands::SetResultDestination(args) => args.execute(ctx, client, out).await,
                 UserCommands::UpdatePayment(args) => args.execute(client, out),
             },
         }

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -59,7 +59,7 @@ impl GeolocationCommand {
                 UserCommands::Create(args) => args.execute(ctx, client, out).await,
                 UserCommands::Update(args) => args.execute(ctx, client, out).await,
                 UserCommands::Delete(args) => args.execute(ctx, client, out).await,
-                UserCommands::Get(args) => args.execute(client, out),
+                UserCommands::Get(args) => args.execute(ctx, client, out).await,
                 UserCommands::List(args) => args.execute(client, out),
                 UserCommands::AddTarget(args) => args.execute(client, out),
                 UserCommands::RemoveTarget(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -64,7 +64,7 @@ impl GeolocationCommand {
                 UserCommands::AddTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::RemoveTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::SetResultDestination(args) => args.execute(ctx, client, out).await,
-                UserCommands::UpdatePayment(args) => args.execute(client, out),
+                UserCommands::UpdatePayment(args) => args.execute(ctx, client, out).await,
             },
         }
     }

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -60,7 +60,7 @@ impl GeolocationCommand {
                 UserCommands::Update(args) => args.execute(ctx, client, out).await,
                 UserCommands::Delete(args) => args.execute(ctx, client, out).await,
                 UserCommands::Get(args) => args.execute(ctx, client, out).await,
-                UserCommands::List(args) => args.execute(client, out),
+                UserCommands::List(args) => args.execute(ctx, client, out).await,
                 UserCommands::AddTarget(args) => args.execute(client, out),
                 UserCommands::RemoveTarget(args) => args.execute(client, out),
                 UserCommands::SetResultDestination(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -58,7 +58,7 @@ impl GeolocationCommand {
             Self::User(cmd) => match cmd.command {
                 UserCommands::Create(args) => args.execute(ctx, client, out).await,
                 UserCommands::Update(args) => args.execute(ctx, client, out).await,
-                UserCommands::Delete(args) => args.execute(client, out),
+                UserCommands::Delete(args) => args.execute(ctx, client, out).await,
                 UserCommands::Get(args) => args.execute(client, out),
                 UserCommands::List(args) => args.execute(client, out),
                 UserCommands::AddTarget(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -62,7 +62,7 @@ impl GeolocationCommand {
                 UserCommands::Get(args) => args.execute(ctx, client, out).await,
                 UserCommands::List(args) => args.execute(ctx, client, out).await,
                 UserCommands::AddTarget(args) => args.execute(ctx, client, out).await,
-                UserCommands::RemoveTarget(args) => args.execute(client, out),
+                UserCommands::RemoveTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::SetResultDestination(args) => args.execute(client, out),
                 UserCommands::UpdatePayment(args) => args.execute(client, out),
             },

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -61,7 +61,7 @@ impl GeolocationCommand {
                 UserCommands::Delete(args) => args.execute(ctx, client, out).await,
                 UserCommands::Get(args) => args.execute(ctx, client, out).await,
                 UserCommands::List(args) => args.execute(ctx, client, out).await,
-                UserCommands::AddTarget(args) => args.execute(client, out),
+                UserCommands::AddTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::RemoveTarget(args) => args.execute(client, out),
                 UserCommands::SetResultDestination(args) => args.execute(client, out),
                 UserCommands::UpdatePayment(args) => args.execute(client, out),

--- a/crates/doublezero-geolocation-cli/src/user/add_target.rs
+++ b/crates/doublezero-geolocation-cli/src/user/add_target.rs
@@ -1,6 +1,9 @@
 use crate::client::GeoCliCommand;
 use clap::{Args, ValueEnum};
-use doublezero_cli_core::validators::{validate_pubkey, validate_pubkey_or_code};
+use doublezero_cli_core::{
+    validators::{validate_pubkey, validate_pubkey_or_code},
+    CliContext,
+};
 use doublezero_geolocation::state::geolocation_user::GeoLocationTargetType;
 use doublezero_sdk::geolocation::{
     geo_probe::{get::GetGeoProbeCommand, list::ListGeoProbeCommand},
@@ -43,7 +46,14 @@ pub struct AddTargetCliCommand {
 }
 
 impl AddTargetCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user add-target");
+
         let (target_type, ip_address, location_offset_port, target_pk) = match self.target_type {
             TargetType::Outbound => {
                 let ip = self
@@ -136,6 +146,7 @@ pub(super) fn resolve_probe<C: GeoCliCommand>(
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geo_probe::GeoProbe,
@@ -147,6 +158,15 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::collections::HashMap;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {
@@ -215,17 +235,20 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -262,17 +285,20 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Inbound,
-            target_ip: None,
-            target_port: 8923,
-            target_signing_pubkey: Some(target_pk.to_string()),
-            probe: Some(probe_pk.to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Inbound,
+                target_ip: None,
+                target_port: 8923,
+                target_signing_pubkey: Some(target_pk.to_string()),
+                probe: Some(probe_pk.to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -313,17 +339,20 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: None,
-            exchange: Some(exchange_pk.to_string()),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: None,
+                exchange: Some(exchange_pk.to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -364,17 +393,20 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: None,
-            exchange: Some("xams".to_string()),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: None,
+                exchange: Some("xams".to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -410,17 +442,20 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::OutboundIcmp,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::OutboundIcmp,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -430,17 +465,20 @@ mod tests {
     fn test_cli_add_target_outbound_icmp_missing_ip() {
         let client = MockGeoCliCommand::new();
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::OutboundIcmp,
-            target_ip: None,
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::OutboundIcmp,
+                target_ip: None,
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("--target-ip"));
     }
@@ -457,17 +495,20 @@ mod tests {
             .expect_get_geo_probe()
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: None,
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: None,
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("--target-ip"));
     }
@@ -476,17 +517,20 @@ mod tests {
     fn test_cli_add_target_inbound_missing_pk() {
         let client = MockGeoCliCommand::new();
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Inbound,
-            target_ip: None,
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Inbound,
+                target_ip: None,
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
         assert!(res
             .unwrap_err()
@@ -517,17 +561,20 @@ mod tests {
             .expect_list_geo_probes()
             .returning(move |_| Ok(probes.clone()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = AddTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_port: 8923,
-            target_signing_pubkey: None,
-            probe: None,
-            exchange: Some(exchange_pk.to_string()),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            AddTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_port: 8923,
+                target_signing_pubkey: None,
+                probe: None,
+                exchange: Some(exchange_pk.to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
         let err = res.unwrap_err().to_string();
         assert!(

--- a/crates/doublezero-geolocation-cli/src/user/add_target.rs
+++ b/crates/doublezero-geolocation-cli/src/user/add_target.rs
@@ -146,7 +146,7 @@ pub(super) fn resolve_probe<C: GeoCliCommand>(
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geo_probe::GeoProbe,
@@ -158,15 +158,6 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::collections::HashMap;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {

--- a/crates/doublezero-geolocation-cli/src/user/create.rs
+++ b/crates/doublezero-geolocation-cli/src/user/create.rs
@@ -1,6 +1,9 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::{validate_code, validate_pubkey};
+use doublezero_cli_core::{
+    validators::{validate_code, validate_pubkey},
+    CliContext,
+};
 use doublezero_sdk::geolocation::geolocation_user::create::CreateGeolocationUserCommand;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -16,7 +19,14 @@ pub struct CreateGeolocationUserCliCommand {
 }
 
 impl CreateGeolocationUserCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, code = %self.code, "geolocation user create");
+
         let token_account: Pubkey = self.token_account.parse().expect("validated by clap");
 
         let (sig, pda) = client.create_geolocation_user(CreateGeolocationUserCommand {
@@ -34,8 +44,18 @@ impl CreateGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geolocation_user_create() {
@@ -58,12 +78,15 @@ mod tests {
             }))
             .returning(move |_| Ok((signature, user_pda)));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = CreateGeolocationUserCliCommand {
-            code: "geo-user-01".to_string(),
-            token_account: token_account.to_string(),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            CreateGeolocationUserCliCommand {
+                code: "geo-user-01".to_string(),
+                token_account: token_account.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/user/create.rs
+++ b/crates/doublezero-geolocation-cli/src/user/create.rs
@@ -44,18 +44,9 @@ impl CreateGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geolocation_user_create() {

--- a/crates/doublezero-geolocation-cli/src/user/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/user/delete.rs
@@ -57,7 +57,7 @@ impl DeleteGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -67,15 +67,6 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     #[test]
     fn test_cli_geolocation_user_delete() {

--- a/crates/doublezero-geolocation-cli/src/user/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/user/delete.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geolocation_user::{
     delete::DeleteGeolocationUserCommand, get::GetGeolocationUserCommand,
 };
@@ -17,7 +17,14 @@ pub struct DeleteGeolocationUserCliCommand {
 }
 
 impl DeleteGeolocationUserCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user delete");
+
         let (_, resolved_user) = client.get_geolocation_user(GetGeolocationUserCommand {
             pubkey_or_code: self.user,
         })?;
@@ -50,6 +57,7 @@ impl DeleteGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -59,6 +67,15 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     #[test]
     fn test_cli_geolocation_user_delete() {
@@ -109,12 +126,15 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = DeleteGeolocationUserCliCommand {
-            user: "geo-user-01".to_string(),
-            yes: true,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            DeleteGeolocationUserCliCommand {
+                user: "geo-user-01".to_string(),
+                yes: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/user/get.rs
+++ b/crates/doublezero-geolocation-cli/src/user/get.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_geolocation::state::geolocation_user::{
     GeoLocationTargetType, GeolocationBillingConfig,
 };
@@ -56,7 +56,14 @@ struct TargetDisplay {
 }
 
 impl GetGeolocationUserCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user get");
+
         let (pubkey, user) = client.get_geolocation_user(GetGeolocationUserCommand {
             pubkey_or_code: self.user,
         })?;
@@ -151,6 +158,7 @@ impl GetGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -161,6 +169,15 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn make_user(code: &str, targets: Vec<GeolocationTarget>) -> GeolocationUser {
         GeolocationUser {
@@ -203,13 +220,16 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeolocationUserCliCommand {
-            user: user_pk.to_string(),
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let has_row = |header: &str, value: &str| {
@@ -241,13 +261,16 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeolocationUserCliCommand {
-            user: user_pk.to_string(),
-            json: true,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: true,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let json: serde_json::Value =
             serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
@@ -274,13 +297,16 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeolocationUserCliCommand {
-            user: user_pk.to_string(),
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(!output_str.contains("Targets:"));
@@ -310,13 +336,16 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = GetGeolocationUserCliCommand {
-            user: user_pk.to_string(),
-            json: false,
-            json_compact: true,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: false,
+                json_compact: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let trimmed = output_str.trim();

--- a/crates/doublezero-geolocation-cli/src/user/get.rs
+++ b/crates/doublezero-geolocation-cli/src/user/get.rs
@@ -158,7 +158,7 @@ impl GetGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -169,15 +169,6 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn make_user(code: &str, targets: Vec<GeolocationTarget>) -> GeolocationUser {
         GeolocationUser {

--- a/crates/doublezero-geolocation-cli/src/user/list.rs
+++ b/crates/doublezero-geolocation-cli/src/user/list.rs
@@ -1,5 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
+use doublezero_cli_core::CliContext;
 use doublezero_program_common::serializer;
 use doublezero_sdk::geolocation::geolocation_user::list::ListGeolocationUserCommand;
 use serde::Serialize;
@@ -30,7 +31,14 @@ pub struct GeolocationUserDisplay {
 }
 
 impl ListGeolocationUserCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, "geolocation user list");
+
         let users = client.list_geolocation_users(ListGeolocationUserCommand)?;
 
         let mut displays: Vec<GeolocationUserDisplay> = users
@@ -67,6 +75,7 @@ impl ListGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -76,6 +85,15 @@ mod tests {
     };
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn make_user(code: &str) -> GeolocationUser {
         GeolocationUser {
@@ -104,12 +122,15 @@ mod tests {
             .expect_list_geolocation_users()
             .returning(move |_| Ok(users.clone()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeolocationUserCliCommand {
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeolocationUserCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("geo-user-01"));
@@ -130,12 +151,15 @@ mod tests {
             .expect_list_geolocation_users()
             .returning(move |_| Ok(users.clone()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeolocationUserCliCommand {
-            json: true,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeolocationUserCliCommand {
+                json: true,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         let parsed: Vec<serde_json::Value> = serde_json::from_str(output_str.trim()).unwrap();
@@ -152,12 +176,15 @@ mod tests {
             .expect_list_geolocation_users()
             .returning(|_| Ok(HashMap::new()));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = ListGeolocationUserCliCommand {
-            json: false,
-            json_compact: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            ListGeolocationUserCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
     }
 }

--- a/crates/doublezero-geolocation-cli/src/user/list.rs
+++ b/crates/doublezero-geolocation-cli/src/user/list.rs
@@ -75,7 +75,7 @@ impl ListGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -85,15 +85,6 @@ mod tests {
     };
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn make_user(code: &str) -> GeolocationUser {
         GeolocationUser {

--- a/crates/doublezero-geolocation-cli/src/user/remove_target.rs
+++ b/crates/doublezero-geolocation-cli/src/user/remove_target.rs
@@ -1,6 +1,9 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::{validate_pubkey, validate_pubkey_or_code};
+use doublezero_cli_core::{
+    validators::{validate_pubkey, validate_pubkey_or_code},
+    CliContext,
+};
 use doublezero_geolocation::state::geolocation_user::GeoLocationTargetType;
 use doublezero_sdk::geolocation::geolocation_user::{
     get::GetGeolocationUserCommand, remove_target::RemoveTargetCommand,
@@ -34,7 +37,14 @@ pub struct RemoveTargetCliCommand {
 }
 
 impl RemoveTargetCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user remove-target");
+
         let (target_type, ip_address, target_pk) = match self.target_type {
             TargetType::Outbound => {
                 let ip = self
@@ -83,6 +93,7 @@ impl RemoveTargetCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geo_probe::GeoProbe,
@@ -94,6 +105,15 @@ mod tests {
     use doublezero_sdk::geolocation::geo_probe::get::GetGeoProbeCommand;
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {
@@ -167,16 +187,19 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = RemoveTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Outbound,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            RemoveTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Outbound,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -217,16 +240,19 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = RemoveTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::OutboundIcmp,
-            target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
-            target_signing_pubkey: None,
-            probe: Some("ams-probe-01".to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            RemoveTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::OutboundIcmp,
+                target_ip: Some(Ipv4Addr::new(8, 8, 8, 8)),
+                target_signing_pubkey: None,
+                probe: Some("ams-probe-01".to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -268,16 +294,19 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = RemoveTargetCliCommand {
-            user: "geo-user-01".to_string(),
-            target_type: TargetType::Inbound,
-            target_ip: None,
-            target_signing_pubkey: Some(target_pk.to_string()),
-            probe: Some(probe_pk.to_string()),
-            exchange: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            RemoveTargetCliCommand {
+                user: "geo-user-01".to_string(),
+                target_type: TargetType::Inbound,
+                target_ip: None,
+                target_signing_pubkey: Some(target_pk.to_string()),
+                probe: Some(probe_pk.to_string()),
+                exchange: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/user/remove_target.rs
+++ b/crates/doublezero-geolocation-cli/src/user/remove_target.rs
@@ -93,7 +93,7 @@ impl RemoveTargetCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geo_probe::GeoProbe,
@@ -105,15 +105,6 @@ mod tests {
     use doublezero_sdk::geolocation::geo_probe::get::GetGeoProbeCommand;
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {

--- a/crates/doublezero-geolocation-cli/src/user/set_result_destination.rs
+++ b/crates/doublezero-geolocation-cli/src/user/set_result_destination.rs
@@ -124,7 +124,7 @@ impl SetResultDestinationCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -135,15 +135,6 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn make_user(targets: Vec<GeolocationTarget>) -> GeolocationUser {
         GeolocationUser {

--- a/crates/doublezero-geolocation-cli/src/user/set_result_destination.rs
+++ b/crates/doublezero-geolocation-cli/src/user/set_result_destination.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_code;
+use doublezero_cli_core::{validators::validate_code, CliContext};
 use doublezero_geolocation::validation::validate_public_ip;
 use doublezero_sdk::geolocation::geolocation_user::{
     get::GetGeolocationUserCommand, set_result_destination::SetResultDestinationCommand,
@@ -79,7 +79,14 @@ fn validate_destination(destination: &str) -> eyre::Result<()> {
 }
 
 impl SetResultDestinationCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user set-result-destination");
+
         let destination = if self.clear {
             String::new()
         } else {
@@ -117,6 +124,7 @@ impl SetResultDestinationCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -127,6 +135,15 @@ mod tests {
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
     use std::net::Ipv4Addr;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn make_user(targets: Vec<GeolocationTarget>) -> GeolocationUser {
         GeolocationUser {
@@ -194,13 +211,16 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = SetResultDestinationCliCommand {
-            user: "geo-user-01".to_string(),
-            destination: Some("185.199.108.1:9000".to_string()),
-            clear: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            SetResultDestinationCliCommand {
+                user: "geo-user-01".to_string(),
+                destination: Some("185.199.108.1:9000".to_string()),
+                clear: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -231,13 +251,16 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = SetResultDestinationCliCommand {
-            user: "geo-user-01".to_string(),
-            destination: None,
-            clear: true,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            SetResultDestinationCliCommand {
+                user: "geo-user-01".to_string(),
+                destination: None,
+                clear: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -247,13 +270,16 @@ mod tests {
     fn test_cli_set_result_destination_missing_destination() {
         let client = MockGeoCliCommand::new();
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = SetResultDestinationCliCommand {
-            user: "geo-user-01".to_string(),
-            destination: None,
-            clear: false,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            SetResultDestinationCliCommand {
+                user: "geo-user-01".to_string(),
+                destination: None,
+                clear: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_err());
         assert!(res.unwrap_err().to_string().contains("--destination"));
     }
@@ -273,13 +299,16 @@ mod tests {
         ];
         for (dest, expected_msg) in cases {
             let client = MockGeoCliCommand::new();
+            let ctx = cli_context_default_for_tests();
             let mut output = Vec::new();
-            let res = SetResultDestinationCliCommand {
-                user: "geo-user-01".to_string(),
-                destination: Some(dest.to_string()),
-                clear: false,
-            }
-            .execute(&client, &mut output);
+            let res = block_on(
+                SetResultDestinationCliCommand {
+                    user: "geo-user-01".to_string(),
+                    destination: Some(dest.to_string()),
+                    clear: false,
+                }
+                .execute(&ctx, &client, &mut output),
+            );
             assert!(res.is_err(), "expected error for destination \"{dest}\"");
             let err = res.unwrap_err().to_string();
             assert!(

--- a/crates/doublezero-geolocation-cli/src/user/update.rs
+++ b/crates/doublezero-geolocation-cli/src/user/update.rs
@@ -45,7 +45,7 @@ impl UpdateGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -55,15 +55,6 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::signature::Signature;
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn make_user(token_account: Pubkey) -> GeolocationUser {
         GeolocationUser {

--- a/crates/doublezero-geolocation-cli/src/user/update.rs
+++ b/crates/doublezero-geolocation-cli/src/user/update.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::Args;
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geolocation_user::{
     get::GetGeolocationUserCommand, update::UpdateGeolocationUserCommand,
 };
@@ -18,7 +18,14 @@ pub struct UpdateGeolocationUserCliCommand {
 }
 
 impl UpdateGeolocationUserCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user update");
+
         let (_, resolved_user) = client.get_geolocation_user(GetGeolocationUserCommand {
             pubkey_or_code: self.user,
         })?;
@@ -38,6 +45,7 @@ impl UpdateGeolocationUserCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -47,6 +55,15 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::signature::Signature;
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn make_user(token_account: Pubkey) -> GeolocationUser {
         GeolocationUser {
@@ -90,12 +107,15 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = UpdateGeolocationUserCliCommand {
-            user: "geo-user-01".to_string(),
-            token_account: new_token,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            UpdateGeolocationUserCliCommand {
+                user: "geo-user-01".to_string(),
+                token_account: new_token,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
+++ b/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
@@ -1,6 +1,6 @@
 use crate::client::GeoCliCommand;
 use clap::{Args, ValueEnum};
-use doublezero_cli_core::validators::validate_pubkey_or_code;
+use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_geolocation::state::geolocation_user::GeolocationPaymentStatus;
 use doublezero_sdk::geolocation::geolocation_user::{
     get::GetGeolocationUserCommand, update_payment_status::UpdatePaymentStatusCommand,
@@ -27,7 +27,14 @@ pub struct UpdatePaymentStatusCliCommand {
 }
 
 impl UpdatePaymentStatusCliCommand {
-    pub fn execute<C: GeoCliCommand, W: Write>(self, client: &C, out: &mut W) -> eyre::Result<()> {
+    pub async fn execute<C: GeoCliCommand, W: Write>(
+        self,
+        ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user update-payment");
+
         let payment_status = match self.status {
             PaymentStatus::Paid => GeolocationPaymentStatus::Paid,
             PaymentStatus::Delinquent => GeolocationPaymentStatus::Delinquent,
@@ -56,6 +63,7 @@ impl UpdatePaymentStatusCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
+    use doublezero_cli_core::testing::cli_context_default_for_tests;
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -64,6 +72,15 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use tokio::runtime::Builder;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {
@@ -110,13 +127,16 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = UpdatePaymentStatusCliCommand {
-            user: "geo-user-01".to_string(),
-            status: PaymentStatus::Paid,
-            last_deduction_epoch: Some(42),
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            UpdatePaymentStatusCliCommand {
+                user: "geo-user-01".to_string(),
+                status: PaymentStatus::Paid,
+                last_deduction_epoch: Some(42),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
@@ -145,13 +165,16 @@ mod tests {
             }))
             .returning(move |_| Ok(signature));
 
+        let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
-        let res = UpdatePaymentStatusCliCommand {
-            user: "geo-user-01".to_string(),
-            status: PaymentStatus::Delinquent,
-            last_deduction_epoch: None,
-        }
-        .execute(&client, &mut output);
+        let res = block_on(
+            UpdatePaymentStatusCliCommand {
+                user: "geo-user-01".to_string(),
+                status: PaymentStatus::Delinquent,
+                last_deduction_epoch: None,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));

--- a/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
+++ b/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
@@ -63,7 +63,7 @@ impl UpdatePaymentStatusCliCommand {
 mod tests {
     use super::*;
     use crate::client::MockGeoCliCommand;
-    use doublezero_cli_core::testing::cli_context_default_for_tests;
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
         geolocation_user::{
@@ -72,15 +72,6 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
-    use tokio::runtime::Builder;
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(f)
-    }
 
     fn mock_get_geolocation_user(client: &mut MockGeoCliCommand) {
         client.expect_get_geolocation_user().returning(move |cmd| {


### PR DESCRIPTION
## Summary

Convert all 9 `doublezero geolocation user ...` verbs to the RFC-20 `async fn execute(ctx, client, out)` form. Per [RFC-20 §3 and §5](../blob/main/rfcs/rfc20-cli-standardization.md), every verb in a module crate must be `async fn` and receive environment-derived configuration through `CliContext`.

This is PR 3 of a stack. Stacked on #3797 (probe verb conversion). After #3792 and #3797 land, this rebases onto main.

## What changes

- Each of the 9 user verb files (`create`, `update`, `delete`, `get`, `list`, `add_target`, `remove_target`, `set_result_destination`, `update_payment_status`) now exposes `pub async fn execute<C: GeoCliCommand, W: Write>(self, ctx: &CliContext, client: &C, out: &mut W) -> eyre::Result<()>`.
- A `tracing::debug!(env = %ctx.env, ..., "geolocation user <verb>")` breadcrumb is the first statement of each verb body.
- Verb tests use the existing `block_on` helper and build a `CliContext` via `doublezero_cli_core::testing::cli_context_default_for_tests()`.
- All 9 `UserCommands::*` arms in `GeolocationCommand::execute` now `.await`.

## What stays the same

- All verb arguments, output, JSON schemas, exit codes unchanged.
- The `Init` arm stays sync — PR 4 converts it.
- No new flags, no validator changes, no new public API.

## RFC reference

[RFC-20: CLI Standardization §3, §5](../blob/main/rfcs/rfc20-cli-standardization.md)

## Testing Verification

- [x] `make rust-lint` clean in dev container (rustfmt nightly + clippy)
- [x] `cargo test -p doublezero-geolocation-cli`: 41/41
- [x] `cargo test -p doublezero`: 133/133