### PR TITLE
telemetry/state-ingest: add mroute and msdp default commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file.
   - Reconcile the RFC-20 docs with the implemented global logging flag: `rfcs/rfc20-cli-standardization.md` and `docs/cli-standard.md` now describe `--log-level <off|error|warn|info|debug|trace>` (default `warn`) instead of the never-implemented repeatable `--log-verbose`. Documentation only; the binary is unchanged.
 - Telemetry
   - Replace the geoprobe `MinCache` best/backup eviction with a guarded-backup pattern: a backup is only collected while `best` is within its final `maxAge/2` ("guard") window, so on `best`'s expiry the promoted value is always a recent-window minimum rather than a stale fallback. A new record low resets `best` and clears `backup`, and expiry now promotes in a loop so a backup that is itself already expired cannot be promoted. `Best` / `BestRttNs` become pure read-through accessors returning the lower of the two non-expired slots without mutating or promoting.
+  - Add `ip-mroute`, `ip-mroute-count`, and the four MSDP show-commands (`ip-msdp-summary`, `ip-msdp-pim-sa-cache`, `ip-msdp-sa-cache`, `ip-msdp-sa-cache-rejected`) to the state-ingest server's default state-collect command list. Devices with `--state-collect-enable` will run each command via Arista eAPI and upload signed JSON snapshots to S3; downstream parsing into ClickHouse lands in separate `lake/indexer/pkg/dzingest` PRs (one per kind family).
 
 ## [v0.24.0](https://github.com/malbeclabs/doublezero/compare/client/v0.23.0...client/v0.24.0) - 2026-05-22
 

--- a/telemetry/state-ingest/pkg/server/config.go
+++ b/telemetry/state-ingest/pkg/server/config.go
@@ -23,6 +23,12 @@ var (
 	defaultStateToCollectShowCommands = map[string]string{
 		"snmp-mib-ifmib-ifindex": "show snmp mib ifmib ifindex",
 		"isis-database-detail":   "show isis database detail",
+		"ip-mroute":              "show ip mroute",
+		"ip-mroute-count":        "show ip mroute count",
+		"ip-msdp-summary":        "show ip msdp summary",
+		"ip-msdp-pim-sa-cache":   "show ip msdp pim sa-cache",
+		"ip-msdp-sa-cache":       "show ip msdp sa-cache",
+		"ip-msdp-sa-cache-rejected": "show ip msdp sa-cache rejected",
 	}
 	defaultStateToCollectCustom = []string{
 		"bgp-sockets",

--- a/telemetry/state-ingest/pkg/server/config.go
+++ b/telemetry/state-ingest/pkg/server/config.go
@@ -21,13 +21,13 @@ const (
 
 var (
 	defaultStateToCollectShowCommands = map[string]string{
-		"snmp-mib-ifmib-ifindex": "show snmp mib ifmib ifindex",
-		"isis-database-detail":   "show isis database detail",
-		"ip-mroute":              "show ip mroute",
-		"ip-mroute-count":        "show ip mroute count",
-		"ip-msdp-summary":        "show ip msdp summary",
-		"ip-msdp-pim-sa-cache":   "show ip msdp pim sa-cache",
-		"ip-msdp-sa-cache":       "show ip msdp sa-cache",
+		"snmp-mib-ifmib-ifindex":    "show snmp mib ifmib ifindex",
+		"isis-database-detail":      "show isis database detail",
+		"ip-mroute":                 "show ip mroute",
+		"ip-mroute-count":           "show ip mroute count",
+		"ip-msdp-summary":           "show ip msdp summary",
+		"ip-msdp-pim-sa-cache":      "show ip msdp pim sa-cache",
+		"ip-msdp-sa-cache":          "show ip msdp sa-cache",
 		"ip-msdp-sa-cache-rejected": "show ip msdp sa-cache rejected",
 	}
 	defaultStateToCollectCustom = []string{

--- a/telemetry/state-ingest/pkg/server/handler_test.go
+++ b/telemetry/state-ingest/pkg/server/handler_test.go
@@ -860,7 +860,7 @@ func TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAnd
 
 	var resp types.StateToCollectResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	require.Len(t, resp.ShowCommands, 2)
+	require.Len(t, resp.ShowCommands, 8)
 	require.Len(t, resp.Custom, 1)
 
 	// Convert to map for order-independent comparison (map iteration is non-deterministic)
@@ -869,8 +869,14 @@ func TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAnd
 		respMap[sc.Kind] = sc.Command
 	}
 	require.Equal(t, map[string]string{
-		"snmp-mib-ifmib-ifindex": "show snmp mib ifmib ifindex",
-		"isis-database-detail":   "show isis database detail",
+		"snmp-mib-ifmib-ifindex":    "show snmp mib ifmib ifindex",
+		"isis-database-detail":      "show isis database detail",
+		"ip-mroute":                 "show ip mroute",
+		"ip-mroute-count":           "show ip mroute count",
+		"ip-msdp-summary":           "show ip msdp summary",
+		"ip-msdp-pim-sa-cache":      "show ip msdp pim sa-cache",
+		"ip-msdp-sa-cache":          "show ip msdp sa-cache",
+		"ip-msdp-sa-cache-rejected": "show ip msdp sa-cache rejected",
 	}, respMap)
 	require.Equal(t, []string{"bgp-sockets"}, resp.Custom)
 }


### PR DESCRIPTION
## Summary

- Adds six new state-collect command kinds to the state-ingest server defaults: `ip-mroute`, `ip-mroute-count`, `ip-msdp-summary`, `ip-msdp-pim-sa-cache`, `ip-msdp-sa-cache`, `ip-msdp-sa-cache-rejected`.
- Server-side only; downstream parsing in `lake/indexer/pkg/dzingest` is a separate companion PR per issue.
- JSON output of each command verified on devnet (chi-dn-dzd1).

## Testing Verification

- Existing `TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAndCustom` updated to assert the eight ShowCommands now present in the response (`go test ./telemetry/state-ingest/...` passes).

Partially closes malbeclabs/infra#1416 (server side; lake side is the companion PR).
Partially closes malbeclabs/infra#1417 (server side; lake side is the companion PR).
