### PR TITLE
cli: route user get warning through tracing and reconcile log-level docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - Route the `doublezero user get` "no Access Pass found" warning through `tracing::warn!` instead of `eprintln!`, so diagnostics go to the logging facade per RFC-20 §Diagnostic logging and no longer write directly to stderr. No user-facing output, flag, or schema change.
+  - Reconcile the RFC-20 docs with the implemented global logging flag: `rfcs/rfc20-cli-standardization.md` and `docs/cli-standard.md` now describe `--log-level <off|error|warn|info|debug|trace>` (default `warn`) instead of the never-implemented repeatable `--log-verbose`. Documentation only; the binary is unchanged.
 - feat(controller): enable eos-native gnmi provider ([#3781](https://github.com/malbeclabs/doublezero/pull/3781))
 - CLI
   - Migrate `doublezero geolocation` subcommands into the new `doublezero-geolocation-cli` module crate per RFC-20. The `probe` and `user` subtrees and the hidden `init` verb are now owned by the crate; the binary mounts them via `GeolocationArgs` from `doublezero-geolocation-cli`. The hidden top-level `doublezero init-geolocation-config` alias is removed; use `doublezero geolocation init` instead.

--- a/docs/cli-standard.md
+++ b/docs/cli-standard.md
@@ -100,7 +100,7 @@ The binary owns these globals; modules MUST NOT redeclare them:
 | `--geo-program-id` | Geolocation program ID override. |
 | `--sock-file` | Daemon Unix socket path override. |
 | `--no-version-warning` | Suppress version-check banner. |
-| `--log-verbose` | Diagnostic logging. Repeat for higher levels: once raises to `debug`, twice raises to `trace`. No short alias because `connect`/`disconnect` still own `-v`/`--verbose` for their own flags. |
+| `--log-level` | Diagnostic logging level. One of `off`, `error`, `warn` (default), `info`, `debug`, `trace`. No short alias because `connect`/`disconnect` still own `-v`/`--verbose` for their own flags. |
 | `--version`, `-V` | Print version and exit. |
 
 `--env` resolves through `doublezero-config`. Recognized values are
@@ -118,11 +118,12 @@ tracing::debug!(env = %ctx.env, code = %self.code, "location get");
 ```
 
 Modules MUST NOT call `init_subscriber` themselves; the binary calls
-`doublezero_cli_core::init_logging(verbosity)` once at startup. The
-`RUST_LOG` env var overrides verbosity for per-module filtering.
+`doublezero_cli_core::init_logging(app.log_level)` once at startup from the
+global `--log-level` flag. The `RUST_LOG` env var overrides the level for
+per-module filtering.
 
-JSON output on stdout stays parseable at every verbosity level because logs
-go to stderr.
+JSON output on stdout stays parseable at every log level because logs go to
+stderr.
 
 ## Reference verb: `location get`
 

--- a/rfcs/rfc20-cli-standardization.md
+++ b/rfcs/rfc20-cli-standardization.md
@@ -136,7 +136,7 @@ Modules MUST NOT mutate `CliContext` and MUST NOT re-resolve any value from `--e
 
 Diagnostic output is separate from user-facing output and goes to standard error through the shared logging facade in the CLI core crate. Modules use the standard log macros (`debug!`, `info!`, `warn!`, `error!`, and `trace!` when finer granularity is justified) for anything that explains what a verb is doing internally: backend requests issued, retries, resolution of pubkey-or-code arguments, polling progress, and similar.
 
-The binary configures the global log level from `--log-verbose`: warnings and errors only by default, `debug` when `--log-verbose` is set once, and `trace` when set twice (`--log-verbose --log-verbose`). The flag is spelled `--log-verbose` rather than `--verbose, -v` because `connect` and `disconnect` still own their own per-subcommand `--verbose` (`-v`) flags from earlier releases; a future RFC may deprecate those and reclaim the shorter spelling. Modules MUST NOT set or override the log level themselves and MUST NOT use `println!` or `eprintln!` for diagnostics. JSON output remains parseable regardless of `--log-verbose` because diagnostic logs go to stderr and the user-facing writer goes to stdout.
+The binary configures the global log level from `--log-level`, an enum flag accepting `off`, `error`, `warn` (the default), `info`, `debug`, and `trace`. The flag is spelled `--log-level` rather than `--verbose, -v` because `connect` and `disconnect` still own their own per-subcommand `--verbose` (`-v`) flags from earlier releases; a future RFC may deprecate those and reclaim the shorter spelling. Modules MUST NOT set or override the log level themselves and MUST NOT use `println!` or `eprintln!` for diagnostics. JSON output remains parseable regardless of `--log-level` because diagnostic logs go to stderr and the user-facing writer goes to stdout.
 
 ### Environments and configuration resolution
 
@@ -168,7 +168,7 @@ The unified binary owns the following global flags, propagated to every subcomma
 | `--geo-program-id` | Geolocation program ID override. |
 | `--sock-file` | Daemon Unix socket path override. |
 | `--no-version-warning` | Suppress the version-check banner. |
-| `--log-verbose` | Enable diagnostic logging. Repeating (`--log-verbose --log-verbose`) raises the level from `debug` to `trace`. No short alias yet because `connect`/`disconnect` still own `-v`/`--verbose` for legacy per-subcommand flags. |
+| `--log-level` | Diagnostic logging level. One of `off`, `error`, `warn` (default), `info`, `debug`, `trace`. No short alias yet because `connect`/`disconnect` still own `-v`/`--verbose` for legacy per-subcommand flags. |
 | `--version`, `-V` | Print the binary version and exit. |
 
 The DZ-ledger and Solana-L1 transports use separate override flags by design: confusing the two leads to verbs that quietly run against the wrong network. When `--env` is set, all transports resolve consistently; when an override is needed for one transport, the others continue to follow `--env`.

--- a/smartcontract/cli/src/user/get.rs
+++ b/smartcontract/cli/src/user/get.rs
@@ -88,9 +88,10 @@ impl GetUserCliCommand {
             })?
             .map(|(_, ap)| ap.to_string());
         if accesspass_str.is_none() {
-            eprintln!(
-                "Warning: no Access Pass found for this user (client-ip: {}, payer: {})",
-                user.client_ip, user.owner
+            tracing::warn!(
+                client_ip = %user.client_ip,
+                payer = %user.owner,
+                "no access pass found for user"
             );
         }
         let multicast_groups = client.list_multicastgroup(ListMulticastGroupCommand {})?;


### PR DESCRIPTION
## Summary of Changes
- Replace the `eprintln!` "no Access Pass found" warning in `doublezero user get` with `tracing::warn!`, so the diagnostic flows through the logging facade per RFC-20 §Diagnostic logging instead of writing directly to stderr.
- Reconcile the RFC-20 docs with the implemented logging flag: RFC-20 and `docs/cli-standard.md` now describe `--log-level <off|error|warn|info|debug|trace>` (default `warn`) instead of the never-implemented repeatable `--log-verbose`. The binary already ships `--log-level`; this is a docs-only correction with the code as the source of truth.
- No user-facing command, flag, output, or JSON-schema change.

Related RFC: [RFC-20: CLI Standardization and Library Composition](../blob/main/rfcs/rfc20-cli-standardization.md)

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Docs         |     3 | +11 / -7    |  +4  |
| Scaffolding  |     1 | +4 / -3     |  +1  |
| **Total**    |     4 | +15 / -10   |  +5  |

Small, low-risk change: one diagnostic-logging line in a migrated verb plus documentation reconciliation. No core logic or tests changed.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/user/get.rs` — swap the missing-Access-Pass `eprintln!` for a structured `tracing::warn!` (client_ip, payer fields)
- `rfcs/rfc20-cli-standardization.md` — global-flags table row and Diagnostic logging section now describe `--log-level`
- `docs/cli-standard.md` — global-flags table row and `init_logging(app.log_level)` wording updated to `--log-level`
- `CHANGELOG.md` — Unreleased entry for both changes

</details>

## Testing Verification
- `cargo test -p doublezero-serviceability-cli user::get` — both tests pass, including the no-Access-Pass path that now logs instead of printing to stderr.
- `cargo clippy -p doublezero-serviceability-cli --all-targets -- -Dclippy::all -Dwarnings` — clean.
- Grepped the migrated resource execute paths to confirm no `println!`/`eprintln!` remain.
