### PR TITLE
release: testnet v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [v0.25.0](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.0) - 2026-05-29
+
+### Breaking
+
 ### Changes
 
 - Controller

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bitflags",
  "clap",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "eyre",
  "serde",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation-cli"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "clap",
  "doublezero-cli-core",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability-cli"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -2114,7 +2114,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary

- Bump workspace version `0.24.0` → `0.25.0` (`Cargo.toml`, `Cargo.lock`)
- Roll the `CHANGELOG.md` `Unreleased` section into `v0.25.0`

Testnet release tracking issue: #3806

## Testing Verification

- `cargo update --workspace --offline` regenerated `Cargo.lock` with only the 13 in-tree crate versions bumped (no dependency drift)
