### PR TITLE
cli: honor build-configured default environment when no config.yml is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - SDK (Go)
   - Add CreateUser / DeleteUser to the serviceability executor with cross-language wire-format fixtures and four new PDA helpers (GetUserPDA, GetAccessPassPDA, GetTunnelIdsPDA, GetDzPrefixBlockPDA)
+- CLI
+  - Honor the build-configured default environment (`Testnet` by default, `MainnetBeta` under the `default-mainnet-beta` feature) when neither `--env` nor a persisted `config.yml` selects one. The RFC-20 context-build previously fell back to `Environment::default()`, which is always `Devnet` regardless of the build, so a testnet build with no config silently targeted Devnet's ledger URLs and program IDs. The binary now resolves the fallback through the new `doublezero_sdk::default_environment()`, matching the legacy `DZClient::new` defaults (`default_program_id`, `ClientConfig::default`) which already key off the compiled-in environment ([#3810](https://github.com/malbeclabs/doublezero/pull/3810))
 
 ## [v0.25.0](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.0) - 2026-05-29
 

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -85,6 +85,27 @@ struct App {
     version: bool,
 }
 
+/// Resolve the active [`Environment`] from the `--env` flag and any persisted
+/// config, falling back to the build-configured default
+/// ([`doublezero_sdk::default_environment`]) when neither selects one.
+///
+/// The fallback MUST use the compiled default — not [`Environment::default`],
+/// which is always `Devnet` — so testnet / mainnet-beta builds honor their
+/// baked-in environment when no `config.yml` is present. `persisted` is `Some`
+/// only when a config file actually exists on disk.
+fn resolve_environment(
+    env_flag: Option<&str>,
+    persisted: Option<&doublezero_sdk::ClientConfig>,
+) -> eyre::Result<Environment> {
+    match env_flag {
+        Some(s) => s.parse::<Environment>(),
+        None => Ok(persisted
+            .and_then(|c| c.program_id.as_deref())
+            .and_then(|pid| Environment::from_program_id(pid).ok())
+            .unwrap_or_else(doublezero_sdk::default_environment)),
+    }
+}
+
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     unsafe {
@@ -119,18 +140,11 @@ async fn main() -> eyre::Result<()> {
     let persisted_exists = persisted_path.is_file();
 
     let env_explicit = app.env.is_some();
-    let env = match app.env.as_deref() {
-        Some(s) => s.parse::<Environment>().unwrap_or_else(|e| {
+    let env = resolve_environment(app.env.as_deref(), persisted_exists.then_some(&persisted))
+        .unwrap_or_else(|e| {
             doublezero_cli_core::error::render_eyre(&e);
             std::process::exit(1);
-        }),
-        None if persisted_exists => persisted
-            .program_id
-            .as_deref()
-            .and_then(|pid| Environment::from_program_id(pid).ok())
-            .unwrap_or_default(),
-        None => Environment::default(),
-    };
+        });
 
     let mut ctx_builder = doublezero_cli_core::CliContextBuilder::new().with_env(env);
 
@@ -371,5 +385,56 @@ mod tests {
     fn url_alone_parses() {
         App::try_parse_from(["doublezero", "--url", "https://x.invalid/"])
             .expect("--url alone should parse");
+    }
+
+    use super::resolve_environment;
+    use doublezero_config::Environment;
+
+    // Regression: with no `--env` and no persisted config, the active
+    // environment must be the build-configured default, not `Environment::default()`
+    // (which is always Devnet). A testnet build must resolve to Testnet here.
+    #[test]
+    fn no_env_flag_no_config_uses_build_default() {
+        assert_eq!(
+            resolve_environment(None, None).unwrap(),
+            doublezero_sdk::default_environment(),
+        );
+    }
+
+    #[test]
+    fn env_flag_overrides_default() {
+        assert_eq!(
+            resolve_environment(Some("mainnet-beta"), None).unwrap(),
+            Environment::MainnetBeta,
+        );
+    }
+
+    #[test]
+    fn persisted_program_id_selects_its_environment() {
+        let devnet_pid = Environment::Devnet
+            .config()
+            .unwrap()
+            .serviceability_program_id
+            .to_string();
+        let cfg = doublezero_sdk::ClientConfig {
+            program_id: Some(devnet_pid),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_environment(None, Some(&cfg)).unwrap(),
+            Environment::Devnet,
+        );
+    }
+
+    #[test]
+    fn persisted_config_without_program_id_uses_build_default() {
+        let cfg = doublezero_sdk::ClientConfig {
+            program_id: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_environment(None, Some(&cfg)).unwrap(),
+            doublezero_sdk::default_environment(),
+        );
     }
 }

--- a/smartcontract/sdk/rs/src/config.rs
+++ b/smartcontract/sdk/rs/src/config.rs
@@ -15,6 +15,15 @@ const DEFAULT_ENVIRONMENT: Environment = Environment::MainnetBeta;
 #[cfg(not(feature = "default-mainnet-beta"))]
 const DEFAULT_ENVIRONMENT: Environment = Environment::Testnet;
 
+/// The environment the binary defaults to when neither `--env` nor a persisted
+/// config selects one. Build-feature-aware: `Testnet` by default, `MainnetBeta`
+/// under `default-mainnet-beta`. Mirrors the legacy `DZClient::new` defaults
+/// (`default_program_id`, `ClientConfig::default`), which all key off the same
+/// compiled-in environment.
+pub fn default_environment() -> Environment {
+    DEFAULT_ENVIRONMENT
+}
+
 /// Returns the default program ID based on the compiled-in environment.
 pub fn default_program_id() -> Pubkey {
     DEFAULT_ENVIRONMENT

--- a/smartcontract/sdk/rs/src/lib.rs
+++ b/smartcontract/sdk/rs/src/lib.rs
@@ -1,7 +1,7 @@
 pub use crate::config::{
-    convert_geo_program_moniker, create_new_pubkey_user, default_geolocation_program_id,
-    default_program_id, get_doublezero_pubkey, read_doublezero_config, write_doublezero_config,
-    ClientConfig,
+    convert_geo_program_moniker, create_new_pubkey_user, default_environment,
+    default_geolocation_program_id, default_program_id, get_doublezero_pubkey,
+    read_doublezero_config, write_doublezero_config, ClientConfig,
 };
 pub use doublezero_serviceability::{
     addresses::*,


### PR DESCRIPTION
## Summary
- The RFC-20 context-build in the `doublezero` binary resolved the no-config / no-`--env` fallback environment via `Environment::default()` — which is always `Devnet`, independent of the build. The legacy `DZClient::new` path instead keyed off the compile-time `DEFAULT_ENVIRONMENT` (`Testnet` by default, `MainnetBeta` under the `default-mainnet-beta` feature). The migration silently dropped that.
- **Impact:** a plain (testnet) build with no `config.yml` and no `--env` silently targeted Devnet's URLs and program IDs instead of Testnet. Setting `DZ_LEDGER_RPC_URL` made it worse, not better — that env var overrides only the URLs inside `Environment::config()`, so the binary would hit the testnet ledger with Devnet program IDs.
- Expose `doublezero_sdk::default_environment()` (the build-feature-aware default) and route the binary's environment resolution through it, restoring the legacy behavior exactly.
- Extract the previously-inline resolution into a testable `resolve_environment` helper — the lack of a seam here is why nothing caught the regression.

Deliberately did **not** change `Environment::default()`'s `#[default] Devnet` derive, which is referenced elsewhere (e.g. the `build_without_env` placeholder in `doublezero-cli-core`); routing the binary through `DEFAULT_ENVIRONMENT` keeps the change surgical.

Related RFC: [`rfcs/rfc20-cli-standardization.md`](rfcs/rfc20-cli-standardization.md)

## Testing Verification
- New unit tests in `client/doublezero` assert: no `--env` + no config resolves to `default_environment()` (fails before the fix — returned Devnet); a persisted config's `program_id` selects its environment; a persisted config without a `program_id` falls back to the build default; an explicit `--env` flag wins.
- `make rust-lint` clean (rustfmt + clippy); full `doublezero` bin test suite passes (137 tests).