### PR TITLE
geolocation/cli: show codes instead of pubkeys in user get and probe get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- SDK (Go)
+  - Add CreateUser / DeleteUser to the serviceability executor with cross-language wire-format fixtures and four new PDA helpers (GetUserPDA, GetAccessPassPDA, GetTunnelIdsPDA, GetDzPrefixBlockPDA)
+- SDK (Rust)
+  - Add `DZClient::from_context` and `GeoClient::from_context`, which build clients directly from a resolved RFC-20 `CliContext` instead of re-reading `~/.config/doublezero/cli/config.yml` and re-applying moniker conversion. The context already carries the fully resolved ledger RPC/WS URLs and program IDs, so these constructors consume them verbatim, making the context the single source of truth and removing the double-resolution the binary previously incurred. Keypair precedence is preserved exactly (CLI flag > `DOUBLEZERO_KEYPAIR` > stdin > context keypair path > default): the raw `--keypair` flag is passed as the highest-precedence source and the context keypair path is used only as the low-precedence fallback, so the env var still wins. The new constructors and their `doublezero-cli-core` dependency are gated behind a `cli-context` cargo feature so non-CLI SDK consumers (controlplane, telemetry, e2e) keep a dependency-light default build. `DZClient::new` / `GeoClient::new` are unchanged for callers that do not build a `CliContext` (e.g. `controlplane/doublezero-admin`).
 - CLI
   - Change `geolocation user update-payment` to `update-payment-status` for clarity. 
+  - geolocation `user get`: Show probe code, rather than probe pubkey in target list. 
+  - geolocation `probe get`: Show exchange code, rather than exchange pubkeys.
 - ci(e2e): report trusted fork e2e/shreds shard results onto the PR head SHA so branch protection's required `e2e (shard N)` / `shard-e2e (shard N)` checks are satisfied by a `/run-e2e` dispatch, removing the need for a maintainer to bypass the ruleset to merge fork PRs; also make the dispatcher's confirmation comment non-fatal so a capped `GITHUB_TOKEN` no longer fails the job after the runs have already launched (follow-up to [#3777](https://github.com/malbeclabs/doublezero/pull/3777))
 - Tools
   - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- SDK (Go)
-  - Add CreateUser / DeleteUser to the serviceability executor with cross-language wire-format fixtures and four new PDA helpers (GetUserPDA, GetAccessPassPDA, GetTunnelIdsPDA, GetDzPrefixBlockPDA)
-- SDK (Rust)
-  - Add `DZClient::from_context` and `GeoClient::from_context`, which build clients directly from a resolved RFC-20 `CliContext` instead of re-reading `~/.config/doublezero/cli/config.yml` and re-applying moniker conversion. The context already carries the fully resolved ledger RPC/WS URLs and program IDs, so these constructors consume them verbatim, making the context the single source of truth and removing the double-resolution the binary previously incurred. Keypair precedence is preserved exactly (CLI flag > `DOUBLEZERO_KEYPAIR` > stdin > context keypair path > default): the raw `--keypair` flag is passed as the highest-precedence source and the context keypair path is used only as the low-precedence fallback, so the env var still wins. The new constructors and their `doublezero-cli-core` dependency are gated behind a `cli-context` cargo feature so non-CLI SDK consumers (controlplane, telemetry, e2e) keep a dependency-light default build. `DZClient::new` / `GeoClient::new` are unchanged for callers that do not build a `CliContext` (e.g. `controlplane/doublezero-admin`).
 - CLI
   - Change `geolocation user update-payment` to `update-payment-status` for clarity. 
   - geolocation `user get`: Show probe code, rather than probe pubkey in target list. 

--- a/crates/doublezero-geolocation-cli/src/probe/get.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/get.rs
@@ -36,8 +36,7 @@ struct GeoProbeGetDisplay {
     pub code: String,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
-    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
-    pub exchange: Pubkey,
+    pub exchange: String,
     pub public_ip: Ipv4Addr,
     pub port: u16,
     #[serde(serialize_with = "serialize_pubkey_vec_as_string_array")]
@@ -64,6 +63,12 @@ impl GetGeoProbeCliCommand {
             pubkey_or_code: self.probe,
         })?;
 
+        let exchanges = client.list_exchanges()?;
+        let exchange = exchanges
+            .get(&probe.exchange_pk)
+            .map(|ex| ex.code.clone())
+            .unwrap_or_else(|| probe.exchange_pk.to_string());
+
         let parent_devices_display = format!(
             "[{}]",
             probe
@@ -77,7 +82,7 @@ impl GetGeoProbeCliCommand {
             account: pubkey,
             code: probe.code,
             owner: probe.owner,
-            exchange: probe.exchange_pk,
+            exchange,
             public_ip: probe.public_ip,
             port: probe.location_offset_port,
             parent_devices: probe.parent_devices,
@@ -112,9 +117,34 @@ mod tests {
     use crate::client::MockGeoCliCommand;
     use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{accounttype::AccountType, geo_probe::GeoProbe};
+    use doublezero_sdk::{AccountType as SvcAccountType, Exchange, ExchangeStatus};
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
-    use std::net::Ipv4Addr;
+    use std::{collections::HashMap, net::Ipv4Addr};
+
+    fn make_exchanges(exchange_pk: Pubkey, code: &str) -> HashMap<Pubkey, Exchange> {
+        let mut exchanges = HashMap::new();
+        exchanges.insert(
+            exchange_pk,
+            Exchange {
+                account_type: SvcAccountType::Exchange,
+                owner: exchange_pk,
+                index: 0,
+                bump_seed: 0,
+                reference_count: 0,
+                device1_pk: Pubkey::default(),
+                device2_pk: Pubkey::default(),
+                lat: 0.0,
+                lng: 0.0,
+                bgp_community: 0,
+                unused: 0,
+                status: ExchangeStatus::Activated,
+                code: code.to_string(),
+                name: code.to_string(),
+            },
+        );
+        exchanges
+    }
 
     fn setup_client() -> (MockGeoCliCommand, Pubkey, Pubkey, Pubkey, Pubkey) {
         let client = MockGeoCliCommand::new();
@@ -161,6 +191,11 @@ mod tests {
             .expect_get_geo_probe()
             .returning(move |_| Err(eyre::eyre!("not found")));
 
+        let exchanges = make_exchanges(exchange_pk, "ams");
+        client
+            .expect_list_exchanges()
+            .returning(move || Ok(exchanges.clone()));
+
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
         let res = block_on(
@@ -192,7 +227,9 @@ mod tests {
         assert!(has_row("account", &probe_pk.to_string()));
         assert!(has_row("code", "ams-probe-01"));
         assert!(has_row("owner", &owner_pk.to_string()));
-        assert!(has_row("exchange", &exchange_pk.to_string()));
+        // exchange column shows the code, not the pubkey
+        assert!(has_row("exchange", "ams"));
+        assert!(!output_str.contains(&exchange_pk.to_string()));
         assert!(has_row("public_ip", "10.0.0.1"));
         assert!(has_row("port", "8923"));
         assert!(has_row("signing_pubkey", &metrics_pk.to_string()));
@@ -212,6 +249,11 @@ mod tests {
             }))
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
+        let exchanges = make_exchanges(exchange_pk, "ams");
+        client
+            .expect_list_exchanges()
+            .returning(move || Ok(exchanges.clone()));
+
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
         let res = block_on(
@@ -228,7 +270,7 @@ mod tests {
         assert_eq!(json["account"].as_str().unwrap(), probe_pk.to_string());
         assert_eq!(json["code"].as_str().unwrap(), "ams-probe-01");
         assert_eq!(json["owner"].as_str().unwrap(), owner_pk.to_string());
-        assert_eq!(json["exchange"].as_str().unwrap(), exchange_pk.to_string());
+        assert_eq!(json["exchange"].as_str().unwrap(), "ams");
         assert_eq!(json["public_ip"].as_str().unwrap(), "10.0.0.1");
         assert_eq!(json["port"].as_u64().unwrap(), 8923);
         let parents = json["parent_devices"].as_array().unwrap();
@@ -254,6 +296,11 @@ mod tests {
             }))
             .returning(move |_| Ok((probe_pk, probe.clone())));
 
+        let exchanges = make_exchanges(exchange_pk, "ams");
+        client
+            .expect_list_exchanges()
+            .returning(move || Ok(exchanges.clone()));
+
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
         let res = block_on(
@@ -271,6 +318,38 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(trimmed).unwrap();
         assert_eq!(json["account"].as_str().unwrap(), probe_pk.to_string());
         assert_eq!(json["code"].as_str().unwrap(), "ams-probe-01");
+        assert_eq!(json["exchange"].as_str().unwrap(), "ams");
         assert_eq!(json["parent_devices"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_cli_geo_probe_get_unknown_exchange_falls_back_to_pubkey() {
+        let (mut client, probe_pk, owner_pk, exchange_pk, metrics_pk) = setup_client();
+        let probe = make_probe(owner_pk, exchange_pk, metrics_pk, vec![]);
+
+        client
+            .expect_get_geo_probe()
+            .with(predicate::eq(GetGeoProbeCommand {
+                pubkey_or_code: probe_pk.to_string(),
+            }))
+            .returning(move |_| Ok((probe_pk, probe.clone())));
+
+        client
+            .expect_list_exchanges()
+            .returning(|| Ok(HashMap::new()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: probe_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains(&exchange_pk.to_string()));
     }
 }

--- a/crates/doublezero-geolocation-cli/src/probe/get.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/get.rs
@@ -36,7 +36,11 @@ struct GeoProbeGetDisplay {
     pub code: String,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
-    pub exchange: String,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    #[tabled(skip)]
+    pub exchange: Pubkey,
+    #[tabled(rename = "exchange")]
+    pub exchange_code: String,
     pub public_ip: Ipv4Addr,
     pub port: u16,
     #[serde(serialize_with = "serialize_pubkey_vec_as_string_array")]
@@ -63,8 +67,11 @@ impl GetGeoProbeCliCommand {
             pubkey_or_code: self.probe,
         })?;
 
-        let exchanges = client.list_exchanges()?;
-        let exchange = exchanges
+        let exchanges = client.list_exchanges().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to list exchanges; showing exchange pubkey");
+            Default::default()
+        });
+        let exchange_code = exchanges
             .get(&probe.exchange_pk)
             .map(|ex| ex.code.clone())
             .unwrap_or_else(|| probe.exchange_pk.to_string());
@@ -82,7 +89,8 @@ impl GetGeoProbeCliCommand {
             account: pubkey,
             code: probe.code,
             owner: probe.owner,
-            exchange,
+            exchange: probe.exchange_pk,
+            exchange_code,
             public_ip: probe.public_ip,
             port: probe.location_offset_port,
             parent_devices: probe.parent_devices,
@@ -270,7 +278,9 @@ mod tests {
         assert_eq!(json["account"].as_str().unwrap(), probe_pk.to_string());
         assert_eq!(json["code"].as_str().unwrap(), "ams-probe-01");
         assert_eq!(json["owner"].as_str().unwrap(), owner_pk.to_string());
-        assert_eq!(json["exchange"].as_str().unwrap(), "ams");
+        // exchange retains the canonical pubkey; the code is a separate field
+        assert_eq!(json["exchange"].as_str().unwrap(), exchange_pk.to_string());
+        assert_eq!(json["exchange_code"].as_str().unwrap(), "ams");
         assert_eq!(json["public_ip"].as_str().unwrap(), "10.0.0.1");
         assert_eq!(json["port"].as_u64().unwrap(), 8923);
         let parents = json["parent_devices"].as_array().unwrap();
@@ -318,7 +328,8 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(trimmed).unwrap();
         assert_eq!(json["account"].as_str().unwrap(), probe_pk.to_string());
         assert_eq!(json["code"].as_str().unwrap(), "ams-probe-01");
-        assert_eq!(json["exchange"].as_str().unwrap(), "ams");
+        assert_eq!(json["exchange"].as_str().unwrap(), exchange_pk.to_string());
+        assert_eq!(json["exchange_code"].as_str().unwrap(), "ams");
         assert_eq!(json["parent_devices"].as_array().unwrap().len(), 1);
     }
 
@@ -337,6 +348,38 @@ mod tests {
         client
             .expect_list_exchanges()
             .returning(|| Ok(HashMap::new()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            GetGeoProbeCliCommand {
+                probe: probe_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains(&exchange_pk.to_string()));
+    }
+
+    #[test]
+    fn test_cli_geo_probe_get_exchange_list_error_falls_back_to_pubkey() {
+        let (mut client, probe_pk, owner_pk, exchange_pk, metrics_pk) = setup_client();
+        let probe = make_probe(owner_pk, exchange_pk, metrics_pk, vec![]);
+
+        client
+            .expect_get_geo_probe()
+            .with(predicate::eq(GetGeoProbeCommand {
+                pubkey_or_code: probe_pk.to_string(),
+            }))
+            .returning(move |_| Ok((probe_pk, probe.clone())));
+
+        // A failure to list exchanges must not abort the command; it falls back to the pubkey.
+        client
+            .expect_list_exchanges()
+            .returning(|| Err(eyre::eyre!("rpc error")));
 
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();

--- a/crates/doublezero-geolocation-cli/src/user/get.rs
+++ b/crates/doublezero-geolocation-cli/src/user/get.rs
@@ -72,7 +72,12 @@ impl GetGeolocationUserCliCommand {
             pubkey_or_code: self.user,
         })?;
 
-        let probes = client.list_geo_probes(ListGeoProbeCommand)?;
+        let probes = client
+            .list_geo_probes(ListGeoProbeCommand)
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to list geo probes; showing probe pubkey");
+                Default::default()
+            });
 
         let targets: Vec<TargetDisplay> = user
             .targets
@@ -305,6 +310,50 @@ mod tests {
         client
             .expect_list_geo_probes()
             .returning(|_| Ok(HashMap::new()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains(&probe_pk.to_string()));
+    }
+
+    #[test]
+    fn test_cli_geolocation_user_get_probe_list_error_falls_back_to_pubkey() {
+        let mut client = MockGeoCliCommand::new();
+        let user_pk = Pubkey::from_str_const("BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB");
+        let probe_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+
+        let user = make_user(
+            "geo-user-01",
+            vec![GeolocationTarget {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                location_offset_port: 8923,
+                target_pk: Pubkey::default(),
+                geoprobe_pk: probe_pk,
+            }],
+        );
+
+        client
+            .expect_get_geolocation_user()
+            .with(predicate::eq(GetGeolocationUserCommand {
+                pubkey_or_code: user_pk.to_string(),
+            }))
+            .returning(move |_| Ok((user_pk, user.clone())));
+
+        // A failure to list probes must not abort the command; it falls back to the pubkey.
+        client
+            .expect_list_geo_probes()
+            .returning(|_| Err(eyre::eyre!("rpc error")));
 
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();

--- a/crates/doublezero-geolocation-cli/src/user/get.rs
+++ b/crates/doublezero-geolocation-cli/src/user/get.rs
@@ -5,7 +5,9 @@ use doublezero_geolocation::state::geolocation_user::{
     GeoLocationTargetType, GeolocationBillingConfig,
 };
 use doublezero_program_common::serializer;
-use doublezero_sdk::geolocation::geolocation_user::get::GetGeolocationUserCommand;
+use doublezero_sdk::geolocation::{
+    geo_probe::list::ListGeoProbeCommand, geolocation_user::get::GetGeolocationUserCommand,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -50,8 +52,10 @@ struct TargetDisplay {
     pub port: u16,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub target_signing_pubkey: Pubkey,
-    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     #[tabled(rename = "probe")]
+    pub probe: String,
+    #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
+    #[tabled(skip)]
     pub geoprobe_pk: Pubkey,
 }
 
@@ -68,6 +72,8 @@ impl GetGeolocationUserCliCommand {
             pubkey_or_code: self.user,
         })?;
 
+        let probes = client.list_geo_probes(ListGeoProbeCommand)?;
+
         let targets: Vec<TargetDisplay> = user
             .targets
             .iter()
@@ -78,11 +84,16 @@ impl GetGeolocationUserCliCommand {
                     }
                     GeoLocationTargetType::Inbound => ("-".to_string(), 0),
                 };
+                let probe = probes
+                    .get(&t.geoprobe_pk)
+                    .map(|p| p.code.clone())
+                    .unwrap_or_else(|| t.geoprobe_pk.to_string());
                 TargetDisplay {
                     target_type: t.target_type.to_string(),
                     ip,
                     port,
                     target_signing_pubkey: t.target_pk,
+                    probe,
                     geoprobe_pk: t.geoprobe_pk,
                 }
             })
@@ -161,6 +172,7 @@ mod tests {
     use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
     use doublezero_geolocation::state::{
         accounttype::AccountType,
+        geo_probe::GeoProbe,
         geolocation_user::{
             FlatPerEpochConfig, GeoLocationTargetType, GeolocationPaymentStatus, GeolocationTarget,
             GeolocationUser, GeolocationUserStatus,
@@ -168,7 +180,27 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::pubkey::Pubkey;
-    use std::net::Ipv4Addr;
+    use std::{collections::HashMap, net::Ipv4Addr};
+
+    fn make_probes(probe_pk: Pubkey, code: &str) -> HashMap<Pubkey, GeoProbe> {
+        let mut probes = HashMap::new();
+        probes.insert(
+            probe_pk,
+            GeoProbe {
+                account_type: AccountType::GeoProbe,
+                owner: Pubkey::default(),
+                exchange_pk: Pubkey::default(),
+                public_ip: Ipv4Addr::new(10, 0, 0, 1),
+                location_offset_port: 8923,
+                code: code.to_string(),
+                parent_devices: vec![],
+                metrics_publisher_pk: Pubkey::default(),
+                reference_count: 0,
+                target_update_count: 0,
+            },
+        );
+        probes
+    }
 
     fn make_user(code: &str, targets: Vec<GeolocationTarget>) -> GeolocationUser {
         GeolocationUser {
@@ -211,6 +243,11 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let probes = make_probes(probe_pk, "ams-probe-01");
+        client
+            .expect_list_geo_probes()
+            .returning(move |_| Ok(probes.clone()));
+
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
         let res = block_on(
@@ -236,6 +273,52 @@ mod tests {
         assert!(has_row("target_count", "1"));
         assert!(output_str.contains("Targets:"));
         assert!(output_str.contains("8.8.8.8"));
+        // probe column shows the code, not the pubkey
+        assert!(output_str.contains("ams-probe-01"));
+        assert!(!output_str.contains(&probe_pk.to_string()));
+    }
+
+    #[test]
+    fn test_cli_geolocation_user_get_unknown_probe_falls_back_to_pubkey() {
+        let mut client = MockGeoCliCommand::new();
+        let user_pk = Pubkey::from_str_const("BmrLoL9jzYo4yiPUsFhYFU8hgE3CD3Npt8tgbqvneMyB");
+        let probe_pk = Pubkey::from_str_const("HQ3UUt18uJqKaQFJhgV9zaTdQxUZjNrsKFgoEDquBkcx");
+
+        let user = make_user(
+            "geo-user-01",
+            vec![GeolocationTarget {
+                target_type: GeoLocationTargetType::Outbound,
+                ip_address: Ipv4Addr::new(8, 8, 8, 8),
+                location_offset_port: 8923,
+                target_pk: Pubkey::default(),
+                geoprobe_pk: probe_pk,
+            }],
+        );
+
+        client
+            .expect_get_geolocation_user()
+            .with(predicate::eq(GetGeolocationUserCommand {
+                pubkey_or_code: user_pk.to_string(),
+            }))
+            .returning(move |_| Ok((user_pk, user.clone())));
+
+        client
+            .expect_list_geo_probes()
+            .returning(|_| Ok(HashMap::new()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            GetGeolocationUserCliCommand {
+                user: user_pk.to_string(),
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains(&probe_pk.to_string()));
     }
 
     #[test]
@@ -251,6 +334,10 @@ mod tests {
                 pubkey_or_code: user_pk.to_string(),
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
+
+        client
+            .expect_list_geo_probes()
+            .returning(|_| Ok(HashMap::new()));
 
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
@@ -287,6 +374,10 @@ mod tests {
                 pubkey_or_code: user_pk.to_string(),
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
+
+        client
+            .expect_list_geo_probes()
+            .returning(|_| Ok(HashMap::new()));
 
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
@@ -327,6 +418,11 @@ mod tests {
             }))
             .returning(move |_| Ok((user_pk, user.clone())));
 
+        let probes = make_probes(probe_pk, "ams-probe-01");
+        client
+            .expect_list_geo_probes()
+            .returning(move |_| Ok(probes.clone()));
+
         let ctx = cli_context_default_for_tests();
         let mut output = Vec::new();
         let res = block_on(
@@ -347,5 +443,14 @@ mod tests {
         assert_eq!(json["target_count"].as_u64().unwrap(), 1);
         assert_eq!(json["targets"].as_array().unwrap().len(), 1);
         assert_eq!(json["targets"][0]["ip"].as_str().unwrap(), "8.8.8.8");
+        // JSON carries the resolved probe code plus the canonical pubkey
+        assert_eq!(
+            json["targets"][0]["probe"].as_str().unwrap(),
+            "ams-probe-01"
+        );
+        assert_eq!(
+            json["targets"][0]["geoprobe_pk"].as_str().unwrap(),
+            probe_pk.to_string()
+        );
     }
 }


### PR DESCRIPTION
## Summary of Changes
- `geolocation user get`: the Targets table `probe` column now shows the human-readable probe code instead of the raw geoprobe pubkey, resolved via `list_geo_probes` with a pubkey fallback. JSON gains a `probe` code field while retaining the canonical `geoprobe_pk`.
- `geolocation probe get`: the `exchange` field now shows the exchange code instead of the raw pubkey, resolved via `list_exchanges` with a pubkey fallback — making it consistent with `geolocation probe list`, which already does this.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +25 / -9    |  +16 |
| Tests        |     2 | +168 / -0   | +168 |
| **Total**    |     2 | +193 / -9   | +184 |

Two small CLI display fixes in the geolocation crate; the bulk of the diff is test coverage for code resolution and pubkey fallback.

<details>
<summary>Key files (click to expand)</summary>

- `crates/doublezero-geolocation-cli/src/user/get.rs` — resolve `geoprobe_pk` → probe code in the Targets table; keep `geoprobe_pk` in JSON, add `probe` code field; tests for code rendering and fallback
- `crates/doublezero-geolocation-cli/src/probe/get.rs` — resolve `exchange_pk` → exchange code, matching `probe list`; tests for code rendering and fallback

</details>

## Testing Verification
- `user get`: table asserts the probe code (`ams-probe-01`) and not the pubkey; new fallback test when the probe isn't found; compact-JSON test asserts both `probe` code and retained `geoprobe_pk`
- `probe get`: table asserts the exchange code (`ams`) and not the pubkey; new fallback test when the exchange isn't found; JSON/compact tests updated to expect the code
- All `user::get` and `probe::get` tests pass; `make rust-lint` clean in the dev container
