### PR TITLE
tools/stress/device-observer: EOS syslog + tail-based readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Tools
   - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.
+  - Add `tools/stress/device-observer/`, a per-device sampling tool for the GRE Tunnel Capacity Study. Each tick issues five eAPI `show` commands, scrapes the doublezero-agent Prometheus endpoint, polls EOS syslog via `show logging last` with cross-tick dedupe, tails the orchestrator's agent log for abort-trigger patterns, and tails the orchestrator's runlog to compute provision/deprovision durations. The abort decider is stubbed.
 
 ## [v0.25.1](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.1) - 2026-06-01
 

--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -137,14 +137,16 @@ Row schema:
   "time": "May 29 12:34:56",
   "severity": "3",
   "facility": "BGP",
-  "message": "BGP-3-NOTIFICATION: ..."
+  "message": "peer 10.0.0.1 went down"
 }
 ```
 
-Lines that don't match the default Arista syslog format (timestamp +
-`FACILITY-SEV-MNEMONIC:` tag) still land in the file with empty `severity`
-and `facility` and the full line under `message`, so unusual formats are
-not silently dropped.
+The parser extracts `facility` and `severity` from the Arista
+`FACILITY-SEV-MNEMONIC:` tag; `message` contains only the text after the
+colon. The mnemonic (e.g. `NOTIFICATION`) is not preserved in any field.
+Lines that don't match the default format still land in the file with
+empty `severity` and `facility` and the full line under `message`, so
+unusual formats are not silently dropped.
 
 ## Agent log output
 

--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -1,7 +1,7 @@
 # device-observer
 
 > Alpha — eAPI sampler, Prometheus scrape, and log tailers are wired up.
-> The abort decider (PR #3796) is still a no-op stub in this revision.
+> The abort decider is still a no-op stub in this revision.
 
 `device-observer` samples an Arista cEOS device-under-test (DUT) during the
 GRE Tunnel Capacity Study sweep. On every tick of `--sample-interval` it
@@ -60,7 +60,7 @@ observer reads them but does not write them:
 | `orchestrator.agent.log`        | orchestrator | observer |
 
 The abort sentinel at `--abort-file` (default `<working-dir>/abort`) is
-written by the observer (in PR #3796) and read by the orchestrator.
+written by the observer's abort decider and read by the orchestrator.
 
 Filenames use the observer's local clock formatted as ISO 8601 UTC with
 nanosecond precision, with `:` replaced by `-` for filesystem portability
@@ -115,8 +115,8 @@ so the file can be consumed with line-oriented tools (`jq -c`, ClickHouse
 JSONEachRow) without schema-on-write decisions about variable label sets.
 
 Counter family totals (sum across all label series) are also exposed via
-`Scraper.Snapshot()` for in-process consumers; the abort decider in
-PR #3796 will use this to detect mid-sample counter increments.
+`Scraper.Snapshot()` for in-process consumers; the abort decider uses
+this to detect mid-sample counter increments.
 
 A per-tick HTTP failure, parse failure, or write failure is logged at WARN
 and the loop continues — the abort decider owns repeated-failure policy.
@@ -182,8 +182,8 @@ in bounded rings (1024 entries each).
 
 `Reader.ProvisionDurations(window)` and `Reader.DeprovisionDurations(window)`
 return the durations whose completion timestamp lies within `window` of
-the current wall clock. The abort decider (PR #3796) will use these to
-detect a provisioning slowdown.
+the current wall clock. The abort decider uses these to detect a
+provisioning slowdown.
 
 ## Tailer behavior
 
@@ -239,7 +239,7 @@ head /tmp/observer-out/observer.agent_metrics.json | jq -c .
 
 A failure on a single `show` command logs at WARN and continues to the
 next command. The next tick retries from a clean slate. The abort decider
-(PR #3796) owns the policy for declaring repeated failures fatal.
+owns the policy for declaring repeated failures fatal.
 
 On `SIGINT` / `SIGTERM` the observer cancels its context and exits without
 finishing a partially-started tick. Each file is written via a single
@@ -259,7 +259,7 @@ old samples is the orchestrator's responsibility.
 tools/stress/device-observer/
 ├── cmd/device-observer/main.go
 ├── internal/
-│   ├── abort/         # PR #3796 (stub here)
+│   ├── abort/         # abort decider (stub)
 │   ├── collector/     # Collector interface + Noop
 │   ├── eapi/          # thin goeapi wrapper
 │   ├── loggingtail/   # EOS-syslog poller + agent-log tailer

--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -1,7 +1,7 @@
 # device-observer
 
-> Alpha — eAPI sampler and Prometheus scrape are wired up. Log tailers
-> (PR #3795) and abort decider (PR #3796) are no-op stubs in this revision.
+> Alpha — eAPI sampler, Prometheus scrape, and log tailers are wired up.
+> The abort decider (PR #3796) is still a no-op stub in this revision.
 
 `device-observer` samples an Arista cEOS device-under-test (DUT) during the
 GRE Tunnel Capacity Study sweep. On every tick of `--sample-interval` it
@@ -48,14 +48,16 @@ The observer writes the following files into `--working-dir`:
 | `show-logging-errors-<ts>.log`           | observer  | one per tick                                    |
 | `show-logging-critical-<ts>.log`         | observer  | one per tick                                    |
 | `observer.agent_metrics.json`            | observer  | NDJSON, one row per metric sample, appended     |
+| `observer.eos_logging.json`              | observer  | NDJSON, one row per deduped `show logging last` entry, appended |
+| `observer.agent_log.json`                | observer  | NDJSON, one row per agent-log line, appended    |
 
 The orchestrator additionally owns these files in the same directory; the
-observer reads them (in later PRs) but does not write them:
+observer reads them but does not write them:
 
-| File                          | Owner        | Read by                       |
-| ----------------------------- | ------------ | ----------------------------- |
-| `orchestrator-runlog.json`    | orchestrator | observer (PR #3795)           |
-| `orchestrator.agent.log`      | orchestrator | observer (PR #3795)           |
+| File                            | Owner        | Read by  |
+| ------------------------------- | ------------ | -------- |
+| `orchestrator-runlog.jsonl`     | orchestrator | observer |
+| `orchestrator.agent.log`        | orchestrator | observer |
 
 The abort sentinel at `--abort-file` (default `<working-dir>/abort`) is
 written by the observer (in PR #3796) and read by the orchestrator.
@@ -119,6 +121,88 @@ PR #3796 will use this to detect mid-sample counter increments.
 A per-tick HTTP failure, parse failure, or write failure is logged at WARN
 and the loop continues — the abort decider owns repeated-failure policy.
 
+## EOS syslog output
+
+`observer.eos_logging.json` captures the device's syslog stream. Each tick
+runs `show logging last <N> seconds` over eAPI where `N` is
+`max(2 * sample_interval, 30 seconds)`, parses each line, and deduplicates
+against the prior tick's set so overlap doesn't double-emit. The dedupe key
+is `(timestamp, message)`.
+
+Row schema:
+
+```json
+{
+  "t_ns": 1748520896123456789,
+  "time": "May 29 12:34:56",
+  "severity": "3",
+  "facility": "BGP",
+  "message": "BGP-3-NOTIFICATION: ..."
+}
+```
+
+Lines that don't match the default Arista syslog format (timestamp +
+`FACILITY-SEV-MNEMONIC:` tag) still land in the file with empty `severity`
+and `facility` and the full line under `message`, so unusual formats are
+not silently dropped.
+
+## Agent log output
+
+`observer.agent_log.json` mirrors each new line of
+`<working-dir>/orchestrator.agent.log` (written by the orchestrator's
+SSH-backed agent runner). The tailer handles a missing file (returns no
+rows until it appears), rotation (rename + recreate), and truncation.
+
+Row schema:
+
+```json
+{
+  "t_ns": 1748520896123456789,
+  "line": "INFO: Committing config session due to diffs detected: ..."
+}
+```
+
+`AgentTail.Snapshot()` also exposes:
+
+- `LastLineAt` — wall-clock timestamp of the most recent observed line
+  (zero before the first line). The abort decider uses this to flag
+  agent silence beyond a threshold.
+- `MatchCounts` — running counts of three abort-trigger substrings:
+  `diff_timeout` ("could not get diff"), `lock_not_taken`
+  ("not overriding lock since its age is less than"), and
+  `commit_session` ("Committing config session due to diffs detected:").
+
+## Runlog reader
+
+`runlog.Reader` tails `<working-dir>/orchestrator-runlog.jsonl` (written
+by the orchestrator) and pairs `submit` / `activate` and
+`deprovision_submit` / `deprovision_activate` events by `user_index` to
+produce per-user provision and deprovision durations. Durations are held
+in bounded rings (1024 entries each).
+
+`Reader.ProvisionDurations(window)` and `Reader.DeprovisionDurations(window)`
+return the durations whose completion timestamp lies within `window` of
+the current wall clock. The abort decider (PR #3796) will use these to
+detect a provisioning slowdown.
+
+## Tailer behavior
+
+The agent-log and runlog consumers share a poll-based tailer
+(`internal/tailer`) that:
+
+- treats a missing source file as a no-op (returns `nil, nil`) so the
+  observer can start before the orchestrator creates the file,
+- detects rotation via inode change and reads the new file from offset
+  zero,
+- detects truncation when the file size drops below the previously-read
+  offset and reopens from offset zero,
+- buffers a trailing fragment (data not yet terminated by `\n`) across
+  polls so partial writes are not surfaced to the consumer.
+
+Linux-only: inode comparison uses `syscall.Stat_t.Ino`. This matches the
+device-observer's existing Linux-only assumptions (cEOS containers,
+`/sys/class/net` for ifindex lookups).
+
 ## Local devnet smoke test
 
 Against `dz-local-device-dz1` (see top-level `CLAUDE.md` for devnet setup):
@@ -178,9 +262,10 @@ tools/stress/device-observer/
 │   ├── abort/         # PR #3796 (stub here)
 │   ├── collector/     # Collector interface + Noop
 │   ├── eapi/          # thin goeapi wrapper
-│   ├── loggingtail/   # PR #3795 (stubs here)
+│   ├── loggingtail/   # EOS-syslog poller + agent-log tailer
 │   ├── promscrape/    # Prometheus scraper for the doublezero-agent
-│   ├── runlog/        # PR #3795 (stub here)
-│   └── sample/        # eAPI sampler
+│   ├── runlog/        # orchestrator-runlog.jsonl reader + duration rings
+│   ├── sample/        # eAPI sampler
+│   └── tailer/        # shared poll-based file tailer
 └── README.md
 ```

--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -4,10 +4,13 @@
 > The abort decider is still a no-op stub in this revision.
 
 `device-observer` samples an Arista cEOS device-under-test (DUT) during the
-GRE Tunnel Capacity Study sweep. On every tick of `--sample-interval` it
-issues five `show` commands over eAPI and writes one file per command into
-the working directory, and it scrapes the doublezero-agent's Prometheus
-metrics endpoint and appends rows to `observer.agent_metrics.json`.
+GRE Tunnel Capacity Study sweep. On every tick of `--sample-interval` it:
+
+- issues five `show` commands over eAPI and writes one file per command,
+- scrapes the doublezero-agent's Prometheus metrics endpoint,
+- polls `show logging last <N> seconds` for EOS syslog entries,
+- tails the orchestrator's agent log for pattern matches, and
+- tails the orchestrator's runlog to compute provision/deprovision durations.
 
 It is designed to be driven by an external orchestrator: the orchestrator
 sets the flags, owns the working directory, and signals the observer to
@@ -127,7 +130,8 @@ and the loop continues — the abort decider owns repeated-failure policy.
 runs `show logging last <N> seconds` over eAPI where `N` is
 `max(2 * sample_interval, 30 seconds)`, parses each line, and deduplicates
 against the prior tick's set so overlap doesn't double-emit. The dedupe key
-is `(timestamp, message)`.
+is the full raw syslog line, so distinct events at the same second with
+different facility/severity/mnemonic are preserved.
 
 Row schema:
 
@@ -179,8 +183,13 @@ Row schema:
 `runlog.Reader` tails `<working-dir>/orchestrator-runlog.jsonl` (written
 by the orchestrator) and pairs `submit` / `activate` and
 `deprovision_submit` / `deprovision_activate` events by `user_index` to
-produce per-user provision and deprovision durations. Durations are held
-in bounded rings (1024 entries each).
+produce per-user provision and deprovision durations. The reader is
+read-only — it does not write an output file; durations are held in
+memory only.
+
+Durations are stored in bounded rings (1024 entries each). The pending-
+submit maps (one per flow) are capped at 4096 entries; on overflow the
+oldest pending entry is evicted.
 
 `Reader.ProvisionDurations(window)` and `Reader.DeprovisionDurations(window)`
 return the durations whose completion timestamp lies within `window` of
@@ -199,7 +208,10 @@ The agent-log and runlog consumers share a poll-based tailer
 - detects truncation when the file size drops below the previously-read
   offset and reopens from offset zero,
 - buffers a trailing fragment (data not yet terminated by `\n`) across
-  polls so partial writes are not surfaced to the consumer.
+  polls so partial writes are not surfaced to the consumer,
+- caps the unterminated-line buffer at 1 MiB; if a fragment exceeds this
+  without a newline it is dropped and `ErrOversizeLine` is returned
+  alongside any complete lines already extracted.
 
 Linux-only: inode comparison uses `syscall.Stat_t.Ino`. This matches the
 device-observer's existing Linux-only assumptions (cEOS containers,

--- a/tools/stress/device-observer/cmd/device-observer/main.go
+++ b/tools/stress/device-observer/cmd/device-observer/main.go
@@ -110,12 +110,20 @@ func run() error {
 		return err
 	}
 
+	// EOS syslog lookback must cover the sample interval so consecutive
+	// `show logging last <window>` calls overlap and the in-memory dedupe
+	// catches duplicates. 2 × interval (min 30 s) is the contract.
+	eosLookback := 2 * *sampleInterval
+	if eosLookback < 30*time.Second {
+		eosLookback = 30 * time.Second
+	}
+
 	collectors := []collector.Collector{
 		sample.NewSampler(client, *workingDir, *sampleInterval, logger),
 		promscrape.New(*agentMetricsURL, *workingDir, *sampleInterval, logger),
-		loggingtail.NewEOS(client, *workingDir),
-		loggingtail.NewAgent(*workingDir),
-		runlog.New(*workingDir),
+		loggingtail.NewEOS(client, *workingDir, *sampleInterval, eosLookback, logger),
+		loggingtail.NewAgent(*workingDir, *sampleInterval, logger),
+		runlog.New(*workingDir, *sampleInterval, logger),
 		abort.New(*abortFile),
 	}
 

--- a/tools/stress/device-observer/cmd/device-observer/main.go
+++ b/tools/stress/device-observer/cmd/device-observer/main.go
@@ -1,6 +1,5 @@
 // device-observer samples an Arista cEOS device-under-test during the GRE
-// Tunnel Capacity Study. PR #3793 implements the eAPI sampler; subsequent
-// PRs replace the stub collectors with real implementations.
+// Tunnel Capacity Study.
 package main
 
 import (
@@ -81,8 +80,7 @@ func run() error {
 		return fmt.Errorf("resolve --abort-file: %w", err)
 	}
 	// Constrain --abort-file to live under --working-dir so the sentinel
-	// path PR #3796 will write to is bounded by the orchestrator's
-	// archive surface.
+	// is bounded by the orchestrator's archive surface.
 	if !strings.HasPrefix(absAbort+string(os.PathSeparator), absWorking+string(os.PathSeparator)) {
 		return fmt.Errorf("--abort-file %q must be inside --working-dir %q", absAbort, absWorking)
 	}
@@ -110,13 +108,8 @@ func run() error {
 		return err
 	}
 
-	// EOS syslog lookback must cover the sample interval so consecutive
-	// `show logging last <window>` calls overlap and the in-memory dedupe
-	// catches duplicates. 2 × interval (min 30 s) is the contract.
-	eosLookback := 2 * *sampleInterval
-	if eosLookback < 30*time.Second {
-		eosLookback = 30 * time.Second
-	}
+	// 2 × interval (min 30 s) so consecutive show-logging windows overlap.
+	eosLookback := max(2**sampleInterval, 30*time.Second)
 
 	collectors := []collector.Collector{
 		sample.NewSampler(client, *workingDir, *sampleInterval, logger),

--- a/tools/stress/device-observer/cmd/device-observer/main.go
+++ b/tools/stress/device-observer/cmd/device-observer/main.go
@@ -108,13 +108,10 @@ func run() error {
 		return err
 	}
 
-	// 2 × interval (min 30 s) so consecutive show-logging windows overlap.
-	eosLookback := max(2**sampleInterval, 30*time.Second)
-
 	collectors := []collector.Collector{
 		sample.NewSampler(client, *workingDir, *sampleInterval, logger),
 		promscrape.New(*agentMetricsURL, *workingDir, *sampleInterval, logger),
-		loggingtail.NewEOS(client, *workingDir, *sampleInterval, eosLookback, logger),
+		loggingtail.NewEOS(client, *workingDir, *sampleInterval, logger),
 		loggingtail.NewAgent(*workingDir, *sampleInterval, logger),
 		runlog.New(*workingDir, *sampleInterval, logger),
 		abort.New(*abortFile),

--- a/tools/stress/device-observer/internal/loggingtail/agent.go
+++ b/tools/stress/device-observer/internal/loggingtail/agent.go
@@ -3,6 +3,7 @@ package loggingtail
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -108,8 +109,12 @@ type agentLogRow struct {
 func (a *AgentTail) tick() {
 	lines, err := a.tail.Poll()
 	if err != nil {
+		// ErrOversizeLine is non-fatal: the partial was dropped, but any
+		// complete lines surfaced before the overflow are still valid.
 		a.logger.Warn("agent log tail failed", "path", a.inPath, "err", err)
-		return
+		if !errors.Is(err, tailer.ErrOversizeLine) {
+			return
+		}
 	}
 	if len(lines) == 0 {
 		return

--- a/tools/stress/device-observer/internal/loggingtail/agent.go
+++ b/tools/stress/device-observer/internal/loggingtail/agent.go
@@ -21,15 +21,13 @@ const (
 )
 
 // Pattern names exposed via Snapshot. Naming is stable so the abort
-// decider (PR #3796) can reference them by string.
+// decider can reference them by string.
 const (
 	PatternDiffTimeout   = "diff_timeout"
 	PatternLockNotTaken  = "lock_not_taken"
 	PatternCommitSession = "commit_session"
 )
 
-// agentPatterns holds the substring matches the abort decider needs.
-// Substrings (not regex) keep the match cheap and intent-obvious.
 var agentPatterns = []struct {
 	name, substr string
 }{
@@ -38,8 +36,8 @@ var agentPatterns = []struct {
 	{PatternCommitSession, "Committing config session due to diffs detected:"},
 }
 
-// AgentSnapshot reports the latest tail state for downstream consumers
-// (the abort decider). LastLineAt is zero before the first line is seen.
+// AgentSnapshot reports the latest tail state for the abort decider.
+// LastLineAt is zero before the first line is seen.
 type AgentSnapshot struct {
 	LastLineAt  time.Time
 	MatchCounts map[string]int
@@ -89,8 +87,7 @@ func (a *AgentTail) Run(ctx context.Context) error {
 	}
 }
 
-// Snapshot returns a copy of the current tail state. Safe for concurrent
-// use; the abort decider reads from a separate goroutine.
+// Snapshot returns a copy of the current tail state. Safe for concurrent use.
 func (a *AgentTail) Snapshot() AgentSnapshot {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/tools/stress/device-observer/internal/loggingtail/agent.go
+++ b/tools/stress/device-observer/internal/loggingtail/agent.go
@@ -1,8 +1,146 @@
 package loggingtail
 
-import "github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 
-func NewAgent(workingDir string) collector.Collector {
-	_ = workingDir
-	return collector.Noop{}
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/tailer"
+)
+
+const (
+	agentInputFilename  = "orchestrator.agent.log"
+	agentOutputFilename = "observer.agent_log.json"
+)
+
+// Pattern names exposed via Snapshot. Naming is stable so the abort
+// decider (PR #3796) can reference them by string.
+const (
+	PatternDiffTimeout   = "diff_timeout"
+	PatternLockNotTaken  = "lock_not_taken"
+	PatternCommitSession = "commit_session"
+)
+
+// agentPatterns holds the substring matches the abort decider needs.
+// Substrings (not regex) keep the match cheap and intent-obvious.
+var agentPatterns = []struct {
+	name, substr string
+}{
+	{PatternDiffTimeout, "could not get diff"},
+	{PatternLockNotTaken, "not overriding lock since its age is less than"},
+	{PatternCommitSession, "Committing config session due to diffs detected:"},
 }
+
+// AgentSnapshot reports the latest tail state for downstream consumers
+// (the abort decider). LastLineAt is zero before the first line is seen.
+type AgentSnapshot struct {
+	LastLineAt  time.Time
+	MatchCounts map[string]int
+}
+
+// AgentTail tails <working-dir>/orchestrator.agent.log via tailer.Tailer
+// and appends one NDJSON row per line to observer.agent_log.json. It also
+// tracks the latest line timestamp and per-pattern match counts.
+type AgentTail struct {
+	inPath   string
+	outPath  string
+	interval time.Duration
+	logger   *slog.Logger
+	tail     *tailer.Tailer
+	now      func() time.Time
+
+	mu          sync.RWMutex
+	lastLineAt  time.Time
+	matchCounts map[string]int
+}
+
+func NewAgent(workingDir string, interval time.Duration, logger *slog.Logger) *AgentTail {
+	inPath := filepath.Join(workingDir, agentInputFilename)
+	return &AgentTail{
+		inPath:      inPath,
+		outPath:     filepath.Join(workingDir, agentOutputFilename),
+		interval:    interval,
+		logger:      logger,
+		tail:        tailer.New(inPath),
+		now:         time.Now,
+		matchCounts: map[string]int{},
+	}
+}
+
+func (a *AgentTail) Run(ctx context.Context) error {
+	ticker := time.NewTicker(a.interval)
+	defer ticker.Stop()
+	defer a.tail.Close()
+	a.tick()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			a.tick()
+		}
+	}
+}
+
+// Snapshot returns a copy of the current tail state. Safe for concurrent
+// use; the abort decider reads from a separate goroutine.
+func (a *AgentTail) Snapshot() AgentSnapshot {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	counts := make(map[string]int, len(a.matchCounts))
+	for k, v := range a.matchCounts {
+		counts[k] = v
+	}
+	return AgentSnapshot{LastLineAt: a.lastLineAt, MatchCounts: counts}
+}
+
+type agentLogRow struct {
+	TNS  int64  `json:"t_ns"`
+	Line string `json:"line"`
+}
+
+func (a *AgentTail) tick() {
+	lines, err := a.tail.Poll()
+	if err != nil {
+		a.logger.Warn("agent log tail failed", "path", a.inPath, "err", err)
+		return
+	}
+	if len(lines) == 0 {
+		return
+	}
+	now := a.now().UTC()
+	tNS := now.UnixNano()
+	f, err := os.OpenFile(a.outPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		a.logger.Warn("agent log append failed", "path", a.outPath, "err", err)
+		return
+	}
+	defer f.Close()
+	a.mu.Lock()
+	for _, line := range lines {
+		row, err := json.Marshal(agentLogRow{TNS: tNS, Line: line})
+		if err != nil {
+			continue
+		}
+		row = append(row, '\n')
+		if _, err := f.Write(row); err != nil {
+			a.logger.Warn("agent log write failed", "path", a.outPath, "err", err)
+			break
+		}
+		for _, p := range agentPatterns {
+			if strings.Contains(line, p.substr) {
+				a.matchCounts[p.name]++
+			}
+		}
+	}
+	a.lastLineAt = now
+	a.mu.Unlock()
+}
+
+var _ collector.Collector = (*AgentTail)(nil)

--- a/tools/stress/device-observer/internal/loggingtail/agent_test.go
+++ b/tools/stress/device-observer/internal/loggingtail/agent_test.go
@@ -1,0 +1,149 @@
+package loggingtail
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+)
+
+func appendLog(t *testing.T, path, s string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(s); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func readAgentRows(t *testing.T, path string) []agentLogRow {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var rows []agentLogRow
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var r agentLogRow
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		rows = append(rows, r)
+	}
+	return rows
+}
+
+// TestAgentMissingFileSnapshotZero: before the orchestrator writes the
+// agent log, Snapshot's LastLineAt remains zero.
+func TestAgentMissingFileSnapshotZero(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAgent(dir, time.Hour, discardLogger())
+	a.tick()
+	if !a.Snapshot().LastLineAt.IsZero() {
+		t.Errorf("LastLineAt should be zero before any line, got %v", a.Snapshot().LastLineAt)
+	}
+}
+
+// TestAgentLineAppend: each new line yields an NDJSON row in the output.
+func TestAgentLineAppend(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAgent(dir, time.Hour, discardLogger())
+	in := filepath.Join(dir, agentInputFilename)
+	appendLog(t, in, "first\nsecond\n")
+	a.tick()
+
+	rows := readAgentRows(t, filepath.Join(dir, agentOutputFilename))
+	if len(rows) != 2 || rows[0].Line != "first" || rows[1].Line != "second" {
+		t.Fatalf("rows = %+v, want [first second]", rows)
+	}
+	if a.Snapshot().LastLineAt.IsZero() {
+		t.Errorf("LastLineAt should be advanced after a line was seen")
+	}
+}
+
+// TestAgentPatternCounts: each substring is matched and counted; lines
+// without any pattern do not bump counters.
+func TestAgentPatternCounts(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAgent(dir, time.Hour, discardLogger())
+	in := filepath.Join(dir, agentInputFilename)
+	body := "INFO: could not get diff foo timed out after 60 seconds\n" +
+		"INFO: Committing config session due to diffs detected: x\n" +
+		"INFO: not overriding lock since its age is less than 5m\n" +
+		"INFO: unrelated noise\n" +
+		"INFO: Committing config session due to diffs detected: y\n"
+	appendLog(t, in, body)
+	a.tick()
+
+	snap := a.Snapshot()
+	if snap.MatchCounts[PatternDiffTimeout] != 1 {
+		t.Errorf("diff_timeout = %d, want 1", snap.MatchCounts[PatternDiffTimeout])
+	}
+	if snap.MatchCounts[PatternLockNotTaken] != 1 {
+		t.Errorf("lock_not_taken = %d, want 1", snap.MatchCounts[PatternLockNotTaken])
+	}
+	if snap.MatchCounts[PatternCommitSession] != 2 {
+		t.Errorf("commit_session = %d, want 2", snap.MatchCounts[PatternCommitSession])
+	}
+}
+
+// TestAgentRotation: a renamed-and-recreated log file is re-tailed from
+// the start, lines from both halves are emitted, and the LastLineAt
+// advances rather than going backward.
+func TestAgentRotation(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAgent(dir, time.Hour, discardLogger())
+	in := filepath.Join(dir, agentInputFilename)
+	appendLog(t, in, "before\n")
+	a.tick()
+	first := a.Snapshot().LastLineAt
+
+	if err := os.Rename(in, in+".1"); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	appendLog(t, in, "after\n")
+	// Ensure clock advances at least 1 ns so we can detect LastLineAt motion.
+	time.Sleep(time.Millisecond)
+	a.tick()
+	second := a.Snapshot().LastLineAt
+
+	rows := readAgentRows(t, filepath.Join(dir, agentOutputFilename))
+	if len(rows) != 2 {
+		t.Fatalf("rows after rotation = %d, want 2", len(rows))
+	}
+	if !second.After(first) {
+		t.Errorf("LastLineAt did not advance: first=%v second=%v", first, second)
+	}
+}
+
+// TestAgentRunCancels: Run returns nil on context cancel.
+func TestAgentRunCancels(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAgent(dir, time.Hour, discardLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s")
+	}
+}
+
+var _ collector.Collector = (*AgentTail)(nil)

--- a/tools/stress/device-observer/internal/loggingtail/eos.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos.go
@@ -21,13 +21,9 @@ import (
 
 const (
 	eosOutputFilename = "observer.eos_logging.json"
-	// Minimum dedupe window so consecutive ticks always overlap, even when
-	// the operator picks a very short --sample-interval.
-	eosMinLookback = 30 * time.Second
+	eosMinLookback    = 30 * time.Second // floor so consecutive ticks always overlap
 )
 
-// eosLogRunner is the subset of *eapi.Client used by EOSPoller; tests
-// substitute a fake.
 type eosLogRunner interface {
 	RunShowText(cmd string) (string, error)
 }
@@ -60,12 +56,7 @@ type EOSPoller struct {
 // NewEOS returns an EOSPoller. lookback is clamped to max(2*interval, 30s)
 // so consecutive ticks overlap and dedupe is effective.
 func NewEOS(client eosLogRunner, workingDir string, interval, lookback time.Duration, logger *slog.Logger) *EOSPoller {
-	if lookback < 2*interval {
-		lookback = 2 * interval
-	}
-	if lookback < eosMinLookback {
-		lookback = eosMinLookback
-	}
+	lookback = max(lookback, 2*interval, eosMinLookback)
 	return &EOSPoller{
 		client:   client,
 		outPath:  filepath.Join(workingDir, eosOutputFilename),
@@ -103,9 +94,6 @@ func (p *EOSPoller) tick() {
 	tNS := p.now().UTC().UnixNano()
 	parsed, scanErr := parseEOSLog(out, tNS)
 	if scanErr != nil {
-		// bufio.ErrTooLong (or a similar scanner error) terminates the
-		// scanner early — surface a WARN so the operator notices silent
-		// truncation rather than blaming the device.
 		p.logger.Warn("eos logging parse truncated", "err", scanErr)
 	}
 	p.mu.Lock()

--- a/tools/stress/device-observer/internal/loggingtail/eos.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos.go
@@ -54,10 +54,10 @@ type EOSPoller struct {
 	prev     map[string]struct{}
 }
 
-// NewEOS returns an EOSPoller. lookback is clamped to max(2*interval, 30s)
-// so consecutive ticks overlap and dedupe is effective.
-func NewEOS(client eosLogRunner, workingDir string, interval, lookback time.Duration, logger *slog.Logger) *EOSPoller {
-	lookback = max(lookback, 2*interval, eosMinLookback)
+// NewEOS returns an EOSPoller. The lookback window is derived from interval
+// as max(2*interval, 30s) so consecutive ticks overlap and dedupe is effective.
+func NewEOS(client eosLogRunner, workingDir string, interval time.Duration, logger *slog.Logger) *EOSPoller {
+	lookback := max(2*interval, eosMinLookback)
 	return &EOSPoller{
 		client:   client,
 		outPath:  filepath.Join(workingDir, eosOutputFilename),

--- a/tools/stress/device-observer/internal/loggingtail/eos.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos.go
@@ -1,13 +1,177 @@
-// Package loggingtail will follow agent and orchestrator logs. Real
-// implementations land in PR #3795.
+// Package loggingtail contains the device-observer's EOS-syslog poller and
+// orchestrator-agent log tailer. Both append one NDJSON row per line to a
+// well-known file in the working directory.
 package loggingtail
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
-	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/eapi"
 )
 
-func NewEOS(client *eapi.Client, workingDir string) collector.Collector {
-	_, _ = client, workingDir
-	return collector.Noop{}
+const (
+	eosOutputFilename = "observer.eos_logging.json"
+	// Minimum dedupe window so consecutive ticks always overlap, even when
+	// the operator picks a very short --sample-interval.
+	eosMinLookback = 30 * time.Second
+)
+
+// eosLogRunner is the subset of *eapi.Client used by EOSPoller; tests
+// substitute a fake.
+type eosLogRunner interface {
+	RunShowText(cmd string) (string, error)
 }
+
+// eosLine is the parsed shape of one syslog row. Severity and facility are
+// empty when the line does not match the default Arista format; the full
+// line still lands in Message so unparseable lines are not silently lost.
+type eosLine struct {
+	TNS      int64  `json:"t_ns"`
+	Time     string `json:"time"`
+	Severity string `json:"severity"`
+	Facility string `json:"facility"`
+	Message  string `json:"message"`
+}
+
+// EOSPoller queries `show logging last <window>` on every tick, dedupes
+// across the rolling window, and appends NDJSON rows to
+// observer.eos_logging.json.
+type EOSPoller struct {
+	client   eosLogRunner
+	outPath  string
+	interval time.Duration
+	lookback time.Duration
+	logger   *slog.Logger
+	now      func() time.Time
+	mu       sync.Mutex
+	prev     map[string]struct{}
+}
+
+// NewEOS returns an EOSPoller. lookback is clamped to max(2*interval, 30s)
+// so consecutive ticks overlap and dedupe is effective.
+func NewEOS(client eosLogRunner, workingDir string, interval, lookback time.Duration, logger *slog.Logger) *EOSPoller {
+	if lookback < 2*interval {
+		lookback = 2 * interval
+	}
+	if lookback < eosMinLookback {
+		lookback = eosMinLookback
+	}
+	return &EOSPoller{
+		client:   client,
+		outPath:  filepath.Join(workingDir, eosOutputFilename),
+		interval: interval,
+		lookback: lookback,
+		logger:   logger,
+		now:      time.Now,
+		prev:     map[string]struct{}{},
+	}
+}
+
+// Run polls immediately and then on every tick of interval, until ctx is
+// canceled. Per-tick failures are logged at WARN and the loop continues.
+func (p *EOSPoller) Run(ctx context.Context) error {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	p.tick()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			p.tick()
+		}
+	}
+}
+
+func (p *EOSPoller) tick() {
+	cmd := fmt.Sprintf("show logging last %d seconds", int(p.lookback.Seconds()))
+	out, err := p.client.RunShowText(cmd)
+	if err != nil {
+		p.logger.Warn("eos logging poll failed", "cmd", cmd, "err", err)
+		return
+	}
+	tNS := p.now().UTC().UnixNano()
+	parsed := parseEOSLog(out, tNS)
+	p.mu.Lock()
+	next := make(map[string]struct{}, len(parsed))
+	var fresh []eosLine
+	for _, line := range parsed {
+		key := line.Time + "|" + line.Message
+		next[key] = struct{}{}
+		if _, seen := p.prev[key]; seen {
+			continue
+		}
+		fresh = append(fresh, line)
+	}
+	p.prev = next
+	p.mu.Unlock()
+	if len(fresh) == 0 {
+		return
+	}
+	if err := appendNDJSON(p.outPath, fresh); err != nil {
+		p.logger.Warn("eos logging append failed", "path", p.outPath, "err", err)
+	}
+}
+
+// Arista's default syslog format is:
+//
+//	MMM dd HH:MM:SS hostname FACILITY-SEV-MNEMONIC: message
+//
+// The capture is intentionally permissive: anything that doesn't match the
+// timestamp+tag prefix still becomes a row with empty severity/facility.
+var eosLineRE = regexp.MustCompile(`^(\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+\S+\s+([A-Za-z0-9_]+)-(\d)-[A-Za-z0-9_]+:\s*(.*)$`)
+
+func parseEOSLog(text string, tNS int64) []eosLine {
+	var out []eosLine
+	sc := bufio.NewScanner(strings.NewReader(text))
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if m := eosLineRE.FindStringSubmatch(line); m != nil {
+			out = append(out, eosLine{
+				TNS:      tNS,
+				Time:     m[1],
+				Facility: m[2],
+				Severity: m[3],
+				Message:  m[4],
+			})
+			continue
+		}
+		out = append(out, eosLine{TNS: tNS, Message: line})
+	}
+	return out
+}
+
+func appendNDJSON(path string, rows []eosLine) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, r := range rows {
+		buf, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		buf = append(buf, '\n')
+		if _, err := f.Write(buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ collector.Collector = (*EOSPoller)(nil)

--- a/tools/stress/device-observer/internal/loggingtail/eos.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos.go
@@ -37,6 +37,7 @@ type eosLine struct {
 	Severity string `json:"severity"`
 	Facility string `json:"facility"`
 	Message  string `json:"message"`
+	raw      string // full source line; used as dedupe key so distinct events at the same second don't collapse
 }
 
 // EOSPoller queries `show logging last <window>` on every tick, dedupes
@@ -100,7 +101,7 @@ func (p *EOSPoller) tick() {
 	next := make(map[string]struct{}, len(parsed))
 	var fresh []eosLine
 	for _, line := range parsed {
-		key := line.Time + "|" + line.Message
+		key := line.raw
 		next[key] = struct{}{}
 		if _, seen := p.prev[key]; seen {
 			continue
@@ -141,10 +142,11 @@ func parseEOSLog(text string, tNS int64) ([]eosLine, error) {
 				Facility: m[2],
 				Severity: m[3],
 				Message:  m[4],
+				raw:      line,
 			})
 			continue
 		}
-		out = append(out, eosLine{TNS: tNS, Message: line})
+		out = append(out, eosLine{TNS: tNS, Message: line, raw: line})
 	}
 	return out, sc.Err()
 }

--- a/tools/stress/device-observer/internal/loggingtail/eos.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos.go
@@ -101,7 +101,13 @@ func (p *EOSPoller) tick() {
 		return
 	}
 	tNS := p.now().UTC().UnixNano()
-	parsed := parseEOSLog(out, tNS)
+	parsed, scanErr := parseEOSLog(out, tNS)
+	if scanErr != nil {
+		// bufio.ErrTooLong (or a similar scanner error) terminates the
+		// scanner early — surface a WARN so the operator notices silent
+		// truncation rather than blaming the device.
+		p.logger.Warn("eos logging parse truncated", "err", scanErr)
+	}
 	p.mu.Lock()
 	next := make(map[string]struct{}, len(parsed))
 	var fresh []eosLine
@@ -131,7 +137,7 @@ func (p *EOSPoller) tick() {
 // timestamp+tag prefix still becomes a row with empty severity/facility.
 var eosLineRE = regexp.MustCompile(`^(\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+\S+\s+([A-Za-z0-9_]+)-(\d)-[A-Za-z0-9_]+:\s*(.*)$`)
 
-func parseEOSLog(text string, tNS int64) []eosLine {
+func parseEOSLog(text string, tNS int64) ([]eosLine, error) {
 	var out []eosLine
 	sc := bufio.NewScanner(strings.NewReader(text))
 	sc.Buffer(make([]byte, 64*1024), 1024*1024)
@@ -152,7 +158,7 @@ func parseEOSLog(text string, tNS int64) []eosLine {
 		}
 		out = append(out, eosLine{TNS: tNS, Message: line})
 	}
-	return out
+	return out, sc.Err()
 }
 
 func appendNDJSON(path string, rows []eosLine) error {

--- a/tools/stress/device-observer/internal/loggingtail/eos_test.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos_test.go
@@ -1,0 +1,213 @@
+package loggingtail
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+)
+
+type fakeEOSRunner struct {
+	resp atomic.Value // string
+	err  atomic.Value // error (nil-safe)
+}
+
+func newFakeEOSRunner(initial string) *fakeEOSRunner {
+	r := &fakeEOSRunner{}
+	r.resp.Store(initial)
+	return r
+}
+
+func (f *fakeEOSRunner) set(s string)   { f.resp.Store(s) }
+func (f *fakeEOSRunner) setErr(e error) { f.err.Store(errorWrap{e}) }
+func (f *fakeEOSRunner) RunShowText(cmd string) (string, error) {
+	if v, ok := f.err.Load().(errorWrap); ok && v.e != nil {
+		return "", v.e
+	}
+	return f.resp.Load().(string), nil
+}
+
+type errorWrap struct{ e error }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func readEOSRows(t *testing.T, path string) []eosLine {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var rows []eosLine
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var r eosLine
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("decode %q: %v", sc.Text(), err)
+		}
+		rows = append(rows, r)
+	}
+	return rows
+}
+
+// TestParseHappyPath verifies the timestamp + facility/severity capture
+// works for default Arista-format syslog lines.
+func TestParseHappyPath(t *testing.T) {
+	const text = `May 29 12:34:56 dz1 BGP-3-NOTIFICATION: bgp event
+May 29 12:34:57 dz1 SYS-6-INFO: hello world
+`
+	rows := parseEOSLog(text, 12345)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].Facility != "BGP" || rows[0].Severity != "3" {
+		t.Errorf("row0 facility/sev = %q/%q, want BGP/3", rows[0].Facility, rows[0].Severity)
+	}
+	if rows[0].Message != "bgp event" {
+		t.Errorf("row0 message = %q, want %q", rows[0].Message, "bgp event")
+	}
+	if rows[1].Facility != "SYS" || rows[1].Severity != "6" {
+		t.Errorf("row1 facility/sev = %q/%q, want SYS/6", rows[1].Facility, rows[1].Severity)
+	}
+}
+
+// TestParseUnparseable: a line not matching the prefix is still emitted
+// with empty severity/facility and the full line in Message.
+func TestParseUnparseable(t *testing.T) {
+	rows := parseEOSLog("this is not syslog\n", 7)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Severity != "" || rows[0].Facility != "" {
+		t.Errorf("unparseable row should have empty severity/facility, got %+v", rows[0])
+	}
+	if rows[0].Message != "this is not syslog" {
+		t.Errorf("message = %q, want full line", rows[0].Message)
+	}
+}
+
+// TestDedupeAcrossTicks: a line seen on two consecutive ticks is written
+// to the output exactly once.
+func TestDedupeAcrossTicks(t *testing.T) {
+	dir := t.TempDir()
+	body := "May 29 12:00:00 dz1 BGP-3-NOTIF: a\nMay 29 12:00:01 dz1 BGP-3-NOTIF: b\n"
+	runner := newFakeEOSRunner(body)
+	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+
+	p.tick()
+	// Same response; overlap window should dedupe.
+	p.tick()
+
+	rows := readEOSRows(t, filepath.Join(dir, eosOutputFilename))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (dedupe failed)", len(rows))
+	}
+}
+
+// TestNewLineAfterDedupe: a new line appearing on the second tick is
+// emitted, the previously-seen lines are not duplicated.
+func TestNewLineAfterDedupe(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: a\n")
+	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p.tick()
+	runner.set("May 29 12:00:00 dz1 BGP-3-NOTIF: a\nMay 29 12:00:01 dz1 BGP-3-NOTIF: b\n")
+	p.tick()
+
+	rows := readEOSRows(t, filepath.Join(dir, eosOutputFilename))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].Message != "a" || rows[1].Message != "b" {
+		t.Errorf("rows = %v, want messages a, b", rows)
+	}
+}
+
+// TestTickErrorContinues: a per-tick eAPI failure logs WARN and does not
+// produce any output, but subsequent successful ticks recover.
+func TestTickErrorContinues(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: a\n")
+	runner.setErr(errors.New("boom"))
+	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+
+	p.tick()
+	if _, err := os.Stat(filepath.Join(dir, eosOutputFilename)); !os.IsNotExist(err) {
+		t.Fatalf("output file should not exist on failure, stat err = %v", err)
+	}
+	runner.setErr(nil)
+	p.tick()
+	rows := readEOSRows(t, filepath.Join(dir, eosOutputFilename))
+	if len(rows) != 1 || rows[0].Message != "a" {
+		t.Errorf("rows = %v, want [a]", rows)
+	}
+}
+
+// TestLookbackFloor: a short interval is bumped up to the 30 s floor so
+// short --sample-interval runs still have overlap.
+func TestLookbackFloor(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeEOSRunner("")
+	p := NewEOS(runner, dir, time.Second, 2*time.Second, discardLogger())
+	if p.lookback < 30*time.Second {
+		t.Fatalf("lookback = %v, want >= 30s", p.lookback)
+	}
+}
+
+// TestRunCancelsCleanly confirms Run returns nil promptly on ctx cancel.
+func TestRunCancelsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeEOSRunner("")
+	p := NewEOS(runner, dir, time.Hour, 30*time.Second, discardLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s")
+	}
+}
+
+// TestNDJSONShape: each row decodes as JSON with the expected fields.
+func TestNDJSONShape(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: hello\n")
+	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p.tick()
+
+	body, err := os.ReadFile(filepath.Join(dir, eosOutputFilename))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	line := strings.TrimRight(string(body), "\n")
+	var row map[string]any
+	if err := json.Unmarshal([]byte(line), &row); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, field := range []string{"t_ns", "time", "severity", "facility", "message"} {
+		if _, ok := row[field]; !ok {
+			t.Errorf("missing field %q in %v", field, row)
+		}
+	}
+}
+
+var _ collector.Collector = (*EOSPoller)(nil)

--- a/tools/stress/device-observer/internal/loggingtail/eos_test.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos_test.go
@@ -68,7 +68,7 @@ func TestParseHappyPath(t *testing.T) {
 	const text = `May 29 12:34:56 dz1 BGP-3-NOTIFICATION: bgp event
 May 29 12:34:57 dz1 SYS-6-INFO: hello world
 `
-	rows := parseEOSLog(text, 12345)
+	rows, _ := parseEOSLog(text, 12345)
 	if len(rows) != 2 {
 		t.Fatalf("rows = %d, want 2", len(rows))
 	}
@@ -86,7 +86,7 @@ May 29 12:34:57 dz1 SYS-6-INFO: hello world
 // TestParseUnparseable: a line not matching the prefix is still emitted
 // with empty severity/facility and the full line in Message.
 func TestParseUnparseable(t *testing.T) {
-	rows := parseEOSLog("this is not syslog\n", 7)
+	rows, _ := parseEOSLog("this is not syslog\n", 7)
 	if len(rows) != 1 {
 		t.Fatalf("rows = %d, want 1", len(rows))
 	}

--- a/tools/stress/device-observer/internal/loggingtail/eos_test.go
+++ b/tools/stress/device-observer/internal/loggingtail/eos_test.go
@@ -104,7 +104,7 @@ func TestDedupeAcrossTicks(t *testing.T) {
 	dir := t.TempDir()
 	body := "May 29 12:00:00 dz1 BGP-3-NOTIF: a\nMay 29 12:00:01 dz1 BGP-3-NOTIF: b\n"
 	runner := newFakeEOSRunner(body)
-	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Second, discardLogger())
 
 	p.tick()
 	// Same response; overlap window should dedupe.
@@ -121,7 +121,7 @@ func TestDedupeAcrossTicks(t *testing.T) {
 func TestNewLineAfterDedupe(t *testing.T) {
 	dir := t.TempDir()
 	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: a\n")
-	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Second, discardLogger())
 	p.tick()
 	runner.set("May 29 12:00:00 dz1 BGP-3-NOTIF: a\nMay 29 12:00:01 dz1 BGP-3-NOTIF: b\n")
 	p.tick()
@@ -141,7 +141,7 @@ func TestTickErrorContinues(t *testing.T) {
 	dir := t.TempDir()
 	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: a\n")
 	runner.setErr(errors.New("boom"))
-	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Second, discardLogger())
 
 	p.tick()
 	if _, err := os.Stat(filepath.Join(dir, eosOutputFilename)); !os.IsNotExist(err) {
@@ -160,7 +160,7 @@ func TestTickErrorContinues(t *testing.T) {
 func TestLookbackFloor(t *testing.T) {
 	dir := t.TempDir()
 	runner := newFakeEOSRunner("")
-	p := NewEOS(runner, dir, time.Second, 2*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Second, discardLogger())
 	if p.lookback < 30*time.Second {
 		t.Fatalf("lookback = %v, want >= 30s", p.lookback)
 	}
@@ -170,7 +170,7 @@ func TestLookbackFloor(t *testing.T) {
 func TestRunCancelsCleanly(t *testing.T) {
 	dir := t.TempDir()
 	runner := newFakeEOSRunner("")
-	p := NewEOS(runner, dir, time.Hour, 30*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Hour, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -191,7 +191,7 @@ func TestRunCancelsCleanly(t *testing.T) {
 func TestNDJSONShape(t *testing.T) {
 	dir := t.TempDir()
 	runner := newFakeEOSRunner("May 29 12:00:00 dz1 BGP-3-NOTIF: hello\n")
-	p := NewEOS(runner, dir, time.Second, 30*time.Second, discardLogger())
+	p := NewEOS(runner, dir, time.Second, discardLogger())
 	p.tick()
 
 	body, err := os.ReadFile(filepath.Join(dir, eosOutputFilename))

--- a/tools/stress/device-observer/internal/runlog/reader.go
+++ b/tools/stress/device-observer/internal/runlog/reader.go
@@ -1,6 +1,6 @@
 // Package runlog reads the orchestrator's runlog (orchestrator-runlog.jsonl)
 // via tailer.Tailer and maintains bounded rings of provision and deprovision
-// durations for the abort decider (PR #3796).
+// durations for the abort decider.
 package runlog
 
 import (
@@ -18,17 +18,12 @@ import (
 
 const (
 	inputFilename = "orchestrator-runlog.jsonl"
-	// ringCapacity bounds memory for a very long sweep. 1024 covers ~10x the
-	// expected ~100-user sweep with headroom for retries.
-	ringCapacity = 1024
-	// maxPending caps each pending-submit map. A misbehaving orchestrator
-	// that emits submits without matching activates would otherwise grow
-	// these maps until OOM. On overflow we evict the oldest entry.
-	maxPending = 4096
+	ringCapacity  = 1024 // bounded duration ring; ~10x a typical sweep
+	maxPending    = 4096 // cap per pending-submit map; evicts oldest on overflow
 )
 
-// Row mirrors the orchestrator's runlog schema. We re-declare it here so
-// the observer does not take a build-time dep on tools/stress/device-orchestrator.
+// Row mirrors the orchestrator's runlog schema (redeclared to avoid a
+// build-time dep on tools/stress/device-orchestrator).
 type Row struct {
 	UserIndex int    `json:"user_index"`
 	Event     string `json:"event"`
@@ -125,11 +120,8 @@ func (r *Reader) tick() {
 	}
 }
 
-// insertPending caps the pending map at maxPending entries. On overflow it
-// evicts the oldest entry by scanning the map (O(maxPending) per overflow,
-// which is acceptable since the map is bounded). Without this cap a
-// misbehaving orchestrator that never emits matching activates would grow
-// the map until OOM.
+// insertPending caps the pending map at maxPending entries, evicting the
+// oldest on overflow.
 func insertPending(m map[int]time.Time, userIndex int, at time.Time) {
 	if _, exists := m[userIndex]; !exists && len(m) >= maxPending {
 		var oldestKey int
@@ -146,8 +138,6 @@ func insertPending(m map[int]time.Time, userIndex int, at time.Time) {
 	m[userIndex] = at
 }
 
-// truncateForLog bounds a log field so a flood of large malformed lines
-// cannot balloon the observer's own log.
 func truncateForLog(s string) string {
 	const max = 256
 	if len(s) <= max {
@@ -160,7 +150,6 @@ func pushRing(ring []durationSample, s durationSample) []durationSample {
 	if len(ring) < ringCapacity {
 		return append(ring, s)
 	}
-	// Drop the oldest by copying the tail forward in place.
 	copy(ring, ring[1:])
 	ring[len(ring)-1] = s
 	return ring

--- a/tools/stress/device-observer/internal/runlog/reader.go
+++ b/tools/stress/device-observer/internal/runlog/reader.go
@@ -1,10 +1,167 @@
-// Package runlog will tail the orchestrator-written run log. Real
-// implementation lands in PR #3795.
+// Package runlog reads the orchestrator's runlog (orchestrator-runlog.jsonl)
+// via tailer.Tailer and maintains bounded rings of provision and deprovision
+// durations for the abort decider (PR #3796).
 package runlog
 
-import "github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
 
-func New(workingDir string) collector.Collector {
-	_ = workingDir
-	return collector.Noop{}
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/tailer"
+)
+
+const (
+	inputFilename = "orchestrator-runlog.jsonl"
+	// ringCapacity bounds memory for a very long sweep. 1024 covers ~10x the
+	// expected ~100-user sweep with headroom for retries.
+	ringCapacity = 1024
+)
+
+// Row mirrors the orchestrator's runlog schema. We re-declare it here so
+// the observer does not take a build-time dep on tools/stress/device-orchestrator.
+type Row struct {
+	UserIndex int    `json:"user_index"`
+	Event     string `json:"event"`
+	TNs       int64  `json:"t_ns"`
 }
+
+// Reader tails the orchestrator runlog and exposes pair-completion duration
+// rings for the provision (submit → activate) and deprovision flows.
+type Reader struct {
+	inPath   string
+	interval time.Duration
+	logger   *slog.Logger
+	tail     *tailer.Tailer
+
+	mu                  sync.RWMutex
+	pendingSubmit       map[int]time.Time
+	pendingDeprovSubmit map[int]time.Time
+	provisionRing       []durationSample
+	deprovisionRing     []durationSample
+}
+
+type durationSample struct {
+	at  time.Time
+	dur time.Duration
+}
+
+func New(workingDir string, interval time.Duration, logger *slog.Logger) *Reader {
+	inPath := filepath.Join(workingDir, inputFilename)
+	return &Reader{
+		inPath:              inPath,
+		interval:            interval,
+		logger:              logger,
+		tail:                tailer.New(inPath),
+		pendingSubmit:       map[int]time.Time{},
+		pendingDeprovSubmit: map[int]time.Time{},
+	}
+}
+
+func (r *Reader) Run(ctx context.Context) error {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	defer r.tail.Close()
+	r.tick()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r.tick()
+		}
+	}
+}
+
+func (r *Reader) tick() {
+	lines, err := r.tail.Poll()
+	if err != nil {
+		r.logger.Warn("runlog tail failed", "path", r.inPath, "err", err)
+		return
+	}
+	if len(lines) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, line := range lines {
+		var row Row
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			r.logger.Warn("runlog decode failed", "line", line, "err", err)
+			continue
+		}
+		at := time.Unix(0, row.TNs)
+		switch row.Event {
+		case "submit":
+			r.pendingSubmit[row.UserIndex] = at
+		case "activate":
+			if start, ok := r.pendingSubmit[row.UserIndex]; ok {
+				delete(r.pendingSubmit, row.UserIndex)
+				r.provisionRing = pushRing(r.provisionRing, durationSample{at: at, dur: at.Sub(start)})
+			}
+		case "deprovision_submit":
+			r.pendingDeprovSubmit[row.UserIndex] = at
+		case "deprovision_activate":
+			if start, ok := r.pendingDeprovSubmit[row.UserIndex]; ok {
+				delete(r.pendingDeprovSubmit, row.UserIndex)
+				r.deprovisionRing = pushRing(r.deprovisionRing, durationSample{at: at, dur: at.Sub(start)})
+			}
+		}
+	}
+}
+
+func pushRing(ring []durationSample, s durationSample) []durationSample {
+	if len(ring) < ringCapacity {
+		return append(ring, s)
+	}
+	// Drop the oldest by copying the tail forward in place.
+	copy(ring, ring[1:])
+	ring[len(ring)-1] = s
+	return ring
+}
+
+// ProvisionDurations returns the durations of submit→activate pairs whose
+// activate timestamp lies within window of the current wall clock. Returns
+// an empty slice if no completions are in the window.
+func (r *Reader) ProvisionDurations(window time.Duration) []time.Duration {
+	return r.filterDurations(r.provisionRingSnapshot(), window)
+}
+
+// DeprovisionDurations is ProvisionDurations for the deprovision pair.
+func (r *Reader) DeprovisionDurations(window time.Duration) []time.Duration {
+	return r.filterDurations(r.deprovisionRingSnapshot(), window)
+}
+
+func (r *Reader) provisionRingSnapshot() []durationSample {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]durationSample, len(r.provisionRing))
+	copy(out, r.provisionRing)
+	return out
+}
+
+func (r *Reader) deprovisionRingSnapshot() []durationSample {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]durationSample, len(r.deprovisionRing))
+	copy(out, r.deprovisionRing)
+	return out
+}
+
+func (r *Reader) filterDurations(ring []durationSample, window time.Duration) []time.Duration {
+	cutoff := time.Now().Add(-window)
+	out := make([]time.Duration, 0, len(ring))
+	for _, s := range ring {
+		if s.at.Before(cutoff) {
+			continue
+		}
+		out = append(out, s.dur)
+	}
+	return out
+}
+
+var _ collector.Collector = (*Reader)(nil)

--- a/tools/stress/device-observer/internal/runlog/reader.go
+++ b/tools/stress/device-observer/internal/runlog/reader.go
@@ -6,6 +6,7 @@ package runlog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"path/filepath"
 	"sync"
@@ -20,6 +21,10 @@ const (
 	// ringCapacity bounds memory for a very long sweep. 1024 covers ~10x the
 	// expected ~100-user sweep with headroom for retries.
 	ringCapacity = 1024
+	// maxPending caps each pending-submit map. A misbehaving orchestrator
+	// that emits submits without matching activates would otherwise grow
+	// these maps until OOM. On overflow we evict the oldest entry.
+	maxPending = 4096
 )
 
 // Row mirrors the orchestrator's runlog schema. We re-declare it here so
@@ -80,8 +85,12 @@ func (r *Reader) Run(ctx context.Context) error {
 func (r *Reader) tick() {
 	lines, err := r.tail.Poll()
 	if err != nil {
+		// ErrOversizeLine is non-fatal: any complete lines surfaced before
+		// the overflow are still valid runlog rows.
 		r.logger.Warn("runlog tail failed", "path", r.inPath, "err", err)
-		return
+		if !errors.Is(err, tailer.ErrOversizeLine) {
+			return
+		}
 	}
 	if len(lines) == 0 {
 		return
@@ -91,20 +100,22 @@ func (r *Reader) tick() {
 	for _, line := range lines {
 		var row Row
 		if err := json.Unmarshal([]byte(line), &row); err != nil {
-			r.logger.Warn("runlog decode failed", "line", line, "err", err)
+			// Truncate the logged line so a flood of malformed rows cannot
+			// inflate the observer's own log without bound.
+			r.logger.Warn("runlog decode failed", "line", truncateForLog(line), "err", err)
 			continue
 		}
 		at := time.Unix(0, row.TNs)
 		switch row.Event {
 		case "submit":
-			r.pendingSubmit[row.UserIndex] = at
+			insertPending(r.pendingSubmit, row.UserIndex, at)
 		case "activate":
 			if start, ok := r.pendingSubmit[row.UserIndex]; ok {
 				delete(r.pendingSubmit, row.UserIndex)
 				r.provisionRing = pushRing(r.provisionRing, durationSample{at: at, dur: at.Sub(start)})
 			}
 		case "deprovision_submit":
-			r.pendingDeprovSubmit[row.UserIndex] = at
+			insertPending(r.pendingDeprovSubmit, row.UserIndex, at)
 		case "deprovision_activate":
 			if start, ok := r.pendingDeprovSubmit[row.UserIndex]; ok {
 				delete(r.pendingDeprovSubmit, row.UserIndex)
@@ -112,6 +123,37 @@ func (r *Reader) tick() {
 			}
 		}
 	}
+}
+
+// insertPending caps the pending map at maxPending entries. On overflow it
+// evicts the oldest entry by scanning the map (O(maxPending) per overflow,
+// which is acceptable since the map is bounded). Without this cap a
+// misbehaving orchestrator that never emits matching activates would grow
+// the map until OOM.
+func insertPending(m map[int]time.Time, userIndex int, at time.Time) {
+	if _, exists := m[userIndex]; !exists && len(m) >= maxPending {
+		var oldestKey int
+		var oldestAt time.Time
+		first := true
+		for k, v := range m {
+			if first || v.Before(oldestAt) {
+				oldestKey, oldestAt = k, v
+				first = false
+			}
+		}
+		delete(m, oldestKey)
+	}
+	m[userIndex] = at
+}
+
+// truncateForLog bounds a log field so a flood of large malformed lines
+// cannot balloon the observer's own log.
+func truncateForLog(s string) string {
+	const max = 256
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
 }
 
 func pushRing(ring []durationSample, s durationSample) []durationSample {

--- a/tools/stress/device-observer/internal/runlog/reader_test.go
+++ b/tools/stress/device-observer/internal/runlog/reader_test.go
@@ -136,6 +136,31 @@ func TestRingEviction(t *testing.T) {
 	}
 }
 
+// TestPendingMapBounded: inserting more than maxPending entries evicts
+// the oldest by submit time so the map never grows past the cap.
+func TestPendingMapBounded(t *testing.T) {
+	m := map[int]time.Time{}
+	base := time.Unix(0, 0)
+	for i := 0; i < maxPending+10; i++ {
+		insertPending(m, i, base.Add(time.Duration(i)*time.Second))
+	}
+	if len(m) != maxPending {
+		t.Fatalf("len(map) = %d, want %d", len(m), maxPending)
+	}
+	// The first 10 keys should have been evicted (oldest by time).
+	for i := 0; i < 10; i++ {
+		if _, ok := m[i]; ok {
+			t.Errorf("key %d should have been evicted", i)
+		}
+	}
+	// The newest keys should still be present.
+	for i := maxPending; i < maxPending+10; i++ {
+		if _, ok := m[i]; !ok {
+			t.Errorf("key %d should be present", i)
+		}
+	}
+}
+
 // TestLateRunlogFile: the runlog file appearing after the first tick is
 // picked up on the next poll without error.
 func TestLateRunlogFile(t *testing.T) {

--- a/tools/stress/device-observer/internal/runlog/reader_test.go
+++ b/tools/stress/device-observer/internal/runlog/reader_test.go
@@ -1,0 +1,176 @@
+package runlog
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-observer/internal/collector"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func appendRow(t *testing.T, path string, row map[string]any) {
+	t.Helper()
+	buf, err := json.Marshal(row)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	buf = append(buf, '\n')
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(buf); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestProvisionPair: submit followed by activate for the same user yields
+// one provision duration and zero deprovision durations.
+func TestProvisionPair(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	path := filepath.Join(dir, inputFilename)
+	base := time.Now().UnixNano()
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "submit", "t_ns": base})
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "activate", "t_ns": base + int64(2*time.Second)})
+
+	r.tick()
+
+	got := r.ProvisionDurations(time.Hour)
+	if len(got) != 1 || got[0] != 2*time.Second {
+		t.Fatalf("provision durations = %v, want [2s]", got)
+	}
+	if len(r.DeprovisionDurations(time.Hour)) != 0 {
+		t.Errorf("deprovision durations should be empty, got %v", r.DeprovisionDurations(time.Hour))
+	}
+}
+
+// TestDeprovisionPair: deprovision_submit followed by deprovision_activate
+// yields one deprovision duration.
+func TestDeprovisionPair(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	path := filepath.Join(dir, inputFilename)
+	base := time.Now().UnixNano()
+	appendRow(t, path, map[string]any{"user_index": 7, "event": "deprovision_submit", "t_ns": base})
+	appendRow(t, path, map[string]any{"user_index": 7, "event": "deprovision_activate", "t_ns": base + int64(time.Second)})
+
+	r.tick()
+
+	got := r.DeprovisionDurations(time.Hour)
+	if len(got) != 1 || got[0] != time.Second {
+		t.Fatalf("deprovision durations = %v, want [1s]", got)
+	}
+}
+
+// TestOrphanSubmit: an activate without a prior submit (or a submit
+// without a matching activate) does not produce a duration.
+func TestOrphanSubmit(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	path := filepath.Join(dir, inputFilename)
+	base := time.Now().UnixNano()
+	// Activate with no submit.
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "activate", "t_ns": base})
+	// Submit with no matching activate.
+	appendRow(t, path, map[string]any{"user_index": 2, "event": "submit", "t_ns": base})
+
+	r.tick()
+
+	if len(r.ProvisionDurations(time.Hour)) != 0 {
+		t.Errorf("orphan should not produce durations, got %v", r.ProvisionDurations(time.Hour))
+	}
+}
+
+// TestWindowFilter: completions older than the requested window are
+// excluded from the returned slice.
+func TestWindowFilter(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	path := filepath.Join(dir, inputFilename)
+
+	// Old completion: 1 hour ago.
+	oldStart := time.Now().Add(-time.Hour - time.Second).UnixNano()
+	oldEnd := time.Now().Add(-time.Hour).UnixNano()
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "submit", "t_ns": oldStart})
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "activate", "t_ns": oldEnd})
+
+	// Recent completion: ~now.
+	now := time.Now().UnixNano()
+	appendRow(t, path, map[string]any{"user_index": 2, "event": "submit", "t_ns": now - int64(500*time.Millisecond)})
+	appendRow(t, path, map[string]any{"user_index": 2, "event": "activate", "t_ns": now})
+
+	r.tick()
+
+	got := r.ProvisionDurations(10 * time.Minute)
+	if len(got) != 1 {
+		t.Fatalf("window filter got %d durations, want 1 (recent only)", len(got))
+	}
+}
+
+// TestRingEviction: pushing more than ringCapacity samples evicts the
+// oldest. Inspect the ring directly to avoid coupling to clock-window
+// behavior.
+func TestRingEviction(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	for i := 0; i < ringCapacity+5; i++ {
+		r.provisionRing = pushRing(r.provisionRing, durationSample{at: time.Now(), dur: time.Duration(i)})
+	}
+	if len(r.provisionRing) != ringCapacity {
+		t.Fatalf("ring len = %d, want %d", len(r.provisionRing), ringCapacity)
+	}
+	// First sample should now be the 6th original (index 5) due to eviction.
+	if r.provisionRing[0].dur != time.Duration(5) {
+		t.Errorf("oldest after eviction = %v, want 5", r.provisionRing[0].dur)
+	}
+}
+
+// TestLateRunlogFile: the runlog file appearing after the first tick is
+// picked up on the next poll without error.
+func TestLateRunlogFile(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+	r.tick() // file absent; should be a no-op
+	path := filepath.Join(dir, inputFilename)
+	base := time.Now().UnixNano()
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "submit", "t_ns": base})
+	appendRow(t, path, map[string]any{"user_index": 1, "event": "activate", "t_ns": base + int64(time.Second)})
+	r.tick()
+
+	if len(r.ProvisionDurations(time.Hour)) != 1 {
+		t.Errorf("late file: expected 1 duration, got %d", len(r.ProvisionDurations(time.Hour)))
+	}
+}
+
+// TestRunCancels: Run returns nil on context cancel.
+func TestRunCancels(t *testing.T) {
+	dir := t.TempDir()
+	r := New(dir, time.Hour, discardLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s")
+	}
+}
+
+var _ collector.Collector = (*Reader)(nil)

--- a/tools/stress/device-observer/internal/tailer/tailer.go
+++ b/tools/stress/device-observer/internal/tailer/tailer.go
@@ -15,10 +15,23 @@ import (
 	"syscall"
 )
 
-// readChunkSize is the size of the per-Poll read buffer. The agent log and
-// runlog are short-line files; 32 KiB amortizes syscalls without holding
-// excess memory.
-const readChunkSize = 32 * 1024
+const (
+	// readChunkSize is the size of the per-Poll read buffer. The agent log
+	// and runlog are short-line files; 32 KiB amortizes syscalls without
+	// holding excess memory.
+	readChunkSize = 32 * 1024
+
+	// maxPartialBytes bounds the in-memory buffer for an unterminated line.
+	// A misbehaving writer that never emits '\n' would otherwise grow the
+	// buffer until the process OOMs. On overflow the partial is dropped
+	// with a WARN-equivalent signal (oversize-line error from Poll).
+	maxPartialBytes = 1 << 20
+)
+
+// ErrOversizeLine is returned from Poll when an unterminated line exceeds
+// maxPartialBytes. The tailer drops the in-progress fragment and continues
+// from the next byte read.
+var ErrOversizeLine = errors.New("tailer: oversize line dropped")
 
 // Tailer reads newly-appended complete lines from a file across multiple
 // Poll calls. It is not safe for concurrent use; callers own the polling
@@ -72,31 +85,48 @@ func (t *Tailer) Poll() ([]string, error) {
 	}
 	buf := make([]byte, readChunkSize)
 	var lines []string
+	oversize := false
 	for {
 		n, err := t.f.Read(buf)
 		if n > 0 {
 			t.offset += int64(n)
 			t.partial = append(t.partial, buf[:n]...)
+			// Extract any complete lines before checking the overflow
+			// cap: a long file with normal-length lines and a trailing
+			// fragment shorter than the cap must still surface every
+			// complete line.
+			for {
+				idx := bytes.IndexByte(t.partial, '\n')
+				if idx < 0 {
+					break
+				}
+				lines = append(lines, string(t.partial[:idx]))
+				t.partial = t.partial[idx+1:]
+			}
+			if len(t.partial) > maxPartialBytes {
+				// No newline within the cap; the in-progress fragment is
+				// pathological. Drop it so memory stays bounded.
+				t.partial = t.partial[:0]
+				oversize = true
+			}
 		}
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
+			if oversize {
+				return lines, ErrOversizeLine
+			}
 			return lines, err
 		}
-	}
-	for {
-		idx := bytes.IndexByte(t.partial, '\n')
-		if idx < 0 {
-			break
-		}
-		lines = append(lines, string(t.partial[:idx]))
-		t.partial = t.partial[idx+1:]
 	}
 	// Re-compact partial so the underlying capacity does not grow without
 	// bound across many polls on a steadily-appended file.
 	if cap(t.partial) > 4*readChunkSize {
 		t.partial = append([]byte(nil), t.partial...)
+	}
+	if oversize {
+		return lines, ErrOversizeLine
 	}
 	return lines, nil
 }

--- a/tools/stress/device-observer/internal/tailer/tailer.go
+++ b/tools/stress/device-observer/internal/tailer/tailer.go
@@ -1,0 +1,133 @@
+// Package tailer is a poll-based file tailer for the device-observer log
+// consumers. It tracks open file + offset + inode, detects rotation
+// (inode change) and truncation (size shrink), and buffers partial
+// trailing data (no newline) until a subsequent Poll completes the line.
+//
+// Linux-only: rotation detection uses syscall.Stat_t.Ino, which matches the
+// rest of the device-observer's Linux-only assumptions.
+package tailer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"syscall"
+)
+
+// readChunkSize is the size of the per-Poll read buffer. The agent log and
+// runlog are short-line files; 32 KiB amortizes syscalls without holding
+// excess memory.
+const readChunkSize = 32 * 1024
+
+// Tailer reads newly-appended complete lines from a file across multiple
+// Poll calls. It is not safe for concurrent use; callers own the polling
+// goroutine.
+type Tailer struct {
+	path    string
+	f       *os.File
+	inode   uint64
+	offset  int64
+	partial []byte
+}
+
+// New returns a Tailer for path. The file is not opened until the first
+// Poll; a missing file is not an error.
+func New(path string) *Tailer { return &Tailer{path: path} }
+
+// Poll returns newly completed lines (without trailing '\n') since the
+// previous call. Returns nil, nil before the file exists. On rotation
+// (inode change) or truncation (size shrink) the tailer reopens from
+// offset zero and the held partial fragment is discarded.
+func (t *Tailer) Poll() ([]string, error) {
+	if t.f == nil {
+		if err := t.open(); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	}
+	info, err := os.Stat(t.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, errors.New("tailer: cannot extract inode")
+	}
+	if sys.Ino != t.inode || info.Size() < t.offset {
+		_ = t.f.Close()
+		t.f = nil
+		t.partial = nil
+		if err := t.open(); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	}
+	buf := make([]byte, readChunkSize)
+	var lines []string
+	for {
+		n, err := t.f.Read(buf)
+		if n > 0 {
+			t.offset += int64(n)
+			t.partial = append(t.partial, buf[:n]...)
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return lines, err
+		}
+	}
+	for {
+		idx := bytes.IndexByte(t.partial, '\n')
+		if idx < 0 {
+			break
+		}
+		lines = append(lines, string(t.partial[:idx]))
+		t.partial = t.partial[idx+1:]
+	}
+	// Re-compact partial so the underlying capacity does not grow without
+	// bound across many polls on a steadily-appended file.
+	if cap(t.partial) > 4*readChunkSize {
+		t.partial = append([]byte(nil), t.partial...)
+	}
+	return lines, nil
+}
+
+func (t *Tailer) open() error {
+	f, err := os.Open(t.path)
+	if err != nil {
+		return err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		_ = f.Close()
+		return errors.New("tailer: cannot extract inode")
+	}
+	t.f = f
+	t.inode = sys.Ino
+	t.offset = 0
+	return nil
+}
+
+// Close releases the underlying file handle. Safe to call multiple times.
+func (t *Tailer) Close() error {
+	if t.f == nil {
+		return nil
+	}
+	err := t.f.Close()
+	t.f = nil
+	return err
+}

--- a/tools/stress/device-observer/internal/tailer/tailer.go
+++ b/tools/stress/device-observer/internal/tailer/tailer.go
@@ -16,21 +16,12 @@ import (
 )
 
 const (
-	// readChunkSize is the size of the per-Poll read buffer. The agent log
-	// and runlog are short-line files; 32 KiB amortizes syscalls without
-	// holding excess memory.
-	readChunkSize = 32 * 1024
-
-	// maxPartialBytes bounds the in-memory buffer for an unterminated line.
-	// A misbehaving writer that never emits '\n' would otherwise grow the
-	// buffer until the process OOMs. On overflow the partial is dropped
-	// with a WARN-equivalent signal (oversize-line error from Poll).
-	maxPartialBytes = 1 << 20
+	readChunkSize   = 32 * 1024
+	maxPartialBytes = 1 << 20 // cap on unterminated-line buffer; prevents OOM
 )
 
-// ErrOversizeLine is returned from Poll when an unterminated line exceeds
-// maxPartialBytes. The tailer drops the in-progress fragment and continues
-// from the next byte read.
+// ErrOversizeLine is returned (alongside any complete lines) when an
+// unterminated fragment exceeds maxPartialBytes. The fragment is dropped.
 var ErrOversizeLine = errors.New("tailer: oversize line dropped")
 
 // Tailer reads newly-appended complete lines from a file across multiple
@@ -152,7 +143,6 @@ func (t *Tailer) open() error {
 	return nil
 }
 
-// Close releases the underlying file handle. Safe to call multiple times.
 func (t *Tailer) Close() error {
 	if t.f == nil {
 		return nil

--- a/tools/stress/device-observer/internal/tailer/tailer_test.go
+++ b/tools/stress/device-observer/internal/tailer/tailer_test.go
@@ -1,6 +1,7 @@
 package tailer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -138,6 +139,32 @@ func TestPollRotation(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != "fresh" {
 		t.Fatalf("Poll 2 = %v, want [fresh]", got)
+	}
+}
+
+// TestPollOversizeLine: an unterminated line larger than maxPartialBytes
+// is dropped and ErrOversizeLine is returned, but any complete lines that
+// preceded it are still returned to the caller.
+func TestPollOversizeLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	// One complete line followed by a single oversize fragment (>1 MiB,
+	// no newline).
+	huge := make([]byte, maxPartialBytes+1024)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	if err := os.WriteFile(path, append([]byte("good\n"), huge...), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tl := New(path)
+	defer tl.Close()
+	got, err := tl.Poll()
+	if !errors.Is(err, ErrOversizeLine) {
+		t.Fatalf("Poll err = %v, want ErrOversizeLine", err)
+	}
+	if len(got) != 1 || got[0] != "good" {
+		t.Fatalf("Poll = %v, want [good]", got)
 	}
 }
 

--- a/tools/stress/device-observer/internal/tailer/tailer_test.go
+++ b/tools/stress/device-observer/internal/tailer/tailer_test.go
@@ -1,0 +1,161 @@
+package tailer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helper to append a string to a file.
+func appendStr(t *testing.T, path, s string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open append: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(s); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestPollMissingFile covers the pre-existence case: Poll returns nil
+// without error when the file does not exist yet.
+func TestPollMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	tl := New(filepath.Join(dir, "absent.log"))
+	defer tl.Close()
+	lines, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll missing: %v", err)
+	}
+	if lines != nil {
+		t.Fatalf("Poll missing returned %v, want nil", lines)
+	}
+}
+
+// TestPollAppend covers the basic happy path: open, return complete lines,
+// then resume from the offset on the next Poll.
+func TestPollAppend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	if err := os.WriteFile(path, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tl := New(path)
+	defer tl.Close()
+	got, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("Poll = %v, want [a b]", got)
+	}
+	appendStr(t, path, "c\nd\n")
+	got, err = tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
+		t.Fatalf("Poll 2 = %v, want [c d]", got)
+	}
+}
+
+// TestPollPartialLine: data without trailing '\n' is buffered until the
+// terminator arrives.
+func TestPollPartialLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	appendStr(t, path, "abc")
+	tl := New(path)
+	defer tl.Close()
+	got, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Poll partial = %v, want nil", got)
+	}
+	appendStr(t, path, "def\n")
+	got, err = tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	if len(got) != 1 || got[0] != "abcdef" {
+		t.Fatalf("Poll 2 = %v, want [abcdef]", got)
+	}
+}
+
+// TestPollTruncate: shrinking the file size between polls forces a reopen
+// from offset zero and the partial buffer is dropped.
+func TestPollTruncate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	if err := os.WriteFile(path, []byte("longer-old\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tl := New(path)
+	defer tl.Close()
+	if _, err := tl.Poll(); err != nil {
+		t.Fatalf("Poll 1: %v", err)
+	}
+	// Write a strictly shorter body so size < offset triggers reopen.
+	if err := os.WriteFile(path, []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	got, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	if len(got) != 1 || got[0] != "new" {
+		t.Fatalf("Poll 2 = %v, want [new]", got)
+	}
+}
+
+// TestPollRotation: renaming the file and creating a new one with the
+// same path is detected via inode change and the new file is read from
+// the start.
+func TestPollRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tl := New(path)
+	defer tl.Close()
+	if _, err := tl.Poll(); err != nil {
+		t.Fatalf("Poll 1: %v", err)
+	}
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("fresh\n"), 0o644); err != nil {
+		t.Fatalf("recreate: %v", err)
+	}
+	got, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	if len(got) != 1 || got[0] != "fresh" {
+		t.Fatalf("Poll 2 = %v, want [fresh]", got)
+	}
+}
+
+// TestPollEOFMidLine: partial data plus a complete line in the same
+// poll must surface only the complete one.
+func TestPollEOFMidLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tail.log")
+	if err := os.WriteFile(path, []byte("done\npart"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tl := New(path)
+	defer tl.Close()
+	got, err := tl.Poll()
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(got) != 1 || got[0] != "done" {
+		t.Fatalf("Poll = %v, want [done]", got)
+	}
+}


### PR DESCRIPTION
## Summary

* Add `internal/tailer`, a shared poll-based file tailer with inode-based rotation detection, size-based truncation detection, partial-line buffering, and a 1 MiB oversize-line cap
* Add `internal/loggingtail/eos.go`: `EOSPoller` polls `show logging last <N> seconds` over eAPI each tick, parses Arista syslog lines, deduplicates across the rolling overlap window using the full raw line as key, and appends NDJSON rows to `observer.eos_logging.json`
* Add `internal/loggingtail/agent.go`: `AgentTail` tails `orchestrator.agent.log`, appends NDJSON to `observer.agent_log.json`, and exposes `Snapshot()` with `LastLineAt` and per-pattern match counts for the abort decider
* Add `internal/runlog/reader.go`: `Reader` tails `orchestrator-runlog.jsonl`, pairs `submit`/`activate` and `deprovision_submit`/`deprovision_activate` events into bounded duration rings (cap 1024), exposes `ProvisionDurations(window)` / `DeprovisionDurations(window)`, and caps pending-submit maps at 4096 entries with oldest-eviction
* Wire the new constructors in `cmd/device-observer/main.go`; the EOS lookback is derived inside `NewEOS` as `max(2*interval, 30s)`

## Testing

* Add unit tests for all new functionality

