### PR TITLE
telemetry/state-ingest: drop redundant ip-msdp-sa-cache default kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Tools
   - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.
   - Add `tools/stress/device-observer/`, a per-device sampling tool for the GRE Tunnel Capacity Study. Each tick issues five eAPI `show` commands, scrapes the doublezero-agent Prometheus endpoint, polls EOS syslog via `show logging last` with cross-tick dedupe, tails the orchestrator's agent log for abort-trigger patterns, and tails the orchestrator's runlog to compute provision/deprovision durations. The abort decider is stubbed.
+- Telemetry
+  - Drop the redundant `ip-msdp-sa-cache` kind from the state-ingest server's default state-collect command list. `show ip msdp sa-cache rejected` already returns the full SA cache (accepted SAs in the `acceptedSaMsg` array plus any rejected SAs in `rejectedSaMsg`), so the bare `show ip msdp sa-cache` collection is redundant — devices were running both commands per tick and uploading the same accepted-SA data twice. The `ip-msdp-sa-cache-rejected` kind is retained.
 
 ## [v0.25.1](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.1) - 2026-06-01
 

--- a/telemetry/state-ingest/pkg/server/config.go
+++ b/telemetry/state-ingest/pkg/server/config.go
@@ -27,7 +27,6 @@ var (
 		"ip-mroute-count":           "show ip mroute count",
 		"ip-msdp-summary":           "show ip msdp summary",
 		"ip-msdp-pim-sa-cache":      "show ip msdp pim sa-cache",
-		"ip-msdp-sa-cache":          "show ip msdp sa-cache",
 		"ip-msdp-sa-cache-rejected": "show ip msdp sa-cache rejected",
 	}
 	defaultStateToCollectCustom = []string{

--- a/telemetry/state-ingest/pkg/server/handler_test.go
+++ b/telemetry/state-ingest/pkg/server/handler_test.go
@@ -860,7 +860,7 @@ func TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAnd
 
 	var resp types.StateToCollectResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	require.Len(t, resp.ShowCommands, 8)
+	require.Len(t, resp.ShowCommands, 7)
 	require.Len(t, resp.Custom, 1)
 
 	// Convert to map for order-independent comparison (map iteration is non-deterministic)
@@ -875,7 +875,6 @@ func TestTelemetry_StateIngest_Handler_StateToCollect_UsesDefaultShowCommandsAnd
 		"ip-mroute-count":           "show ip mroute count",
 		"ip-msdp-summary":           "show ip msdp summary",
 		"ip-msdp-pim-sa-cache":      "show ip msdp pim sa-cache",
-		"ip-msdp-sa-cache":          "show ip msdp sa-cache",
 		"ip-msdp-sa-cache-rejected": "show ip msdp sa-cache rejected",
 	}, respMap)
 	require.Equal(t, []string{"bgp-sockets"}, resp.Custom)


### PR DESCRIPTION
## Summary

- Drop the redundant `ip-msdp-sa-cache` kind from the state-ingest server's default state-collect command list. Per the Arista docs (`show ip msdp sa-cache [rejected]`), the `rejected` variant "displays rejected SAs in addition to the SA cache contents" — i.e. it returns the same accepted-SA list plus any rejected ones. So `ip-msdp-sa-cache-rejected` is a strict superset of `ip-msdp-sa-cache`, and running both is wasted device + bandwidth.
- `ip-msdp-sa-cache-rejected` is retained as the single source of truth; downstream lake-side parsing in PR (forthcoming) reads both the `acceptedSaMsg` and `rejectedSaMsg` arrays from this kind's snapshot.

## Testing Verification

- `go test ./telemetry/state-ingest/...` updated assertion (`require.Len(t, resp.ShowCommands, 7)` and the expected-map literal) now passes.
- Validated against prod (`show-switch fra001-dz002`) that both commands return identical `acceptedSaMsg`/`rejectedSaMsg` envelope shapes — confirms the `rejected` keyword only affects which arrays get populated, not the JSON schema.

## Notes

Pairs with the lake-side MSDP ingest PR (forthcoming, `lake/indexer/pkg/dz/msdp/`), which consumes only the `ip-msdp-sa-cache-rejected` kind. No coordination required between merges — once this lands, devices stop running the redundant command on their next collector tick; lake-side has been written to ignore `ip-msdp-sa-cache` snapshots in S3 regardless.



Closes malbeclabs/infra#1417.

