### PR TITLE
telemetry/geoprobe: retry transient bind errors in publisher AddProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
   - Add `tools/stress/device-observer/`, a per-device sampling tool for the GRE Tunnel Capacity Study. Each tick issues five eAPI `show` commands, scrapes the doublezero-agent Prometheus endpoint, polls EOS syslog via `show logging last` with cross-tick dedupe, tails the orchestrator's agent log for abort-trigger patterns, and tails the orchestrator's runlog to compute provision/deprovision durations. The abort decider is stubbed.
 - Telemetry
   - Drop the redundant `ip-msdp-sa-cache` kind from the state-ingest server's default state-collect command list. `show ip msdp sa-cache rejected` already returns the full SA cache (accepted SAs in the `acceptedSaMsg` array plus any rejected SAs in `rejectedSaMsg`), so the bare `show ip msdp sa-cache` collection is redundant — devices were running both commands per tick and uploading the same accepted-SA data twice. The `ip-msdp-sa-cache-rejected` kind is retained.
+- Telemetry (geoprobe)
+  - Retry transient `bind: invalid argument` failures when allocating per-probe UDP sockets in `Publisher.AddProbe`, matching the existing retry-on-bind pattern in `Pinger`. The shared retry helper is lifted into `retry.go` so the publisher and pinger paths use the same exponential-backoff logic. Fixes intermittent `TestPublisher_RemoveProbe`/`TestPublisher_AddProbe` CI flakes caused by concurrent ephemeral-port allocation ([#3765](https://github.com/malbeclabs/doublezero/issues/3765))
 
 ## [v0.25.1](https://github.com/malbeclabs/doublezero/compare/client/v0.24.0...client/v0.25.1) - 2026-06-01
 

--- a/controlplane/telemetry/internal/geoprobe/pinger.go
+++ b/controlplane/telemetry/internal/geoprobe/pinger.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -50,34 +49,10 @@ func NewPinger(cfg *PingerConfig) *Pinger {
 	}
 }
 
-func isBindError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "bind:")
-}
-
 func newSenderWithRetry(ctx context.Context, log *slog.Logger, iface string, local, remote *net.UDPAddr) (twamplight.Sender, error) {
-	var lastErr error
-	for attempt := range senderRetries {
-		sender, err := twamplight.NewSender(ctx, log, iface, local, remote)
-		if err == nil {
-			return sender, nil
-		}
-		lastErr = err
-		if !isBindError(err) {
-			return nil, err
-		}
-		delay := senderRetryMin * time.Duration(1<<attempt)
-		log.Warn("Bind failed, retrying", "attempt", attempt+1, "delay", delay, "error", err)
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(delay):
-		}
-	}
-	return nil, lastErr
+	return retryOnBindError(ctx, log, func() (twamplight.Sender, error) {
+		return twamplight.NewSender(ctx, log, iface, local, remote)
+	})
 }
 
 func (p *Pinger) AddProbe(ctx context.Context, addr ProbeAddress) error {

--- a/controlplane/telemetry/internal/geoprobe/publisher.go
+++ b/controlplane/telemetry/internal/geoprobe/publisher.go
@@ -99,8 +99,10 @@ func (p *Publisher) AddProbe(ctx context.Context, addr ProbeAddress) error {
 	var conn *net.UDPConn
 	var err error
 
+	// Retry transient bind failures inside the namespace closure so that all
+	// attempts stay on the same OS-thread-locked netns. See retry.go.
 	createConn := func() (*net.UDPConn, error) {
-		return NewUDPConn()
+		return retryOnBindError(ctx, p.log, NewUDPConn)
 	}
 
 	if p.cfg.ManagementNamespace != "" {

--- a/controlplane/telemetry/internal/geoprobe/retry.go
+++ b/controlplane/telemetry/internal/geoprobe/retry.go
@@ -1,0 +1,46 @@
+package geoprobe
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// isBindError reports whether err is a transient socket bind failure. The
+// kernel can return EINVAL from bind(2) under load when many goroutines
+// create ephemeral sockets concurrently; retrying typically succeeds.
+func isBindError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "bind:")
+}
+
+// retryOnBindError calls fn up to senderRetries times, retrying with
+// exponential backoff (senderRetryMin * 2^attempt) only when fn returns an
+// error classified by isBindError. Non-bind errors are returned immediately.
+func retryOnBindError[T any](ctx context.Context, log *slog.Logger, fn func() (T, error)) (T, error) {
+	var (
+		zero    T
+		lastErr error
+	)
+	for attempt := range senderRetries {
+		v, err := fn()
+		if err == nil {
+			return v, nil
+		}
+		lastErr = err
+		if !isBindError(err) {
+			return zero, err
+		}
+		delay := senderRetryMin * time.Duration(1<<attempt)
+		log.Warn("Bind failed, retrying", "attempt", attempt+1, "delay", delay, "error", err)
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return zero, lastErr
+}

--- a/controlplane/telemetry/internal/geoprobe/retry_test.go
+++ b/controlplane/telemetry/internal/geoprobe/retry_test.go
@@ -1,0 +1,92 @@
+package geoprobe
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestIsBindError(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isBindError(nil))
+	assert.False(t, isBindError(errors.New("connection refused")))
+	assert.True(t, isBindError(errors.New("listen udp4 0.0.0.0:0: bind: invalid argument")))
+	assert.True(t, isBindError(errors.New("bind: address already in use")))
+}
+
+func TestRetryOnBindError_SucceedsAfterTransientBindFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	fn := func() (string, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return "", errors.New("listen udp4 0.0.0.0:0: bind: invalid argument")
+		}
+		return "ok", nil
+	}
+
+	got, err := retryOnBindError(context.Background(), quietLogger(), fn)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestRetryOnBindError_FailsFastOnNonBindError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	nonBind := errors.New("connection refused")
+	fn := func() (string, error) {
+		calls.Add(1)
+		return "", nonBind
+	}
+
+	got, err := retryOnBindError(context.Background(), quietLogger(), fn)
+	require.ErrorIs(t, err, nonBind)
+	assert.Empty(t, got)
+	assert.Equal(t, int32(1), calls.Load(), "non-bind errors must not be retried")
+}
+
+func TestRetryOnBindError_GivesUpAfterMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	bind := errors.New("bind: invalid argument")
+	fn := func() (string, error) {
+		calls.Add(1)
+		return "", bind
+	}
+
+	_, err := retryOnBindError(context.Background(), quietLogger(), fn)
+	require.ErrorIs(t, err, bind)
+	assert.Equal(t, int32(senderRetries), calls.Load())
+}
+
+func TestRetryOnBindError_HonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fn := func() (string, error) {
+		return "", errors.New("bind: invalid argument")
+	}
+
+	start := time.Now()
+	_, err := retryOnBindError(ctx, quietLogger(), fn)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), senderRetryMin, "should return promptly when context is already cancelled")
+}


### PR DESCRIPTION
## Summary of Changes
* Wrap the per-probe UDP socket allocation in `Publisher.AddProbe` with a retry-on-bind-error helper, mirroring the existing mitigation in `Pinger`. The kernel can return `EINVAL` from `bind(2)` when many goroutines concurrently allocate ephemeral sockets, which intermittently fails `TestPublisher_RemoveProbe`/`TestPublisher_AddProbe` in CI with `bind: invalid argument`.
* Lift `isBindError` and the retry loop out of `pinger.go` into a small package-shared `retry.go`, exposing a generic `retryOnBindError[T]` helper. The pinger path now calls the same helper, removing duplicated logic.
* The retry runs *inside* the `netns.RunInNamespace` closure so all attempts and backoffs stay on the same OS-thread-locked netns when `ManagementNamespace` is set.
* Fixes #3765

## Testing Verification
* New `retry_test.go` covers the four important branches of the helper: success after a transient bind failure, fail-fast on a non-bind error, give-up after `senderRetries` attempts, and prompt return on a cancelled context.
* `go test -race -count=5 -run 'TestRetryOnBindError|TestIsBindError|TestPublisher_AddProbe|TestPublisher_RemoveProbe' ./controlplane/telemetry/internal/geoprobe/...` passes locally.
* Full `go test ./controlplane/telemetry/internal/geoprobe/...` passes.
* `golangci-lint run ./controlplane/telemetry/internal/geoprobe/...` reports `0 issues`.