### PR TITLE
geolocation-cli: route prompts through writer, add TTY guard, rename update-payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - Change `geolocation user update-payment` to `update-payment-status` for clarity. 
 - Tools
   - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.
   - Add `tools/stress/device-observer/`, a per-device sampling tool for the GRE Tunnel Capacity Study. Each tick issues five eAPI `show` commands, scrapes the doublezero-agent Prometheus endpoint, polls EOS syslog via `show logging last` with cross-tick dedupe, tails the orchestrator's agent log for abort-trigger patterns, and tails the orchestrator's runlog to compute provision/deprovision durations. The abort decider is stubbed.

--- a/crates/doublezero-geolocation-cli/src/cli.rs
+++ b/crates/doublezero-geolocation-cli/src/cli.rs
@@ -64,7 +64,7 @@ impl GeolocationCommand {
                 UserCommands::AddTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::RemoveTarget(args) => args.execute(ctx, client, out).await,
                 UserCommands::SetResultDestination(args) => args.execute(ctx, client, out).await,
-                UserCommands::UpdatePayment(args) => args.execute(ctx, client, out).await,
+                UserCommands::UpdatePaymentStatus(args) => args.execute(ctx, client, out).await,
             },
         }
     }

--- a/crates/doublezero-geolocation-cli/src/init.rs
+++ b/crates/doublezero-geolocation-cli/src/init.rs
@@ -2,7 +2,7 @@ use crate::client::GeoCliCommand;
 use clap::Args;
 use doublezero_cli_core::CliContext;
 use doublezero_sdk::geolocation::programconfig::init::InitProgramConfigCommand;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
 #[derive(Args, Debug)]
 pub struct InitProgramConfigCliCommand {
@@ -21,7 +21,14 @@ impl InitProgramConfigCliCommand {
         tracing::debug!(env = %ctx.env, "geolocation init");
 
         if !self.yes {
-            eprint!("Initialize geolocation program config? This is a one-time operation. [y/N]: ");
+            if !std::io::stdin().is_terminal() {
+                eyre::bail!("stdin is not a terminal — pass --yes to skip confirmation");
+            }
+            write!(
+                out,
+                "Initialize geolocation program config? This is a one-time operation. [y/N]: "
+            )?;
+            out.flush()?;
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
             if !input.trim().eq_ignore_ascii_case("y") {
@@ -71,5 +78,22 @@ mod tests {
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
         assert!(output_str.contains(&config_pda.to_string()));
+    }
+
+    #[test]
+    fn test_cli_geo_init_rejects_non_tty() {
+        let client = MockGeoCliCommand::new();
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(InitProgramConfigCliCommand { yes: false }.execute(
+            &ctx,
+            &client,
+            &mut output,
+        ));
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("stdin is not a terminal"),
+            "expected non-TTY error, got: {err}"
+        );
     }
 }

--- a/crates/doublezero-geolocation-cli/src/probe/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/probe/delete.rs
@@ -4,7 +4,7 @@ use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geo_probe::{
     delete::DeleteGeoProbeCommand, get::GetGeoProbeCommand,
 };
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
 #[derive(Args, Debug)]
 pub struct DeleteGeoProbeCliCommand {
@@ -31,7 +31,11 @@ impl DeleteGeoProbeCliCommand {
         let code = resolved_probe.code;
 
         if !self.yes {
-            eprint!("Delete probe '{code}'? [y/N]: ");
+            if !std::io::stdin().is_terminal() {
+                eyre::bail!("stdin is not a terminal — pass --yes to skip confirmation");
+            }
+            write!(out, "Delete probe '{code}'? [y/N]: ")?;
+            out.flush()?;
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
             if !input.trim().eq_ignore_ascii_case("y") {
@@ -122,5 +126,48 @@ mod tests {
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
+    }
+
+    #[test]
+    fn test_cli_geo_probe_delete_rejects_non_tty() {
+        let mut client = MockGeoCliCommand::new();
+
+        client
+            .expect_get_geo_probe()
+            .with(predicate::eq(GetGeoProbeCommand {
+                pubkey_or_code: "ams-probe-01".to_string(),
+            }))
+            .returning(move |_| {
+                Ok((
+                    Pubkey::new_unique(),
+                    GeoProbe {
+                        account_type: AccountType::GeoProbe,
+                        owner: Pubkey::new_unique(),
+                        exchange_pk: Pubkey::new_unique(),
+                        public_ip: Ipv4Addr::new(10, 0, 0, 1),
+                        location_offset_port: 8923,
+                        code: "ams-probe-01".to_string(),
+                        parent_devices: vec![],
+                        metrics_publisher_pk: Pubkey::new_unique(),
+                        reference_count: 0,
+                        target_update_count: 0,
+                    },
+                ))
+            });
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            DeleteGeoProbeCliCommand {
+                probe: "ams-probe-01".to_string(),
+                yes: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("stdin is not a terminal"),
+            "expected non-TTY error, got: {err}"
+        );
     }
 }

--- a/crates/doublezero-geolocation-cli/src/user/delete.rs
+++ b/crates/doublezero-geolocation-cli/src/user/delete.rs
@@ -4,7 +4,7 @@ use doublezero_cli_core::{validators::validate_pubkey_or_code, CliContext};
 use doublezero_sdk::geolocation::geolocation_user::{
     delete::DeleteGeolocationUserCommand, get::GetGeolocationUserCommand,
 };
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
 #[derive(Args, Debug)]
 pub struct DeleteGeolocationUserCliCommand {
@@ -31,7 +31,11 @@ impl DeleteGeolocationUserCliCommand {
         let code = resolved_user.code;
 
         if !self.yes {
-            eprint!("Delete user '{}'? [y/N]: ", &code);
+            if !std::io::stdin().is_terminal() {
+                eyre::bail!("stdin is not a terminal — pass --yes to skip confirmation");
+            }
+            write!(out, "Delete user '{}'? [y/N]: ", &code)?;
+            out.flush()?;
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
             if !input.trim().eq_ignore_ascii_case("y") {
@@ -129,5 +133,50 @@ mod tests {
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Signature:"));
+    }
+
+    #[test]
+    fn test_cli_geolocation_user_delete_rejects_non_tty() {
+        let mut client = MockGeoCliCommand::new();
+
+        client
+            .expect_get_geolocation_user()
+            .with(predicate::eq(GetGeolocationUserCommand {
+                pubkey_or_code: "geo-user-01".to_string(),
+            }))
+            .returning(move |_| {
+                Ok((
+                    Pubkey::new_unique(),
+                    GeolocationUser {
+                        account_type: AccountType::GeolocationUser,
+                        owner: Pubkey::new_unique(),
+                        code: "geo-user-01".to_string(),
+                        token_account: Pubkey::new_unique(),
+                        payment_status: GeolocationPaymentStatus::Paid,
+                        billing: GeolocationBillingConfig::FlatPerEpoch(FlatPerEpochConfig {
+                            rate: 1000,
+                            last_deduction_dz_epoch: 42,
+                        }),
+                        status: GeolocationUserStatus::Activated,
+                        targets: vec![],
+                        result_destination: String::new(),
+                    },
+                ))
+            });
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            DeleteGeolocationUserCliCommand {
+                user: "geo-user-01".to_string(),
+                yes: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("stdin is not a terminal"),
+            "expected non-TTY error, got: {err}"
+        );
     }
 }

--- a/crates/doublezero-geolocation-cli/src/user/mod.rs
+++ b/crates/doublezero-geolocation-cli/src/user/mod.rs
@@ -45,5 +45,5 @@ pub enum UserCommands {
     /// Set result destination for geolocation results
     SetResultDestination(SetResultDestinationCliCommand),
     /// Update payment status (foundation-only)
-    UpdatePayment(UpdatePaymentStatusCliCommand),
+    UpdatePaymentStatus(UpdatePaymentStatusCliCommand),
 }

--- a/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
+++ b/crates/doublezero-geolocation-cli/src/user/update_payment_status.rs
@@ -33,7 +33,7 @@ impl UpdatePaymentStatusCliCommand {
         client: &C,
         out: &mut W,
     ) -> eyre::Result<()> {
-        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user update-payment");
+        tracing::debug!(env = %ctx.env, user = %self.user, "geolocation user update-payment-status");
 
         let payment_status = match self.status {
             PaymentStatus::Paid => GeolocationPaymentStatus::Paid,

--- a/e2e/geoprobe_test.go
+++ b/e2e/geoprobe_test.go
@@ -907,11 +907,11 @@ func createGeolocationUser(t *testing.T, dn *devnet.Devnet, code, tokenAccount s
 func updateGeolocationUserPayment(t *testing.T, dn *devnet.Devnet, code, status string) {
 	t.Helper()
 	output, err := dn.Manager.Exec(t.Context(), []string{
-		"doublezero", "geolocation", "user", "update-payment",
+		"doublezero", "geolocation", "user", "update-payment-status",
 		"--user", code,
 		"--status", status,
 	})
-	require.NoError(t, err, "user update-payment failed: %s", string(output))
+	require.NoError(t, err, "user update-payment-status failed: %s", string(output))
 }
 
 // setGeolocationUserResultDestination sets the result destination on a GeolocationUser.


### PR DESCRIPTION
## Summary of Changes

* Route confirmation prompts in `init.rs`, `user/delete.rs`, and `probe/delete.rs` through the injected `Write` parameter instead of `eprint!`, complying with RFC-20 rule 7
* Add `std::io::IsTerminal` TTY guard so non-interactive contexts (CI, scripts) get a clear error directing them to pass `--yes` instead of hanging on stdin
* Rename `UserCommands::UpdatePayment` to `UpdatePaymentStatus` so the CLI subcommand (`user update-payment-status`) matches the file and SDK naming
* Fixes malbeclabs/infra#1461

## Testing Verification

* All 44 tests in `doublezero-geolocation-cli` pass, including 3 new tests verifying non-TTY rejection for each destructive verb (`init`, `user delete`, `probe delete`)
* `cargo clippy -p doublezero-geolocation-cli -- -Dclippy::all -Dwarnings` passes with no warnings
* `make rust-fmt` applied with no formatting changes required
