### PR TITLE
ci(e2e): satisfy branch protection for trusted fork PR runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,6 +174,7 @@ jobs:
     permissions:
       packages: read
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
@@ -190,6 +191,24 @@ jobs:
             echo "::error::PR head SHA changed: expected ${{ github.event.inputs.head_sha }}, got $actual_head"
             exit 1
           fi
+      # Trusted (workflow_dispatch) runs execute on the base ref, so their native
+      # check runs attach to that commit, not the PR head. Report a check run on
+      # the validated PR head SHA so branch protection's required context is met.
+      - name: Report check-run start on PR head
+        if: github.event_name == 'workflow_dispatch'
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'e2e (shard ${{ matrix.shard }})',
+              head_sha: context.payload.inputs.head_sha,
+              status: 'in_progress',
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            core.setOutput('id', String(data.id));
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -237,6 +256,22 @@ jobs:
           pull_with_retry ghcr.io/malbeclabs/dz-e2e/prometheus:v2.54.1
           pull_with_retry public.ecr.aws/influxdb/influxdb:1.8
       - name: test
+        id: test
         env:
           DZ_E2E_NO_BUILD: "1"
         run: go test -tags=e2e -timeout=20m -parallel=12 -run '${{ matrix.run }}' -v
+      - name: Report check-run result on PR head
+        if: always() && github.event_name == 'workflow_dispatch' && steps.check.outputs.id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const outcome = '${{ steps.test.outcome }}';
+            const conclusion = outcome === 'success' ? 'success' : (outcome === 'cancelled' ? 'cancelled' : 'failure');
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: Number('${{ steps.check.outputs.id }}'),
+              status: 'completed',
+              conclusion,
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -166,10 +166,29 @@ jobs:
     permissions:
       packages: read
       contents: read
+      checks: write
     defaults:
       run:
         working-directory: e2e/
     steps:
+      # Trusted (workflow_dispatch) runs execute on the base ref, so their native
+      # check runs attach to that commit, not the PR head. Report a check run on
+      # the PR head SHA so branch protection's required context is met.
+      - name: Report check-run start on PR head
+        if: github.event_name == 'workflow_dispatch'
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'shard-e2e (shard ${{ matrix.shard }})',
+              head_sha: context.payload.inputs.head_sha,
+              status: 'in_progress',
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            core.setOutput('id', String(data.id));
       - name: Checkout doublezero-shreds
         uses: actions/checkout@v4
         with:
@@ -210,6 +229,22 @@ jobs:
           pull_with_retry ${{ env.SHRED_IMAGE_REPO }}/oracle:${{ env.SHRED_IMAGE_TAG }}
           pull_with_retry ${{ env.SHRED_IMAGE_REPO }}/client:${{ env.SHRED_IMAGE_TAG }}
       - name: Run e2e tests
+        id: test
         env:
           SHRED_E2E_NO_BUILD: "1"
         run: go test -tags=e2e -timeout=12m -count=1 -run '${{ matrix.run }}' -v .
+      - name: Report check-run result on PR head
+        if: always() && github.event_name == 'workflow_dispatch' && steps.check.outputs.id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const outcome = '${{ steps.test.outcome }}';
+            const conclusion = outcome === 'success' ? 'success' : (outcome === 'cancelled' ? 'cancelled' : 'failure');
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: Number('${{ steps.check.outputs.id }}'),
+              status: 'completed',
+              conclusion,
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/trusted-fork-e2e.yml
+++ b/.github/workflows/trusted-fork-e2e.yml
@@ -107,16 +107,23 @@ jobs:
               .map((workflow) => `- [${workflow}](https://github.com/${owner}/${repo}/actions/workflows/${workflow})`)
               .join('\n');
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: [
-                `Trusted e2e requested by @${context.actor} for \`${headSha}\`.`,
-                '',
-                `Image tag: \`${imageTag}\``,
-                '',
-                'Dispatched workflows:',
-                links,
-              ].join('\n'),
-            });
+            // The dispatches above are the load-bearing work; a failure to post
+            // the confirmation comment (e.g. a capped GITHUB_TOKEN denying
+            // issues:write) must not fail the job and leave the runs orphaned.
+            try {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: [
+                  `Trusted e2e requested by @${context.actor} for \`${headSha}\`.`,
+                  '',
+                  `Image tag: \`${imageTag}\``,
+                  '',
+                  'Dispatched workflows:',
+                  links,
+                ].join('\n'),
+              });
+            } catch (e) {
+              core.warning(`Could not post confirmation comment: ${e.message}`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - CLI
   - Change `geolocation user update-payment` to `update-payment-status` for clarity. 
+- ci(e2e): report trusted fork e2e/shreds shard results onto the PR head SHA so branch protection's required `e2e (shard N)` / `shard-e2e (shard N)` checks are satisfied by a `/run-e2e` dispatch, removing the need for a maintainer to bypass the ruleset to merge fork PRs; also make the dispatcher's confirmation comment non-fatal so a capped `GITHUB_TOKEN` no longer fails the job after the runs have already launched (follow-up to [#3777](https://github.com/malbeclabs/doublezero/pull/3777))
 - Tools
   - Complete the device-stress orchestrator (part 3): replace the stubbed agent runner with an SSH-backed runner that execs `doublezero-agent -verbose` on the DUT and tees its output to `orchestrator.agent.log`, and a log parser that turns the agent's commit-diff lines into `pre_commit_log` / `applied` runlog events. Adds `--dut-ssh-user` and `--no-agent` flags.
   - Add `tools/stress/device-observer/`, a per-device sampling tool for the GRE Tunnel Capacity Study. Each tick issues five eAPI `show` commands, scrapes the doublezero-agent Prometheus endpoint, polls EOS syslog via `show logging last` with cross-tick dedupe, tails the orchestrator's agent log for abort-trigger patterns, and tails the orchestrator's runlog to compute provision/deprovision durations. The abort decider is stubbed.


### PR DESCRIPTION
## Summary of Changes

- Report each trusted (`/run-e2e`) e2e and shreds shard's result as a check run on the **PR head SHA**, so branch protection's required `e2e (shard N)` / `shard-e2e (shard N)` contexts are satisfied. External fork PRs can now be merged normally instead of requiring a maintainer to bypass the `main` ruleset.
- Checks are created by the GitHub Actions app — the integration the required contexts are pinned to — and gated to `workflow_dispatch`, so internal `pull_request` runs keep using their native checks (no double-reporting).
- Make the `trusted-fork-e2e` dispatcher's confirmation comment non-fatal: a capped `GITHUB_TOKEN` denying `issues:write` was failing the dispatch job *after* the runs had already launched. It is now wrapped in try/catch so the failure is a warning, not a red job.

This is builds on #3777: that PR let maintainers *run* trusted e2e on fork PRs, but the runs execute on the base ref so their native checks attach to `main`, never the PR head — leaving fork PRs BLOCKED even after a green run. This change makes those results *count* by re-reporting them onto the validated PR head SHA.

Related RFC/PRs: builds on [#3777](https://github.com/malbeclabs/doublezero/pull/3777); unblocks fork PRs such as [#3654](https://github.com/malbeclabs/doublezero/pull/3654).

## Diff Breakdown

| Category          | Files | Lines (+/-)     | Net    |
|-------------------|-------|-----------------|--------|
| Config/build      |     3 | +90    / -13    |    +77 |
| Docs              |     1 | +1     / -0     |     +1 |
| **Total**         |     4 | +91    / -13    |    +78 |

Entirely GitHub Actions workflow changes plus a changelog entry; no application code.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/e2e.yml` — add `checks: write`; in each `e2e (shard N)` job, create an `in_progress` check run on the dispatched `head_sha` before the tests and update it to success/failure after, gated to `workflow_dispatch`.
- `.github/workflows/shreds-e2e.yml` — same per-shard check-run reporting for the `shard-e2e (shard N)` jobs.
- `.github/workflows/trusted-fork-e2e.yml` — wrap the dispatcher's confirmation `createComment` in try/catch so a denied `issues:write` no longer fails the job.

</details>

## Testing Verification

- `actionlint` (with the repo's `.github/actionlint.yaml` runner-label config) reports no findings on all three modified workflows.
- End-to-end validation requires a real dispatch (the check-run path only runs under `workflow_dispatch`): after merge, comment `/run-e2e` on a fork PR (e.g. #3654) and confirm the `e2e (shard N)` / `shard-e2e (shard N)` checks turn green **on the PR head** and clear branch protection.

## Notes for reviewers

- To satisfy *all* required contexts, the maintainer must run the full `/run-e2e` (the default, which dispatches both suites). A partial `/run-e2e e2e` posts only the 5 `e2e` checks and leaves the 4 `shard-e2e` contexts unreported, so the PR stays blocked.
- Checks bind to a specific SHA. If the contributor pushes a new commit, a maintainer must re-run `/run-e2e` — this is intentional (never auto-run untrusted new code).
- Known follow-up (not in this PR): if the dispatched `setup` job fails before the shards run, no checks post and the PR stays blocked; `setup` could post failure checks for all shards to surface that on the PR.
