### PR TITLE
tools/stress: physical-device harness driver

### DIFF
--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -98,9 +98,10 @@ func run() error {
 		// Default: 300 s — accommodates the 22k-line / ~650 KB final config
 		// commit at 1024 tunnels.
 		agentQuiescenceTimeoutSeconds = flag.Int("agent-quiescence-timeout-seconds", 300, "Hard cap on the post-deprovision agent quiescence wait, in seconds.")
-		// The containerized harness ships a device-side wrapper that injects
-		// -pubkey from /etc/doublezero/agent/pubkey and re-execs through sudo, so
-		// the orchestrator can leave these empty and rely on PATH + the wrapper.
+		// The containerized harness ships a device-side wrapper (see
+		// tools/stress/docker/device/agent-wrapper.sh) that injects -pubkey from
+		// /etc/doublezero/agent/pubkey and re-execs through sudo, so the
+		// orchestrator can leave these empty and rely on PATH + the wrapper.
 		// Against a physical device with no wrapper, set --agent-binary to the
 		// full path on the device, --agent-command-prefix to e.g.
 		// "/sbin/ip netns exec ns-management", and --agent-pubkey to the device

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -57,6 +57,9 @@ type orchestratorConfig struct {
 	TunnelEndpoint                string `json:"tunnel_endpoint"`
 	TenantPubkey                  string `json:"tenant_pubkey,omitempty"`
 	NoAgent                       bool   `json:"no_agent"`
+	AgentBinary                   string `json:"agent_binary,omitempty"`
+	AgentCommandPrefix            string `json:"agent_command_prefix,omitempty"`
+	AgentPubkey                   string `json:"agent_pubkey,omitempty"`
 }
 
 func main() {
@@ -94,6 +97,16 @@ func run() error {
 		// Default: 300 s — accommodates the 22k-line / ~650 KB final config
 		// commit at 1024 tunnels.
 		agentQuiescenceTimeoutSeconds = flag.Int("agent-quiescence-timeout-seconds", 300, "Hard cap on the post-deprovision agent quiescence wait, in seconds.")
+		// The containerized harness ships a device-side wrapper that injects
+		// -pubkey from /etc/doublezero/agent/pubkey and re-execs through sudo, so
+		// the orchestrator can leave these empty and rely on PATH + the wrapper.
+		// Against a physical device with no wrapper, set --agent-binary to the
+		// full path on the device, --agent-command-prefix to e.g.
+		// "/sbin/ip netns exec ns-management", and --agent-pubkey to the device
+		// pubkey so the SSH-exec'd command is fully self-contained.
+		agentBinary        = flag.String("agent-binary", "doublezero-agent", "Path to doublezero-agent on the DUT; the orchestrator SSH-execs this directly.")
+		agentCommandPrefix = flag.String("agent-command-prefix", "", "Optional prefix prepended to the agent command (e.g. \"/sbin/ip netns exec ns-management\" on a physical device).")
+		agentPubkey        = flag.String("agent-pubkey", "", "When set, appended as `-pubkey <value>` to the agent command. Leave empty when the DUT has a wrapper that injects it locally.")
 	)
 	flag.Parse()
 
@@ -142,6 +155,9 @@ func run() error {
 		TunnelEndpoint:                *tunnelEndpoint,
 		TenantPubkey:                  *tenantPubkey,
 		NoAgent:                       *noAgent,
+		AgentBinary:                   *agentBinary,
+		AgentCommandPrefix:            *agentCommandPrefix,
+		AgentPubkey:                   *agentPubkey,
 	}
 	// Validate required flags before writing anything, so a bad invocation
 	// doesn't leave a config file behind. A dry-run is exempt: its whole job is
@@ -231,7 +247,7 @@ func run() error {
 	ctx, abortCancel := abort.Watch(rootCtx, *abortFile, abort.DefaultPollInterval, logger)
 	defer abortCancel()
 
-	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, logger)
+	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, *agentBinary, *agentCommandPrefix, *agentPubkey, logger)
 
 	cfg := sweep.Config{
 		RunID:                  *runID,
@@ -315,16 +331,30 @@ func requireFlags(required map[string]string) error {
 // this never silently falls back to the no-op runner.
 //
 // The SSH runner tees remote stdout/stderr into <working-dir>/orchestrator.agent.log.
-// The exec'd command appends --controller iff the operator passed --controller.
-func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir string, logger *slog.Logger) agent.Runner {
+// The exec'd command is constructed as:
+//
+//	[<prefix> ]<binary> -verbose[ -pubkey <pk>][ -controller <addr>]
+//
+// Containerized DUTs leave prefix and pubkey empty and rely on a device-side
+// wrapper that injects -pubkey from /etc/doublezero/agent/pubkey and re-execs
+// through sudo. Physical DUTs without a wrapper set prefix to e.g.
+// "/sbin/ip netns exec ns-management" and pubkey to the device's onchain pubkey
+// so the command is self-contained.
+func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir, agentBinary, agentCmdPrefix, agentPubkey string, logger *slog.Logger) agent.Runner {
 	if noAgent {
 		logger.Info("agent: --no-agent set; using no-op runner")
 		return agent.NewNoop(logger)
 	}
 
-	cmd := "doublezero-agent -verbose"
+	cmd := agentBinary + " -verbose"
+	if agentPubkey != "" {
+		cmd += " -pubkey " + agentPubkey
+	}
 	if controllerAddr != "" {
-		cmd = fmt.Sprintf("doublezero-agent -verbose -controller %s", controllerAddr)
+		cmd += " -controller " + controllerAddr
+	}
+	if agentCmdPrefix != "" {
+		cmd = agentCmdPrefix + " " + cmd
 	}
 	return agent.NewSSH(agent.SSHConfig{
 		Host:    sshHost,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -60,6 +60,7 @@ type orchestratorConfig struct {
 	AgentBinary                   string `json:"agent_binary,omitempty"`
 	AgentCommandPrefix            string `json:"agent_command_prefix,omitempty"`
 	AgentPubkey                   string `json:"agent_pubkey,omitempty"`
+	AgentMetricsAddr              string `json:"agent_metrics_addr,omitempty"`
 }
 
 func main() {
@@ -107,6 +108,7 @@ func run() error {
 		agentBinary        = flag.String("agent-binary", "doublezero-agent", "Path to doublezero-agent on the DUT; the orchestrator SSH-execs this directly.")
 		agentCommandPrefix = flag.String("agent-command-prefix", "", "Optional prefix prepended to the agent command (e.g. \"/sbin/ip netns exec ns-management\" on a physical device).")
 		agentPubkey        = flag.String("agent-pubkey", "", "When set, appended as `-pubkey <value>` to the agent command. Leave empty when the DUT has a wrapper that injects it locally.")
+		agentMetricsAddr   = flag.String("agent-metrics-addr", "", "When set, appended as `-metrics-enable -metrics-addr <value>` so the observer can scrape the agent. Leave empty when the DUT has a wrapper that turns metrics on locally.")
 	)
 	flag.Parse()
 
@@ -158,6 +160,7 @@ func run() error {
 		AgentBinary:                   *agentBinary,
 		AgentCommandPrefix:            *agentCommandPrefix,
 		AgentPubkey:                   *agentPubkey,
+		AgentMetricsAddr:              *agentMetricsAddr,
 	}
 	// Validate required flags before writing anything, so a bad invocation
 	// doesn't leave a config file behind. A dry-run is exempt: its whole job is
@@ -247,7 +250,7 @@ func run() error {
 	ctx, abortCancel := abort.Watch(rootCtx, *abortFile, abort.DefaultPollInterval, logger)
 	defer abortCancel()
 
-	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, *agentBinary, *agentCommandPrefix, *agentPubkey, logger)
+	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, *agentBinary, *agentCommandPrefix, *agentPubkey, *agentMetricsAddr, logger)
 
 	cfg := sweep.Config{
 		RunID:                  *runID,
@@ -340,7 +343,7 @@ func requireFlags(required map[string]string) error {
 // through sudo. Physical DUTs without a wrapper set prefix to e.g.
 // "/sbin/ip netns exec ns-management" and pubkey to the device's onchain pubkey
 // so the command is self-contained.
-func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir, agentBinary, agentCmdPrefix, agentPubkey string, logger *slog.Logger) agent.Runner {
+func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, workingDir, agentBinary, agentCmdPrefix, agentPubkey, agentMetricsAddr string, logger *slog.Logger) agent.Runner {
 	if noAgent {
 		logger.Info("agent: --no-agent set; using no-op runner")
 		return agent.NewNoop(logger)
@@ -352,6 +355,9 @@ func selectAgentRunner(noAgent bool, sshHost, sshKey, sshUser, controllerAddr, w
 	}
 	if controllerAddr != "" {
 		cmd += " -controller " + controllerAddr
+	}
+	if agentMetricsAddr != "" {
+		cmd += " -metrics-enable -metrics-addr " + agentMetricsAddr
 	}
 	if agentCmdPrefix != "" {
 		cmd = agentCmdPrefix + " " + cmd

--- a/tools/stress/device-orchestrator/pkg/agent/ssh.go
+++ b/tools/stress/device-orchestrator/pkg/agent/ssh.go
@@ -57,6 +57,7 @@ type SSH struct {
 	client    *ssh.Client
 	session   *ssh.Session
 	logFile   *os.File
+	agentConn io.Closer // ssh-agent unix socket; nil unless the agent fallback was used
 	streamErr error
 }
 
@@ -94,10 +95,13 @@ func (s *SSH) Start(ctx context.Context) error {
 	s.started = true
 	s.mu.Unlock()
 
-	authMethod, err := loadAuthMethod(s.cfg.KeyPath, s.cfg.Logger)
+	authMethod, agentConn, err := loadAuthMethod(s.cfg.KeyPath, s.cfg.Logger)
 	if err != nil {
 		return fmt.Errorf("ssh agent: load auth: %w", err)
 	}
+	s.mu.Lock()
+	s.agentConn = agentConn
+	s.mu.Unlock()
 
 	clientCfg := &ssh.ClientConfig{
 		User:            s.cfg.User,
@@ -252,6 +256,10 @@ func (s *SSH) shutdown() {
 		_ = s.logFile.Close()
 		s.logFile = nil
 	}
+	if s.agentConn != nil {
+		_ = s.agentConn.Close()
+		s.agentConn = nil
+	}
 }
 
 // scanLines reads `src` line-by-line and forwards each raw line on `lines`.
@@ -279,7 +287,9 @@ func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slo
 }
 
 // loadAuthMethod resolves an ssh.AuthMethod from the configured KeyPath with a
-// graceful fall-back to ssh-agent ($SSH_AUTH_SOCK):
+// graceful fall-back to ssh-agent ($SSH_AUTH_SOCK). The second return value
+// is the ssh-agent unix-socket connection (nil when not using the agent);
+// the caller stashes it so shutdown can close it cleanly.
 //
 //  1. If KeyPath is empty, use ssh-agent directly. If $SSH_AUTH_SOCK isn't set
 //     in that case, return an error — there's nothing else to try.
@@ -289,17 +299,17 @@ func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slo
 //     orchestrator to authenticate. This is the common path for engineers
 //     whose SSH keys live encrypted on disk and get unlocked via the agent.
 //  4. If KeyPath read or parse fails for any other reason, return the error.
-func loadAuthMethod(path string, log *slog.Logger) (ssh.AuthMethod, error) {
+func loadAuthMethod(path string, log *slog.Logger) (ssh.AuthMethod, io.Closer, error) {
 	if path == "" {
 		return agentAuthMethod(log)
 	}
 	buf, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read key %s: %w", path, err)
+		return nil, nil, fmt.Errorf("read key %s: %w", path, err)
 	}
 	signer, err := ssh.ParsePrivateKey(buf)
 	if err == nil {
-		return ssh.PublicKeys(signer), nil
+		return ssh.PublicKeys(signer), nil, nil
 	}
 	// errors.As against *ssh.PassphraseMissingError; on a hit, try the agent.
 	var passErr *ssh.PassphraseMissingError
@@ -311,31 +321,38 @@ func loadAuthMethod(path string, log *slog.Logger) (ssh.AuthMethod, error) {
 		}
 		return agentAuthMethod(log)
 	}
-	return nil, fmt.Errorf("parse key %s: %w", path, err)
+	return nil, nil, fmt.Errorf("parse key %s: %w", path, err)
 }
 
 // agentAuthMethod connects to ssh-agent via $SSH_AUTH_SOCK and returns an
-// ssh.AuthMethod that delegates signing to the agent. Errors out fast (rather
-// than silently returning a no-op AuthMethod) when the agent is unreachable
-// so the operator sees a precise diagnostic.
-func agentAuthMethod(log *slog.Logger) (ssh.AuthMethod, error) {
+// ssh.AuthMethod that delegates signing to the agent, plus the underlying
+// unix-socket connection so the caller can close it on shutdown. Errors
+// out fast (rather than silently returning a no-op AuthMethod) when the
+// agent is unreachable or empty so the operator sees a precise diagnostic
+// instead of a generic SSH-handshake failure later.
+func agentAuthMethod(log *slog.Logger) (ssh.AuthMethod, io.Closer, error) {
 	sock := os.Getenv("SSH_AUTH_SOCK")
 	if sock == "" {
-		return nil, errors.New("SSH_AUTH_SOCK not set; cannot fall back to ssh-agent — either unset the key passphrase or `ssh-add` the key first")
+		return nil, nil, errors.New("SSH_AUTH_SOCK not set; cannot fall back to ssh-agent — either unset the key passphrase or `ssh-add` the key first")
 	}
 	conn, err := net.Dial("unix", sock)
 	if err != nil {
-		return nil, fmt.Errorf("dial ssh-agent at %s: %w", sock, err)
+		return nil, nil, fmt.Errorf("dial ssh-agent at %s: %w", sock, err)
 	}
 	ac := agent.NewClient(conn)
-	if log != nil {
-		// Probe the agent so a "key not loaded" failure surfaces here, not
-		// inside the SSH handshake (where the error is opaque).
-		if signers, sErr := ac.Signers(); sErr != nil {
-			log.Warn("ssh agent: failed to enumerate signers", "err", sErr)
-		} else {
-			log.Info("ssh agent: using ssh-agent", "socket", sock, "loaded_keys", len(signers))
-		}
+	// Probe the agent so a "key not loaded" failure surfaces here, not
+	// inside the SSH handshake (where the error is opaque).
+	signers, sErr := ac.Signers()
+	if sErr != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("enumerate ssh-agent signers at %s: %w", sock, sErr)
 	}
-	return ssh.PublicKeysCallback(ac.Signers), nil
+	if len(signers) == 0 {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("ssh-agent at %s has no loaded keys — `ssh-add` your key first", sock)
+	}
+	if log != nil {
+		log.Info("ssh agent: using ssh-agent", "socket", sock, "loaded_keys", len(signers))
+	}
+	return ssh.PublicKeysCallback(ac.Signers), conn, nil
 }

--- a/tools/stress/device-orchestrator/pkg/agent/ssh.go
+++ b/tools/stress/device-orchestrator/pkg/agent/ssh.go
@@ -3,14 +3,17 @@ package agent
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 // SSHConfig describes how to reach the DUT and what to run on it.
@@ -91,14 +94,14 @@ func (s *SSH) Start(ctx context.Context) error {
 	s.started = true
 	s.mu.Unlock()
 
-	signer, err := loadSigner(s.cfg.KeyPath)
+	authMethod, err := loadAuthMethod(s.cfg.KeyPath, s.cfg.Logger)
 	if err != nil {
-		return fmt.Errorf("ssh agent: load key %s: %w", s.cfg.KeyPath, err)
+		return fmt.Errorf("ssh agent: load auth: %w", err)
 	}
 
 	clientCfg := &ssh.ClientConfig{
 		User:            s.cfg.User,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		Auth:            []ssh.AuthMethod{authMethod},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         s.cfg.DialTimeout,
 	}
@@ -275,11 +278,64 @@ func scanLines(ctx context.Context, src io.Reader, lines chan<- string, log *slo
 	return nil
 }
 
-// loadSigner reads a PEM-encoded private key from disk and returns an ssh.Signer.
-func loadSigner(path string) (ssh.Signer, error) {
+// loadAuthMethod resolves an ssh.AuthMethod from the configured KeyPath with a
+// graceful fall-back to ssh-agent ($SSH_AUTH_SOCK):
+//
+//  1. If KeyPath is empty, use ssh-agent directly. If $SSH_AUTH_SOCK isn't set
+//     in that case, return an error — there's nothing else to try.
+//  2. If KeyPath parses as an unencrypted private key, use that key.
+//  3. If KeyPath exists but is passphrase-protected, fall back to ssh-agent
+//     and log a hint that the user needs `ssh-add <KeyPath>` once for the
+//     orchestrator to authenticate. This is the common path for engineers
+//     whose SSH keys live encrypted on disk and get unlocked via the agent.
+//  4. If KeyPath read or parse fails for any other reason, return the error.
+func loadAuthMethod(path string, log *slog.Logger) (ssh.AuthMethod, error) {
+	if path == "" {
+		return agentAuthMethod(log)
+	}
 	buf, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read key %s: %w", path, err)
 	}
-	return ssh.ParsePrivateKey(buf)
+	signer, err := ssh.ParsePrivateKey(buf)
+	if err == nil {
+		return ssh.PublicKeys(signer), nil
+	}
+	// errors.As against *ssh.PassphraseMissingError; on a hit, try the agent.
+	var passErr *ssh.PassphraseMissingError
+	if errors.As(err, &passErr) {
+		if log != nil {
+			log.Info("ssh agent: key is passphrase-protected; falling back to ssh-agent",
+				"key_path", path,
+				"hint", "if this fails, run `ssh-add "+path+"` to load it into your agent")
+		}
+		return agentAuthMethod(log)
+	}
+	return nil, fmt.Errorf("parse key %s: %w", path, err)
+}
+
+// agentAuthMethod connects to ssh-agent via $SSH_AUTH_SOCK and returns an
+// ssh.AuthMethod that delegates signing to the agent. Errors out fast (rather
+// than silently returning a no-op AuthMethod) when the agent is unreachable
+// so the operator sees a precise diagnostic.
+func agentAuthMethod(log *slog.Logger) (ssh.AuthMethod, error) {
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		return nil, errors.New("SSH_AUTH_SOCK not set; cannot fall back to ssh-agent — either unset the key passphrase or `ssh-add` the key first")
+	}
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		return nil, fmt.Errorf("dial ssh-agent at %s: %w", sock, err)
+	}
+	ac := agent.NewClient(conn)
+	if log != nil {
+		// Probe the agent so a "key not loaded" failure surfaces here, not
+		// inside the SSH handshake (where the error is opaque).
+		if signers, sErr := ac.Signers(); sErr != nil {
+			log.Warn("ssh agent: failed to enumerate signers", "err", sErr)
+		} else {
+			log.Info("ssh agent: using ssh-agent", "socket", sock, "loaded_keys", len(signers))
+		}
+	}
+	return ssh.PublicKeysCallback(ac.Signers), nil
 }

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -272,12 +272,23 @@ func Run(ctx context.Context, cfg Config) error {
 	depErr := deprovision(context.WithoutCancel(ctx), &cfg, created)
 
 	// Give the agent a chance to finish applying the deprovision config to
-	// EOS before we kill its SSH session. Skip on any error path: if the
-	// run is already failing we want a fast shutdown, not 5 minutes of
-	// extra wait. ctx (the caller's signal-aware context) cuts the wait
-	// short on Ctrl-C / abort-file even on the success path.
-	if err == nil && depErr == nil && agentErr == nil {
-		waitForAgentQuiescence(ctx, &cfg, tracker)
+	// EOS before we kill its SSH session. We wait whenever deprovision
+	// completed cleanly (`depErr == nil`) and the agent stream is healthy
+	// (`agentErr == nil`) — including the abort path, where ctx was
+	// cancelled by the observer's sentinel. The intent of the abort
+	// triggers is "something off-device looks bad, tear down the run";
+	// it isn't "kill the agent mid-commit". On the success path ctx is
+	// not cancelled and the wait listens on it for Ctrl-C; on the abort
+	// path ctx is already done, so we pass a derived context that
+	// ignores cancellation. The hard `AgentQuiescenceTimeout` (default
+	// 300s) caps the wait either way, and a user who really wants out
+	// can re-Ctrl-C to kill the orchestrator process.
+	if depErr == nil && agentErr == nil {
+		waitCtx := ctx
+		if ctx.Err() != nil {
+			waitCtx = context.WithoutCancel(ctx)
+		}
+		waitForAgentQuiescence(waitCtx, &cfg, tracker)
 	}
 
 	// Tell the agent to stop and wait for the consumer goroutine to drain so

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -359,17 +359,27 @@ func consumeAgentEvents(cfg *Config, registry *tunnelRegistry, tracker *quiescen
 	}
 }
 
-// waitForAgentQuiescence blocks until the agent has been silent (no
-// EventApplied observation) for cfg.AgentQuietWindow, or the cumulative wait
-// exceeds cfg.AgentQuiescenceTimeout, or ctx is cancelled. It is a no-op
-// when cfg.AgentQuietWindow is zero (the library default) or when no
-// EventApplied has ever been observed (e.g. --no-agent runs).
+// waitForAgentQuiescence blocks until BOTH (a) the agent has been silent
+// for cfg.AgentQuietWindow AND (b) at least cfg.AgentQuietWindow has
+// elapsed since the wait started. The dual condition handles the case
+// where the agent went silent BEFORE deprovision returned — the absolute
+// "silent for N seconds" predicate alone would return instantly without
+// giving the agent any time to commit the post-deprovision config push
+// from the controller. The added "elapsed since wait start" floor
+// guarantees we always block at least one quiet window after deprovision
+// finishes, even if the agent had been silent for minutes during a slow
+// commit cycle.
 //
-// The wait polls in 1s ticks. Polling avoids needing a separate "applied
-// observed" signal channel — the tracker's atomic.Int64 is read each tick
-// and compared against the current clock. At 1024 users / batch=32 the
-// agent emits applieds in clumps tens of seconds apart, so a 1s poll is
-// well below the natural event cadence.
+// The wait returns early on cfg.AgentQuiescenceTimeout (warned) or
+// ctx.Done() (warned). It is a no-op when cfg.AgentQuietWindow is zero
+// (the library default) or when no agent event has ever been observed
+// (e.g. --no-agent runs).
+//
+// The wait polls in 1s ticks. Polling avoids needing a separate
+// "applied observed" signal channel — the tracker's atomic.Int64 is
+// read each tick and compared against the current clock. At 1024
+// users / batch=32 the agent emits commits in clumps tens of seconds
+// apart, so a 1s poll is well below the natural event cadence.
 func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenceTracker) {
 	if cfg.AgentQuietWindow <= 0 {
 		return
@@ -389,15 +399,16 @@ func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenc
 		now := cfg.Clock.Now()
 		last, _ = tracker.lastEvent()
 		sinceLast := now.Sub(last)
-		if sinceLast >= cfg.AgentQuietWindow {
+		elapsed := now.Sub(start)
+		if elapsed >= cfg.AgentQuietWindow && sinceLast >= cfg.AgentQuietWindow {
 			cfg.Logger.Info("sweep: agent quiesced",
 				"quiet_for", sinceLast,
-				"wait_elapsed", now.Sub(start))
+				"wait_elapsed", elapsed)
 			return
 		}
 		if !now.Before(deadline) {
 			cfg.Logger.Warn("sweep: agent quiescence timed out; proceeding with shutdown anyway",
-				"wait_elapsed", now.Sub(start),
+				"wait_elapsed", elapsed,
 				"since_last_event", sinceLast)
 			return
 		}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -776,3 +776,85 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 	assert.Less(t, elapsed, time.Second,
 		"Run took %v with a 30s quiet window but no Applied events — wait should have skipped", elapsed)
 }
+
+// TestRun_WaitsForAgentQuiescenceEvenOnAbort proves that the quiescence
+// wait also engages when provision was cancelled by ctx (e.g. the
+// observer's abort sentinel). Before this case was covered, the wait
+// was guarded by `err == nil` and got skipped on the abort path —
+// agentCancel() then killed the SSH session mid-commit, leaving
+// in-flight tunnels stranded on the device even though the onchain
+// deprovision had completed.
+func TestRun_WaitsForAgentQuiescenceEvenOnAbort(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	// Cancel ctx after the first user is created so provision exits with
+	// context.Canceled on the next loop iteration. Deprovision still
+	// runs to completion (uses WithoutCancel internally), and the wait
+	// should engage despite the cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	exec.afterCreate = func(calls int) {
+		if calls == 1 {
+			// Emit a synthetic agent commit so the tracker sees activity
+			// during the (brief) provision phase. Without an event,
+			// the wait would skip per TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved.
+			ag.Emit(agent.Event{Kind: agent.EventCommit, TunnelID: 0, At: time.Now()})
+			cancel()
+		}
+	}
+
+	const quietWindow = 100 * time.Millisecond
+	cfg := sweep.Config{
+		RunID:                  "run-quiesce-abort",
+		Target:                 4,
+		UsersPerBatch:          1,
+		Hold:                   0,
+		AgentQuietWindow:       quietWindow,
+		AgentQuiescenceTimeout: 5 * time.Second,
+		OwnerFilter:            owner,
+		Executor:               exec,
+		Agent:                  ag,
+		Runlog:                 w,
+		Clock:                  sweep.RealClock{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(ctx, cfg) }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s")
+	}
+	require.Error(t, runErr, "Run should surface the ctx-cancellation error")
+	assert.ErrorIs(t, runErr, context.Canceled)
+
+	// The wait should have engaged (not been guarded away by the
+	// `err == nil` check); we can't directly measure its duration here
+	// because deprovision races with it, but the sweep's overall
+	// runtime should be ≥ quietWindow when the wait actually fires.
+	// (Pre-fix: total runtime would be < 10ms because the wait was
+	// skipped on err != nil.)
+	// We rely on the test framework's timing to bound this loosely;
+	// the stronger assertion is the absence of stranded tunnels in
+	// real runs.
+	rows := readRows(t, path)
+	var sawCommit bool
+	for _, r := range rows {
+		if r.Event == runlog.EventDeprovisionActivate {
+			sawCommit = true
+			break
+		}
+	}
+	assert.True(t, sawCommit, "deprovision should still complete onchain after abort")
+}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -778,12 +778,19 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 }
 
 // TestRun_WaitsForAgentQuiescenceEvenOnAbort proves that the quiescence
-// wait also engages when provision was cancelled by ctx (e.g. the
-// observer's abort sentinel). Before this case was covered, the wait
-// was guarded by `err == nil` and got skipped on the abort path —
-// agentCancel() then killed the SSH session mid-commit, leaving
-// in-flight tunnels stranded on the device even though the onchain
-// deprovision had completed.
+// wait engages and blocks for the full window when provision was
+// cancelled by ctx (e.g. the observer's abort sentinel). The new branch
+// (introduced together with the elapsed-since-wait-start floor) needs
+// to be observable: the test asserts that the run blocks at least
+// `quietWindow` after deprovision returns, even though the agent emits
+// no events after ctx-cancellation. A regression that reverts either
+// (a) the `err == nil` guard removal or (b) the elapsed-since-wait-start
+// floor would surface here:
+//   - reverting (a) → wait is skipped, run returns in well under
+//     quietWindow.
+//   - reverting (b) → the absolute "silent for quietWindow" predicate
+//     is satisfied immediately (agent was already silent at wait
+//     start), so the wait returns instantly even with the new branch.
 func TestRun_WaitsForAgentQuiescenceEvenOnAbort(t *testing.T) {
 	t.Parallel()
 
@@ -802,17 +809,19 @@ func TestRun_WaitsForAgentQuiescenceEvenOnAbort(t *testing.T) {
 	// should engage despite the cancellation.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// Emit the synthetic agent event well before cancellation so the
+	// tracker's `lastEvent` timestamp is meaningfully older than the
+	// wait's start. This forces the wait to rely on the elapsed-since-
+	// wait-start floor — the absolute "silent for quietWindow" predicate
+	// would otherwise be satisfied immediately.
+	ag.Emit(agent.Event{Kind: agent.EventCommit, TunnelID: 0, At: time.Now()})
 	exec.afterCreate = func(calls int) {
 		if calls == 1 {
-			// Emit a synthetic agent commit so the tracker sees activity
-			// during the (brief) provision phase. Without an event,
-			// the wait would skip per TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved.
-			ag.Emit(agent.Event{Kind: agent.EventCommit, TunnelID: 0, At: time.Now()})
 			cancel()
 		}
 	}
 
-	const quietWindow = 100 * time.Millisecond
+	const quietWindow = 200 * time.Millisecond
 	cfg := sweep.Config{
 		RunID:                  "run-quiesce-abort",
 		Target:                 4,
@@ -828,6 +837,7 @@ func TestRun_WaitsForAgentQuiescenceEvenOnAbort(t *testing.T) {
 	}
 
 	done := make(chan error, 1)
+	start := time.Now()
 	go func() { done <- sweep.Run(ctx, cfg) }()
 
 	var runErr error
@@ -836,25 +846,24 @@ func TestRun_WaitsForAgentQuiescenceEvenOnAbort(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return within 2s")
 	}
+	elapsed := time.Since(start)
 	require.Error(t, runErr, "Run should surface the ctx-cancellation error")
 	assert.ErrorIs(t, runErr, context.Canceled)
-
-	// The wait should have engaged (not been guarded away by the
-	// `err == nil` check); we can't directly measure its duration here
-	// because deprovision races with it, but the sweep's overall
-	// runtime should be ≥ quietWindow when the wait actually fires.
-	// (Pre-fix: total runtime would be < 10ms because the wait was
-	// skipped on err != nil.)
-	// We rely on the test framework's timing to bound this loosely;
-	// the stronger assertion is the absence of stranded tunnels in
-	// real runs.
+	// The wait must block at least quietWindow even though ctx is
+	// cancelled — that's the whole point of the abort-path branch.
+	// Allow a generous lower bound (quietWindow/2) to absorb scheduler
+	// jitter; the negative case (wait skipped) returns in well under
+	// 10 ms.
+	assert.GreaterOrEqual(t, elapsed, quietWindow/2,
+		"Run returned in %v under abort; expected ≥ %v (quiet window floor)", elapsed, quietWindow/2)
+	// Deprovision should still complete onchain regardless of the wait.
 	rows := readRows(t, path)
-	var sawCommit bool
+	var sawDeprovisionActivate bool
 	for _, r := range rows {
 		if r.Event == runlog.EventDeprovisionActivate {
-			sawCommit = true
+			sawDeprovisionActivate = true
 			break
 		}
 	}
-	assert.True(t, sawCommit, "deprovision should still complete onchain after abort")
+	assert.True(t, sawDeprovisionActivate, "deprovision should still complete onchain after abort")
 }

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -94,7 +94,7 @@ Differences from the containerized harness:
 | Serviceability | deployed fresh per `dzctl start` | pre-deployed at `DZ_PROGRAM_ID`, initialized on first run |
 | Controller | `dz-local-controller` container | `go run controlplane/controller/cmd/controller start ...` on the host |
 | Device | cEOS container + agent wrapper script | physical DUT over SSH, no wrapper |
-| Agent invocation | wrapper injects `-pubkey` + sudo | orchestrator passes `-pubkey` directly and prefixes `/sbin/ip netns exec ns-management` |
+| Agent invocation | wrapper injects `-pubkey` + sudo | orchestrator passes `-pubkey` directly and prefixes `bash sudo /sbin/ip netns exec ns-management` (the `bash` keyword escapes EOS Cli into the shell; `sudo` provides CAP_SYS_ADMIN for `ip netns exec`) |
 
 The orchestrator gained four additive flags (`--agent-binary`,
 `--agent-command-prefix`, `--agent-pubkey`, `--agent-metrics-addr`) to
@@ -146,10 +146,17 @@ SDK checks or the agent will run but fail to apply config:
    `EAPI_USER` / `EAPI_PASS` before running.
 
 5. **Management netns.** The orchestrator wraps the agent command in
-   `ip netns exec ns-management` so it can reach the controller via
-   the management interface and dial the SDK in VRF management. EOS
-   auto-creates `ns-management` when a `vrf management` is configured;
-   confirm with `bash sudo ip netns list`.
+   `ip netns exec <netns>` so it can reach the controller via the
+   management interface and dial the SDK in the management VRF. EOS
+   auto-creates one netns per configured VRF; the netns name matches
+   the VRF name (e.g. `vrf management` → `ns-management`, `vrf mgmt` →
+   `ns-mgmt`). The harness defaults to `ns-management` to match the
+   long-form VRF name used by chi-dn-dzd5; override the
+   `AGENT_COMMAND_PREFIX` env var and the `DZ_STRESS_DEVICE_MGMT_VRF`
+   env var consistently if your device uses a different name (cEOS
+   uses `vrf mgmt`, so the containerized harness configures
+   `mgmt_vrf=mgmt` onchain). Confirm what's available with
+   `bash sudo ip netns list`.
 
 ## Quick start
 

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -96,9 +96,60 @@ Differences from the containerized harness:
 | Device | cEOS container + agent wrapper script | physical DUT over SSH, no wrapper |
 | Agent invocation | wrapper injects `-pubkey` + sudo | orchestrator passes `-pubkey` directly and prefixes `/sbin/ip netns exec ns-management` |
 
-The orchestrator gained three additive flags (`--agent-binary`,
-`--agent-command-prefix`, `--agent-pubkey`) to support the physical case.
-All default to empty so the containerized path is unchanged.
+The orchestrator gained four additive flags (`--agent-binary`,
+`--agent-command-prefix`, `--agent-pubkey`, `--agent-metrics-addr`) to
+support the physical case. All default to empty so the containerized
+path is unchanged.
+
+## Prerequisites on the physical DUT
+
+The script does not configure EOS — it assumes a few things are already
+in place on the device. Without these the script will either fail SSH /
+SDK checks or the agent will run but fail to apply config:
+
+1. **SSH access for the operator.** A user with a `/bin/bash` login
+   shell and passwordless sudo. cEOS pins `admin` to RunCli, so don't
+   use `admin`; create a separate operator user (this harness defaults
+   to `nik`) keyed with `$DUT_SSH_KEY.pub`.
+
+2. **`doublezero-agent` binary on disk.** Built statically for
+   `linux/amd64` and SCP'd to `$AGENT_BINARY` (default
+   `/mnt/flash/doublezero-agent`, which persists across reboots).
+   Build with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o
+   doublezero-agent ./controlplane/agent/cmd/agent` on a host with the
+   repo checked out.
+
+3. **EOS SDK RPC agent (`eapilocal`)** running in the management VRF —
+   the agent dials its local SDK at `127.0.0.1:9543`. cEOS provides
+   this implicitly via `management api eos-sdk-rpc / transport grpc
+   foo / localhost loopback`; physical EOS requires an explicit
+   `daemon eapilocal` block plus a VRF qualifier on the transport:
+   ```
+   daemon eapilocal
+      exec /usr/bin/EosSdkRpcAgent --daemon-name eapilocal
+      no shutdown
+   !
+   management api eos-sdk-rpc
+      transport grpc eapilocal
+         localhost loopback vrf management
+         service all
+         no disabled
+   !
+   ```
+   Verify with `show management api eos-sdk-rpc` — `Server: running`,
+   `Listening on: ... port: 9543, VRF: management`.
+
+4. **eAPI HTTP-commands enabled.** The device-observer scrapes `show
+   gre tunnel static`, `show processes top once`, etc. via eAPI. Make
+   sure `management api http-commands` is `no shutdown` and an admin
+   user with a password the harness can use exists. Export
+   `EAPI_USER` / `EAPI_PASS` before running.
+
+5. **Management netns.** The orchestrator wraps the agent command in
+   `ip netns exec ns-management` so it can reach the controller via
+   the management interface and dial the SDK in VRF management. EOS
+   auto-creates `ns-management` when a `vrf management` is configured;
+   confirm with `bash sudo ip netns list`.
 
 ## Quick start
 
@@ -106,6 +157,11 @@ All default to empty so the containerized path is unchanged.
 # Required: the stress-test serviceability program ID lives in the
 # private infra repo, not here. Export it before running.
 export DZ_PROGRAM_ID='<stress-program-id-from-infra-repo>'
+
+# Required: eAPI credentials for the observer. EAPI_USER defaults to
+# $DUT_SSH_USER; password must be supplied (no plaintext default).
+export EAPI_USER=admin
+read -s EAPI_PASS; export EAPI_PASS
 
 # Optional overrides (defaults shown in the script header):
 # export DZ_RPC_URL='https://...'
@@ -152,5 +208,7 @@ All knobs are env vars (defaults in the script header):
 | `CONTROLLER_ADVERTISE_ADDR` | Address advertised to the device (default: auto-detect) |
 | `CONTROLLER_LISTEN_PORT`  | Controller listen port (default `7000`)                   |
 | `SOLANA_KEYPAIR`          | Operator keypair (signs init + access-passes)             |
+| `EAPI_USER`               | eAPI HTTP basic-auth user (default `admin`)               |
+| `EAPI_PASS`               | eAPI HTTP basic-auth password (no default — required)     |
 | `DEVICE_CODE`             | Device code onchain (default `chi-dn-dzd5`)               |
 | `DEVICE_DZ_PREFIX`        | Device's dz-prefix /29 (carved from the tunnel block)     |

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -103,13 +103,16 @@ All default to empty so the containerized path is unchanged.
 ## Quick start
 
 ```bash
-# Required env (set per operator):
-export DZ_RPC_URL='https://doublezerolocalnet.rpcpool.com/...'   # devnet pool
-export DZ_PROGRAM_ID='GXxf6xgCdngKsRPGg3svaoKUQskVnu4mTuUoJ5PhNUau'
-export DUT_HOST=10.0.0.141
-export DUT_SSH_USER=admin
-export DUT_SSH_KEY=$HOME/.ssh/id_ed25519
-export SOLANA_KEYPAIR=$HOME/.config/solana/id.json
+# Required: the stress-test serviceability program ID lives in the
+# private infra repo, not here. Export it before running.
+export DZ_PROGRAM_ID='<stress-program-id-from-infra-repo>'
+
+# Optional overrides (defaults shown in the script header):
+# export DZ_RPC_URL='https://...'
+# export DUT_HOST=10.0.0.15
+# export DUT_SSH_USER=nik
+# export DUT_SSH_KEY=$HOME/.ssh/nik@malbeclabs.com
+# export SOLANA_KEYPAIR=$HOME/.config/doublezero/id.json
 
 # 4-user smoke run
 tools/stress/scripts/run-stress-physical.sh --target-users 4 --users-per-batch 2 --hold 0

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -77,3 +77,77 @@ script points the observer's `--agent-metrics-url` at the same port.
 dev/dzctl destroy -y
 docker rm -f dz-local-device-dzstress 2>/dev/null
 ```
+
+---
+
+# Physical-device harness
+
+`run-stress-physical.sh` reuses the same orchestrator/observer binaries
+against a real Arista EOS device, with a host-local controller and the
+devnet ledger.
+
+Differences from the containerized harness:
+
+| | Containerized | Physical |
+| --- | --- | --- |
+| Ledger | local solana-test-validator | devnet RPC (`DZ_RPC_URL`) |
+| Serviceability | deployed fresh per `dzctl start` | pre-deployed at `DZ_PROGRAM_ID`, initialized on first run |
+| Controller | `dz-local-controller` container | `go run controlplane/controller/cmd/controller start ...` on the host |
+| Device | cEOS container + agent wrapper script | physical DUT over SSH, no wrapper |
+| Agent invocation | wrapper injects `-pubkey` + sudo | orchestrator passes `-pubkey` directly and prefixes `/sbin/ip netns exec ns-management` |
+
+The orchestrator gained three additive flags (`--agent-binary`,
+`--agent-command-prefix`, `--agent-pubkey`) to support the physical case.
+All default to empty so the containerized path is unchanged.
+
+## Quick start
+
+```bash
+# Required env (set per operator):
+export DZ_RPC_URL='https://doublezerolocalnet.rpcpool.com/...'   # devnet pool
+export DZ_PROGRAM_ID='GXxf6xgCdngKsRPGg3svaoKUQskVnu4mTuUoJ5PhNUau'
+export DUT_HOST=10.0.0.141
+export DUT_SSH_USER=admin
+export DUT_SSH_KEY=$HOME/.ssh/id_ed25519
+export SOLANA_KEYPAIR=$HOME/.config/solana/id.json
+
+# 4-user smoke run
+tools/stress/scripts/run-stress-physical.sh --target-users 4 --users-per-batch 2 --hold 0
+```
+
+The script:
+1. SSH-pings the DUT and verifies `$AGENT_BINARY` exists on it.
+2. Initializes the serviceability program (global-config + one location +
+   one exchange + contributor `co01`) if not already initialized.
+3. Creates the device + loopbacks onchain (idempotent).
+4. Launches the controller on the host with
+   `--max-user-tunnel-slots $TARGET_USERS` and waits for the gRPC port.
+5. Sets up access passes in parallel against the devnet RPC.
+6. Builds the orchestrator + observer binaries and launches them in the
+   background, pointing at the physical DUT.
+
+The controller pid is recorded in `dev/.deploy/stress-physical/run/controller.pid`;
+the orchestrator + observer pids land in the per-run subdirectory
+(`run/<UTC timestamp>/`). Stop everything with the `kill $(cat …)`
+snippet the script prints.
+
+## Overrides
+
+All knobs are env vars (defaults in the script header):
+
+| Var                       | Purpose                                                   |
+| ------------------------- | --------------------------------------------------------- |
+| `DZ_RPC_URL`              | Devnet RPC URL                                            |
+| `DZ_PROGRAM_ID`           | Pre-deployed serviceability program ID                    |
+| `DUT_HOST`                | Device IP/hostname                                        |
+| `DUT_SSH_USER`            | SSH user on the device                                    |
+| `DUT_SSH_KEY`             | SSH private key path                                      |
+| `AGENT_BINARY`            | Path of `doublezero-agent` on the device                  |
+| `AGENT_COMMAND_PREFIX`    | Prepended to the agent command (default: ns-management)   |
+| `AGENT_METRICS_PORT`      | Metrics listener port on the device (default `50100`)     |
+| `CONTROLLER_BIND_ADDR`    | Controller listen address (default `0.0.0.0`)             |
+| `CONTROLLER_ADVERTISE_ADDR` | Address advertised to the device (default: auto-detect) |
+| `CONTROLLER_LISTEN_PORT`  | Controller listen port (default `7000`)                   |
+| `SOLANA_KEYPAIR`          | Operator keypair (signs init + access-passes)             |
+| `DEVICE_CODE`             | Device code onchain (default `chi-dn-dzd5`)               |
+| `DEVICE_DZ_PREFIX`        | Device's dz-prefix /29 (carved from the tunnel block)     |

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -15,15 +15,20 @@
 #   tools/stress/scripts/run-stress-physical.sh \
 #       --target-users 4 --users-per-batch 2 --hold 0
 #
-# Required env (or defaults shown):
+# Required env:
+#   DZ_PROGRAM_ID       serviceability program id (no default — operator
+#                       passes the stress-test program id, e.g. from the
+#                       private infra repo)
+# Env (defaults shown — override per operator):
 #   DZ_RPC_URL          devnet RPC (default: doublezerolocalnet pool)
-#   DZ_PROGRAM_ID       serviceability program id (default: GXxf6xgC...)
-#   DUT_HOST            device IP or hostname (default: 10.0.0.141)
+#   DUT_HOST            device IP or hostname
 #   DUT_SSH_USER        SSH user on the DUT
 #   DUT_SSH_KEY         SSH private key path
-#   CONTROLLER_BIND_ADDR  controller listen address (default: 10.0.0.141's gateway from the DUT)
-#   AGENT_BINARY        path to doublezero-agent on the DUT (default: /usr/local/bin/doublezero-agent)
-#   SOLANA_KEYPAIR      operator's keypair (default: $HOME/.config/solana/id.json)
+#   CONTROLLER_BIND_ADDR  controller listen address (default: 0.0.0.0)
+#   AGENT_BINARY        path to doublezero-agent on the DUT
+#   SOLANA_KEYPAIR      operator's keypair (default: $HOME/.config/doublezero/id.json
+#                       — the same default the doublezero CLI uses, so `dz` calls
+#                       and orchestrator share the operator's authority)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
@@ -33,7 +38,10 @@ WORKSPACE_DIR="$(cd -- "${SCRIPT_DIR}/../../.." &> /dev/null && pwd)"
 # Config (env-overridable)
 # ---------------------------------------------------------------------------
 DZ_RPC_URL="${DZ_RPC_URL:-https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16}"
-DZ_PROGRAM_ID="${DZ_PROGRAM_ID:-GXxf6xgCdngKsRPGg3svaoKUQskVnu4mTuUoJ5PhNUau}"
+# DZ_PROGRAM_ID has no default: the stress-test serviceability program ID is
+# kept in the private infra repo, not here. Operators export it before
+# running the script.
+DZ_PROGRAM_ID="${DZ_PROGRAM_ID:?DZ_PROGRAM_ID is required (stress-test serviceability program id; see infra repo)}"
 
 DUT_HOST="${DUT_HOST:-10.0.0.15}"
 DUT_SSH_USER="${DUT_SSH_USER:-nik}"
@@ -69,7 +77,11 @@ CONTROLLER_BIND_ADDR="${CONTROLLER_BIND_ADDR:-0.0.0.0}"
 CONTROLLER_ADVERTISE_ADDR="${CONTROLLER_ADVERTISE_ADDR:-}"
 CONTROLLER_LISTEN_PORT="${CONTROLLER_LISTEN_PORT:-7000}"
 
-SOLANA_KEYPAIR="${SOLANA_KEYPAIR:-$HOME/.config/solana/id.json}"
+# Default to the doublezero CLI's keypair location so `dz` (which reads this
+# location implicitly) and the orchestrator's --keypair both use the same
+# operator authority. The standard solana CLI default at ~/.config/solana/id.json
+# may be a different key and would need an explicit override.
+SOLANA_KEYPAIR="${SOLANA_KEYPAIR:-$HOME/.config/doublezero/id.json}"
 
 DEPLOY_DIR="${WORKSPACE_DIR}/dev/.deploy/stress-physical"
 WORKING_DIR="${DZ_STRESS_WORKING_DIR:-${DEPLOY_DIR}/run}"

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -296,6 +296,26 @@ if ss -ltn "sport = :$CONTROLLER_LISTEN_PORT" 2>/dev/null | tail -n +2 | grep -q
 fi
 
 log "starting controller (listen=${CONTROLLER_BIND_ADDR}:${CONTROLLER_LISTEN_PORT}, max-slots=${TARGET_USERS})"
+
+# Teardown trap: kill the controller on script exit so a Ctrl-C doesn't leave
+# it lingering. The orchestrator + observer are intentionally NOT killed by
+# this script — they run in the background past script exit.
+#
+# Cleanup tries the listener pid (set after the port is up) first, then
+# falls back to the `go run` parent. Killing only `go run` orphans its
+# child; killing the listener causes `go run` to exit on its own. The
+# trap is armed BEFORE the `nohup go run ... &` so a `set -e` failure
+# anywhere between launch and trap arming can't orphan the controller.
+cleanup_controller() {
+    for pid in "${CONTROLLER_LISTENER_PID:-}" "${CONTROLLER_PARENT_PID:-}"; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            log "stopping controller (pid=$pid)"
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+}
+trap cleanup_controller EXIT
+
 (
     cd "$WORKSPACE_DIR"
     nohup go run ./controlplane/controller/cmd/controller start \
@@ -314,23 +334,6 @@ log "starting controller (listen=${CONTROLLER_BIND_ADDR}:${CONTROLLER_LISTEN_POR
 # the child. We overwrite this once the port is up.
 CONTROLLER_PARENT_PID="$(cat "$CONTROLLER_PID_FILE")"
 log "controller (go run) pid: $CONTROLLER_PARENT_PID (log: $CONTROLLER_LOG)"
-
-# Teardown trap: kill the controller on script exit so a Ctrl-C doesn't leave
-# it lingering. The orchestrator + observer are intentionally NOT killed by
-# this script — they run in the background past script exit.
-#
-# Cleanup tries the listener pid (set after the port is up) first, then
-# falls back to the `go run` parent. Killing only `go run` orphans its
-# child; killing the listener causes `go run` to exit on its own.
-cleanup_controller() {
-    for pid in "${CONTROLLER_LISTENER_PID:-}" "$CONTROLLER_PARENT_PID"; do
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            log "stopping controller (pid=$pid)"
-            kill "$pid" 2>/dev/null || true
-        fi
-    done
-}
-trap cleanup_controller EXIT
 
 # Wait for the controller's listen port to accept connections (gRPC handshake).
 # The cleanup trap stays armed through every following phase (access-pass
@@ -358,7 +361,17 @@ fi
 # compiled binary that `go run` exec'd) and overwrite the pid file so
 # `kill $(cat $CONTROLLER_PID_FILE)` from any subsequent invocation kills
 # the listener, not just the `go run` shim.
-CONTROLLER_LISTENER_PID="$(ss -ltnp "sport = :$CONTROLLER_LISTEN_PORT" 2>/dev/null | grep -oP 'pid=\K\d+' | head -1)"
+#
+# Primary: `ss -ltnp pid=` parses the listener pid from the kernel's
+# socket table. Requires the user to own the socket (or be root) AND
+# GNU grep for `\K`. Fallback: `pgrep -P` walks the process tree from
+# the `go run` parent to its compiled-binary child, which doesn't need
+# either privilege or GNU grep — covers e.g. BSD/macOS or restricted
+# environments where the ss form returns nothing.
+CONTROLLER_LISTENER_PID="$(ss -ltnp "sport = :$CONTROLLER_LISTEN_PORT" 2>/dev/null | grep -oP 'pid=\K\d+' | head -1 || true)"
+if [ -z "$CONTROLLER_LISTENER_PID" ] && [ -n "$CONTROLLER_PARENT_PID" ]; then
+    CONTROLLER_LISTENER_PID="$(pgrep -P "$CONTROLLER_PARENT_PID" | head -1 || true)"
+fi
 if [ -n "$CONTROLLER_LISTENER_PID" ]; then
     echo "$CONTROLLER_LISTENER_PID" > "$CONTROLLER_PID_FILE"
     log "controller listener pid: $CONTROLLER_LISTENER_PID (overwrote pidfile)"

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# Bring up a host-local controller against the devnet ledger and run the
+# stress-test orchestrator + observer against a physical Arista EOS device.
+#
+# Sister to run-stress-local.sh; same orchestrator/observer binaries, different
+# environment:
+#   - ledger:     devnet RPC (DZ_RPC_URL)
+#   - serviceability: pre-deployed program at DZ_PROGRAM_ID, initialized here
+#                     on first run via doublezero CLI (idempotent)
+#   - controller: launched directly via `go run controlplane/controller/...`
+#   - device:     physical DUT reachable over SSH (DUT_HOST), agent invoked
+#                 inside the device's `ns-management` network namespace
+#
+# Usage:
+#   tools/stress/scripts/run-stress-physical.sh \
+#       --target-users 4 --users-per-batch 2 --hold 0
+#
+# Required env (or defaults shown):
+#   DZ_RPC_URL          devnet RPC (default: doublezerolocalnet pool)
+#   DZ_PROGRAM_ID       serviceability program id (default: GXxf6xgC...)
+#   DUT_HOST            device IP or hostname (default: 10.0.0.141)
+#   DUT_SSH_USER        SSH user on the DUT
+#   DUT_SSH_KEY         SSH private key path
+#   CONTROLLER_BIND_ADDR  controller listen address (default: 10.0.0.141's gateway from the DUT)
+#   AGENT_BINARY        path to doublezero-agent on the DUT (default: /usr/local/bin/doublezero-agent)
+#   SOLANA_KEYPAIR      operator's keypair (default: $HOME/.config/solana/id.json)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+WORKSPACE_DIR="$(cd -- "${SCRIPT_DIR}/../../.." &> /dev/null && pwd)"
+
+# ---------------------------------------------------------------------------
+# Config (env-overridable)
+# ---------------------------------------------------------------------------
+DZ_RPC_URL="${DZ_RPC_URL:-https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16}"
+DZ_PROGRAM_ID="${DZ_PROGRAM_ID:-GXxf6xgCdngKsRPGg3svaoKUQskVnu4mTuUoJ5PhNUau}"
+
+DUT_HOST="${DUT_HOST:-10.0.0.141}"
+DUT_SSH_USER="${DUT_SSH_USER:-admin}"
+DUT_SSH_KEY="${DUT_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+AGENT_BINARY="${AGENT_BINARY:-/usr/local/bin/doublezero-agent}"
+AGENT_COMMAND_PREFIX="${AGENT_COMMAND_PREFIX:-/sbin/ip netns exec ns-management}"
+AGENT_METRICS_PORT="${AGENT_METRICS_PORT:-50100}"
+
+DEVICE_CODE="${DZ_STRESS_DEVICE_CODE:-chi-dn-dzd5}"
+DEVICE_LOCATION="${DZ_STRESS_DEVICE_LOCATION:-ewr}"
+DEVICE_EXCHANGE="${DZ_STRESS_DEVICE_EXCHANGE:-xewr}"
+DEVICE_PUBLIC_IP="${DZ_STRESS_DEVICE_PUBLIC_IP:-$DUT_HOST}"
+# /29 carved out of the device-tunnel-block. Override if it collides with
+# another device's prefixes in the program.
+DEVICE_DZ_PREFIX="${DZ_STRESS_DEVICE_DZ_PREFIX:-9.210.180.176/29}"
+
+# Where the device reaches the controller. Default to the same address the
+# user mentioned the device can reach (chi-dn-bm1's mgmt IP from the DUT).
+# Override if the host has a different routable address.
+CONTROLLER_BIND_ADDR="${CONTROLLER_BIND_ADDR:-0.0.0.0}"
+CONTROLLER_ADVERTISE_ADDR="${CONTROLLER_ADVERTISE_ADDR:-}"
+CONTROLLER_LISTEN_PORT="${CONTROLLER_LISTEN_PORT:-7000}"
+
+SOLANA_KEYPAIR="${SOLANA_KEYPAIR:-$HOME/.config/solana/id.json}"
+
+DEPLOY_DIR="${WORKSPACE_DIR}/dev/.deploy/stress-physical"
+WORKING_DIR="${DZ_STRESS_WORKING_DIR:-${DEPLOY_DIR}/run}"
+
+TARGET_USERS="${DZ_STRESS_TARGET_USERS:-4}"
+USERS_PER_BATCH="${DZ_STRESS_USERS_PER_BATCH:-2}"
+HOLD_SECONDS="${DZ_STRESS_HOLD_SECONDS:-0}"
+SAMPLE_INTERVAL="${DZ_STRESS_SAMPLE_INTERVAL:-10s}"
+ACCESS_PASS_PARALLEL="${DZ_STRESS_ACCESS_PASS_PARALLEL:-16}"
+# Same routability constraint as run-stress-local.sh: client_ip must be
+# globally routable (the program rejects CGNAT).
+CLIENT_IP_BASE="${DZ_STRESS_CLIENT_IP_BASE:-9.200.0.0}"
+
+NO_AGENT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-agent) NO_AGENT=true; shift ;;
+        --target-users) TARGET_USERS="$2"; shift 2 ;;
+        --users-per-batch) USERS_PER_BATCH="$2"; shift 2 ;;
+        --hold) HOLD_SECONDS="$2"; shift 2 ;;
+        --sample-interval) SAMPLE_INTERVAL="$2"; shift 2 ;;
+        -h|--help) sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { printf '\033[1;36m[stress-physical]\033[0m %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"
+}
+require doublezero
+require solana
+require go
+require jq
+require ssh
+require nc
+require python3   # IP-in-subnet math
+[ -r "$SOLANA_KEYPAIR" ] || die "solana keypair not readable: $SOLANA_KEYPAIR"
+[ -r "$DUT_SSH_KEY" ]    || die "DUT SSH key not readable: $DUT_SSH_KEY"
+
+# All doublezero CLI invocations go through this wrapper so RPC + program id
+# overrides are consistent regardless of $DOUBLEZERO_ENV in the operator's
+# environment.
+dz() {
+    doublezero --url "$DZ_RPC_URL" --program-id "$DZ_PROGRAM_ID" "$@"
+}
+
+solana_cli() {
+    solana --url "$DZ_RPC_URL" --keypair "$SOLANA_KEYPAIR" "$@"
+}
+
+mkdir -p "$DEPLOY_DIR" "$WORKING_DIR"
+
+# ---------------------------------------------------------------------------
+# Phase 1: connectivity sanity checks
+# ---------------------------------------------------------------------------
+log "verifying SSH reachability of $DUT_HOST"
+ssh -i "$DUT_SSH_KEY" -o BatchMode=yes -o ConnectTimeout=5 \
+    -o StrictHostKeyChecking=accept-new \
+    "$DUT_SSH_USER@$DUT_HOST" "echo ssh-ok" >/dev/null \
+    || die "cannot SSH into $DUT_SSH_USER@$DUT_HOST with $DUT_SSH_KEY"
+
+log "verifying $AGENT_BINARY exists on the DUT"
+ssh -i "$DUT_SSH_KEY" -o BatchMode=yes "$DUT_SSH_USER@$DUT_HOST" \
+    "test -x $AGENT_BINARY" \
+    || die "agent binary not found at $AGENT_BINARY on $DUT_HOST — set AGENT_BINARY"
+
+log "verifying solana RPC reachability"
+solana_cli cluster-version >/dev/null \
+    || die "cannot reach Solana RPC at $DZ_RPC_URL"
+
+# ---------------------------------------------------------------------------
+# Phase 2: initialize the serviceability program (idempotent)
+#
+# Mirrors the steps in e2e/internal/devnet/smartcontract_init.go:64-148,
+# scoped down to the single location/exchange we use. Each step checks
+# whether the resource already exists so reruns are safe.
+# ---------------------------------------------------------------------------
+PAYER_PUBKEY="$(solana-keygen pubkey "$SOLANA_KEYPAIR" | tr -d '[:space:]')"
+log "operator pubkey (signer + access-pass payer): $PAYER_PUBKEY"
+
+balance="$(solana_cli balance --output json 2>/dev/null | jq -r '.lamports // 0')"
+if [ "${balance:-0}" -eq 0 ]; then
+    log "operator balance is 0; requesting airdrop"
+    solana_cli airdrop 10 "$PAYER_PUBKEY" >/dev/null \
+        || die "airdrop failed — fund $PAYER_PUBKEY manually before retrying"
+fi
+
+if dz global-config get >/dev/null 2>&1; then
+    log "global-config already initialized; skipping init"
+else
+    log "running doublezero init"
+    dz init
+    dz global-config set \
+        --local-asn 65000 --remote-asn 65342 \
+        --device-tunnel-block 9.210.180.0/24 \
+        --user-tunnel-block 169.254.0.0/16 \
+        --multicastgroup-block 233.84.178.0/24 \
+        --multicast-publisher-block 148.51.120.0/21
+    dz global-config authority set \
+        --activator-authority me --sentinel-authority me
+fi
+
+if ! dz location get --code "$DEVICE_LOCATION" >/dev/null 2>&1; then
+    log "creating location $DEVICE_LOCATION"
+    dz location create --code "$DEVICE_LOCATION" --name "New York" \
+        --country US --lat 40.780297071772125 --lng -74.07203003496925
+fi
+
+if ! dz exchange get --code "$DEVICE_EXCHANGE" >/dev/null 2>&1; then
+    log "creating exchange $DEVICE_EXCHANGE"
+    dz exchange create --code "$DEVICE_EXCHANGE" --name "New York" \
+        --lat 40.780297071772125 --lng -74.07203003496925
+fi
+
+if ! dz contributor get --code co01 >/dev/null 2>&1; then
+    log "creating contributor co01"
+    dz contributor create --code co01 --owner me
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3: create the device onchain
+# ---------------------------------------------------------------------------
+if ! dz device get --code "$DEVICE_CODE" >/dev/null 2>&1; then
+    log "creating device onchain (code=$DEVICE_CODE)"
+    dz device create \
+        --contributor co01 \
+        --code "$DEVICE_CODE" \
+        --location "$DEVICE_LOCATION" \
+        --exchange "$DEVICE_EXCHANGE" \
+        --public-ip "$DEVICE_PUBLIC_IP" \
+        --dz-prefixes "$DEVICE_DZ_PREFIX" \
+        --mgmt-vrf mgmt
+    DEVICE_PK="$(dz device get --code "$DEVICE_CODE" --json | jq -r .account)"
+    dz device update --pubkey "$DEVICE_PK" --max-users "$TARGET_USERS" \
+        --desired-status activated
+fi
+
+DEVICE_PUBKEY="$(dz device get --code "$DEVICE_CODE" --json | jq -r .account)"
+log "device onchain pubkey: $DEVICE_PUBKEY"
+
+for entry in "Loopback255:vpnv4" "Loopback256:ipv4"; do
+    iface="${entry%:*}"
+    iftype="${entry#*:}"
+    out=$(dz device interface create "$DEVICE_CODE" "$iface" \
+        --loopback-type "$iftype" --bandwidth 10G 2>&1) || true
+    if echo "$out" | grep -q "already exists"; then
+        log "loopback ${iface} (${iftype}) already exists onchain"
+    else
+        log "registered loopback ${iface} (${iftype})"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Phase 4: launch the controller
+#
+# `go run` is intentional per the user spec — convenient for iteration; the
+# operator can later swap to a built binary if startup time matters.
+# ---------------------------------------------------------------------------
+CONTROLLER_LOG="${WORKING_DIR}/controller.log"
+CONTROLLER_PID_FILE="${WORKING_DIR}/controller.pid"
+
+log "starting controller (listen=${CONTROLLER_BIND_ADDR}:${CONTROLLER_LISTEN_PORT}, max-slots=${TARGET_USERS})"
+(
+    cd "$WORKSPACE_DIR"
+    nohup go run ./controlplane/controller/cmd/controller start \
+        --program-id "$DZ_PROGRAM_ID" \
+        --solana-rpc-endpoint "$DZ_RPC_URL" \
+        --device-local-asn 65000 \
+        --listen-addr "$CONTROLLER_BIND_ADDR" \
+        --listen-port "$CONTROLLER_LISTEN_PORT" \
+        --max-user-tunnel-slots "$TARGET_USERS" \
+        --no-hardware \
+        > "$CONTROLLER_LOG" 2>&1 &
+    echo $! > "$CONTROLLER_PID_FILE"
+)
+CONTROLLER_PID="$(cat "$CONTROLLER_PID_FILE")"
+log "controller pid: $CONTROLLER_PID (log: $CONTROLLER_LOG)"
+
+# Teardown trap: kill the controller on script exit so a Ctrl-C doesn't leave
+# it lingering. The orchestrator + observer are intentionally NOT killed by
+# this script — they run in the background past script exit.
+cleanup_controller() {
+    if kill -0 "$CONTROLLER_PID" 2>/dev/null; then
+        log "stopping controller (pid=$CONTROLLER_PID)"
+        kill "$CONTROLLER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_controller EXIT
+
+# Wait for the controller's listen port to accept connections (gRPC handshake).
+log "waiting for controller to accept connections"
+for _ in $(seq 1 30); do
+    if nc -z -w 1 127.0.0.1 "$CONTROLLER_LISTEN_PORT" 2>/dev/null; then
+        log "controller listening on :${CONTROLLER_LISTEN_PORT}"
+        # Disarm the trap — controller is up and should outlive this script.
+        trap - EXIT
+        break
+    fi
+    sleep 1
+done
+if ! nc -z -w 1 127.0.0.1 "$CONTROLLER_LISTEN_PORT" 2>/dev/null; then
+    log "controller log tail:"
+    tail -50 "$CONTROLLER_LOG" >&2 || true
+    die "controller did not start listening within 30s"
+fi
+
+# Determine the address the device will use to reach the controller. If the
+# operator didn't override it, default to the host's primary IP that's
+# routable from the device's subnet (best-effort).
+if [ -z "$CONTROLLER_ADVERTISE_ADDR" ]; then
+    CONTROLLER_ADVERTISE_ADDR="$(python3 -c '
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.connect(("'"$DUT_HOST"'", 80))
+print(s.getsockname()[0])
+s.close()
+' 2>/dev/null || echo "")"
+fi
+[ -n "$CONTROLLER_ADVERTISE_ADDR" ] || die "could not determine controller advertise addr; set CONTROLLER_ADVERTISE_ADDR"
+log "controller reachable to device at: ${CONTROLLER_ADVERTISE_ADDR}:${CONTROLLER_LISTEN_PORT}"
+
+# ---------------------------------------------------------------------------
+# Phase 5: access-pass setup (parallel)
+# ---------------------------------------------------------------------------
+IFS=. read -r b1 b2 b3 b4 <<<"$CLIENT_IP_BASE"
+log "creating access passes for ${CLIENT_IP_BASE}+0..$((TARGET_USERS-1)) (payer=$PAYER_PUBKEY, parallel=$ACCESS_PASS_PARALLEL)"
+export DZ_RPC_URL DZ_PROGRAM_ID PAYER_PUBKEY b1 b2 b3 b4
+seq 0 $((TARGET_USERS - 1)) | xargs -P "$ACCESS_PASS_PARALLEL" -I{} bash -c '
+    i=$1
+    host=$(( (b3 << 8) + b4 + i ))
+    octet3=$(( (host >> 8) & 0xff ))
+    octet4=$(( host & 0xff ))
+    client_ip="${b1}.${b2}.${octet3}.${octet4}"
+    doublezero --url "$DZ_RPC_URL" --program-id "$DZ_PROGRAM_ID" \
+        access-pass set \
+            --accesspass-type prepaid \
+            --client-ip "$client_ip" \
+            --user-payer "$PAYER_PUBKEY" >/dev/null
+' _ {}
+
+# ---------------------------------------------------------------------------
+# Phase 6: build orchestrator + observer
+# ---------------------------------------------------------------------------
+log "building orchestrator + observer binaries"
+ORCH_BIN="${DEPLOY_DIR}/device-orchestrator"
+OBS_BIN="${DEPLOY_DIR}/device-observer"
+( cd "$WORKSPACE_DIR" && \
+  go build -o "$ORCH_BIN" ./tools/stress/device-orchestrator/cmd/device-orchestrator && \
+  go build -o "$OBS_BIN"  ./tools/stress/device-observer/cmd/device-observer )
+
+# ---------------------------------------------------------------------------
+# Phase 7: launch orchestrator + observer
+# ---------------------------------------------------------------------------
+RUN_DIR="${WORKING_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$RUN_DIR"
+log "run working-dir: $RUN_DIR"
+
+ORCH_ARGS=(
+    --dut-pubkey "$DEVICE_PUBKEY"
+    --rpc-url "$DZ_RPC_URL"
+    --program-id "$DZ_PROGRAM_ID"
+    --keypair "$SOLANA_KEYPAIR"
+    --working-dir "$RUN_DIR"
+    --abort-file "${RUN_DIR}/abort"
+    --target-user-count "$TARGET_USERS"
+    --users-per-batch "$USERS_PER_BATCH"
+    --hold-seconds "$HOLD_SECONDS"
+    --client-ip-base "$CLIENT_IP_BASE"
+    --dut-ssh-host "${DUT_HOST}:22"
+    --dut-ssh-user "$DUT_SSH_USER"
+    --dut-ssh-key "$DUT_SSH_KEY"
+    --controller "${CONTROLLER_ADVERTISE_ADDR}:${CONTROLLER_LISTEN_PORT}"
+    --agent-binary "$AGENT_BINARY"
+    --agent-command-prefix "$AGENT_COMMAND_PREFIX"
+    --agent-pubkey "$DEVICE_PUBKEY"
+)
+if [ "$NO_AGENT" = true ]; then
+    ORCH_ARGS+=(--no-agent)
+fi
+
+log "launching orchestrator (background)"
+nohup "$ORCH_BIN" "${ORCH_ARGS[@]}" \
+    > "${RUN_DIR}/orchestrator.stdout" \
+    2> "${RUN_DIR}/orchestrator.stderr" &
+ORCH_PID=$!
+echo "$ORCH_PID" > "${RUN_DIR}/orchestrator.pid"
+
+log "launching observer (background)"
+nohup "$OBS_BIN" \
+    --dut-host "$DUT_HOST" \
+    --eapi-user "$DUT_SSH_USER" --eapi-pass "" \
+    --agent-metrics-url "http://${DUT_HOST}:${AGENT_METRICS_PORT}/metrics" \
+    --working-dir "$RUN_DIR" \
+    --abort-file "${RUN_DIR}/abort" \
+    --sample-interval "$SAMPLE_INTERVAL" \
+    --force \
+    > "${RUN_DIR}/observer.stdout" \
+    2> "${RUN_DIR}/observer.stderr" &
+OBS_PID=$!
+echo "$OBS_PID" > "${RUN_DIR}/observer.pid"
+
+cat <<EOF
+
+==> stress test launched against $DUT_HOST
+    controller   pid : $CONTROLLER_PID  (log: $CONTROLLER_LOG)
+    orchestrator pid : $ORCH_PID  (logs: ${RUN_DIR}/orchestrator.std{out,err})
+    observer     pid : $OBS_PID  (logs: ${RUN_DIR}/observer.std{out,err})
+    working dir      : ${RUN_DIR}
+    abort sentinel   : ${RUN_DIR}/abort
+
+To stop everything:  kill \$(cat ${CONTROLLER_PID_FILE} ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid)
+To follow:           tail -F ${RUN_DIR}/orchestrator.stderr ${RUN_DIR}/observer.stderr ${CONTROLLER_LOG}
+EOF

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -77,6 +77,11 @@ DEVICE_PUBLIC_IP="${DZ_STRESS_DEVICE_PUBLIC_IP:-9.210.180.5}"
 # the device advertises for its tunnels — separate from device-tunnel-block
 # (which is the private pool the program auto-allocates loopback IPs from).
 DEVICE_DZ_PREFIX="${DZ_STRESS_DEVICE_DZ_PREFIX:-9.210.180.176/29}"
+# The mgmt VRF name baked into the device account. The controller renders
+# config like `ntp server vrf <MGMT_VRF> ...`, so this must match the VRF
+# name actually configured on the DUT. cEOS uses `mgmt`; real Arista EOS
+# typically uses the full `management`. Override if the device differs.
+DEVICE_MGMT_VRF="${DZ_STRESS_DEVICE_MGMT_VRF:-management}"
 
 # Where the device reaches the controller. Default to the same address the
 # user mentioned the device can reach (chi-dn-bm1's mgmt IP from the DUT).
@@ -230,19 +235,21 @@ if ! dz device get --code "$DEVICE_CODE" >/dev/null 2>&1; then
         --exchange "$DEVICE_EXCHANGE" \
         --public-ip "$DEVICE_PUBLIC_IP" \
         --dz-prefixes "$DEVICE_DZ_PREFIX" \
-        --mgmt-vrf mgmt
+        --mgmt-vrf "$DEVICE_MGMT_VRF"
 fi
 
 DEVICE_PUBKEY="$(dz device get --code "$DEVICE_CODE" --json | jq -r .account)"
 log "device onchain pubkey: $DEVICE_PUBKEY"
 
-# Keep the onchain cap in sync with TARGET_USERS on every run. The create
-# branch above sets it implicitly on first run, but reruns with a larger
-# --target-users would otherwise leave the cap at its original value and
-# silently truncate the sweep — the controller's --max-user-tunnel-slots
-# would advertise the new number while the device account still capped at
-# the old one. (Reported by @elitegreg in #3829 review.)
-dz device update --pubkey "$DEVICE_PUBKEY" --max-users "$TARGET_USERS" \
+# Keep the onchain device record in sync with the script's env on every
+# run. The create branch above sets these implicitly on first run, but
+# reruns with a changed --target-users or DEVICE_MGMT_VRF would otherwise
+# leave the old values stuck — the controller's rendered config (and the
+# orchestrator's slot accounting) would then disagree with onchain state.
+# (--max-users issue reported by @elitegreg in #3829 review.)
+dz device update --pubkey "$DEVICE_PUBKEY" \
+    --max-users "$TARGET_USERS" \
+    --mgmt-vrf "$DEVICE_MGMT_VRF" \
     --desired-status activated
 
 for entry in "Loopback255:vpnv4" "Loopback256:ipv4"; do
@@ -302,17 +309,26 @@ log "starting controller (listen=${CONTROLLER_BIND_ADDR}:${CONTROLLER_LISTEN_POR
         > "$CONTROLLER_LOG" 2>&1 &
     echo $! > "$CONTROLLER_PID_FILE"
 )
-CONTROLLER_PID="$(cat "$CONTROLLER_PID_FILE")"
-log "controller pid: $CONTROLLER_PID (log: $CONTROLLER_LOG)"
+# Provisionally tracks the `go run` parent PID. `go run` compiles a temp
+# binary then exec's it as a child process; the actual port listener is
+# the child. We overwrite this once the port is up.
+CONTROLLER_PARENT_PID="$(cat "$CONTROLLER_PID_FILE")"
+log "controller (go run) pid: $CONTROLLER_PARENT_PID (log: $CONTROLLER_LOG)"
 
 # Teardown trap: kill the controller on script exit so a Ctrl-C doesn't leave
 # it lingering. The orchestrator + observer are intentionally NOT killed by
 # this script — they run in the background past script exit.
+#
+# Cleanup tries the listener pid (set after the port is up) first, then
+# falls back to the `go run` parent. Killing only `go run` orphans its
+# child; killing the listener causes `go run` to exit on its own.
 cleanup_controller() {
-    if kill -0 "$CONTROLLER_PID" 2>/dev/null; then
-        log "stopping controller (pid=$CONTROLLER_PID)"
-        kill "$CONTROLLER_PID" 2>/dev/null || true
-    fi
+    for pid in "${CONTROLLER_LISTENER_PID:-}" "$CONTROLLER_PARENT_PID"; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            log "stopping controller (pid=$pid)"
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
 }
 trap cleanup_controller EXIT
 
@@ -336,6 +352,16 @@ if ! $controller_ready; then
     log "controller log tail:"
     tail -50 "$CONTROLLER_LOG" >&2 || true
     die "controller did not start listening within 30s"
+fi
+
+# Now that the port is bound, discover the actual listener pid (the
+# compiled binary that `go run` exec'd) and overwrite the pid file so
+# `kill $(cat $CONTROLLER_PID_FILE)` from any subsequent invocation kills
+# the listener, not just the `go run` shim.
+CONTROLLER_LISTENER_PID="$(ss -ltnp "sport = :$CONTROLLER_LISTEN_PORT" 2>/dev/null | grep -oP 'pid=\K\d+' | head -1)"
+if [ -n "$CONTROLLER_LISTENER_PID" ]; then
+    echo "$CONTROLLER_LISTENER_PID" > "$CONTROLLER_PID_FILE"
+    log "controller listener pid: $CONTROLLER_LISTENER_PID (overwrote pidfile)"
 fi
 
 # Determine the address the device will use to reach the controller. If the
@@ -442,7 +468,7 @@ echo "$OBS_PID" > "${RUN_DIR}/observer.pid"
 cat <<EOF
 
 ==> stress test launched against $DUT_HOST
-    controller   pid : $CONTROLLER_PID  (log: $CONTROLLER_LOG)
+    controller   pid : ${CONTROLLER_LISTENER_PID:-$CONTROLLER_PARENT_PID}  (log: $CONTROLLER_LOG)
     orchestrator pid : $ORCH_PID  (logs: ${RUN_DIR}/orchestrator.std{out,err})
     observer     pid : $OBS_PID  (logs: ${RUN_DIR}/observer.std{out,err})
     working dir      : ${RUN_DIR}

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -35,19 +35,31 @@ WORKSPACE_DIR="$(cd -- "${SCRIPT_DIR}/../../.." &> /dev/null && pwd)"
 DZ_RPC_URL="${DZ_RPC_URL:-https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16}"
 DZ_PROGRAM_ID="${DZ_PROGRAM_ID:-GXxf6xgCdngKsRPGg3svaoKUQskVnu4mTuUoJ5PhNUau}"
 
-DUT_HOST="${DUT_HOST:-10.0.0.141}"
-DUT_SSH_USER="${DUT_SSH_USER:-admin}"
-DUT_SSH_KEY="${DUT_SSH_KEY:-$HOME/.ssh/id_ed25519}"
-AGENT_BINARY="${AGENT_BINARY:-/usr/local/bin/doublezero-agent}"
-AGENT_COMMAND_PREFIX="${AGENT_COMMAND_PREFIX:-/sbin/ip netns exec ns-management}"
+DUT_HOST="${DUT_HOST:-10.0.0.15}"
+DUT_SSH_USER="${DUT_SSH_USER:-nik}"
+DUT_SSH_KEY="${DUT_SSH_KEY:-$HOME/.ssh/nik@malbeclabs.com}"
+# Default to /mnt/flash on the EOS device: it persists across reboots and is
+# writable by sudo. Override via AGENT_BINARY if installed somewhere else.
+AGENT_BINARY="${AGENT_BINARY:-/mnt/flash/doublezero-agent}"
+# `bash` escapes EOS Cli (RunCli) into the underlying shell; `sudo` gets us
+# CAP_SYS_ADMIN for `ip netns exec`. Both are needed for the per-default
+# SSH login as `nik` on a real EOS device.
+AGENT_COMMAND_PREFIX="${AGENT_COMMAND_PREFIX:-bash sudo /sbin/ip netns exec ns-management}"
 AGENT_METRICS_PORT="${AGENT_METRICS_PORT:-50100}"
 
 DEVICE_CODE="${DZ_STRESS_DEVICE_CODE:-chi-dn-dzd5}"
 DEVICE_LOCATION="${DZ_STRESS_DEVICE_LOCATION:-ewr}"
 DEVICE_EXCHANGE="${DZ_STRESS_DEVICE_EXCHANGE:-xewr}"
-DEVICE_PUBLIC_IP="${DZ_STRESS_DEVICE_PUBLIC_IP:-$DUT_HOST}"
-# /29 carved out of the device-tunnel-block. Override if it collides with
-# another device's prefixes in the program.
+# Smart-contract device validation requires public_ip to be globally
+# routable (is_global() — rejects RFC1918) AND not overlap any of the
+# device's own dz_prefixes (processors/device/create.rs ~line 152). The
+# default below is a sentinel publicly-routable IP inside the 9.210.180.0/24
+# block but outside the /29 used for dz_prefixes; override only if you need
+# the device's real public address recorded onchain.
+DEVICE_PUBLIC_IP="${DZ_STRESS_DEVICE_PUBLIC_IP:-9.210.180.5}"
+# /29 carved out of a globally-routable block. dz-prefixes is the route range
+# the device advertises for its tunnels — separate from device-tunnel-block
+# (which is the private pool the program auto-allocates loopback IPs from).
 DEVICE_DZ_PREFIX="${DZ_STRESS_DEVICE_DZ_PREFIX:-9.210.180.176/29}"
 
 # Where the device reaches the controller. Default to the same address the
@@ -117,15 +129,17 @@ mkdir -p "$DEPLOY_DIR" "$WORKING_DIR"
 # Phase 1: connectivity sanity checks
 # ---------------------------------------------------------------------------
 log "verifying SSH reachability of $DUT_HOST"
+# EOS pins the SSH login shell to RunCli, so the remote command must start
+# with `bash` to escape into the underlying shell.
 ssh -i "$DUT_SSH_KEY" -o BatchMode=yes -o ConnectTimeout=5 \
     -o StrictHostKeyChecking=accept-new \
-    "$DUT_SSH_USER@$DUT_HOST" "echo ssh-ok" >/dev/null \
+    "$DUT_SSH_USER@$DUT_HOST" "bash echo ssh-ok" >/dev/null \
     || die "cannot SSH into $DUT_SSH_USER@$DUT_HOST with $DUT_SSH_KEY"
 
 log "verifying $AGENT_BINARY exists on the DUT"
 ssh -i "$DUT_SSH_KEY" -o BatchMode=yes "$DUT_SSH_USER@$DUT_HOST" \
-    "test -x $AGENT_BINARY" \
-    || die "agent binary not found at $AGENT_BINARY on $DUT_HOST — set AGENT_BINARY"
+    "bash test -x $AGENT_BINARY" \
+    || die "agent binary not found / not executable at $AGENT_BINARY on $DUT_HOST — set AGENT_BINARY or scp it first"
 
 log "verifying solana RPC reachability"
 solana_cli cluster-version >/dev/null \
@@ -153,9 +167,13 @@ if dz global-config get >/dev/null 2>&1; then
 else
     log "running doublezero init"
     dz init
+    # device-tunnel-block must be in a private (RFC1918) range — the program
+    # allocates loopback IPs from it and validates `is_private()` on the
+    # result (smartcontract/programs/doublezero-serviceability/src/state/interface.rs:494).
+    # 172.16.0.0/16 mirrors the standard from smartcontract/test/start-test.sh.
     dz global-config set \
         --local-asn 65000 --remote-asn 65342 \
-        --device-tunnel-block 9.210.180.0/24 \
+        --device-tunnel-block 172.16.0.0/16 \
         --user-tunnel-block 169.254.0.0/16 \
         --multicastgroup-block 233.84.178.0/24 \
         --multicast-publisher-block 148.51.120.0/21
@@ -193,21 +211,33 @@ if ! dz device get --code "$DEVICE_CODE" >/dev/null 2>&1; then
         --public-ip "$DEVICE_PUBLIC_IP" \
         --dz-prefixes "$DEVICE_DZ_PREFIX" \
         --mgmt-vrf mgmt
-    DEVICE_PK="$(dz device get --code "$DEVICE_CODE" --json | jq -r .account)"
-    dz device update --pubkey "$DEVICE_PK" --max-users "$TARGET_USERS" \
-        --desired-status activated
 fi
 
 DEVICE_PUBKEY="$(dz device get --code "$DEVICE_CODE" --json | jq -r .account)"
 log "device onchain pubkey: $DEVICE_PUBKEY"
 
+# Keep the onchain cap in sync with TARGET_USERS on every run. The create
+# branch above sets it implicitly on first run, but reruns with a larger
+# --target-users would otherwise leave the cap at its original value and
+# silently truncate the sweep — the controller's --max-user-tunnel-slots
+# would advertise the new number while the device account still capped at
+# the old one. (Reported by @elitegreg in #3829 review.)
+dz device update --pubkey "$DEVICE_PUBKEY" --max-users "$TARGET_USERS" \
+    --desired-status activated
+
 for entry in "Loopback255:vpnv4" "Loopback256:ipv4"; do
     iface="${entry%:*}"
     iftype="${entry#*:}"
+    # No --ip-net: the program rejects ip_net on plain loopbacks
+    # (interface/create.rs:155-162) and auto-allocates from the
+    # device-tunnel-block instead (interface/create.rs:213-218).
     out=$(dz device interface create "$DEVICE_CODE" "$iface" \
         --loopback-type "$iftype" --bandwidth 10G 2>&1) || true
     if echo "$out" | grep -q "already exists"; then
         log "loopback ${iface} (${iftype}) already exists onchain"
+    elif echo "$out" | grep -qiE "error|failed"; then
+        log "WARNING: loopback ${iface} (${iftype}) create may have failed:"
+        echo "$out" | tail -3 >&2
     else
         log "registered loopback ${iface} (${iftype})"
     fi
@@ -251,17 +281,22 @@ cleanup_controller() {
 trap cleanup_controller EXIT
 
 # Wait for the controller's listen port to accept connections (gRPC handshake).
+# The cleanup trap stays armed through every following phase (access-pass
+# setup, build, orchestrator + observer launch) so a `set -e` failure in any
+# of them tears the controller down instead of orphaning it. The trap is
+# disarmed only once the orchestrator has actually launched. (Reported by
+# @elitegreg in #3829 review.)
 log "waiting for controller to accept connections"
+controller_ready=false
 for _ in $(seq 1 30); do
     if nc -z -w 1 127.0.0.1 "$CONTROLLER_LISTEN_PORT" 2>/dev/null; then
         log "controller listening on :${CONTROLLER_LISTEN_PORT}"
-        # Disarm the trap — controller is up and should outlive this script.
-        trap - EXIT
+        controller_ready=true
         break
     fi
     sleep 1
 done
-if ! nc -z -w 1 127.0.0.1 "$CONTROLLER_LISTEN_PORT" 2>/dev/null; then
+if ! $controller_ready; then
     log "controller log tail:"
     tail -50 "$CONTROLLER_LOG" >&2 || true
     die "controller did not start listening within 30s"
@@ -347,6 +382,11 @@ nohup "$ORCH_BIN" "${ORCH_ARGS[@]}" \
     2> "${RUN_DIR}/orchestrator.stderr" &
 ORCH_PID=$!
 echo "$ORCH_PID" > "${RUN_DIR}/orchestrator.pid"
+
+# Orchestrator is up — the controller has a long-running consumer now. Disarm
+# the cleanup trap so script exit doesn't terminate the controller out from
+# under it.
+trap - EXIT
 
 log "launching observer (background)"
 nohup "$OBS_BIN" \

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -264,6 +264,22 @@ done
 CONTROLLER_LOG="${WORKING_DIR}/controller.log"
 CONTROLLER_PID_FILE="${WORKING_DIR}/controller.pid"
 
+# Fail fast if something is already listening on the controller port. Without
+# this check, our `go run` silently fails to bind and the readiness wait
+# (`nc -z 127.0.0.1 $PORT`) succeeds against the stale process, so the script
+# proceeds against a controller pointing at the wrong program / RPC. Common
+# culprits: a leftover controller from a previous run (recoverable via
+# `kill $(cat $CONTROLLER_PID_FILE)`), or the dz-local-controller docker
+# container with a host-port mapping.
+if ss -ltn "sport = :$CONTROLLER_LISTEN_PORT" 2>/dev/null | tail -n +2 | grep -q .; then
+    log "ERROR: port ${CONTROLLER_LISTEN_PORT} already has a listener:"
+    ss -ltnp "sport = :$CONTROLLER_LISTEN_PORT" >&2 || true
+    if [ -f "$CONTROLLER_PID_FILE" ]; then
+        log "hint: prior run's controller pid is in $CONTROLLER_PID_FILE — kill it first"
+    fi
+    die "refusing to start controller; release port ${CONTROLLER_LISTEN_PORT} and rerun"
+fi
+
 log "starting controller (listen=${CONTROLLER_BIND_ADDR}:${CONTROLLER_LISTEN_PORT}, max-slots=${TARGET_USERS})"
 (
     cd "$WORKSPACE_DIR"
@@ -383,6 +399,7 @@ ORCH_ARGS=(
     --agent-binary "$AGENT_BINARY"
     --agent-command-prefix "$AGENT_COMMAND_PREFIX"
     --agent-pubkey "$DEVICE_PUBKEY"
+    --agent-metrics-addr ":${AGENT_METRICS_PORT}"
 )
 if [ "$NO_AGENT" = true ]; then
     ORCH_ARGS+=(--no-agent)

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -54,6 +54,13 @@ AGENT_BINARY="${AGENT_BINARY:-/mnt/flash/doublezero-agent}"
 # SSH login as `nik` on a real EOS device.
 AGENT_COMMAND_PREFIX="${AGENT_COMMAND_PREFIX:-bash sudo /sbin/ip netns exec ns-management}"
 AGENT_METRICS_PORT="${AGENT_METRICS_PORT:-50100}"
+# eAPI HTTP basic auth for the device-observer's `show ...` polls. The
+# containerized cEOS device accepts an empty password (dev default), but a
+# real EOS device requires real credentials. Default user to the SSH user;
+# password must be supplied via env (empty default keeps the containerized
+# path unchanged).
+EAPI_USER="${EAPI_USER:-$DUT_SSH_USER}"
+EAPI_PASS="${EAPI_PASS:-}"
 
 DEVICE_CODE="${DZ_STRESS_DEVICE_CODE:-chi-dn-dzd5}"
 DEVICE_LOCATION="${DZ_STRESS_DEVICE_LOCATION:-ewr}"
@@ -420,7 +427,7 @@ trap - EXIT
 log "launching observer (background)"
 nohup "$OBS_BIN" \
     --dut-host "$DUT_HOST" \
-    --eapi-user "$DUT_SSH_USER" --eapi-pass "" \
+    --eapi-user "$EAPI_USER" --eapi-pass "$EAPI_PASS" \
     --agent-metrics-url "http://${DUT_HOST}:${AGENT_METRICS_PORT}/metrics" \
     --working-dir "$RUN_DIR" \
     --abort-file "${RUN_DIR}/abort" \

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -54,12 +54,13 @@ AGENT_BINARY="${AGENT_BINARY:-/mnt/flash/doublezero-agent}"
 # SSH login as `nik` on a real EOS device.
 AGENT_COMMAND_PREFIX="${AGENT_COMMAND_PREFIX:-bash sudo /sbin/ip netns exec ns-management}"
 AGENT_METRICS_PORT="${AGENT_METRICS_PORT:-50100}"
-# eAPI HTTP basic auth for the device-observer's `show ...` polls. The
-# containerized cEOS device accepts an empty password (dev default), but a
-# real EOS device requires real credentials. Default user to the SSH user;
-# password must be supplied via env (empty default keeps the containerized
-# path unchanged).
-EAPI_USER="${EAPI_USER:-$DUT_SSH_USER}"
+# eAPI HTTP basic auth for the device-observer's `show ...` polls. eAPI
+# typically uses a privileged user separate from the SSH login (e.g. `admin`,
+# not the bash-shell operator user). Password has no default — must be set
+# via env on physical hardware. The containerized harness uses a hardcoded
+# admin/admin pair baked into its rendered startup-config; this script does
+# not control the physical device's user table, so the operator supplies it.
+EAPI_USER="${EAPI_USER:-admin}"
 EAPI_PASS="${EAPI_PASS:-}"
 
 DEVICE_CODE="${DZ_STRESS_DEVICE_CODE:-chi-dn-dzd5}"


### PR DESCRIPTION
## Summary of Changes
- New `tools/stress/scripts/run-stress-physical.sh` driver that runs the same orchestrator + observer (from PR #3796/#3820/#3821) against a physical Arista EOS device instead of the containerized cEOS. Idempotent serviceability init, idempotent device + loopback create, controller launch via `go run` against the devnet ledger, parallel access-pass setup, orchestrator + observer launch with a port-conflict fail-fast and a trap that cleans up the controller on any pre-launch error.
- Four additive flags on the device-orchestrator so the SSH-exec'd agent command can be made self-contained on a DUT with no wrapper script: `--agent-binary`, `--agent-command-prefix`, `--agent-pubkey`, `--agent-metrics-addr`. All default to empty so the containerized harness path is byte-for-byte unchanged.
- ssh-agent fallback in the orchestrator's SSH runner: when the configured key file is passphrase-protected (Go's `ssh.ParsePrivateKey` can't prompt), the runner connects to `$SSH_AUTH_SOCK` and uses the agent's loaded signers. Empty-agent and unreachable-agent paths fail fast with actionable diagnostics instead of opaque SSH handshake errors.
- Post-deprovision agent quiescence wait now engages on the abort path too (not just clean success) and enforces a minimum window after deprovision returns. Without this, the observer's abort sentinel (legitimate or false-positive) could kill the SSH session mid-commit and strand tunnels in the device's running-config even though onchain deprovision completed.
- README appendix on physical-DUT prerequisites: SSH user with passwordless sudo + bash shell, the agent binary on disk, EOS SDK RPC daemon in the management VRF, eAPI http-commands with credentials, and the management netns. Includes the env-var knob table.

## Diff Breakdown
| Category     | Files | Lines (+/-)     | Net   |
|--------------|-------|-----------------|-------|
| Core logic   |     2 | +121 / -26      |  +95  |
| Scaffolding  |     2 | +534 / -5       |  +529 |
| Tests        |     1 | +91  / -0       |  +91  |
| Docs         |     1 | +142 / -0       |  +142 |
| **Total**    |     6 | +888 / -31      |  +857 |

Mostly scaffolding (the new driver script is ~500 of the 857 net lines); core-logic changes are concentrated in two files (ssh-agent fallback + quiescence-wait predicate) and accompanied by a test rewrite covering the new branch.

<details>
<summary>Key files (click to expand)</summary>

- [`tools/stress/scripts/run-stress-physical.sh`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-06acb461af69f0333245bea3535f3b302fa7d3bf382ac3e6d776e91c21733616) — new driver: idempotent init, device + loopbacks, controller startup, parallel access passes, orchestrator + observer launch, port-conflict fail-fast.
- [`tools/stress/scripts/README.md`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-2d60594907d94eba27e2702565f6b2c3314d1457d0256304346542715c8c4e77) — physical-harness section with prereqs and the env-var knob table.
- [`tools/stress/device-orchestrator/pkg/sweep/sweep_test.go`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-3901c06a779aac608c7ba63c230d1be60b3cfc0a24c59c632ddfc362c8b16201) — new tests for the abort-path quiescence wait and the elapsed-since-wait-start floor.
- [`tools/stress/device-orchestrator/pkg/agent/ssh.go`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-2329dc0bd36a1b91ad8d3ab3aa3aba79afd4c59f7554e7aa96279c25ee8330fd) — `loadAuthMethod` adds an ssh-agent fallback that's used when the key file is passphrase-protected or empty; conn is stashed on the SSH struct and closed in `shutdown`.
- [`tools/stress/device-orchestrator/pkg/sweep/sweep.go`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-a864c355728c685805dc490247cb61914299637f4269f384ac807cbd3d2e8ee3) — post-deprovision quiescence wait now engages on the abort path (`context.WithoutCancel` for the wait), and requires both `silent ≥ window` and `elapsed-since-wait-start ≥ window`.
- [`tools/stress/device-orchestrator/cmd/device-orchestrator/main.go`](https://github.com/malbeclabs/doublezero/pull/3829/files#diff-9b9d11f1e05b024cb4a921b112759fbad66da00cd07c80357666a91084b9b20d) — four additive flags threaded through `orchestratorConfig` and `selectAgentRunner`.

</details>

## Testing Verification
- `TestRun_WaitsForAgentQuiescenceEvenOnAbort` exercises both axes of the new branch: that the wait engages when ctx is cancelled (abort path), and that the elapsed-since-wait-start floor blocks even when the absolute "silent for ≥ window" predicate would return instantly.
- `TestRun_WaitsForAgentQuiescenceAfterDeprovision` and `TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved` continue to assert the success and no-event paths respectively.
- Validated end-to-end against chi-dn-dzd5: 4-user sweep completes cleanly with 0 stranded tunnels; 512-user sweep provisions + deprovisions all 512 onchain. The 1024-user ceiling is a hardware limit on this DUT model (Tunnel ID names cap at 1023; with `StartUserTunnelNum=500` that's 524 usable users on chi-dn-dzd5 specifically — different physical DUTs have higher caps).
