### PR TITLE
serviceability: deprecate access-pass Expired status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain programs
+  - Deprecate the `AccessPassStatus::Expired` access-pass status (renamed `ExpiredDeprecated`; discriminant `3` retained for wire compatibility). Access-pass epoch expiry no longer demotes users to `OutOfCredits`: `update_status` stops producing the status, and both `try_activate` (user creation) and `CheckUserAccessPass` (periodic re-check) keep users `Activated`. Epoch validity is still enforced at user creation for unicast users only; multicast publishers and subscribers are governed by `mgroup_*_allowlist`, not by epoch.
+- SDK
+  - Mirror the access-pass status rename in the Go, Python, and TypeScript deserializers: `AccessPassStatusExpiredDeprecated` (Go), `EXPIRED_DEPRECATED` (Python), and the `"expired (deprecated)"` string across all three.
+- SDK (Rust)
+  - Remove the client-side `User not active` precheck from the multicast subscribe/publish command (`UpdateMulticastGroupRoles`) so non-`Activated` users are no longer blocked before submission; authorization is enforced onchain.
 - CLI
   - Fold `version`, `account`, `accounts`, `log`, and `subscribe` diagnostic verbs from the binary's top-level `Command` enum into `ServiceabilityCommand` per RFC-20. Each verb now takes `&CliContext` + generic `&C: CliCommand` + `&mut W` writer and is async. Add `--json` to `account`, `accounts`, and `log` (RFC-20 §Output). The binary-level `subscribe` override uses the real blocking `DZClient::subscribe` for live event streaming; the module crate's implementation falls back to a `get_all()` snapshot for testability.
   - Change `geolocation user update-payment` to `update-payment-status` for clarity. 

--- a/sdk/serviceability/python/serviceability/state.py
+++ b/sdk/serviceability/python/serviceability/state.py
@@ -390,10 +390,15 @@ class AccessPassStatus(IntEnum):
     REQUESTED = 0
     CONNECTED = 1
     DISCONNECTED = 2
-    EXPIRED = 3
+    EXPIRED_DEPRECATED = 3  # deprecated; epoch expiry no longer demotes access passes
 
     def __str__(self) -> str:
-        _names = {0: "requested", 1: "connected", 2: "disconnected", 3: "expired"}
+        _names = {
+            0: "requested",
+            1: "connected",
+            2: "disconnected",
+            3: "expired (deprecated)",
+        }
         return _names.get(self.value, "unknown")
 
 

--- a/sdk/serviceability/testdata/enum_strings.json
+++ b/sdk/serviceability/testdata/enum_strings.json
@@ -18,6 +18,6 @@
   "UserStatus": {"0": "pending (deprecated)", "1": "activated", "3": "deleting", "4": "rejected (deprecated)", "5": "pending_ban (deprecated)", "6": "banned", "7": "updating (deprecated)", "8": "out_of_credits", "99": "unknown"},
   "MulticastGroupStatus": {"0": "pending (deprecated)", "1": "activated", "2": "suspended", "3": "deleting", "4": "rejected (deprecated)", "99": "unknown"},
   "AccessPassTypeTag": {"0": "prepaid", "1": "solana_validator", "2": "solana_rpc", "3": "solana_multicast_publisher", "4": "solana_multicast_subscriber", "5": "others", "99": "unknown"},
-  "AccessPassStatus": {"0": "requested", "1": "connected", "2": "disconnected", "3": "expired", "99": "unknown"},
+  "AccessPassStatus": {"0": "requested", "1": "connected", "2": "disconnected", "3": "expired (deprecated)", "99": "unknown"},
   "TenantPaymentStatus": {"0": "delinquent", "1": "paid"}
 }

--- a/sdk/serviceability/typescript/serviceability/state.ts
+++ b/sdk/serviceability/typescript/serviceability/state.ts
@@ -286,7 +286,7 @@ const ACCESS_PASS_STATUS_NAMES: Record<number, string> = {
   0: "requested",
   1: "connected",
   2: "disconnected",
-  3: "expired",
+  3: "expired (deprecated)",
 };
 export function accessPassStatusString(v: number): string {
   return ACCESS_PASS_STATUS_NAMES[v] ?? "unknown";

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs
@@ -4,9 +4,9 @@ use crate::{
     processors::validation::validate_program_account,
     serializer::try_acc_write,
     state::{
-        accesspass::{AccessPass, AccessPassStatus},
+        accesspass::AccessPass,
         globalstate::GlobalState,
-        user::{User, UserStatus, UserType},
+        user::{User, UserStatus},
     },
 };
 use borsh::BorshSerialize;
@@ -98,15 +98,9 @@ pub fn process_check_access_pass_user(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    // Multicast users are not subject to epoch expiry — their access is gated by
-    // mgroup_*_allowlist, not by accesspass.last_access_epoch.
-    user.status = if user.user_type == UserType::Multicast {
-        UserStatus::Activated
-    } else if accesspass.status == AccessPassStatus::Expired {
-        UserStatus::OutOfCredits
-    } else {
-        UserStatus::Activated
-    };
+    // Epoch expiry is deprecated and no longer demotes users. Access for all user
+    // types is governed by allowlists, not by accesspass.last_access_epoch.
+    user.status = UserStatus::Activated;
 
     try_acc_write(&user, user_account, payer_account, accounts)?;
     try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs
@@ -206,16 +206,15 @@ pub fn create_user_core(
         }
     }
 
-    // Enforce epoch validity for unicast users only. Multicast access is
-    // governed by mgroup_*_allowlist on the access pass, not by epoch.
-    if user_type != UserType::Multicast {
+    // Enforce epoch validity for unicast users only. Multicast access (publisher or
+    // subscriber) is governed by mgroup_*_allowlist on the access pass, not by epoch.
+    if user_type.is_epoch_gated() {
         let clock = Clock::get()?;
-        let current_epoch = clock.epoch;
-        if accesspass.last_access_epoch < current_epoch {
+        if !epoch_allows_connection(user_type, accesspass.last_access_epoch, clock.epoch) {
             msg!(
                 "Invalid epoch last_access_epoch: {} < current_epoch: {}",
                 accesspass.last_access_epoch,
-                current_epoch
+                clock.epoch
             );
             return Err(DoubleZeroError::AccessPassUnauthorized.into());
         }

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -6,8 +6,8 @@ use crate::{
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
-    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult, msg,
-    program_error::ProgramError, pubkey::Pubkey, sysvar::Sysvar,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+    pubkey::Pubkey,
 };
 use std::{fmt, net::Ipv4Addr};
 
@@ -86,7 +86,7 @@ pub enum AccessPassStatus {
     Requested = 0,
     Connected = 1,
     Disconnected = 2,
-    Expired = 3,
+    ExpiredDeprecated = 3, // deprecated; epoch expiry no longer demotes access passes
 }
 
 impl From<u8> for AccessPassStatus {
@@ -95,7 +95,7 @@ impl From<u8> for AccessPassStatus {
             0 => AccessPassStatus::Requested,
             1 => AccessPassStatus::Connected,
             2 => AccessPassStatus::Disconnected,
-            3 => AccessPassStatus::Expired,
+            3 => AccessPassStatus::ExpiredDeprecated,
             _ => AccessPassStatus::Requested,
         }
     }
@@ -107,7 +107,7 @@ impl fmt::Display for AccessPassStatus {
             AccessPassStatus::Requested => write!(f, "requested"),
             AccessPassStatus::Connected => write!(f, "connected"),
             AccessPassStatus::Disconnected => write!(f, "disconnected"),
-            AccessPassStatus::Expired => write!(f, "expired"),
+            AccessPassStatus::ExpiredDeprecated => write!(f, "expired (deprecated)"),
         }
     }
 }
@@ -255,17 +255,10 @@ impl TryFrom<&AccountInfo<'_>> for AccessPass {
 
 impl AccessPass {
     pub fn update_status(&mut self) -> ProgramResult {
-        let clock = Clock::get()?;
-        let mut current_epoch = clock.epoch;
-
-        // Ensure current_epoch is never zero
-        if current_epoch == 0 {
-            current_epoch = 1;
-        }
-
-        self.status = if self.last_access_epoch < current_epoch {
-            AccessPassStatus::Expired
-        } else if self.connection_count > 0 {
+        // Epoch expiry is deprecated: the access-pass status no longer reflects
+        // last_access_epoch. Epoch is enforced at user creation for unicast users
+        // only (see create_user_core). Status now tracks connection state only.
+        self.status = if self.connection_count > 0 {
             AccessPassStatus::Connected
         } else {
             AccessPassStatus::Requested

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{DoubleZeroError, Validate},
     helper::{deserialize_vec_with_capacity, is_global},
     state::{
-        accesspass::{AccessPass, AccessPassStatus, AccessPassType},
+        accesspass::{AccessPass, AccessPassType},
         accounttype::AccountType,
     },
 };
@@ -37,6 +37,30 @@ impl From<u8> for UserType {
             _ => panic!("Unknown UserType"),
         }
     }
+}
+
+impl UserType {
+    /// Whether connecting as this user type is gated by the access-pass epoch.
+    ///
+    /// Multicast access (publisher or subscriber) is governed by the access-pass
+    /// `mgroup_*_allowlist`, not by `last_access_epoch`, so multicast users are
+    /// exempt. All other (unicast) user types are epoch-gated.
+    pub fn is_epoch_gated(&self) -> bool {
+        *self != UserType::Multicast
+    }
+}
+
+/// Whether a user of `user_type` may connect given the access-pass epoch.
+///
+/// Multicast users are always allowed (allowlist-gated). Unicast users require
+/// `last_access_epoch >= current_epoch`; in particular `last_access_epoch == 0`
+/// (no epoch defined) blocks every unicast type.
+pub fn epoch_allows_connection(
+    user_type: UserType,
+    last_access_epoch: u64,
+    current_epoch: u64,
+) -> bool {
+    !user_type.is_epoch_gated() || last_access_epoch >= current_epoch
 }
 
 impl fmt::Display for UserType {
@@ -451,11 +475,10 @@ impl User {
             _ => Pubkey::default(),
         };
 
-        self.status = if accesspass.status == AccessPassStatus::Expired {
-            UserStatus::OutOfCredits
-        } else {
-            UserStatus::Activated
-        };
+        // Access-pass epoch expiry is deprecated and no longer demotes users.
+        // Epoch is enforced at creation for unicast users only (see
+        // create_user_core); multicast access is governed by mgroup_*_allowlist.
+        self.status = UserStatus::Activated;
 
         Ok(())
     }
@@ -1116,5 +1139,139 @@ mod tests {
             deserialized.tunnel_flags,
             TunnelFlags::CreatedAsPublisher
         ));
+    }
+
+    use crate::state::accesspass::AccessPassStatus;
+
+    fn user_with_type(user_type: UserType) -> User {
+        User {
+            account_type: AccountType::User,
+            owner: Pubkey::new_unique(),
+            index: 1,
+            bump_seed: 1,
+            tenant_pk: Pubkey::default(),
+            user_type,
+            device_pk: Pubkey::new_unique(),
+            cyoa_type: UserCYOA::None,
+            client_ip: [1, 2, 3, 4].into(),
+            dz_ip: [5, 6, 7, 8].into(),
+            tunnel_id: 0,
+            tunnel_net: NetworkV4::default(),
+            status: UserStatus::OutOfCredits,
+            publishers: vec![],
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+            bgp_rtt_ns: 0,
+        }
+    }
+
+    fn accesspass_with_epoch(last_access_epoch: u64) -> AccessPass {
+        AccessPass {
+            account_type: AccountType::AccessPass,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: [1, 2, 3, 4].into(),
+            user_payer: Pubkey::new_unique(),
+            last_access_epoch,
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            flags: 0,
+            tenant_allowlist: vec![],
+        }
+    }
+
+    /// Epoch gating applies to unicast user types only; multicast is exempt.
+    #[test]
+    fn test_user_type_is_epoch_gated() {
+        assert!(UserType::IBRL.is_epoch_gated());
+        assert!(UserType::IBRLWithAllocatedIP.is_epoch_gated());
+        assert!(UserType::EdgeFiltering.is_epoch_gated());
+        assert!(!UserType::Multicast.is_epoch_gated());
+    }
+
+    /// Connection decision matrix for the access-pass epoch (current_epoch = 1).
+    ///
+    /// 1) last_access_epoch = 0 blocks IBRL.
+    /// 2) multicast (publisher or subscriber) connects without an epoch check.
+    /// 3) all other (unicast) user types are blocked with last_access_epoch = 0.
+    #[test]
+    fn test_epoch_allows_connection_matrix() {
+        let current_epoch = 1;
+
+        // 1) IBRL with no epoch defined cannot connect.
+        assert!(!epoch_allows_connection(UserType::IBRL, 0, current_epoch));
+
+        // 2) Multicast connects regardless of epoch (covers publisher + subscriber:
+        //    both use UserType::Multicast).
+        assert!(epoch_allows_connection(
+            UserType::Multicast,
+            0,
+            current_epoch
+        ));
+        assert!(epoch_allows_connection(
+            UserType::Multicast,
+            u64::MAX,
+            current_epoch
+        ));
+
+        // 3) Other unicast types with no epoch defined cannot connect.
+        assert!(!epoch_allows_connection(
+            UserType::IBRLWithAllocatedIP,
+            0,
+            current_epoch
+        ));
+        assert!(!epoch_allows_connection(
+            UserType::EdgeFiltering,
+            0,
+            current_epoch
+        ));
+
+        // Unicast with a current/future epoch is allowed.
+        assert!(epoch_allows_connection(
+            UserType::IBRL,
+            current_epoch,
+            current_epoch
+        ));
+        assert!(epoch_allows_connection(
+            UserType::IBRL,
+            current_epoch + 1,
+            current_epoch
+        ));
+    }
+
+    /// try_activate activates every user type: epoch expiry is deprecated and no
+    /// longer demotes users to OutOfCredits. validator_pubkey is taken from the pass.
+    #[test]
+    fn test_try_activate_always_activates() {
+        for user_type in [
+            UserType::IBRL,
+            UserType::IBRLWithAllocatedIP,
+            UserType::EdgeFiltering,
+            UserType::Multicast,
+        ] {
+            let mut user = user_with_type(user_type);
+            // last_access_epoch = 0 would previously have produced Expired/OutOfCredits.
+            let mut accesspass = accesspass_with_epoch(0);
+            user.try_activate(&mut accesspass).unwrap();
+            assert_eq!(user.status, UserStatus::Activated);
+            // Deprecated status is never produced.
+            assert_ne!(accesspass.status, AccessPassStatus::ExpiredDeprecated);
+        }
+
+        // validator_pubkey is populated from a SolanaValidator access pass.
+        let validator = Pubkey::new_unique();
+        let mut user = user_with_type(UserType::IBRL);
+        let mut accesspass = accesspass_with_epoch(0);
+        accesspass.accesspass_type = AccessPassType::SolanaValidator(validator);
+        user.try_activate(&mut accesspass).unwrap();
+        assert_eq!(user.validator_pubkey, validator);
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
@@ -737,10 +737,10 @@ async fn test_create_subscribe_user_ignores_expired_epoch() {
         .expect("User should exist")
         .get_user()
         .unwrap();
-    // Multicast creation is not blocked by an expired access pass — the user is
-    // still created (and ends up in OutOfCredits because try_activate sees the
-    // pass as Expired). Multicast access is then gated by mgroup_*_allowlist.
-    assert_eq!(user.status, UserStatus::OutOfCredits);
+    // Multicast creation is not blocked by an expired access pass, and the user is
+    // not transitioned to OutOfCredits by epoch expiry: multicast access is gated
+    // by mgroup_*_allowlist, not by accesspass.last_access_epoch.
+    assert_eq!(user.status, UserStatus::Activated);
     assert_eq!(user.publishers, vec![mgroup_pubkey]);
     assert_eq!(user.user_type, UserType::Multicast);
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_tests.rs
@@ -1227,8 +1227,11 @@ async fn test_user_delete_from_banned() {
     assert_eq!(user, None);
 }
 
+/// Epoch expiry is deprecated: CheckUserAccessPass no longer demotes a unicast user
+/// to OutOfCredits when its access pass has last_access_epoch = 0. The user stays
+/// Activated, and DeleteUser still closes the account.
 #[tokio::test]
-async fn test_user_delete_from_out_of_credits() {
+async fn test_user_check_access_pass_expired_epoch_stays_activated_and_delete() {
     let (
         mut banks_client,
         payer,
@@ -1269,7 +1272,8 @@ async fn test_user_delete_from_out_of_credits() {
     )
     .await;
 
-    // CheckUserAccessPass will see the expired access pass and set user to OutOfCredits
+    // CheckUserAccessPass sees the expired access pass but, since epoch expiry is
+    // deprecated, leaves the user Activated instead of demoting it to OutOfCredits.
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -1289,11 +1293,11 @@ async fn test_user_delete_from_out_of_credits() {
         .unwrap()
         .get_user()
         .unwrap();
-    assert_eq!(user.status, UserStatus::OutOfCredits);
+    assert_eq!(user.status, UserStatus::Activated);
 
     let user_owner = user.owner;
 
-    // Atomic DeleteUser succeeds from OutOfCredits and closes the account.
+    // Atomic DeleteUser succeeds and closes the account.
     execute_transaction(
         &mut banks_client,
         recent_blockhash,

--- a/smartcontract/sdk/go/serviceability/state.go
+++ b/smartcontract/sdk/go/serviceability/state.go
@@ -1103,10 +1103,10 @@ const (
 type AccessPassStatus uint8
 
 const (
-	AccessPassStatusRequested    AccessPassStatus = 0
-	AccessPassStatusConnected    AccessPassStatus = 1
-	AccessPassStatusDisconnected AccessPassStatus = 2
-	AccessPassStatusExpired      AccessPassStatus = 3
+	AccessPassStatusRequested         AccessPassStatus = 0
+	AccessPassStatusConnected         AccessPassStatus = 1
+	AccessPassStatusDisconnected      AccessPassStatus = 2
+	AccessPassStatusExpiredDeprecated AccessPassStatus = 3 // deprecated; epoch expiry no longer demotes access passes
 )
 
 func (s AccessPassStatus) String() string {
@@ -1117,8 +1117,8 @@ func (s AccessPassStatus) String() string {
 		return "connected"
 	case AccessPassStatusDisconnected:
 		return "disconnected"
-	case AccessPassStatusExpired:
-		return "expired"
+	case AccessPassStatusExpiredDeprecated:
+		return "expired (deprecated)"
 	default:
 		return "unknown"
 	}

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
@@ -8,11 +8,9 @@ use crate::{
     DoubleZeroClient,
 };
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction,
-    pda::get_resource_extension_pda,
-    processors::multicastgroup::subscribe::UpdateMulticastGroupRolesArgs,
-    resource::ResourceType,
-    state::{multicastgroup::MulticastGroupStatus, user::UserStatus},
+    instructions::DoubleZeroInstruction, pda::get_resource_extension_pda,
+    processors::multicastgroup::subscribe::UpdateMulticastGroupRolesArgs, resource::ResourceType,
+    state::multicastgroup::MulticastGroupStatus,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
@@ -47,10 +47,6 @@ impl UpdateMulticastGroupRolesCommand {
         .execute(client)
         .map_err(|_err| eyre::eyre!("User not found"))?;
 
-        if user.status != UserStatus::Activated {
-            eyre::bail!("User not active");
-        }
-
         let (accesspass_pubkey, accesspass) = GetAccessPassCommand {
             client_ip: Ipv4Addr::UNSPECIFIED,
             user_payer: user.owner,


### PR DESCRIPTION
## Summary of Changes
- Deprecate the `AccessPassStatus::Expired` status: epoch expiry no longer demotes users to `OutOfCredits`. `update_status` stops producing the status, and both `try_activate` (user creation) and `CheckUserAccessPass` (periodic re-check) keep users `Activated`.
- Epoch validity remains enforced at user creation for unicast users only, via the extracted `UserType::is_epoch_gated()` / `epoch_allows_connection()` helpers. Multicast publishers and subscribers are governed by `mgroup_*_allowlist`, not by epoch.
- Rename the enum variant `Expired` → `ExpiredDeprecated` (discriminant `3` retained for wire compatibility) and render it as `"expired (deprecated)"`, mirrored across the Go, Python, and TypeScript SDKs and the shared `enum_strings.json` fixture.
- Remove the client-side `User not active` precheck from the Rust SDK multicast subscribe/publish command so non-`Activated` users are no longer blocked before submission; authorization is enforced onchain.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     5 | +185 / -48  | +137 |
| Scaffolding  |     4 | +15 / -10   |  +5  |
| Tests        |     2 | +12 / -8    |  +4  |
| Docs         |     1 | +6 / -0     |  +6  |
| **Total**    |    12 | +218 / -66  | +152 |

Mostly a focused onchain behavior change; the large `user.rs` count is dominated by new inline unit tests, and the SDK/fixture edits are mechanical enum-mirror updates.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/state/user.rs` — add `UserType::is_epoch_gated()` and `epoch_allows_connection()`; simplify `try_activate` to always activate; add unit-test matrix
- `smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs` — rename `Expired` → `ExpiredDeprecated`; `update_status` no longer derives status from `last_access_epoch` (drops `Clock`)
- `smartcontract/programs/doublezero-serviceability/src/processors/user/check_access_pass.rs` — drop the `Expired → OutOfCredits` branch; always `Activated`
- `smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs` — remove the `User not active` precheck
- `smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs` — creation gate now uses the shared epoch helpers (unicast-only, multicast exempt)
- `smartcontract/sdk/go/serviceability/state.go` — mirror the status rename (`AccessPassStatusExpiredDeprecated`)
- `sdk/serviceability/python/serviceability/state.py` — mirror the rename (`EXPIRED_DEPRECATED`)
- `sdk/serviceability/typescript/serviceability/state.ts` — mirror the `"expired (deprecated)"` string

</details>

## Testing Verification
- Added unit tests in `state/user.rs`: `test_epoch_allows_connection_matrix` (IBRL with `last_access_epoch = 0` blocked; multicast publisher/subscriber allowed without an epoch check; `IBRLWithAllocatedIP`/`EdgeFiltering` blocked; valid-epoch unicast allowed), `test_user_type_is_epoch_gated`, and `test_try_activate_always_activates`.
- Updated integration tests: multicast creation with `last_access_epoch = 0` now asserts `Activated`; repurposed the prior delete-from-OutOfCredits test to confirm `CheckUserAccessPass` keeps an epoch-expired unicast user `Activated` and that delete still closes the account.
- Full `doublezero-serviceability` suite passes (41 test binaries); Go, Python (97 passed), and TypeScript (116 passed) SDK enum-string tests pass against the updated fixture.
