### PR TITLE
serviceability: restrict device tunnel block to private/link-local

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -180,6 +180,8 @@ pub enum DoubleZeroError {
     ArithmeticOverflow, // variant 86
     #[error("Invalid name")]
     InvalidName, // variant 87
+    #[error("Device tunnel block must be a private or link-local address")]
+    InvalidDeviceTunnelBlock, // variant 88
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -273,6 +275,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::MaxMulticastPublishersExceeded => ProgramError::Custom(85),
             DoubleZeroError::ArithmeticOverflow => ProgramError::Custom(86),
             DoubleZeroError::InvalidName => ProgramError::Custom(87),
+            DoubleZeroError::InvalidDeviceTunnelBlock => ProgramError::Custom(88),
         }
     }
 }
@@ -367,6 +370,7 @@ impl From<u32> for DoubleZeroError {
             85 => DoubleZeroError::MaxMulticastPublishersExceeded,
             86 => DoubleZeroError::ArithmeticOverflow,
             87 => DoubleZeroError::InvalidName,
+            88 => DoubleZeroError::InvalidDeviceTunnelBlock,
             _ => DoubleZeroError::Custom(e),
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/helper.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/helper.rs
@@ -95,6 +95,12 @@ pub fn is_global(ip: Ipv4Addr) -> bool {
     true
 }
 
+/// Returns true if the address is private (RFC1918) or link-local (RFC3927).
+/// Matches the restriction enforced on device interface IPs.
+pub fn is_private_or_link_local(ip: Ipv4Addr) -> bool {
+    ip.is_private() || ip.is_link_local()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,6 +151,21 @@ mod tests {
         assert!(!is_global(Ipv4Addr::new(239, 255, 255, 255)));
         assert!(!is_global(Ipv4Addr::new(240, 0, 0, 1))); // reserved
         assert!(!is_global(Ipv4Addr::new(255, 255, 255, 255))); // broadcast
+    }
+
+    #[test]
+    fn test_is_private_or_link_local() {
+        // Private (RFC1918) and link-local (RFC3927) — allowed
+        assert!(is_private_or_link_local(Ipv4Addr::new(10, 0, 0, 0)));
+        assert!(is_private_or_link_local(Ipv4Addr::new(172, 16, 0, 0)));
+        assert!(is_private_or_link_local(Ipv4Addr::new(192, 168, 0, 0)));
+        assert!(is_private_or_link_local(Ipv4Addr::new(169, 254, 0, 0)));
+
+        // Everything else — rejected
+        assert!(!is_private_or_link_local(Ipv4Addr::new(8, 8, 8, 0))); // public
+        assert!(!is_private_or_link_local(Ipv4Addr::new(100, 64, 0, 0))); // CGNAT
+        assert!(!is_private_or_link_local(Ipv4Addr::new(224, 0, 0, 0))); // multicast
+        assert!(!is_private_or_link_local(Ipv4Addr::new(0, 0, 0, 0))); // unspecified
     }
 }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::DoubleZeroError,
+    helper::is_private_or_link_local,
     pda::*,
     processors::resource::create_resource,
     resource::ResourceType,
@@ -13,11 +14,10 @@ use crate::{
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
 use doublezero_program_common::types::NetworkV4;
-#[cfg(test)]
-use solana_program::msg;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    msg,
     pubkey::Pubkey,
 };
 use std::fmt;
@@ -132,6 +132,13 @@ pub fn process_set_globalconfig(
         admin_group_bits_account.key, &admin_group_bits_pda,
         "Invalid AdminGroupBits PubKey"
     );
+
+    // The device tunnel block must be private or link-local, matching the
+    // restriction enforced on device interface IPs (see Interface::validate).
+    if !is_private_or_link_local(value.device_tunnel_block.ip()) {
+        msg!("Invalid device_tunnel_block: {}", value.device_tunnel_block);
+        return Err(DoubleZeroError::InvalidDeviceTunnelBlock.into());
+    }
 
     let next_bgp_community = if let Some(val) = value.next_bgp_community {
         val

--- a/smartcontract/programs/doublezero-serviceability/tests/globalconfig_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/globalconfig_test.rs
@@ -1,0 +1,129 @@
+//! Acceptance test for issue #3832: the global-config `device_tunnel_block`
+//! must be a private (RFC1918) or link-local (RFC3927) prefix, matching the
+//! restriction already enforced on device interface IPs. Anything else is
+//! rejected with `DoubleZeroError::InvalidDeviceTunnelBlock` (custom code 88).
+
+use doublezero_serviceability::{
+    error::DoubleZeroError, instructions::DoubleZeroInstruction, pda::*,
+    processors::globalconfig::set::SetGlobalConfigArgs, resource::ResourceType,
+};
+use solana_program::program_error::ProgramError;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::{AccountMeta, InstructionError},
+    transaction::TransactionError,
+};
+
+mod test_helpers;
+use test_helpers::*;
+
+/// Initialize global state and attempt to set the global config with the given
+/// `device_tunnel_block` (all other blocks are valid). Returns the transaction
+/// result so callers can assert success or a specific failure.
+async fn set_global_config_with_device_block(
+    device_tunnel_block: &str,
+) -> Result<(), BanksClientError> {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (config_pubkey, _) = get_globalconfig_pda(&program_id);
+    let (device_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::UserTunnelBlock);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::LinkIds);
+    let (segment_routing_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids_pda, _, _) = get_resource_extension_pda(&program_id, ResourceType::VrfIds);
+    let (admin_group_bits_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::AdminGroupBits);
+
+    execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(SetGlobalConfigArgs {
+            local_asn: 65000,
+            remote_asn: 65001,
+            device_tunnel_block: device_tunnel_block.parse().unwrap(),
+            user_tunnel_block: "169.254.0.0/24".parse().unwrap(),
+            multicastgroup_block: "224.0.0.0/16".parse().unwrap(),
+            multicast_publisher_block: "148.51.120.0/21".parse().unwrap(),
+            next_bgp_community: None,
+        }),
+        vec![
+            AccountMeta::new(config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(user_tunnel_block_pda, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+            AccountMeta::new(segment_routing_ids_pda, false),
+            AccountMeta::new(multicast_publisher_block_pda, false),
+            AccountMeta::new(vrf_ids_pda, false),
+            AccountMeta::new(admin_group_bits_pda, false),
+        ],
+        &payer,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_set_globalconfig_rejects_public_device_tunnel_block() {
+    let err = set_global_config_with_device_block("8.8.8.0/24")
+        .await
+        .expect_err("expected a public device_tunnel_block to be rejected");
+
+    let expected: ProgramError = DoubleZeroError::InvalidDeviceTunnelBlock.into();
+    let ProgramError::Custom(expected_code) = expected else {
+        panic!("InvalidDeviceTunnelBlock must map to ProgramError::Custom");
+    };
+
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(code),
+        )) => assert_eq!(
+            code, expected_code,
+            "expected InvalidDeviceTunnelBlock (Custom({expected_code})), got Custom({code})"
+        ),
+        other => panic!("expected Custom({expected_code}) InstructionError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_set_globalconfig_accepts_private_device_tunnel_block() {
+    let result = set_global_config_with_device_block("10.100.0.0/24").await;
+    assert!(
+        result.is_ok(),
+        "private device_tunnel_block should be accepted: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_set_globalconfig_accepts_link_local_device_tunnel_block() {
+    let result = set_global_config_with_device_block("169.254.0.0/24").await;
+    assert!(
+        result.is_ok(),
+        "link-local device_tunnel_block should be accepted: {result:?}"
+    );
+}


### PR DESCRIPTION
Resolves: #3832

## Summary of Changes
- Enforce that the global-config `device_tunnel_block` is a private (RFC1918) or link-local (RFC3927) prefix when set onchain, matching the restriction already applied to device interface IPs.
- Reject any out-of-range block (public, CGNAT, multicast, unspecified, etc.) with a new `DoubleZeroError::InvalidDeviceTunnelBlock` (custom code 88) instead of silently accepting it.
- Other global-config blocks (`user_tunnel_block`, `multicastgroup_block`, `multicast_publisher_block`) are intentionally left unchanged.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Tests        |     1 | +129 / -0   | +129 |
| Core logic   |     2 | +30 / -2    |  +28 |
| Scaffolding  |     1 | +4 / -0     |   +4 |
| **Total**    |     4 | +163 / -2   | +161 |

Small, focused enforcement change; the bulk of the line count is the new acceptance test.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/tests/globalconfig_test.rs` — new acceptance test: public block rejected with `Custom(88)`; private and link-local blocks accepted.
- `smartcontract/programs/doublezero-serviceability/src/helper.rs` — adds `is_private_or_link_local()` helper plus unit test covering RFC1918/RFC3927 vs public/CGNAT/multicast/unspecified.
- `smartcontract/programs/doublezero-serviceability/src/processors/globalconfig/set.rs` — validates `device_tunnel_block` in `process_set_globalconfig` before writing state; un-gates the `msg!` import.
- `smartcontract/programs/doublezero-serviceability/src/error.rs` — adds the `InvalidDeviceTunnelBlock` variant and its `From` mappings.

</details>

## Testing Verification
- New integration test `globalconfig_test.rs` asserts a public `device_tunnel_block` (`8.8.8.0/24`) fails with `InvalidDeviceTunnelBlock`, while `10.100.0.0/24` (private) and `169.254.0.0/24` (link-local) succeed.
- New unit test for `is_private_or_link_local` covers the allowed and rejected ranges.
- Full serviceability lib suite (257 tests) and clippy (`-Dclippy::all -Dwarnings`) pass.
