### PR TITLE
serviceability: start user tunnel IDs at 1 (range 1-4096)

### DIFF
--- a/controlplane/controller/config/constants.go
+++ b/controlplane/controller/config/constants.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	// StartUserTunnelNum is the starting tunnel number for user tunnels
-	StartUserTunnelNum = 500
+	StartUserTunnelNum = 1
 
 	// DefaultMaxUserTunnelSlots is the default maximum number of user tunnel slots
 	// per device. Controllers may override this at runtime via the

--- a/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.last.user.tmpl
@@ -147,7 +147,7 @@ no route-map RM-USER-{{$i}}-OUT
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
+no ip prefix-list PL-USER-1
 !
 {{- range $i := seq (add .StartTunnel 1) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}

--- a/controlplane/controller/internal/controller/fixtures/e2e.multi.vrf.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.multi.vrf.tmpl
@@ -87,14 +87,14 @@ mpls ip
 mpls icmp ttl-exceeded tunneling
 mpls icmp ip source-interface Loopback255
 !
-default interface Tunnel500
-default interface Tunnel501
+default interface Tunnel1
+default interface Tunnel2
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 default interface Tunnel{{$i}}
 {{- end}}
-interface Tunnel500
-   description USER-UCAST-500
-   ip access-group SEC-USER-500-IN in
+interface Tunnel1
+   description USER-UCAST-1
+   ip access-group SEC-USER-1-IN in
    vrf vrf1
    mtu 9216
    ip address 169.254.0.0/31
@@ -105,9 +105,9 @@ interface Tunnel500
    tunnel ttl 32
    no shutdown
 !
-interface Tunnel501
-   description USER-UCAST-501
-   ip access-group SEC-USER-501-IN in
+interface Tunnel2
+   description USER-UCAST-2
+   ip access-group SEC-USER-2-IN in
    vrf vrf2
    mtu 9216
    ip address 169.254.0.2/31
@@ -135,9 +135,9 @@ router bgp 65342
       neighbor 169.254.0.1 remote-as 65000
       neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.1 passive
-      neighbor 169.254.0.1 description USER-500
-      neighbor 169.254.0.1 route-map RM-USER-500-IN in
-      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 description USER-1
+      neighbor 169.254.0.1 route-map RM-USER-1-IN in
+      neighbor 169.254.0.1 route-map RM-USER-1-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
    vrf vrf2
@@ -149,9 +149,9 @@ router bgp 65342
       neighbor 169.254.0.3 remote-as 65000
       neighbor 169.254.0.3 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.3 passive
-      neighbor 169.254.0.3 description USER-501
-      neighbor 169.254.0.3 route-map RM-USER-501-IN in
-      neighbor 169.254.0.3 route-map RM-USER-501-OUT out
+      neighbor 169.254.0.3 description USER-2
+      neighbor 169.254.0.3 route-map RM-USER-2-IN in
+      neighbor 169.254.0.3 route-map RM-USER-2-OUT out
       neighbor 169.254.0.3 maximum-routes 1
       neighbor 169.254.0.3 maximum-accepted-routes 1
 !
@@ -170,31 +170,31 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-TST_USERS permit 21682:10050
 !
-no route-map RM-USER-500-OUT
-route-map RM-USER-500-OUT deny 10
+no route-map RM-USER-1-OUT
+route-map RM-USER-1-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-500-OUT permit 20
+route-map RM-USER-1-OUT permit 20
    match community COMM-ALL_USERS
 !
-no route-map RM-USER-501-OUT
-route-map RM-USER-501-OUT deny 10
+no route-map RM-USER-2-OUT
+route-map RM-USER-2-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-501-OUT permit 20
+route-map RM-USER-2-OUT permit 20
    match community COMM-ALL_USERS
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no route-map RM-USER-{{$i}}-OUT
 !
 {{- end}}
-no route-map RM-USER-500-IN
-route-map RM-USER-500-IN permit 10
-   match ip address prefix-list PL-USER-500
+no route-map RM-USER-1-IN
+route-map RM-USER-1-IN permit 10
+   match ip address prefix-list PL-USER-1
    match as-path length = 1
    set community 21682:1200 21682:10050
 !
-no route-map RM-USER-501-IN
-route-map RM-USER-501-IN permit 10
-   match ip address prefix-list PL-USER-501
+no route-map RM-USER-2-IN
+route-map RM-USER-2-IN permit 10
+   match ip address prefix-list PL-USER-2
    match as-path length = 1
    set community 21682:1200 21682:10050
 !
@@ -202,18 +202,18 @@ route-map RM-USER-501-IN permit 10
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
-ip prefix-list PL-USER-500 seq 10 permit 147.100.100.100/32
+no ip prefix-list PL-USER-1
+ip prefix-list PL-USER-1 seq 10 permit 147.100.100.100/32
 !
-no ip prefix-list PL-USER-501
-ip prefix-list PL-USER-501 seq 10 permit 147.100.100.101/32
+no ip prefix-list PL-USER-2
+ip prefix-list PL-USER-2 seq 10 permit 147.100.100.101/32
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}
 !
 {{- end}}
-no ip access-list SEC-USER-500-IN
-ip access-list SEC-USER-500-IN
+no ip access-list SEC-USER-1-IN
+ip access-list SEC-USER-1-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.1/32 any
@@ -227,8 +227,8 @@ ip access-list SEC-USER-500-IN
    permit ip 147.100.100.100/32 any
    deny ip any any
 !
-no ip access-list SEC-USER-501-IN
-ip access-list SEC-USER-501-IN
+no ip access-list SEC-USER-2-IN
+ip access-list SEC-USER-2-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.3/32 any

--- a/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.peer.removal.tmpl
@@ -85,14 +85,14 @@ mpls ip
 mpls icmp ttl-exceeded tunneling
 mpls icmp ip source-interface Loopback255
 !
-default interface Tunnel500
-default interface Tunnel501
+default interface Tunnel1
+default interface Tunnel2
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 default interface Tunnel{{$i}}
 {{- end}}
-interface Tunnel500
-   description USER-UCAST-500
-   ip access-group SEC-USER-500-IN in
+interface Tunnel1
+   description USER-UCAST-1
+   ip access-group SEC-USER-1-IN in
    vrf vrf1
    mtu 9216
    ip address 169.254.0.0/31
@@ -103,10 +103,10 @@ interface Tunnel500
    tunnel ttl 32
    no shutdown
 !
-interface Tunnel501
-   description USER-MCAST-501
+interface Tunnel2
+   description USER-MCAST-2
    ip access-group SEC-USER-SUB-MCAST-IN in
-   multicast ipv4 boundary SEC-USER-MCAST-BOUNDARY-501-OUT out
+   multicast ipv4 boundary SEC-USER-MCAST-BOUNDARY-2-OUT out
    pim ipv4 sparse-mode
    pim ipv4 dr-priority 4294967295
    mtu 9216
@@ -148,9 +148,9 @@ router bgp 65342
    neighbor 169.254.0.3 remote-as 65000
    neighbor 169.254.0.3 local-as 65342 no-prepend replace-as
    neighbor 169.254.0.3 passive
-   neighbor 169.254.0.3 description USER-501
-   neighbor 169.254.0.3 route-map RM-USER-501-IN in
-   neighbor 169.254.0.3 route-map RM-USER-501-OUT out
+   neighbor 169.254.0.3 description USER-2
+   neighbor 169.254.0.3 route-map RM-USER-2-IN in
+   neighbor 169.254.0.3 route-map RM-USER-2-OUT out
    neighbor 169.254.0.3 maximum-routes 1
    neighbor 169.254.0.3 maximum-accepted-routes 1
    address-family ipv4
@@ -167,9 +167,9 @@ router bgp 65342
       neighbor 169.254.0.1 remote-as 65000
       neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.1 passive
-      neighbor 169.254.0.1 description USER-500
-      neighbor 169.254.0.1 route-map RM-USER-500-IN in
-      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 description USER-1
+      neighbor 169.254.0.1 route-map RM-USER-1-IN in
+      neighbor 169.254.0.1 route-map RM-USER-1-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
@@ -188,31 +188,31 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-TST_USERS permit 21682:10050
 !
-no route-map RM-USER-500-OUT
-route-map RM-USER-500-OUT deny 10
+no route-map RM-USER-1-OUT
+route-map RM-USER-1-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-500-OUT permit 20
+route-map RM-USER-1-OUT permit 20
    match community COMM-ALL_USERS
 !
-no route-map RM-USER-501-OUT
-route-map RM-USER-501-OUT deny 10
+no route-map RM-USER-2-OUT
+route-map RM-USER-2-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-501-OUT permit 20
+route-map RM-USER-2-OUT permit 20
    match community COMM-ALL_MCAST_USERS
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no route-map RM-USER-{{$i}}-OUT
 !
 {{- end}}
-no route-map RM-USER-500-IN
-route-map RM-USER-500-IN permit 10
-   match ip address prefix-list PL-USER-500
+no route-map RM-USER-1-IN
+route-map RM-USER-1-IN permit 10
+   match ip address prefix-list PL-USER-1
    match as-path length = 1
    set community 21682:1200 21682:10050
 !
-no route-map RM-USER-501-IN
-route-map RM-USER-501-IN permit 10
-   match ip address prefix-list PL-USER-501
+no route-map RM-USER-2-IN
+route-map RM-USER-2-IN permit 10
+   match ip address prefix-list PL-USER-2
    match as-path length = 1
    set community 21682:1300 21682:10050
 !
@@ -220,18 +220,18 @@ route-map RM-USER-501-IN permit 10
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
-ip prefix-list PL-USER-500 seq 10 permit 147.100.100.100/32
+no ip prefix-list PL-USER-1
+ip prefix-list PL-USER-1 seq 10 permit 147.100.100.100/32
 !
-no ip prefix-list PL-USER-501
-ip prefix-list PL-USER-501 seq 10 deny 0.0.0.0/0 le 32
+no ip prefix-list PL-USER-2
+ip prefix-list PL-USER-2 seq 10 deny 0.0.0.0/0 le 32
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}
 !
 {{- end}}
-no ip access-list SEC-USER-500-IN
-ip access-list SEC-USER-500-IN
+no ip access-list SEC-USER-1-IN
+ip access-list SEC-USER-1-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.1/32 any

--- a/controlplane/controller/internal/controller/fixtures/e2e.tmpl
+++ b/controlplane/controller/internal/controller/fixtures/e2e.tmpl
@@ -128,14 +128,14 @@ mpls ip
 mpls icmp ttl-exceeded tunneling
 mpls icmp ip source-interface Loopback255
 !
-default interface Tunnel500
-default interface Tunnel501
+default interface Tunnel1
+default interface Tunnel2
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 default interface Tunnel{{$i}}
 {{- end}}
-interface Tunnel500
-   description USER-UCAST-500
-   ip access-group SEC-USER-500-IN in
+interface Tunnel1
+   description USER-UCAST-1
+   ip access-group SEC-USER-1-IN in
    vrf vrf1
    mtu 9216
    ip address 169.254.0.0/31
@@ -146,10 +146,10 @@ interface Tunnel500
    tunnel ttl 32
    no shutdown
 !
-interface Tunnel501
-   description USER-MCAST-501
+interface Tunnel2
+   description USER-MCAST-2
    ip access-group SEC-USER-SUB-MCAST-IN in
-   multicast ipv4 boundary SEC-USER-MCAST-BOUNDARY-501-OUT out
+   multicast ipv4 boundary SEC-USER-MCAST-BOUNDARY-2-OUT out
    pim ipv4 sparse-mode
    pim ipv4 dr-priority 4294967295
    mtu 9216
@@ -169,9 +169,9 @@ router bgp 65342
    neighbor 169.254.0.3 remote-as 65000
    neighbor 169.254.0.3 local-as 65342 no-prepend replace-as
    neighbor 169.254.0.3 passive
-   neighbor 169.254.0.3 description USER-501
-   neighbor 169.254.0.3 route-map RM-USER-501-IN in
-   neighbor 169.254.0.3 route-map RM-USER-501-OUT out
+   neighbor 169.254.0.3 description USER-2
+   neighbor 169.254.0.3 route-map RM-USER-2-IN in
+   neighbor 169.254.0.3 route-map RM-USER-2-OUT out
    neighbor 169.254.0.3 maximum-routes 1
    neighbor 169.254.0.3 maximum-accepted-routes 1
    address-family ipv4
@@ -188,9 +188,9 @@ router bgp 65342
       neighbor 169.254.0.1 remote-as 65000
       neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.1 passive
-      neighbor 169.254.0.1 description USER-500
-      neighbor 169.254.0.1 route-map RM-USER-500-IN in
-      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 description USER-1
+      neighbor 169.254.0.1 route-map RM-USER-1-IN in
+      neighbor 169.254.0.1 route-map RM-USER-1-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
@@ -209,31 +209,31 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-TST_USERS permit 21682:10050
 !
-no route-map RM-USER-500-OUT
-route-map RM-USER-500-OUT deny 10
+no route-map RM-USER-1-OUT
+route-map RM-USER-1-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-500-OUT permit 20
+route-map RM-USER-1-OUT permit 20
    match community COMM-ALL_USERS
 !
-no route-map RM-USER-501-OUT
-route-map RM-USER-501-OUT deny 10
+no route-map RM-USER-2-OUT
+route-map RM-USER-2-OUT deny 10
    match community COMM-TST_USERS
-route-map RM-USER-501-OUT permit 20
+route-map RM-USER-2-OUT permit 20
    match community COMM-ALL_MCAST_USERS
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no route-map RM-USER-{{$i}}-OUT
 !
 {{- end}}
-no route-map RM-USER-500-IN
-route-map RM-USER-500-IN permit 10
-   match ip address prefix-list PL-USER-500
+no route-map RM-USER-1-IN
+route-map RM-USER-1-IN permit 10
+   match ip address prefix-list PL-USER-1
    match as-path length = 1
    set community 21682:1200 21682:10050
 !
-no route-map RM-USER-501-IN
-route-map RM-USER-501-IN permit 10
-   match ip address prefix-list PL-USER-501
+no route-map RM-USER-2-IN
+route-map RM-USER-2-IN permit 10
+   match ip address prefix-list PL-USER-2
    match as-path length = 1
    set community 21682:1300 21682:10050
 !
@@ -241,18 +241,18 @@ route-map RM-USER-501-IN permit 10
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
-ip prefix-list PL-USER-500 seq 10 permit 147.100.100.100/32
+no ip prefix-list PL-USER-1
+ip prefix-list PL-USER-1 seq 10 permit 147.100.100.100/32
 !
-no ip prefix-list PL-USER-501
-ip prefix-list PL-USER-501 seq 10 deny 0.0.0.0/0 le 32
+no ip prefix-list PL-USER-2
+ip prefix-list PL-USER-2 seq 10 deny 0.0.0.0/0 le 32
 !
 {{- range $i := seq (add .StartTunnel 2) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}
 !
 {{- end}}
-no ip access-list SEC-USER-500-IN
-ip access-list SEC-USER-500-IN
+no ip access-list SEC-USER-1-IN
+ip access-list SEC-USER-1-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.1/32 any

--- a/controlplane/controller/internal/controller/server_test.go
+++ b/controlplane/controller/internal/controller/server_test.go
@@ -743,7 +743,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{10, 1, 1, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -755,7 +755,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{3, 3, 3, 3},
 					DzIp:         [4]uint8{147, 100, 100, 101},
-					TunnelId:     uint16(501),
+					TunnelId:     uint16(2),
 					TunnelNet:    [5]uint8{10, 1, 1, 2, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -769,7 +769,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{0, 0, 0, 0},
 					DzIp:         [4]uint8{147, 100, 100, 102},
-					TunnelId:     uint16(502),
+					TunnelId:     uint16(3),
 					TunnelNet:    [5]uint8{10, 1, 1, 3, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -783,7 +783,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{5, 5, 5, 5},
 					DzIp:         [4]uint8{0, 0, 0, 0},
-					TunnelId:     uint16(502),
+					TunnelId:     uint16(3),
 					TunnelNet:    [5]uint8{10, 1, 1, 4, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -797,7 +797,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{0, 0, 0, 0},
 					DzIp:         [4]uint8{0, 0, 0, 0},
-					TunnelId:     uint16(502),
+					TunnelId:     uint16(3),
 					TunnelNet:    [5]uint8{10, 1, 1, 5, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -811,7 +811,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{6, 6, 6, 6},
 					DzIp:         [4]uint8{10, 0, 0, 1},
-					TunnelId:     uint16(503),
+					TunnelId:     uint16(4),
 					TunnelNet:    [5]uint8{10, 1, 1, 6, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -824,7 +824,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{7, 7, 7, 7},
 					DzIp:         [4]uint8{127, 0, 0, 1},
-					TunnelId:     uint16(504),
+					TunnelId:     uint16(5),
 					TunnelNet:    [5]uint8{10, 1, 1, 8, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -952,7 +952,7 @@ func TestStateCache(t *testing.T) {
 						BgpCommunity:      10050,
 						Tunnels: append([]*Tunnel{
 							{
-								Id:            500,
+								Id:            1,
 								UnderlaySrcIP: net.IP{2, 2, 2, 2},
 								UnderlayDstIP: net.IP{1, 1, 1, 1},
 								OverlaySrcIP:  net.IP{10, 1, 1, 0},
@@ -965,7 +965,7 @@ func TestStateCache(t *testing.T) {
 								TenantPubKey:  "11111111111111111111111111111111",
 							},
 							{
-								Id:            501,
+								Id:            2,
 								UnderlaySrcIP: net.IP{2, 2, 2, 2},
 								UnderlayDstIP: net.IP{3, 3, 3, 3},
 								OverlaySrcIP:  net.IP{10, 1, 1, 2},
@@ -1061,7 +1061,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{10, 1, 1, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1106,7 +1106,7 @@ func TestStateCache(t *testing.T) {
 						LocationCode:    "unknown",
 						Tunnels: append([]*Tunnel{
 							{
-								Id:            500,
+								Id:            1,
 								UnderlaySrcIP: net.IP{3, 3, 3, 3},
 								UnderlayDstIP: net.IP{1, 1, 1, 1},
 								OverlaySrcIP:  net.IP{10, 1, 1, 0},
@@ -1145,7 +1145,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{10, 1, 1, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1220,7 +1220,7 @@ func TestStateCache(t *testing.T) {
 						},
 						Tunnels: append([]*Tunnel{
 							{
-								Id:            500,
+								Id:            1,
 								UnderlaySrcIP: net.IP{3, 3, 3, 3},
 								UnderlayDstIP: net.IP{1, 1, 1, 1},
 								OverlaySrcIP:  net.IP{10, 1, 1, 0},
@@ -1259,7 +1259,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:       serviceability.CyoaTypeGREOverDIA,
 					ClientIp:       [4]uint8{1, 1, 1, 1},
 					DzIp:           [4]uint8{147, 100, 100, 100},
-					TunnelId:       uint16(500),
+					TunnelId:       uint16(1),
 					TunnelNet:      [5]uint8{10, 1, 1, 0, 31},
 					Status:         serviceability.UserStatusActivated,
 					TunnelEndpoint: [4]uint8{5, 5, 5, 5}, // Explicit tunnel endpoint
@@ -1272,7 +1272,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:       serviceability.CyoaTypeGREOverDIA,
 					ClientIp:       [4]uint8{2, 2, 2, 2},
 					DzIp:           [4]uint8{147, 100, 100, 101},
-					TunnelId:       uint16(501),
+					TunnelId:       uint16(2),
 					TunnelNet:      [5]uint8{10, 1, 1, 2, 31},
 					Status:         serviceability.UserStatusActivated,
 					TunnelEndpoint: [4]uint8{0, 0, 0, 0}, // Unspecified - should fall back to device PublicIP
@@ -1360,7 +1360,7 @@ func TestStateCache(t *testing.T) {
 						},
 						Tunnels: append([]*Tunnel{
 							{
-								Id:            500,
+								Id:            1,
 								UnderlaySrcIP: net.IP{5, 5, 5, 5}, // Uses explicit TunnelEndpoint
 								UnderlayDstIP: net.IP{1, 1, 1, 1},
 								OverlaySrcIP:  net.IP{10, 1, 1, 0},
@@ -1373,7 +1373,7 @@ func TestStateCache(t *testing.T) {
 								TenantPubKey:  "11111111111111111111111111111111",
 							},
 							{
-								Id:            501,
+								Id:            2,
 								UnderlaySrcIP: net.IP{3, 3, 3, 3}, // Falls back to device PublicIP
 								UnderlayDstIP: net.IP{2, 2, 2, 2},
 								OverlaySrcIP:  net.IP{10, 1, 1, 2},
@@ -1423,7 +1423,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{10, 1, 1, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1436,7 +1436,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{2, 2, 2, 2},
 					DzIp:         [4]uint8{147, 100, 100, 101},
-					TunnelId:     uint16(501),
+					TunnelId:     uint16(2),
 					TunnelNet:    [5]uint8{10, 1, 1, 2, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1449,7 +1449,7 @@ func TestStateCache(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{3, 3, 3, 3},
 					DzIp:         [4]uint8{147, 100, 100, 102},
-					TunnelId:     uint16(502),
+					TunnelId:     uint16(3),
 					TunnelNet:    [5]uint8{10, 1, 1, 4, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1523,7 +1523,7 @@ func TestStateCache(t *testing.T) {
 						BgpCommunity:      10050,
 						Tunnels: append([]*Tunnel{
 							{
-								Id:            500,
+								Id:            1,
 								UnderlaySrcIP: net.IP{2, 2, 2, 2},
 								UnderlayDstIP: net.IP{1, 1, 1, 1},
 								OverlaySrcIP:  net.IP{10, 1, 1, 0},
@@ -1535,7 +1535,7 @@ func TestStateCache(t *testing.T) {
 								TenantPubKey:  "g35TxFqwMx95vCk63fTxGTHb6ei4W24qg5t2x6xD3cT",
 							},
 							{
-								Id:            501,
+								Id:            2,
 								UnderlaySrcIP: net.IP{2, 2, 2, 2},
 								UnderlayDstIP: net.IP{2, 2, 2, 2},
 								OverlaySrcIP:  net.IP{10, 1, 1, 2},
@@ -1547,7 +1547,7 @@ func TestStateCache(t *testing.T) {
 								TenantPubKey:  "2M59vuWgsiuHAqQVB6KvuXuaBCJR8138gMAm4uCuR6Du",
 							},
 							{
-								Id:            502,
+								Id:            3,
 								UnderlaySrcIP: net.IP{2, 2, 2, 2},
 								UnderlayDstIP: net.IP{3, 3, 3, 3},
 								OverlaySrcIP:  net.IP{10, 1, 1, 4},
@@ -1663,7 +1663,7 @@ func TestStateCache_DuplicateTunnelId(t *testing.T) {
 						CyoaType:     serviceability.CyoaTypeGREOverDIA,
 						ClientIp:     [4]uint8{1, 1, 1, 1},
 						DzIp:         [4]uint8{147, 100, 100, 100},
-						TunnelId:     uint16(500),
+						TunnelId:     uint16(1),
 						TunnelNet:    [5]uint8{10, 1, 1, 0, 31},
 						Status:       serviceability.UserStatusActivated,
 					},
@@ -1674,7 +1674,7 @@ func TestStateCache_DuplicateTunnelId(t *testing.T) {
 						CyoaType:     serviceability.CyoaTypeGREOverDIA,
 						ClientIp:     [4]uint8{3, 3, 3, 3},
 						DzIp:         [4]uint8{147, 100, 100, 101},
-						TunnelId:     uint16(500), // Duplicate tunnel ID
+						TunnelId:     uint16(1), // Duplicate tunnel ID
 						TunnelNet:    [5]uint8{10, 1, 1, 2, 31},
 						Status:       serviceability.UserStatusActivated,
 					},
@@ -1727,12 +1727,12 @@ func TestStateCache_DuplicateTunnelId(t *testing.T) {
 	if device == nil {
 		t.Fatal("expected device in cache")
 	}
-	tunnel := device.findTunnel(500)
+	tunnel := device.findTunnel(1)
 	if tunnel == nil {
-		t.Fatal("expected tunnel 500 in device")
+		t.Fatal("expected tunnel 1 in device")
 	}
 	if !tunnel.Allocated {
-		t.Fatal("expected tunnel 500 to be allocated")
+		t.Fatal("expected tunnel 1 to be allocated")
 	}
 
 	// Second user (pubkey [32]uint8{20}) should have overwritten the first.
@@ -1922,7 +1922,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{169, 254, 0, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -1934,7 +1934,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{3, 3, 3, 3},
 					DzIp:         [4]uint8{147, 100, 100, 101},
-					TunnelId:     uint16(501),
+					TunnelId:     uint16(2),
 					TunnelNet:    [5]uint8{169, 254, 0, 2, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -2060,7 +2060,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{169, 254, 0, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -2072,7 +2072,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{3, 3, 3, 3},
 					DzIp:         [4]uint8{147, 100, 100, 101},
-					TunnelId:     uint16(501),
+					TunnelId:     uint16(2),
 					TunnelNet:    [5]uint8{169, 254, 0, 2, 31},
 					Status:       serviceability.UserStatusActivated,
 					Subscribers:  [][32]uint8{{1}},
@@ -2251,7 +2251,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{1, 1, 1, 1},
 					DzIp:         [4]uint8{147, 100, 100, 100},
-					TunnelId:     uint16(500),
+					TunnelId:     uint16(1),
 					TunnelNet:    [5]uint8{169, 254, 0, 0, 31},
 					Status:       serviceability.UserStatusActivated,
 				},
@@ -2264,7 +2264,7 @@ func TestEndToEnd(t *testing.T) {
 					CyoaType:     serviceability.CyoaTypeGREOverDIA,
 					ClientIp:     [4]uint8{2, 2, 2, 2},
 					DzIp:         [4]uint8{147, 100, 100, 101},
-					TunnelId:     uint16(501),
+					TunnelId:     uint16(2),
 					TunnelNet:    [5]uint8{169, 254, 0, 2, 31},
 					Status:       serviceability.UserStatusActivated,
 				},

--- a/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_agent_config_user_added.tmpl
@@ -145,8 +145,8 @@ mpls icmp ip source-interface Loopback255
 {{- range $i := seq .StartTunnel .EndTunnel}}
 default interface Tunnel{{$i}}
 {{- end}}
-interface Tunnel500
-   description USER-UCAST-500
+interface Tunnel1
+   description USER-UCAST-1
    vrf vrf1
    mtu 9216
    ip address 169.254.0.0/31
@@ -293,9 +293,9 @@ router bgp 65342
       neighbor 169.254.0.1 remote-as 65000
       neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.1 passive
-      neighbor 169.254.0.1 description USER-500
-      neighbor 169.254.0.1 route-map RM-USER-500-IN in
-      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 description USER-1
+      neighbor 169.254.0.1 route-map RM-USER-1-IN in
+      neighbor 169.254.0.1 route-map RM-USER-1-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
@@ -314,19 +314,19 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-XEWR_USERS permit 21682:10001
 !
-no route-map RM-USER-500-OUT
-route-map RM-USER-500-OUT deny 10
+no route-map RM-USER-1-OUT
+route-map RM-USER-1-OUT deny 10
    match community COMM-XEWR_USERS
-route-map RM-USER-500-OUT permit 20
+route-map RM-USER-1-OUT permit 20
    match community COMM-ALL_USERS
 !
 {{- range $i := seq (add .StartTunnel 1) .EndTunnel}}
 no route-map RM-USER-{{$i}}-OUT
 !
 {{- end}}
-no route-map RM-USER-500-IN
-route-map RM-USER-500-IN permit 10
-   match ip address prefix-list PL-USER-500
+no route-map RM-USER-1-IN
+route-map RM-USER-1-IN permit 10
+   match ip address prefix-list PL-USER-1
    match as-path length = 1
    set community 21682:1200 21682:10001
 !
@@ -334,15 +334,15 @@ route-map RM-USER-500-IN permit 10
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
-ip prefix-list PL-USER-500 seq 10 permit {{ .ClientIP }}/32
+no ip prefix-list PL-USER-1
+ip prefix-list PL-USER-1 seq 10 permit {{ .ClientIP }}/32
 !
 {{- range $i := seq (add .StartTunnel 1) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}
 !
 {{- end}}
-no ip access-list SEC-USER-500-IN
-ip access-list SEC-USER-500-IN
+no ip access-list SEC-USER-1-IN
+ip access-list SEC-USER-1-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.1/32 any

--- a/e2e/fixtures/ibrl/doublezero_user_list_user_added.tmpl
+++ b/e2e/fixtures/ibrl/doublezero_user_list_user_added.tmpl
@@ -1,2 +1,2 @@
  account | tenant | user_type | groups | device   | location | cyoa_type  | client_ip    | dz_ip        | accesspass     | tunnel_id | tunnel_net     | status    | bgp_status | rtt | owner
- IGNORED |        | IBRL      |        | ny5-dz01 | New York | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | Prepaid: (MAX) | 500       | 169.254.0.0/31 | activated | unknown    | -   | {{.ClientPubkeyAddress}}
+ IGNORED |        | IBRL      |        | ny5-dz01 | New York | GREOverDIA | {{.ClientIP}} | {{.ClientIP}} | Prepaid: (MAX) | 1       | 169.254.0.0/31 | activated | unknown    | -   | {{.ClientPubkeyAddress}}

--- a/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
+++ b/e2e/fixtures/ibrl_with_allocated_addr/doublezero_agent_config_user_added.tmpl
@@ -145,8 +145,8 @@ mpls icmp ip source-interface Loopback255
 {{- range $i := seq .StartTunnel .EndTunnel}}
 default interface Tunnel{{$i}}
 {{- end}}
-interface Tunnel500
-   description USER-UCAST-500
+interface Tunnel1
+   description USER-UCAST-1
    vrf vrf1
    mtu 9216
    ip address 169.254.0.0/31
@@ -293,9 +293,9 @@ router bgp 65342
       neighbor 169.254.0.1 remote-as 65000
       neighbor 169.254.0.1 local-as 65342 no-prepend replace-as
       neighbor 169.254.0.1 passive
-      neighbor 169.254.0.1 description USER-500
-      neighbor 169.254.0.1 route-map RM-USER-500-IN in
-      neighbor 169.254.0.1 route-map RM-USER-500-OUT out
+      neighbor 169.254.0.1 description USER-1
+      neighbor 169.254.0.1 route-map RM-USER-1-IN in
+      neighbor 169.254.0.1 route-map RM-USER-1-OUT out
       neighbor 169.254.0.1 maximum-routes 1
       neighbor 169.254.0.1 maximum-accepted-routes 1
 !
@@ -314,19 +314,19 @@ ip community-list COMM-ALL_USERS permit 21682:1200
 ip community-list COMM-ALL_MCAST_USERS permit 21682:1300
 ip community-list COMM-XEWR_USERS permit 21682:10001
 !
-no route-map RM-USER-500-OUT
-route-map RM-USER-500-OUT deny 10
+no route-map RM-USER-1-OUT
+route-map RM-USER-1-OUT deny 10
    match community COMM-XEWR_USERS
-route-map RM-USER-500-OUT permit 20
+route-map RM-USER-1-OUT permit 20
    match community COMM-ALL_USERS
 !
 {{- range $i := seq (add .StartTunnel 1) .EndTunnel}}
 no route-map RM-USER-{{$i}}-OUT
 !
 {{- end}}
-no route-map RM-USER-500-IN
-route-map RM-USER-500-IN permit 10
-   match ip address prefix-list PL-USER-500
+no route-map RM-USER-1-IN
+route-map RM-USER-1-IN permit 10
+   match ip address prefix-list PL-USER-1
    match as-path length = 1
    set community 21682:1200 21682:10001
 !
@@ -334,15 +334,15 @@ route-map RM-USER-500-IN permit 10
 no route-map RM-USER-{{$i}}-IN
 !
 {{- end}}
-no ip prefix-list PL-USER-500
-ip prefix-list PL-USER-500 seq 10 permit {{.ExpectedAllocatedClientIP}}/32
+no ip prefix-list PL-USER-1
+ip prefix-list PL-USER-1 seq 10 permit {{.ExpectedAllocatedClientIP}}/32
 !
 {{- range $i := seq (add .StartTunnel 1) .EndTunnel}}
 no ip prefix-list PL-USER-{{$i}}
 !
 {{- end}}
-no ip access-list SEC-USER-500-IN
-ip access-list SEC-USER-500-IN
+no ip access-list SEC-USER-1-IN
+ip access-list SEC-USER-1-IN
    counters per-entry
    !ICMP
    permit icmp 169.254.0.1/32 any

--- a/e2e/multi_tunnel_endpoint_test.go
+++ b/e2e/multi_tunnel_endpoint_test.go
@@ -475,8 +475,8 @@ func runSimultaneousTunnelTest(t *testing.T, log *slog.Logger, dn *devnet.Devnet
 		if out, err := device.Exec(ctx, []string{"Cli", "-p", "15", "-c", "show running-config section Tunnel"}); err == nil {
 			log.Info("Device Tunnel config", "output", string(out))
 		}
-		if out, err := device.Exec(ctx, []string{"Cli", "-c", "show interfaces Tunnel500"}); err == nil {
-			log.Info("Device Tunnel500 status", "output", string(out))
+		if out, err := device.Exec(ctx, []string{"Cli", "-c", "show interfaces Tunnel1"}); err == nil {
+			log.Info("Device Tunnel1 status", "output", string(out))
 		}
 		if out, err := device.Exec(ctx, []string{"Cli", "-c", "show ip bgp summary"}); err == nil {
 			log.Info("Device BGP summary", "output", string(out))

--- a/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/resource/mod.rs
@@ -64,7 +64,7 @@ pub fn get_resource_extension_range(
                 device.is_some(),
                 "Associated account must be a device for DzPrefixBlock"
             );
-            ResourceExtensionRange::IdRange(500, 4596)
+            ResourceExtensionRange::IdRange(1, 4097)
         }
         ResourceType::LinkIds => ResourceExtensionRange::IdRange(0, 65535),
         ResourceType::SegmentRoutingIds => ResourceExtensionRange::IdRange(1, 65535),

--- a/smartcontract/programs/doublezero-serviceability/src/state/user.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/user.rs
@@ -393,12 +393,10 @@ impl Validate for User {
             return Err(DoubleZeroError::InvalidTunnelNet);
         }
         // tunnel_id must lie within the per-device TunnelIds resource extension
-        // range, which the resource module sizes as [500, 4596) — see
-        // crate::processors::resource::mod.rs. The previous cap of 1024 admitted
-        // only the first ~525 tunnels (500..=1024) per device, blocking the
-        // stress harness from exercising the device past that count even
-        // though the bitmap has 4 096 slots.
-        if self.tunnel_id >= 4596 {
+        // range, which the resource module sizes as [1, 4097) — see
+        // crate::processors::resource::mod.rs. This admits tunnel IDs 1..=4096,
+        // giving each device 4 096 allocatable slots matching the bitmap size.
+        if self.tunnel_id >= 4097 {
             msg!("tunnel_id: {}", self.tunnel_id);
             return Err(DoubleZeroError::InvalidTunnelId);
         }
@@ -746,7 +744,7 @@ mod tests {
             cyoa_type: UserCYOA::GREOverDIA,
             dz_ip: [3, 2, 4, 2].into(),
             client_ip: [1, 2, 3, 4].into(),
-            tunnel_id: 4596, // Invalid: at/above the per-device TunnelIds resource extension's upper bound
+            tunnel_id: 4097, // Invalid: at/above the per-device TunnelIds resource extension's upper bound
             tunnel_net: "169.254.0.0/25".parse().unwrap(),
             status: UserStatus::Activated,
             publishers: vec![Pubkey::new_unique(), Pubkey::new_unique()],

--- a/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
@@ -1019,7 +1019,7 @@ async fn test_update_user_tunnel_id_with_onchain_allocation() {
         .unwrap();
     assert_eq!(user.status, UserStatus::Activated);
     let old_tunnel_id = user.tunnel_id;
-    assert!((500..=4596).contains(&old_tunnel_id));
+    assert!((1..=4096).contains(&old_tunnel_id));
 
     // Pick a new tunnel_id
     let new_tunnel_id: u16 = if old_tunnel_id == 501 { 502 } else { 501 };


### PR DESCRIPTION
## Summary

- Start user tunnel ID allocation at **1** instead of 500, defining the per-device range as **1–4096 inclusive** (4096 usable IDs, unchanged count).
- Onchain: the per-device `TunnelIds` `ResourceExtension` now uses `IdRange(1, 4097)` (`processors/resource/mod.rs`); the half-open `[start, end)` allocator yields IDs `1..=4096`. The `User::validate()` upper-bound guard moves to `tunnel_id >= 4097`.
- Controller: `StartUserTunnelNum` changes 500 → 1, so device tunnel slots and the rendered `interface TunnelN` numbers now begin at 1.
- Test/fixture fallout: the controller maps each onchain `user.TunnelId` to a slot (`StartUserTunnelNum + i`), so the `StateCache`/end-to-end tests and their golden fixtures were renumbered (`500→1, 501→2, …`) to stay within the new slot range.

## Note for reviewers

`rfcs/rfc11-on-chain-activation.md` still documents the tunnel-ID range as `500–4596` in several places. Left unchanged here intentionally — flagging as a follow-up doc update.

## Testing Verification

- `cargo test -p doublezero-serviceability` — passes, including `user_onchain_allocation_test` (allocated tunnel IDs now fall in `1..=4096`) and the `User::validate` boundary test (`tunnel_id = 4097` rejected).
- `go test ./controlplane/controller/...` — passes; `TestStateCache`, `TestStateCache_DuplicateTunnelId`, and `TestEndToEnd` verified against renumbered fixtures.
