### PR TITLE
tools/stress: harden orchestrator + observer for physical EOS

### DIFF
--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -47,7 +47,7 @@ The observer writes the following files into `--working-dir`:
 | ---------------------------------------- | --------- | ----------------------------------------------- |
 | `observer-config.json`                   | observer  | selected flag values (excludes `eapi_pass` and `eapi_port`) + PID + start timestamp |
 | `show-hardware-capacity-<ts>.json`       | observer  | one per tick                                    |
-| `show-gre-tunnel-static-<ts>.json`       | observer  | one per tick                                    |
+| `show-interfaces-description-<ts>.json`  | observer  | one per tick                                    |
 | `show-processes-top-once-<ts>.json`      | observer  | one per tick                                    |
 | `show-logging-errors-<ts>.log`           | observer  | one per tick                                    |
 | `show-logging-critical-<ts>.log`         | observer  | one per tick                                    |
@@ -288,7 +288,7 @@ cancels the observer's root context so the process exits.
 | `lock_not_taken`             | agent-log substring `not overriding lock since its age` | same                                                                                     |
 | `agent_silence`              | `AgentTail.Snapshot().LastLineAt`                     | `LastLineAt` non-zero AND `now - LastLineAt > 120 s` (suppressed before any line is seen). Threshold accommodates the legitimate silent window during a large config apply at high user counts — at ~290 users the agent processes ~22k lines per cycle without intermediate logs. |
 | `ledger_heartbeat_stale`     | mtime of `<working-dir>/orchestrator.ledger_heartbeat` | file present AND `now - mtime > 30 s` (absent file is suppressed forward-compatibly)      |
-| `device_tunnel_gap`          | runlog `n_after_event` vs sampler `greTunnels` map length | orchestrator active-user count exceeds the device's tunnel count by `≥ 4` AND `now - last_activate ≥ 120 s` (suppressed before the first activate is seen). Grace matches `agent_silence` — past that, a stuck agent fires `agent_silence` first; a persistent gap with a healthy agent is the controller's slot cap or similar truncation. |
+| `device_tunnel_gap`          | runlog `n_after_event` vs sampler's `show interfaces description` filtered to interfaces whose description begins `USER-UCAST-` | orchestrator active-user count exceeds the device's tunnel count by `≥ 4` AND `now - last_activate ≥ 120 s` (suppressed before the first activate is seen). Grace matches `agent_silence` — past that, a stuck agent fires `agent_silence` first; a persistent gap with a healthy agent is the controller's slot cap or similar truncation. |
 
 **Startup grace.** The four counter and log-pattern triggers
 (`apply_config_errors`, `get_config_errors`, `diff_timeout`,

--- a/tools/stress/device-observer/internal/abort/decider.go
+++ b/tools/stress/device-observer/internal/abort/decider.go
@@ -99,8 +99,9 @@ type Sources struct {
 	// been seen.
 	ActiveUserCount func() (count int, lastActivate time.Time, ok bool)
 	// TunnelCount returns the most recently observed number of user
-	// tunnels on the device (from `show gre tunnel static`). `ok=false`
-	// before the first successful sample.
+	// tunnels on the device (parsed from `show interfaces description`,
+	// filtered to interfaces whose description begins `USER-UCAST-`).
+	// `ok=false` before the first successful sample.
 	TunnelCount         func() (int, bool)
 	LedgerHeartbeatPath string
 }

--- a/tools/stress/device-observer/internal/sample/eos.go
+++ b/tools/stress/device-observer/internal/sample/eos.go
@@ -15,6 +15,16 @@ import (
 	"time"
 )
 
+// userTunnelDescriptionPrefix identifies user-tunnel interfaces by the
+// description string the controller renders on each user's `interface
+// TunnelN` block. Using the description rather than a numeric range on
+// the tunnel ID lets the observer compare apples-to-apples against the
+// orchestrator's user count regardless of where in the Tunnel<N>
+// namespace the controller chooses to place them (legacy controllers
+// started at 500; the gm/tunnel-id-start-1 fix starts at 1, which
+// overlaps the inter-router routing-fabric range on physical EOS).
+const userTunnelDescriptionPrefix = "USER-UCAST-"
+
 type eapiRunner interface {
 	RunShowJSON(cmd string) (json.RawMessage, error)
 	RunShowText(cmd string) (string, error)
@@ -27,7 +37,7 @@ type commandSpec struct {
 
 var commands = []commandSpec{
 	{"show hardware capacity", "show-hardware-capacity", true},
-	{"show gre tunnel static", "show-gre-tunnel-static", true},
+	{"show interfaces description", "show-interfaces-description", true},
 	{"show processes top once", "show-processes-top-once", true},
 	{"show logging errors", "show-logging-errors", false},
 	{"show logging critical", "show-logging-critical", false},
@@ -61,12 +71,24 @@ func (s *Sampler) LatestCPUPercent() (float64, bool) {
 }
 
 // LatestTunnelCount returns the most recently observed number of user
-// tunnels on the device (`show gre tunnel static`'s greTunnels map
-// length). Returns (0, false) before the first successful parse. The
-// abort decider uses this to detect when the orchestrator's expected
-// active-user count diverges from what the agent has actually applied —
-// e.g. when the controller's per-device tunnel-slot cap silently
-// truncates the rendered device config.
+// tunnel interfaces on the device — i.e. interfaces whose description
+// starts with "USER-UCAST-" (the prefix the controller renders on
+// every per-user `interface TunnelN` block), counted from
+// `show interfaces description`. Returns (0, false) before the first
+// successful parse. The abort decider uses this to detect when the
+// orchestrator's expected active-user count diverges from what the
+// agent has actually applied — e.g. when the controller's per-device
+// tunnel-slot cap silently truncates the rendered device config.
+//
+// Earlier iterations used `show gre tunnel static` (only lists
+// statically-configured GRE-keyed routing-fabric tunnels) and
+// `show ip interface brief` filtered on a Tunnel-index >= 500
+// (worked while user tunnel IDs started at 500 but broke when the
+// controller started allocating from 1, overlapping the routing
+// fabric's low-numbered range). Filtering on the controller's
+// rendered description string is the most stable discriminator:
+// it tracks the controller's namespacing decisions regardless of
+// where in the Tunnel<N> ID space user tunnels happen to land.
 func (s *Sampler) LatestTunnelCount() (int, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -128,13 +150,13 @@ func (s *Sampler) runOne(c commandSpec, ts time.Time) error {
 				s.logger.Warn("could not parse CPU from show processes top once")
 			}
 		}
-		if c.cmd == "show gre tunnel static" {
+		if c.cmd == "show interfaces description" {
 			if n, ok := parseTunnelCount(raw); ok {
 				s.mu.Lock()
 				s.latestTunnelCount, s.tunnelCountValid = n, true
 				s.mu.Unlock()
 			} else {
-				s.logger.Warn("could not parse tunnel count from show gre tunnel static")
+				s.logger.Warn("could not parse tunnel count from show interfaces description")
 			}
 		}
 	} else {
@@ -183,23 +205,40 @@ func parseCPUPercent(raw json.RawMessage) (float64, bool) {
 	return total, true
 }
 
-// parseTunnelCount returns the number of entries in the `greTunnels` map
-// of the `show gre tunnel static | json` eAPI response, shaped as
-// `{"greTunnels": {"<idx>": {…}, …}}`. Returns (0, true) on an empty map
-// — a healthy device with no user tunnels — and (0, false) only when
-// `greTunnels` is missing entirely or the response is malformed, so the
-// abort decider can distinguish "zero confirmed" from "unknown".
+// parseTunnelCount returns the number of user-tunnel interfaces in the
+// `show interfaces description | json` eAPI response, shaped as
+// `{"interfaceDescriptions": {"<name>": {"description": "..."}, …}}`.
+// An interface is a user tunnel when its description begins with
+// `userTunnelDescriptionPrefix` — every per-user `interface TunnelN`
+// block the controller renders carries `description USER-UCAST-<idx>`,
+// so this filter is robust against changes in the Tunnel<N> id
+// range (legacy: 500+; current: 1+).
+//
+// Returns (0, true) on an empty interfaces map and (N, true) on a
+// populated one. Returns (0, false) only when the
+// `interfaceDescriptions` key is missing or the JSON is malformed, so
+// the abort decider can tell "zero confirmed" apart from "unknown" and
+// suppress the sentinel in the latter case.
 func parseTunnelCount(raw json.RawMessage) (int, bool) {
+	type desc struct {
+		Description string `json:"description"`
+	}
 	var env struct {
-		GreTunnels map[string]json.RawMessage `json:"greTunnels"`
+		InterfaceDescriptions map[string]desc `json:"interfaceDescriptions"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return 0, false
 	}
-	if env.GreTunnels == nil {
+	if env.InterfaceDescriptions == nil {
 		return 0, false
 	}
-	return len(env.GreTunnels), true
+	count := 0
+	for _, d := range env.InterfaceDescriptions {
+		if strings.HasPrefix(d.Description, userTunnelDescriptionPrefix) {
+			count++
+		}
+	}
+	return count, true
 }
 
 // fileTimestamp renders t as ISO 8601 UTC with `:` → `-` for filesystem

--- a/tools/stress/device-observer/internal/sample/eos_test.go
+++ b/tools/stress/device-observer/internal/sample/eos_test.go
@@ -62,9 +62,9 @@ func TestTickWritesAllFiles(t *testing.T) {
 	dir := t.TempDir()
 	runner := &fakeRunner{
 		jsonResp: map[string]json.RawMessage{
-			"show hardware capacity":  json.RawMessage(`{"capacity":1}`),
-			"show gre tunnel static":  json.RawMessage(`{"tunnels":[]}`),
-			"show processes top once": json.RawMessage(`{"processes":[]}`),
+			"show hardware capacity":      json.RawMessage(`{"capacity":1}`),
+			"show interfaces description": json.RawMessage(`{"interfaceDescriptions":{}}`),
+			"show processes top once":     json.RawMessage(`{"processes":[]}`),
 		},
 		textResp: map[string]string{
 			"show logging errors":   "errlog\n",
@@ -89,11 +89,11 @@ func TestTickWritesAllFiles(t *testing.T) {
 	}
 
 	expect := map[string]string{
-		"show-hardware-capacity":  `{"capacity":1}`,
-		"show-gre-tunnel-static":  `{"tunnels":[]}`,
-		"show-processes-top-once": `{"processes":[]}`,
-		"show-logging-errors":     "errlog\n",
-		"show-logging-critical":   "critlog\n",
+		"show-hardware-capacity":      `{"capacity":1}`,
+		"show-interfaces-description": `{"interfaceDescriptions":{}}`,
+		"show-processes-top-once":     `{"processes":[]}`,
+		"show-logging-errors":         "errlog\n",
+		"show-logging-critical":       "critlog\n",
 	}
 	for prefix, want := range expect {
 		matches, _ := filepath.Glob(filepath.Join(dir, prefix+"-*"))
@@ -118,7 +118,7 @@ func TestSingleCommandFailureContinues(t *testing.T) {
 	dir := t.TempDir()
 	runner := &fakeRunner{
 		errs: map[string]error{
-			"show gre tunnel static": errors.New("boom"),
+			"show interfaces description": errors.New("boom"),
 		},
 	}
 	frozen := time.Date(2026, 5, 29, 12, 34, 56, 0, time.UTC)
@@ -134,7 +134,7 @@ func TestSingleCommandFailureContinues(t *testing.T) {
 		t.Fatalf("expected 4 files after one failure, got %d", len(entries))
 	}
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "show-gre-tunnel-static") {
+		if strings.HasPrefix(e.Name(), "show-interfaces-description") {
 			t.Errorf("failing command should not have produced a file, got %s", e.Name())
 		}
 	}
@@ -290,10 +290,22 @@ type runnable interface {
 
 var _ runnable = (*Sampler)(nil)
 
-// TestParseTunnelCount covers the three shapes the parser must handle:
-// a populated greTunnels map, an empty map (healthy device with no users),
-// and a missing/malformed response (must signal ok=false so the decider
-// suppresses the device_tunnel_gap trigger).
+// TestParseTunnelCount covers the shapes the parser must handle for
+// `show interfaces description | json`:
+//
+//   - a populated map containing user tunnels (description begins
+//     "USER-UCAST-") mixed with non-user interfaces (Loopback,
+//     Ethernet, Management, inter-router fabric tunnels);
+//   - a map containing no user tunnels (the device has only routing
+//     fabric — valid state, not unknown);
+//   - an empty map;
+//   - a missing or malformed response (must signal ok=false so the
+//     decider suppresses the device_tunnel_gap trigger).
+//
+// Coverage explicitly includes the low-id case (Tunnel1, Tunnel2)
+// since the controller's gm/tunnel-id-start-1 fix allocates user
+// tunnels from index 1 — the previous numeric-range filter rejected
+// these but the description-prefix filter must accept them.
 func TestParseTunnelCount(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -302,19 +314,38 @@ func TestParseTunnelCount(t *testing.T) {
 		wantOK bool
 	}{
 		{
-			name:   "populated map",
-			body:   `{"greTunnels":{"500":{"name":"Tunnel500"},"501":{"name":"Tunnel501"},"502":{"name":"Tunnel502"}}}`,
+			name: "populated map filters by USER-UCAST- description",
+			body: `{"interfaceDescriptions":{
+				"Loopback255":{"description":""},
+				"Loopback256":{"description":""},
+				"Ethernet1":{"description":""},
+				"Management0":{"description":""},
+				"Tunnel19":{"description":"to-chi-dn-dzd9"},
+				"Tunnel1":{"description":"USER-UCAST-1"},
+				"Tunnel2":{"description":"USER-UCAST-2"},
+				"Tunnel500":{"description":"USER-UCAST-500"}
+			}}`,
 			wantN:  3,
 			wantOK: true,
 		},
 		{
-			name:   "empty map",
-			body:   `{"greTunnels":{}}`,
+			name: "only routing-fabric tunnels present (no USER-UCAST- description)",
+			body: `{"interfaceDescriptions":{
+				"Tunnel19":{"description":"to-chi-dn-dzd9"},
+				"Tunnel59":{"description":"to-chi-dn-dzd1"},
+				"Tunnel91":{"description":"to-chi-dn-dzd5"}
+			}}`,
 			wantN:  0,
 			wantOK: true,
 		},
 		{
-			name:   "missing greTunnels key",
+			name:   "empty interfaceDescriptions map",
+			body:   `{"interfaceDescriptions":{}}`,
+			wantN:  0,
+			wantOK: true,
+		},
+		{
+			name:   "missing interfaceDescriptions key",
 			body:   `{}`,
 			wantN:  0,
 			wantOK: false,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -43,6 +43,7 @@ type orchestratorConfig struct {
 	HoldSeconds                   int    `json:"hold_seconds"`
 	AgentQuietSeconds             int    `json:"agent_quiet_seconds"`
 	AgentQuiescenceTimeoutSeconds int    `json:"agent_quiescence_timeout_seconds"`
+	ApplyCatchUpTimeoutSeconds    int    `json:"apply_catch_up_timeout_seconds"`
 	DUTPubkey                     string `json:"dut_pubkey"`
 	DUTSSHHost                    string `json:"dut_ssh_host"`
 	DUTSSHKey                     string `json:"dut_ssh_key"`
@@ -98,6 +99,14 @@ func run() error {
 		// Default: 300 s — accommodates the 22k-line / ~650 KB final config
 		// commit at 1024 tunnels.
 		agentQuiescenceTimeoutSeconds = flag.Int("agent-quiescence-timeout-seconds", 300, "Hard cap on the post-deprovision agent quiescence wait, in seconds.")
+		// Default: 300 s — same cap as agent-quiescence-timeout-seconds.
+		// Aligns the provision→deprovision boundary wait with the
+		// post-deprovision one. The wait blocks until applied >= target
+		// (minus a small grace), which prevents deprovision from
+		// removing users before the agent has had time to add them.
+		// Set to 0 to disable; useful when reproducing pre-3796
+		// behavior or for --no-agent runs where applied never lands.
+		applyCatchUpTimeoutSeconds = flag.Int("apply-catch-up-timeout-seconds", 300, "Hard cap on the provision→deprovision wait for the agent's applied count to catch up to the provisioned-user count. 0 disables the wait.")
 		// The containerized harness ships a device-side wrapper (see
 		// tools/stress/docker/device/agent-wrapper.sh) that injects -pubkey from
 		// /etc/doublezero/agent/pubkey and re-execs through sudo, so the
@@ -144,6 +153,7 @@ func run() error {
 		HoldSeconds:                   *holdSeconds,
 		AgentQuietSeconds:             *agentQuietSeconds,
 		AgentQuiescenceTimeoutSeconds: *agentQuiescenceTimeoutSeconds,
+		ApplyCatchUpTimeoutSeconds:    *applyCatchUpTimeoutSeconds,
 		DUTPubkey:                     *dutPubkey,
 		DUTSSHHost:                    *dutSSHHost,
 		DUTSSHKey:                     *dutSSHKey,
@@ -253,6 +263,15 @@ func run() error {
 
 	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, *agentBinary, *agentCommandPrefix, *agentPubkey, *agentMetricsAddr, logger)
 
+	// With --no-agent there is no agent to emit Applied events, so the
+	// catch-up wait would pin to its full timeout on every run. Zero it
+	// out automatically rather than asking the operator to remember the
+	// matching flag.
+	if *noAgent && *applyCatchUpTimeoutSeconds > 0 {
+		logger.Info("sweep: --no-agent disables apply catch-up wait", "previous_timeout_seconds", *applyCatchUpTimeoutSeconds)
+		*applyCatchUpTimeoutSeconds = 0
+	}
+
 	cfg := sweep.Config{
 		RunID:                  *runID,
 		Target:                 *targetUserCount,
@@ -260,6 +279,7 @@ func run() error {
 		Hold:                   time.Duration(*holdSeconds) * time.Second,
 		AgentQuietWindow:       time.Duration(*agentQuietSeconds) * time.Second,
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
+		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -289,6 +289,7 @@ func run() error {
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
 		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
 		ApplyPerBatchCatchUp:   *applyPerBatchCatchUp,
+		NoAgent:                *noAgent,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -44,6 +44,7 @@ type orchestratorConfig struct {
 	AgentQuietSeconds             int    `json:"agent_quiet_seconds"`
 	AgentQuiescenceTimeoutSeconds int    `json:"agent_quiescence_timeout_seconds"`
 	ApplyCatchUpTimeoutSeconds    int    `json:"apply_catch_up_timeout_seconds"`
+	ApplyPerBatchCatchUp          bool   `json:"apply_per_batch_catch_up"`
 	DUTPubkey                     string `json:"dut_pubkey"`
 	DUTSSHHost                    string `json:"dut_ssh_host"`
 	DUTSSHKey                     string `json:"dut_ssh_key"`
@@ -107,6 +108,12 @@ func run() error {
 		// Set to 0 to disable; useful when reproducing pre-3796
 		// behavior or for --no-agent runs where applied never lands.
 		applyCatchUpTimeoutSeconds = flag.Int("apply-catch-up-timeout-seconds", 300, "Hard cap on the provision→deprovision wait for the agent's applied count to catch up to the provisioned-user count. 0 disables the wait.")
+		// Off by default. Real production traffic adds users at
+		// human cadence, not in burst-fashion, so this flag is the
+		// closer match for measuring per-user latency under steady-
+		// state load. Off matches the default "stress the agent" shape
+		// the harness was originally built for.
+		applyPerBatchCatchUp = flag.Bool("apply-per-batch-catch-up", false, "Pause after each provision batch until the agent's applied count covers the cumulative target; honors --apply-catch-up-timeout-seconds per batch.")
 		// The containerized harness ships a device-side wrapper (see
 		// tools/stress/docker/device/agent-wrapper.sh) that injects -pubkey from
 		// /etc/doublezero/agent/pubkey and re-execs through sudo, so the
@@ -154,6 +161,7 @@ func run() error {
 		AgentQuietSeconds:             *agentQuietSeconds,
 		AgentQuiescenceTimeoutSeconds: *agentQuiescenceTimeoutSeconds,
 		ApplyCatchUpTimeoutSeconds:    *applyCatchUpTimeoutSeconds,
+		ApplyPerBatchCatchUp:          *applyPerBatchCatchUp,
 		DUTPubkey:                     *dutPubkey,
 		DUTSSHHost:                    *dutSSHHost,
 		DUTSSHKey:                     *dutSSHKey,
@@ -280,6 +288,7 @@ func run() error {
 		AgentQuietWindow:       time.Duration(*agentQuietSeconds) * time.Second,
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
 		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
+		ApplyPerBatchCatchUp:   *applyPerBatchCatchUp,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/pkg/agent/agent.go
+++ b/tools/stress/device-orchestrator/pkg/agent/agent.go
@@ -33,6 +33,29 @@ const (
 	// otherwise see the agent as silent throughout the entire deprovision
 	// phase and skip the wait.
 	EventCommit
+	// EventConfigReceived marks the moment the agent finishes pulling a
+	// fresh config from the controller (the "Received N bytes of
+	// configuration from controller" log line). TunnelID is always 0;
+	// the event is purely an activity signal for the quiescence
+	// tracker, which would otherwise treat the agent as silent during
+	// the multi-second diff-check window between a config arrival and
+	// the next commit (~26 µs/byte → tens of seconds for the >1MB
+	// deprovision diff at 1k users). Without this signal, the post-
+	// deprovision quiescence wait can declare the agent "quiesced"
+	// while a deprovision diff is still being analyzed, and kill the
+	// SSH session before the commit lands on the device.
+	EventConfigReceived
+	// EventCommitAborted marks the moment the agent closes a
+	// configure-session with the `abort` command (the post-finalize
+	// log line ends `'...session-name abort'` rather than the more
+	// common `'...session-name commit'`). EOS emits an abort when the
+	// rendered config matches the running-config exactly — i.e. the
+	// agent saw a config it could ingest but found nothing to change.
+	// In steady state after deprovision the agent re-polls every 20s
+	// and aborts each one; the tracker uses this signal to clear the
+	// pending-commit flag set by EventConfigReceived so the quiescence
+	// wait doesn't time out on legitimate no-op poll loops.
+	EventCommitAborted
 )
 
 // Event is one observation emitted by the agent runner: a timestamped tunnel

--- a/tools/stress/device-orchestrator/pkg/agent/parser.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser.go
@@ -23,12 +23,30 @@ import (
 //   - "Configuration session finalized with command '... abort'"
 //     → close the block and clear the buffer with no Applied events.
 //
+// Two diff shapes need to be handled. The containerized cEOS path emits the
+// header itself as an addition ("+interface Tunnel500"), so one regex hit on
+// the header line is enough. Real EOS on chi-dn-dzd5 emits the diff against
+// the running-config: the "interface TunnelN" header lands unprefixed (or
+// space-prefixed as a unified-diff context line) and the additions appear
+// only on the property lines that follow ("+   description ..."). The parser
+// runs a small per-section state machine so both shapes resolve to one
+// EventPreCommitLog per tunnel section that contains any additions.
+//
 // A single Parser is goroutine-safe only against the calling Parse goroutine;
 // callers should funnel all lines through one Parse loop.
 type Parser struct {
 	pending []uint16
-	inDiff  bool             // open between a "Committing..." marker and its finalize line
-	now     func() time.Time // injectable for tests
+	inDiff  bool // open between a "Committing..." marker and its finalize line
+
+	// sectionTunnel is the most recently opened "interface TunnelN" section
+	// in the running diff (0 = no section open). sectionPromoted tracks
+	// whether the section has already produced an EventPreCommitLog; we
+	// only emit one per section even though the section contains many `+`
+	// property lines.
+	sectionTunnel   uint16
+	sectionPromoted bool
+
+	now func() time.Time // injectable for tests
 }
 
 // NewParser returns a Parser that stamps events with the current wallclock.
@@ -53,14 +71,26 @@ func WithClock(now func() time.Time) ParserOption {
 // The returned slice is freshly allocated per call and safe for the caller to
 // retain.
 func (p *Parser) Parse(line string) []Event {
+	// Receipt of a fresh config from the controller is an activity
+	// signal. We match the "bytes" line specifically (the agent emits
+	// both "lines" and "bytes" back-to-back per poll; one signal per
+	// cycle is enough) and emit an EventConfigReceived so the
+	// quiescence tracker doesn't time us out during the diff-check
+	// window that follows.
+	if configReceivedRE.MatchString(line) {
+		return []Event{{Kind: EventConfigReceived, TunnelID: 0, At: p.now()}}
+	}
 	if m := committingRE.FindStringSubmatch(line); m != nil {
-		// Open the diff block and scan the inline remainder of the marker line
-		// (the agent appends the first diff line after the colon).
+		// Open the diff block and scan the inline remainder of the marker line.
+		// cEOS appends the first diff line after the colon; real EOS appends
+		// the "--- file" header that we ignore.
 		p.inDiff = true
-		return p.scanAddedTunnels(m[1])
+		p.resetSection()
+		return p.scanInlineAdditions(m[1])
 	}
 	if finalizedCommitRE.MatchString(line) {
 		p.inDiff = false
+		p.resetSection()
 		now := p.now()
 		// Always emit EventCommit so the consumer can see commit activity
 		// during deprovision (pure-removal diffs leave p.pending empty).
@@ -73,23 +103,33 @@ func (p *Parser) Parse(line string) []Event {
 		return out
 	}
 	if finalizedAbortRE.MatchString(line) {
-		// Abort cleared the session — drop pending without emitting Applied.
+		// Abort cleared the session — drop pending Applieds without emitting,
+		// but emit one EventCommitAborted so the quiescence tracker can
+		// clear its pending-commit flag (set when the matching
+		// `Received N bytes` line arrived).
 		p.inDiff = false
+		p.resetSection()
 		p.pending = p.pending[:0]
-		return nil
+		return []Event{{Kind: EventCommitAborted, TunnelID: 0, At: p.now()}}
 	}
 	if p.inDiff {
-		// A diff-body line inside an open commit block: the "+ interface
-		// Tunnel<ID>" additions arrive here, one (or more) per line.
-		return p.scanAddedTunnels(line)
+		return p.parseDiffLine(line)
 	}
 	return nil
 }
 
-// scanAddedTunnels emits one EventPreCommitLog per "+ interface Tunnel<ID>"
-// found in s, recording the IDs as pending. Returns nil when s adds no tunnels
-// (context lines, "- interface" deletions, or unrelated diff text).
-func (p *Parser) scanAddedTunnels(s string) []Event {
+// resetSection clears the in-flight interface-section bookkeeping.
+func (p *Parser) resetSection() {
+	p.sectionTunnel = 0
+	p.sectionPromoted = false
+}
+
+// scanInlineAdditions handles the inline payload trailing the "Committing
+// config session due to diffs detected:" marker. This is the cEOS shape,
+// where the entire diff can land on one line. Real EOS only puts the
+// "--- file" unified-diff header here; the diff body itself arrives on
+// subsequent lines and is processed by parseDiffLine.
+func (p *Parser) scanInlineAdditions(s string) []Event {
 	ids := extractAddedTunnelIDs(s)
 	if len(ids) == 0 {
 		return nil
@@ -101,6 +141,63 @@ func (p *Parser) scanAddedTunnels(s string) []Event {
 		out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
 	}
 	return out
+}
+
+// parseDiffLine processes one line inside an open Committing diff block.
+// It handles three shapes:
+//
+//   - cEOS additive header  "+interface TunnelN" / "+ interface TunnelN"
+//     emits EventPreCommitLog directly and closes any open section.
+//   - Real-EOS section header  "interface TunnelN" or " interface TunnelN"
+//     (unified-diff context prefix) opens a section without emitting yet.
+//   - Property addition inside a section  "+   description ..."  promotes
+//     the section: emits EventPreCommitLog for the section's tunnel ID once.
+//
+// A " !" terminator (or the start of the next section) closes the current
+// section without emitting if it had no `+` lines (pure-removal section).
+func (p *Parser) parseDiffLine(line string) []Event {
+	// cEOS shape: the header line itself is an addition. The added-tunnel
+	// regex is anchored on `+\s*interface Tunnel`, so this only fires when
+	// the section *header* is in the diff body — not on `+   description ...`
+	// property lines (no "interface" token).
+	if ids := extractAddedTunnelIDs(line); len(ids) > 0 {
+		p.pending = append(p.pending, ids...)
+		now := p.now()
+		out := make([]Event, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
+		}
+		// The cEOS shape declares a new interface block in its entirety;
+		// any in-flight real-EOS section is no longer the relevant frame.
+		p.resetSection()
+		return out
+	}
+	// Real-EOS section header — context (space-prefixed) or unprefixed.
+	if m := sectionStartRE.FindStringSubmatch(line); m != nil {
+		id, err := strconv.ParseUint(m[1], 10, 16)
+		if err != nil {
+			// uint16 overflow on the section ID: drop it so we can't
+			// later promote the wrong tunnel into pending.
+			p.resetSection()
+			return nil
+		}
+		p.sectionTunnel = uint16(id)
+		p.sectionPromoted = false
+		return nil
+	}
+	// Section terminator ("!" as a context line). Closes without emitting.
+	if sectionTerminatorRE.MatchString(line) {
+		p.resetSection()
+		return nil
+	}
+	// Property addition inside an open section: promote once.
+	if p.sectionTunnel != 0 && !p.sectionPromoted && addedPropertyRE.MatchString(line) {
+		id := p.sectionTunnel
+		p.sectionPromoted = true
+		p.pending = append(p.pending, id)
+		return []Event{{Kind: EventPreCommitLog, TunnelID: id, At: p.now()}}
+	}
+	return nil
 }
 
 // Pending exposes the in-flight tunnel IDs awaiting an Applied event; tests
@@ -118,9 +215,36 @@ var (
 	// the multi-line diff arrives on subsequent lines (handled via inDiff).
 	committingRE = regexp.MustCompile(`Committing config session due to diffs detected:\s*(.*)$`)
 
-	// addedTunnelRE matches an additive interface-Tunnel diff line; the `\b` on
-	// the right keeps "Tunnel50001" out of a "Tunnel500" match.
+	// configReceivedRE matches the "Received N bytes of configuration"
+	// agent log line. The agent emits both a "lines" and a "bytes"
+	// counterpart back-to-back per poll cycle; we anchor on bytes so
+	// the EventConfigReceived signal fires exactly once per cycle.
+	configReceivedRE = regexp.MustCompile(`Received \d+ bytes of configuration from controller`)
+
+	// addedTunnelRE matches the cEOS additive header shape, where the
+	// "interface TunnelN" line is itself diff-added: "+interface TunnelN"
+	// or "+ interface TunnelN". The `\b` keeps "Tunnel50001" out of a
+	// "Tunnel500" match.
 	addedTunnelRE = regexp.MustCompile(`\+\s*interface Tunnel(\d+)\b`)
+
+	// sectionStartRE matches the real-EOS section header inside a diff
+	// body. EOS emits "interface TunnelN" with no prefix on the first
+	// section and " interface TunnelN" (a unified-diff context prefix) on
+	// subsequent sections when the interface already exists in
+	// running-config but has no properties yet.
+	sectionStartRE = regexp.MustCompile(`^[ ]?interface Tunnel(\d+)\b`)
+
+	// addedPropertyRE matches a "+   description ..." (or other property)
+	// addition line inside an interface section. The `\s+\S` rules out
+	// the "+++ session:/..." unified-diff file marker (no whitespace
+	// between the +s) and bare "+" lines.
+	addedPropertyRE = regexp.MustCompile(`^\+\s+\S`)
+
+	// sectionTerminatorRE matches the EOS "!" section terminator emitted
+	// as a context line (" !"). cEOS prefixes its terminator with "+", so
+	// it does not hit this regex — fine, because cEOS sections close
+	// implicitly via the next addedTunnelRE-matched header.
+	sectionTerminatorRE = regexp.MustCompile(`^[ ]!`)
 
 	// finalizedCommitRE matches the post-commit log line on a successful
 	// commit. The quoted command always ends in "...commit" for actual commits

--- a/tools/stress/device-orchestrator/pkg/agent/parser_test.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser_test.go
@@ -127,8 +127,13 @@ func TestParser_AbortClearsBufferWithoutAppliedEvents(t *testing.T) {
 	require.Len(t, events, 1)
 	require.Equal(t, []uint16{500}, p.Pending())
 
+	// Abort emits exactly one EventCommitAborted (so the quiescence
+	// tracker can clear its pending-commit flag) and drops the
+	// per-tunnel Applieds.
 	events = p.Parse(`Configuration session finalized with command 'configure session foo abort'`)
-	assert.Empty(t, events, "abort emits no events")
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventCommitAborted, events[0].Kind)
+	assert.Equal(t, uint16(0), events[0].TunnelID)
 	assert.Empty(t, p.Pending(), "abort still clears pending")
 }
 
@@ -177,6 +182,29 @@ func TestParser_UnrelatedLinesIgnored(t *testing.T) {
 	}
 }
 
+// TestParser_ReceivedBytesEmitsConfigReceived covers the activity-signal
+// shim the orchestrator's quiescence tracker uses to keep itself awake
+// during the multi-second diff-check window that follows a fresh config
+// pull. Without this, the agent can be silent for tens of seconds while
+// analyzing a >1 MB deprovision diff and the tracker will mistake the
+// silence for "agent quiesced" and tear down the SSH session.
+func TestParser_ReceivedBytesEmitsConfigReceived(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	p := agent.NewParser(agent.WithClock(fixedClock(now)))
+
+	// The "lines" sibling should not produce an event (we anchor on
+	// "bytes" so exactly one EventConfigReceived fires per poll cycle).
+	assert.Empty(t, p.Parse(`2026/06/04 22:00:00.000000 eapi.go:217: Received 51553 lines of configuration from controller`))
+
+	events := p.Parse(`2026/06/04 22:00:00.000010 eapi.go:218: Received 1622130 bytes of configuration from controller`)
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventConfigReceived, events[0].Kind)
+	assert.Equal(t, uint16(0), events[0].TunnelID)
+	assert.Equal(t, now, events[0].At)
+}
+
 func TestParser_RejectsOversizedTunnelID(t *testing.T) {
 	t.Parallel()
 
@@ -196,4 +224,102 @@ func TestParser_DoesNotConfuseInterfaceNamePrefixes(t *testing.T) {
 	events := p.Parse(`Committing config session due to diffs detected: + interface Tunnel5000`)
 	require.Len(t, events, 1)
 	assert.Equal(t, uint16(5000), events[0].TunnelID)
+}
+
+// TestParser_RealEOSDiffFormat covers the shape real Arista EOS hardware
+// emits when diffing a session against running-config: the
+// "interface TunnelN" section header is a context line (no prefix on the
+// first section, space-prefixed on subsequent sections) and the additions
+// land on the property lines below it. cEOS containers don't do this —
+// they prefix the entire section, header included, with "+". The parser
+// must promote a section into pending the first time it sees a `+   ...`
+// property line inside it, and only once per section.
+func TestParser_RealEOSDiffFormat(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	lines := []string{
+		`2026/06/04 13:40:10 Committing config session due to diffs detected: --- system:/running-config`,
+		`+++ session:/doublezero-agent-1780580398-session-config`,
+		`interface Tunnel500`,
+		`+   description USER-UCAST-500`,
+		`+   mtu 9216`,
+		`+   vrf vrf1`,
+		`+   ip address 169.254.0.0/31`,
+		` !`,
+		` interface Tunnel501`,
+		`+   description USER-UCAST-501`,
+		`+   mtu 9216`,
+		` !`,
+		` interface Tunnel502`,
+		`+   description USER-UCAST-502`,
+		` !`,
+	}
+	var events []agent.Event
+	for _, l := range lines {
+		events = append(events, p.Parse(l)...)
+	}
+	require.Len(t, events, 3, "one EventPreCommitLog per real-EOS section, not per + line")
+	for i, want := range []uint16{500, 501, 502} {
+		assert.Equal(t, agent.EventPreCommitLog, events[i].Kind)
+		assert.Equal(t, want, events[i].TunnelID)
+	}
+	assert.Equal(t, []uint16{500, 501, 502}, p.Pending())
+
+	applied := p.Parse(`Configuration session finalized with command 'configure session doublezero-agent-1780580398 commit'`)
+	// One EventCommit + one EventApplied per pending tunnel.
+	require.Len(t, applied, 4)
+	assert.Equal(t, agent.EventCommit, applied[0].Kind)
+	assert.Equal(t, []uint16{500, 501, 502}, []uint16{applied[1].TunnelID, applied[2].TunnelID, applied[3].TunnelID})
+}
+
+// TestParser_RealEOSPureRemovalSectionEmitsNothing proves that a real-EOS
+// section that contains only "-   ..." lines (deprovision) does not get
+// promoted into pending — only `+` lines flip the section.
+func TestParser_RealEOSPureRemovalSectionEmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	lines := []string{
+		`Committing config session due to diffs detected: --- system:/running-config`,
+		`+++ session:/foo-config`,
+		` interface Tunnel500`,
+		`-   description USER-UCAST-500`,
+		`-   mtu 9216`,
+		` !`,
+	}
+	for _, l := range lines {
+		assert.Empty(t, p.Parse(l), "line=%q", l)
+	}
+	assert.Empty(t, p.Pending(), "pure-removal section must not pre-commit")
+
+	events := p.Parse(`Configuration session finalized with command 'configure session foo commit'`)
+	require.Len(t, events, 1, "commit fires EventCommit even with no pending")
+	assert.Equal(t, agent.EventCommit, events[0].Kind)
+}
+
+// TestParser_RealEOSEmitsOncePerSectionEvenWithManyAdditions enforces that
+// a section with many `+   ...` property lines produces exactly one
+// EventPreCommitLog (and exactly one entry in pending).
+func TestParser_RealEOSEmitsOncePerSectionEvenWithManyAdditions(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	require.Empty(t, p.Parse(`Committing config session due to diffs detected: --- system:/running-config`))
+	require.Empty(t, p.Parse(`+++ session:/foo-config`))
+	require.Empty(t, p.Parse(`interface Tunnel900`))
+
+	first := p.Parse(`+   description USER-UCAST-900`)
+	require.Len(t, first, 1, "first + line promotes the section")
+	assert.Equal(t, uint16(900), first[0].TunnelID)
+
+	for _, prop := range []string{
+		`+   mtu 9216`,
+		`+   vrf vrf1`,
+		`+   ip address 169.254.0.0/31`,
+		`+   tunnel mode gre`,
+	} {
+		assert.Empty(t, p.Parse(prop), "subsequent + lines in the same section must not re-emit")
+	}
+	assert.Equal(t, []uint16{900}, p.Pending())
 }

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -91,6 +91,20 @@ type Config struct {
 	AgentQuietWindow       time.Duration
 	AgentQuiescenceTimeout time.Duration
 
+	// ApplyCatchUpTimeout bounds how long Run waits between
+	// provision-complete and deprovision-start for the agent's
+	// `applied` event count to catch up to the provision-target
+	// count. With hold=0 and a slow agent (>1 MB configs take ~40s
+	// to diff-check) the orchestrator can finish provisioning all
+	// 1024 users and start deleting them before the agent ever
+	// applies the peak config — users get added and removed in the
+	// same diff and never show up on the device. The wait blocks
+	// until applied >= len(created) OR the timeout fires. Zero
+	// disables the wait (the legacy behavior). A small grace count
+	// (4) is allowed since the last batch's applied events lag by
+	// roughly one poll cycle even on a healthy agent.
+	ApplyCatchUpTimeout time.Duration
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -110,6 +124,8 @@ func (c *Config) validate() error {
 		return errors.New("sweep: AgentQuietWindow must be >= 0")
 	case c.AgentQuiescenceTimeout < 0:
 		return errors.New("sweep: AgentQuiescenceTimeout must be >= 0")
+	case c.ApplyCatchUpTimeout < 0:
+		return errors.New("sweep: ApplyCatchUpTimeout must be >= 0")
 	case c.AgentQuietWindow > 0 && c.AgentQuiescenceTimeout <= 0:
 		// The wait loop only enforces the deadline when timeout > 0. A zero
 		// timeout paired with a positive window would loop until ctx
@@ -144,24 +160,44 @@ func (c *Config) applyDefaults() {
 }
 
 // quiescenceTracker records the wall-clock time of the most recent observed
-// post-commit agent event (EventApplied or EventCommit). The orchestrator
-// polls it after deprovision returns to wait for the agent to finish
-// converging EOS to the new (post-deprovision) config before cancelling the
-// SSH session.
+// post-commit agent event AND whether the agent is currently mid-cycle
+// (a config has been received but not yet committed or aborted). The
+// orchestrator polls it after deprovision returns to wait for the agent
+// to finish converging EOS to the new (post-deprovision) config before
+// cancelling the SSH session.
 //
-// Both signals are post-commit: EventApplied fires per pending tunnel after
-// a successful commit-finalize; EventCommit fires once per successful
-// commit-finalize regardless of which tunnels (if any) changed. We need
-// both because deprovision diffs produce zero EventApplieds (the parser
-// only tracks `+ interface Tunnel<ID>` lines), so without EventCommit the
-// tracker would see the agent as silent through the entire deprovision
-// phase.
+// Why both: post-commit signals (EventApplied / EventCommit) alone are
+// insufficient because the agent goes silent during the diff-check
+// window between EventConfigReceived and the next EventCommit. At >1 MB
+// configs that window can exceed 30s — past the default 15s quiet
+// window — so the tracker would falsely declare quiescence mid-cycle
+// and the orchestrator would kill the SSH session before the
+// deprovision config was committed to EOS. The pending-commit flag
+// closes that gap: while it's true the wait blocks regardless of how
+// long the agent has been silent.
 type quiescenceTracker struct {
 	lastEventNanos atomic.Int64
+	// pendingCommit is true between an EventConfigReceived and the
+	// next terminal cycle event (EventCommit, EventApplied, or — as
+	// far as the tracker is concerned — a brand-new
+	// EventConfigReceived, which implies the previous cycle finished
+	// without an explicit commit).
+	pendingCommit atomic.Bool
+	// appliedCount counts EventApplied observations across the run.
+	// Used by waitForAppliedToCatchUp at the provision→deprovision
+	// boundary to ensure the agent has had time to apply the peak
+	// config before the orchestrator starts removing users.
+	appliedCount atomic.Int64
 }
 
-func (q *quiescenceTracker) markEvent(at time.Time) {
+// markEvent records an agent activity beat that resets the silence
+// timer. pending is true for events that *start* a new
+// commit cycle (EventConfigReceived) and false for events that close
+// it (EventCommit / EventApplied). The tracker uses pendingCommit to
+// decide whether quiescence is safe — see HasPendingCommit.
+func (q *quiescenceTracker) markEvent(at time.Time, pending bool) {
 	q.lastEventNanos.Store(at.UnixNano())
+	q.pendingCommit.Store(pending)
 }
 
 func (q *quiescenceTracker) lastEvent() (time.Time, bool) {
@@ -170,6 +206,24 @@ func (q *quiescenceTracker) lastEvent() (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return time.Unix(0, n), true
+}
+
+// HasPendingCommit reports whether the agent has received a config it
+// hasn't yet committed. While true the quiescence wait must block,
+// regardless of how long the agent has been silent.
+func (q *quiescenceTracker) HasPendingCommit() bool {
+	return q.pendingCommit.Load()
+}
+
+// markApplied increments the per-run EventApplied counter. Called
+// alongside markEvent for EventApplied observations.
+func (q *quiescenceTracker) markApplied() {
+	q.appliedCount.Add(1)
+}
+
+// AppliedCount returns the running total of EventApplied observations.
+func (q *quiescenceTracker) AppliedCount() int64 {
+	return q.appliedCount.Load()
 }
 
 // createdUser tracks an orchestrator-owned user so the deprovision phase can
@@ -261,6 +315,18 @@ func Run(ctx context.Context, cfg Config) error {
 
 	created, err := provision(runCtx, &cfg, registry)
 
+	// Wait for the agent to apply the peak config before tearing down.
+	// At 1k users / hold=0 the orchestrator's provision finishes ~40s
+	// ahead of the agent's slowest diff-check + commit, so without this
+	// wait deprovision starts removing users while the agent is still
+	// trying to add them — users get added and removed in the same
+	// running diff and never show up on the device. We only wait on
+	// the success path: a provision error or context cancel means
+	// we're aborting, and the goal there is to clean up quickly.
+	if err == nil && cfg.ApplyCatchUpTimeout > 0 {
+		waitForAppliedToCatchUp(runCtx, &cfg, tracker, len(created))
+	}
+
 	// Always attempt deprovision so a provision error (or an abort during
 	// provision) still cleans up what the sweep created; the consumer keeps
 	// draining in parallel so any straggling agent events for already-created
@@ -321,11 +387,30 @@ func Run(ctx context.Context, cfg Config) error {
 // is doing work" for the purpose of timing the SSH cancel.
 func consumeAgentEvents(cfg *Config, registry *tunnelRegistry, tracker *quiescenceTracker) {
 	for ev := range cfg.Agent.Events() {
-		if ev.Kind == agent.EventApplied || ev.Kind == agent.EventCommit {
-			tracker.markEvent(cfg.Clock.Now())
+		// All three "agent is doing work" signals reset the silence
+		// timer; only EventConfigReceived sets the pending-commit flag.
+		// EventCommit and EventApplied are terminal — receiving them
+		// means the commit cycle finished, so they clear pending.
+		// EventApplied is per-tunnel and redundant with EventCommit
+		// for tracker purposes, but feeding it through keeps the
+		// silence timer accurate even when a commit's per-tunnel
+		// Applieds arrive out-of-order with the Commit signal.
+		switch ev.Kind {
+		case agent.EventConfigReceived:
+			tracker.markEvent(cfg.Clock.Now(), true)
+		case agent.EventCommit, agent.EventApplied, agent.EventCommitAborted:
+			// All three close a commit cycle from the tracker's
+			// perspective: EventCommit and EventApplied report a
+			// successful finalize; EventCommitAborted reports the
+			// agent gave up on the session (no-op diff in steady-
+			// state polling, most commonly post-deprovision).
+			tracker.markEvent(cfg.Clock.Now(), false)
 		}
-		if ev.Kind == agent.EventCommit {
-			// Pure activity signal — no per-tunnel runlog row to emit.
+		if ev.Kind == agent.EventApplied {
+			tracker.markApplied()
+		}
+		if ev.Kind == agent.EventCommit || ev.Kind == agent.EventConfigReceived || ev.Kind == agent.EventCommitAborted {
+			// Pure activity signals — no per-tunnel runlog row to emit.
 			continue
 		}
 		u, ok := registry.lookup(ev.TunnelID)
@@ -400,7 +485,15 @@ func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenc
 		last, _ = tracker.lastEvent()
 		sinceLast := now.Sub(last)
 		elapsed := now.Sub(start)
-		if elapsed >= cfg.AgentQuietWindow && sinceLast >= cfg.AgentQuietWindow {
+		// Quiescence requires: silent for AgentQuietWindow AND wait
+		// has been running at least AgentQuietWindow AND no commit
+		// cycle is mid-flight (config received, not yet committed).
+		// The last predicate prevents declaring quiescence during a
+		// long diff-check window — the agent goes silent between
+		// `Received N bytes` and the subsequent `Committing config
+		// session` log line for the duration of the diff compute,
+		// which at >1 MB configs can exceed AgentQuietWindow.
+		if elapsed >= cfg.AgentQuietWindow && sinceLast >= cfg.AgentQuietWindow && !tracker.HasPendingCommit() {
 			cfg.Logger.Info("sweep: agent quiesced",
 				"quiet_for", sinceLast,
 				"wait_elapsed", elapsed)
@@ -416,6 +509,59 @@ func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenc
 		case <-cfg.Clock.After(time.Second):
 		case <-ctx.Done():
 			cfg.Logger.Warn("sweep: agent quiescence wait cancelled", "err", ctx.Err())
+			return
+		}
+	}
+}
+
+// waitForAppliedToCatchUp blocks at the provision→deprovision boundary
+// until either (a) the agent has emitted at least `target` EventApplied
+// observations OR (b) cfg.ApplyCatchUpTimeout elapses. The function is
+// a no-op when cfg.ApplyCatchUpTimeout == 0 (the legacy behavior).
+//
+// We allow a small grace (`applyCatchUpGrace`) so the last batch's
+// applied events, which lag by roughly one poll cycle even on a healthy
+// agent, don't pin the wait to its timeout. `target` is len(created):
+// the orchestrator's count of users it actually provisioned (excludes
+// users the executor declined to create).
+//
+// The wait returns silently on hit, warns on ctx cancel or timeout, and
+// never fails the run — deprovision still runs afterwards regardless.
+const applyCatchUpGrace = int64(4)
+
+func waitForAppliedToCatchUp(ctx context.Context, cfg *Config, tracker *quiescenceTracker, target int) {
+	if cfg.ApplyCatchUpTimeout <= 0 || target == 0 {
+		return
+	}
+	start := cfg.Clock.Now()
+	deadline := start.Add(cfg.ApplyCatchUpTimeout)
+	cfg.Logger.Info("sweep: waiting for agent applied to catch up to provision",
+		"target", target,
+		"applied", tracker.AppliedCount(),
+		"grace", applyCatchUpGrace,
+		"timeout", cfg.ApplyCatchUpTimeout)
+	for {
+		applied := tracker.AppliedCount()
+		if applied+applyCatchUpGrace >= int64(target) {
+			cfg.Logger.Info("sweep: applied caught up",
+				"applied", applied,
+				"target", target,
+				"elapsed", cfg.Clock.Now().Sub(start))
+			return
+		}
+		now := cfg.Clock.Now()
+		if !now.Before(deadline) {
+			cfg.Logger.Warn("sweep: apply catch-up timed out; proceeding with deprovision anyway",
+				"applied", applied,
+				"target", target,
+				"shortfall", int64(target)-applied,
+				"elapsed", now.Sub(start))
+			return
+		}
+		select {
+		case <-cfg.Clock.After(time.Second):
+		case <-ctx.Done():
+			cfg.Logger.Warn("sweep: apply catch-up wait cancelled", "err", ctx.Err())
 			return
 		}
 	}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -105,6 +105,26 @@ type Config struct {
 	// roughly one poll cycle even on a healthy agent.
 	ApplyCatchUpTimeout time.Duration
 
+	// ApplyPerBatchCatchUp, when true, makes the provision phase pause
+	// after every batch (not just at provision-complete) until the
+	// agent's applied count covers the cumulative user count submitted
+	// so far. This paces the orchestrator at the agent's throughput,
+	// which matches production better than the current "flood the
+	// agent" shape — users in real life arrive at human cadence, not
+	// in 32/64-user bursts.
+	//
+	// Trade-off: per-batch waits dramatically reduce the diff-check
+	// load per cycle (more, smaller cycles instead of fewer, larger
+	// ones), which is the load-bearing measurement the harness was
+	// built to surface. Off by default; flip on when measuring per-
+	// user latency under steady-state load rather than peak throughput
+	// under burst load.
+	//
+	// Each per-batch wait honors the same ApplyCatchUpTimeout as the
+	// provision-complete wait; that knob's grace (applyCatchUpGrace)
+	// still applies. With ApplyCatchUpTimeout == 0 this flag is a no-op.
+	ApplyPerBatchCatchUp bool
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -313,7 +333,7 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	}()
 
-	created, err := provision(runCtx, &cfg, registry)
+	created, err := provision(runCtx, &cfg, registry, tracker)
 
 	// Wait for the agent to apply the peak config before tearing down.
 	// At 1k users / hold=0 the orchestrator's provision finishes ~40s
@@ -575,7 +595,7 @@ func waitForAppliedToCatchUp(ctx context.Context, cfg *Config, tracker *quiescen
 // to ~14 s. Each created user is registered with the tunnel registry so
 // the agent-event consumer can attribute pre_commit_log / applied events
 // back to a user_index.
-func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry) ([]createdUser, error) {
+func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry, tracker *quiescenceTracker) ([]createdUser, error) {
 	if cfg.Target == 0 {
 		return nil, nil
 	}
@@ -611,6 +631,18 @@ func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry) ([]cr
 		}
 
 		runningTarget = nextTarget
+		// Per-batch catch-up: pace the orchestrator at the agent's
+		// throughput so each batch's users land on the device before
+		// the next batch is submitted. Skipped on the final batch
+		// (the provision-complete wait covers it) and when the
+		// flag's off. Honors the same ApplyCatchUpTimeout as the
+		// provision-complete wait.
+		if cfg.ApplyPerBatchCatchUp && cfg.ApplyCatchUpTimeout > 0 && runningTarget < cfg.Target {
+			waitForAppliedToCatchUp(ctx, cfg, tracker, len(created))
+			if err := ctx.Err(); err != nil {
+				return created, err
+			}
+		}
 		if runningTarget >= cfg.Target {
 			break
 		}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -125,6 +125,17 @@ type Config struct {
 	// still applies. With ApplyCatchUpTimeout == 0 this flag is a no-op.
 	ApplyPerBatchCatchUp bool
 
+	// NoAgent declares that the run is being driven without a real
+	// agent (the caller wired up agent.NewNoop). Used by
+	// waitForAgentQuiescence to skip the wait without inferring the
+	// answer from tracker state — the previous inference races with
+	// the consumer goroutine that updates the tracker, and at high
+	// schedule pressure can fire even on a real-agent run that has
+	// emitted events that the consumer hasn't yet drained. main.go
+	// already turns this flag on when --no-agent is set, alongside
+	// zeroing ApplyCatchUpTimeout.
+	NoAgent bool
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -477,32 +488,42 @@ func consumeAgentEvents(cfg *Config, registry *tunnelRegistry, tracker *quiescen
 //
 // The wait returns early on cfg.AgentQuiescenceTimeout (warned) or
 // ctx.Done() (warned). It is a no-op when cfg.AgentQuietWindow is zero
-// (the library default) or when no agent event has ever been observed
-// (e.g. --no-agent runs).
+// (the library default) or when cfg.NoAgent is true (the caller wired a
+// noop runner). An older version of this function also skipped when
+// tracker.lastEvent() reported no events; that inference raced with
+// the consumer goroutine that updates the tracker (event sitting in
+// the channel buffer but not yet observed) and could falsely fast-path
+// during a real-agent run, killing the SSH session mid-commit. The
+// explicit NoAgent flag from main.go replaces that inference.
 //
 // The wait polls in 1s ticks. Polling avoids needing a separate
 // "applied observed" signal channel — the tracker's atomic.Int64 is
 // read each tick and compared against the current clock. At 1024
 // users / batch=32 the agent emits commits in clumps tens of seconds
 // apart, so a 1s poll is well below the natural event cadence.
+//
+// When tracker.lastEvent() reports no events yet (zero-time), the
+// loop still progresses correctly: sinceLast is "now - zero" which is
+// trivially larger than AgentQuietWindow, so the wait blocks for
+// AgentQuietWindow against the elapsed-since-start guard before
+// returning. That gives the consumer goroutine a generous window to
+// pick up any in-flight events before we declare quiescence.
 func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenceTracker) {
 	if cfg.AgentQuietWindow <= 0 {
 		return
 	}
-	last, ok := tracker.lastEvent()
-	if !ok {
-		cfg.Logger.Info("sweep: no agent events observed; skipping agent quiescence wait")
+	if cfg.NoAgent {
+		cfg.Logger.Info("sweep: --no-agent set; skipping agent quiescence wait")
 		return
 	}
 	start := cfg.Clock.Now()
 	deadline := start.Add(cfg.AgentQuiescenceTimeout)
 	cfg.Logger.Info("sweep: waiting for agent to quiesce",
 		"quiet_window", cfg.AgentQuietWindow,
-		"timeout", cfg.AgentQuiescenceTimeout,
-		"last_event_at", last)
+		"timeout", cfg.AgentQuiescenceTimeout)
 	for {
 		now := cfg.Clock.Now()
-		last, _ = tracker.lastEvent()
+		last, _ := tracker.lastEvent()
 		sinceLast := now.Sub(last)
 		elapsed := now.Sub(start)
 		// Quiescence requires: silent for AgentQuietWindow AND wait

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -1008,10 +1008,13 @@ func TestRun_QuiescenceBlocksOnPendingCommit(t *testing.T) {
 	}
 }
 
-// TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved confirms the wait is a
-// no-op when the agent never emitted an Applied — common in --no-agent runs
-// and on early-failure paths where teardown shouldn't pay the wait cost.
-func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
+// TestRun_SkipsQuiescenceWaitWhenNoAgent confirms the wait is a no-op
+// when the caller declared the run as --no-agent (Config.NoAgent=true).
+// The wait used to skip on an inferred "no events observed" signal,
+// but that inference raced with the consumer goroutine; the explicit
+// flag replaces it. With a 30s quiet window the wait would dominate
+// the run if NoAgent did not short-circuit it.
+func TestRun_SkipsQuiescenceWaitWhenNoAgent(t *testing.T) {
 	t.Parallel()
 
 	owner := solana.NewWallet().PublicKey()
@@ -1032,6 +1035,7 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 		OwnerFilter:            owner,
 		Executor:               exec,
 		Agent:                  agent.NewNoop(nil),
+		NoAgent:                true,
 		Runlog:                 w,
 		Clock:                  sweep.RealClock{},
 	}
@@ -1040,7 +1044,7 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 	require.NoError(t, sweep.Run(context.Background(), cfg))
 	elapsed := time.Since(start)
 	assert.Less(t, elapsed, time.Second,
-		"Run took %v with a 30s quiet window but no Applied events — wait should have skipped", elapsed)
+		"Run took %v with a 30s quiet window and NoAgent=true — wait should have skipped", elapsed)
 }
 
 // TestRun_WaitsForAgentQuiescenceEvenOnAbort proves that the quiescence

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -742,6 +742,96 @@ func TestRun_WaitsForAgentQuiescenceAfterDeprovision(t *testing.T) {
 		"Run returned %v after gate release; expected ≥ %v (quiet window)", elapsed, quietWindow/2)
 }
 
+// TestRun_PerBatchCatchUpWaitsBetweenBatches proves that when
+// ApplyPerBatchCatchUp is set, the sweep blocks after each batch
+// until the agent has emitted enough Applied events to cover the
+// cumulative count submitted so far — i.e. the orchestrator stops
+// pre-creating batches faster than the agent can apply them. Without
+// this, batch 2 would start as soon as batch 1's onchain activates
+// land regardless of agent progress (the default behavior).
+func TestRun_PerBatchCatchUpWaitsBetweenBatches(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	// Signal when batch 2 starts (the 9th CreateUser call). We use a
+	// large enough batch size (8) and target (16) that batch 1's
+	// cumulative target (8) sits above the catch-up grace (4), so
+	// applied=0 actually blocks rather than passing-with-grace.
+	const batchSize = 8
+	const target = 16
+	batch2Reached := make(chan struct{})
+	var once sync.Once
+	exec.afterCreate = func(calls int) {
+		if calls == batchSize+1 {
+			once.Do(func() { close(batch2Reached) })
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:                "run-per-batch-catch-up",
+		Target:               target,
+		UsersPerBatch:        batchSize,
+		Hold:                 0,
+		ApplyCatchUpTimeout:  3 * time.Second,
+		ApplyPerBatchCatchUp: true,
+		OwnerFilter:          owner,
+		Executor:             exec,
+		Agent:                ag,
+		Runlog:               w,
+		Clock:                sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	// Wait for batch 1 to land (batchSize create calls), then confirm
+	// batch 2 hasn't started — the per-batch wait should block it.
+	deadline := time.Now().Add(2 * time.Second)
+	for exec.createN.Load() < batchSize {
+		if time.Now().After(deadline) {
+			t.Fatalf("batch 1 did not complete within 2s (got %d creates)", exec.createN.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-batch2Reached:
+		t.Fatal("batch 2 started before any Applied event — per-batch wait did not block")
+	default:
+	}
+
+	// Emit batchSize-grace+1 Applied events to push applied+grace
+	// past the cumulative target and unblock the wait.
+	for i := 0; i < batchSize; i++ {
+		ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: uint16(500 + i), At: time.Now()})
+	}
+
+	select {
+	case <-batch2Reached:
+		// Expected.
+	case <-time.After(3 * time.Second):
+		t.Fatal("batch 2 did not start within 3s of Applied events")
+	}
+
+	// Let the run finish; emit enough Applieds to clear remaining waits.
+	for i := 0; i < target; i++ {
+		ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: uint16(500 + batchSize + i), At: time.Now()})
+	}
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after all Applieds emitted")
+	}
+}
+
 // TestRun_BlocksDeprovisionUntilAppliedCatchesUp proves the
 // provision→deprovision wait blocks until enough EventApplied
 // observations have landed to cover the provisioned users. Without

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -742,6 +742,182 @@ func TestRun_WaitsForAgentQuiescenceAfterDeprovision(t *testing.T) {
 		"Run returned %v after gate release; expected ≥ %v (quiet window)", elapsed, quietWindow/2)
 }
 
+// TestRun_BlocksDeprovisionUntilAppliedCatchesUp proves the
+// provision→deprovision wait blocks until enough EventApplied
+// observations have landed to cover the provisioned users. Without
+// this gate (hold=0) the orchestrator finishes provisioning ~40s
+// ahead of the agent's slowest commit at high user counts and starts
+// removing users before they've ever been added to the device.
+func TestRun_BlocksDeprovisionUntilAppliedCatchesUp(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:               "run-catch-up",
+		Target:              5,
+		UsersPerBatch:       5,
+		Hold:                0,
+		ApplyCatchUpTimeout: 2 * time.Second,
+		OwnerFilter:         owner,
+		Executor:            exec,
+		Agent:               ag,
+		Runlog:              w,
+		Clock:               sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	// Wait for provision to finish (5 create calls) but no deprovision
+	// yet — the catch-up wait should be blocking.
+	deadline := time.Now().Add(2 * time.Second)
+	for exec.createN.Load() < 5 {
+		if time.Now().After(deadline) {
+			t.Fatalf("provision did not reach 5 users in 2s (got %d)", exec.createN.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Give the wait a beat to enter the loop, then confirm deprovision
+	// hasn't started.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), exec.deleteN.Load(), "deprovision started before applied caught up")
+
+	// Emit enough Applied events to satisfy target - grace (5 - 4 = 1).
+	ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: 500, At: time.Now()})
+
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s after Applied caught up")
+	}
+	assert.Equal(t, int32(5), exec.deleteN.Load(), "all 5 users should have been deprovisioned")
+}
+
+// TestRun_CatchUpWaitHonorsTimeout confirms the wait gives up and
+// proceeds with deprovision when ApplyCatchUpTimeout fires, instead of
+// pinning the orchestrator indefinitely on a stuck agent.
+func TestRun_CatchUpWaitHonorsTimeout(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:               "run-catch-up-timeout",
+		Target:              10,
+		UsersPerBatch:       10,
+		Hold:                0,
+		ApplyCatchUpTimeout: 200 * time.Millisecond,
+		OwnerFilter:         owner,
+		Executor:            exec,
+		Agent:               ag, // never emits Applied
+		Runlog:              w,
+		Clock:               sweep.RealClock{},
+	}
+	start := time.Now()
+	require.NoError(t, sweep.Run(context.Background(), cfg))
+	elapsed := time.Since(start)
+	// Wait should have taken roughly the timeout. The lower bound is
+	// timeout/2 (loose, absorbs scheduler jitter); the upper bound is
+	// timeout * 4 (loose enough to absorb the 1s tick interval).
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond,
+		"Run returned %v; expected at least the catch-up timeout floor", elapsed)
+	assert.Less(t, elapsed, 5*time.Second,
+		"Run took %v; expected catch-up wait to time out, not hang", elapsed)
+	assert.Equal(t, int32(10), exec.deleteN.Load(),
+		"deprovision should still run after the catch-up wait times out")
+}
+
+// TestRun_QuiescenceBlocksOnPendingCommit proves the wait does NOT
+// declare quiescence while the agent has a config received but not
+// yet committed. Without this, the wait could time out mid-diff-check
+// (which can run >30s at >1MB configs) and the orchestrator would
+// cancel the SSH session while the agent was still applying the
+// deprovision config.
+func TestRun_QuiescenceBlocksOnPendingCommit(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	// Block deprovision so we can emit a ConfigReceived during teardown
+	// and observe whether the wait honors the pending-commit flag.
+	gate := make(chan struct{})
+	exec.deleteGate = gate
+
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	const quietWindow = 100 * time.Millisecond
+	cfg := sweep.Config{
+		RunID:                  "run-pending-commit",
+		Target:                 1,
+		UsersPerBatch:          1,
+		Hold:                   0,
+		AgentQuietWindow:       quietWindow,
+		AgentQuiescenceTimeout: 2 * time.Second,
+		OwnerFilter:            owner,
+		Executor:               exec,
+		Agent:                  ag,
+		Runlog:                 w,
+		Clock:                  sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	deadline := time.Now().Add(time.Second)
+	for exec.deleteN.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("sweep did not reach deprovision within 1s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Emit a ConfigReceived to set the pending-commit flag, then go
+	// silent. The wait MUST NOT declare quiescence until the matching
+	// EventCommit lands — even after multiple quietWindow durations
+	// have elapsed.
+	ag.Emit(agent.Event{Kind: agent.EventConfigReceived, TunnelID: 0, At: time.Now()})
+
+	close(gate)
+
+	// Stay quiet for several quiet windows; the wait must still be
+	// blocked because the pending-commit flag is sticky.
+	time.Sleep(5 * quietWindow)
+	select {
+	case <-done:
+		t.Fatal("Run returned while a config was pending commit — quiescence wait should block")
+	default:
+	}
+
+	// Emit the matching commit; only now should the wait complete.
+	ag.Emit(agent.Event{Kind: agent.EventCommit, TunnelID: 0, At: time.Now()})
+
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of EventCommit clearing the pending flag")
+	}
+}
+
 // TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved confirms the wait is a
 // no-op when the agent never emitted an Applied — common in --no-agent runs
 // and on early-failure paths where teardown shouldn't pay the wait cost.


### PR DESCRIPTION
**Stack:** 1 of 4 — base `main`. Followed by [#stress-physical-script-polish], [#stress-reporter-analyze], [#stress-reporter-cli].

## Summary of Changes
- **Orchestrator agent-log parser** learns the real-Arista-EOS unified-diff shape (\`interface TunnelN\` as a context line with \`+   property\` lines below it) on top of the existing cEOS \`+interface TunnelN\` shape. Without this, physical-hardware runs emitted zero \`applied\` events.
- **Two new agent activity events**: \`EventConfigReceived\` (from \`Received N bytes...\`) and \`EventCommitAborted\` (from \`session ... abort\`). The first keeps the post-deprovision quiescence wait alive across the multi-second diff-check window; the second clears the pending-commit flag during steady-state polling so the wait doesn't pin to its 5-min timeout.
- **\`quiescenceTracker\` grows a sticky pending-commit flag** — set on \`EventConfigReceived\`, cleared on the matching terminal event — so the wait blocks across the entire diff-check, not just the visible activity beats.
- **\`waitForAppliedToCatchUp\`** blocks the provision→deprovision boundary until the agent's applied count covers the orchestrator's provisioned-user count. New \`--apply-catch-up-timeout-seconds\` (default 300s) bounds the wait; \`--no-agent\` auto-zeros it.
- **Observer tunnel counter** switches from \`show gre tunnel static\` (returns only routing-fabric tunnels, never user tunnels on either platform tested) to \`show interfaces description\` filtered on the \`USER-UCAST-\` prefix the controller renders on every user-tunnel block. Robust against the controller's tunnel-id range (legacy 500+; current 1+).

## Diff Breakdown
| Category    | Files | Lines (+/-)   | Net   |
|-------------|-------|---------------|-------|
| Core logic  |     5 | +474   / -49  | +425  |
| Scaffolding |     2 | +33    / -2   | +31   |
| Tests       |     3 | +254   / -24  | +230  |
| **Total**   |    10 | +761   / -75  | +686  |

<details>
<summary>Key files (click to expand)</summary>

- [\`tools/stress/device-orchestrator/pkg/agent/parser.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-orchestrator-real-eos/files) — per-section state machine that opens a section on \`[ ]?interface TunnelN\`, promotes it on the first \`+   property\` line, and closes on \`!\` or the next section header. cEOS path preserved.
- [\`tools/stress/device-orchestrator/pkg/sweep/sweep.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-orchestrator-real-eos/files) — pending-commit flag on the tracker; \`waitForAppliedToCatchUp\` with timeout; consumeAgentEvents handles all 5 event kinds.
- [\`tools/stress/device-observer/internal/sample/eos.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-orchestrator-real-eos/files) — description-prefix filter for the tunnel counter.
- [\`tools/stress/device-orchestrator/pkg/agent/agent.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-orchestrator-real-eos/files) — \`EventConfigReceived\` and \`EventCommitAborted\` constants.
- [\`tools/stress/device-orchestrator/cmd/device-orchestrator/main.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-orchestrator-real-eos/files) — \`--apply-catch-up-timeout-seconds\` flag + \`--no-agent\` auto-zero.

</details>

## Testing Verification
- Unit tests cover the new real-EOS state machine, the activate↔applied edge cases, the per-cycle join, both new wait semantics (pending-commit blocking + apply catch-up + its timeout path), and the description-prefix tunnel counter.
- Replay-validated against archived agent logs from chi-dn-dzd5: the parser now yields 524/524 (was 0/0) PreCommitLog + Applied events; cEOS 992-tunnel run still yields 992/992 (no regression).
- End-to-end on physical hardware: 524-user runs on chi-dn-dzd5 + chi-dn-dzd9 and 1023-user runs on both DUTs completed with 100% on-device coverage and clean teardown.