### PR TITLE
tools/stress/device-reporter: add parser + analyzer

### DIFF
--- a/tools/stress/device-observer/README.md
+++ b/tools/stress/device-observer/README.md
@@ -47,7 +47,7 @@ The observer writes the following files into `--working-dir`:
 | ---------------------------------------- | --------- | ----------------------------------------------- |
 | `observer-config.json`                   | observer  | selected flag values (excludes `eapi_pass` and `eapi_port`) + PID + start timestamp |
 | `show-hardware-capacity-<ts>.json`       | observer  | one per tick                                    |
-| `show-gre-tunnel-static-<ts>.json`       | observer  | one per tick                                    |
+| `show-interfaces-description-<ts>.json`  | observer  | one per tick                                    |
 | `show-processes-top-once-<ts>.json`      | observer  | one per tick                                    |
 | `show-logging-errors-<ts>.log`           | observer  | one per tick                                    |
 | `show-logging-critical-<ts>.log`         | observer  | one per tick                                    |
@@ -288,7 +288,7 @@ cancels the observer's root context so the process exits.
 | `lock_not_taken`             | agent-log substring `not overriding lock since its age` | same                                                                                     |
 | `agent_silence`              | `AgentTail.Snapshot().LastLineAt`                     | `LastLineAt` non-zero AND `now - LastLineAt > 120 s` (suppressed before any line is seen). Threshold accommodates the legitimate silent window during a large config apply at high user counts — at ~290 users the agent processes ~22k lines per cycle without intermediate logs. |
 | `ledger_heartbeat_stale`     | mtime of `<working-dir>/orchestrator.ledger_heartbeat` | file present AND `now - mtime > 30 s` (absent file is suppressed forward-compatibly)      |
-| `device_tunnel_gap`          | runlog `n_after_event` vs sampler `greTunnels` map length | orchestrator active-user count exceeds the device's tunnel count by `≥ 4` AND `now - last_activate ≥ 120 s` (suppressed before the first activate is seen). Grace matches `agent_silence` — past that, a stuck agent fires `agent_silence` first; a persistent gap with a healthy agent is the controller's slot cap or similar truncation. |
+| `device_tunnel_gap`          | runlog `n_after_event` vs sampler's `show interfaces description` filtered to interfaces whose description begins `USER-UCAST-` | orchestrator active-user count exceeds the device's tunnel count by `≥ 4` AND `now - last_activate ≥ 120 s` (suppressed before the first activate is seen). Grace matches `agent_silence` — past that, a stuck agent fires `agent_silence` first; a persistent gap with a healthy agent is the controller's slot cap or similar truncation. |
 
 **Startup grace.** The four counter and log-pattern triggers
 (`apply_config_errors`, `get_config_errors`, `diff_timeout`,

--- a/tools/stress/device-observer/internal/abort/decider.go
+++ b/tools/stress/device-observer/internal/abort/decider.go
@@ -99,8 +99,9 @@ type Sources struct {
 	// been seen.
 	ActiveUserCount func() (count int, lastActivate time.Time, ok bool)
 	// TunnelCount returns the most recently observed number of user
-	// tunnels on the device (from `show gre tunnel static`). `ok=false`
-	// before the first successful sample.
+	// tunnels on the device (parsed from `show interfaces description`,
+	// filtered to interfaces whose description begins `USER-UCAST-`).
+	// `ok=false` before the first successful sample.
 	TunnelCount         func() (int, bool)
 	LedgerHeartbeatPath string
 }

--- a/tools/stress/device-observer/internal/sample/eos.go
+++ b/tools/stress/device-observer/internal/sample/eos.go
@@ -15,6 +15,16 @@ import (
 	"time"
 )
 
+// userTunnelDescriptionPrefix identifies user-tunnel interfaces by the
+// description string the controller renders on each user's `interface
+// TunnelN` block. Using the description rather than a numeric range on
+// the tunnel ID lets the observer compare apples-to-apples against the
+// orchestrator's user count regardless of where in the Tunnel<N>
+// namespace the controller chooses to place them (legacy controllers
+// started at 500; the gm/tunnel-id-start-1 fix starts at 1, which
+// overlaps the inter-router routing-fabric range on physical EOS).
+const userTunnelDescriptionPrefix = "USER-UCAST-"
+
 type eapiRunner interface {
 	RunShowJSON(cmd string) (json.RawMessage, error)
 	RunShowText(cmd string) (string, error)
@@ -27,7 +37,7 @@ type commandSpec struct {
 
 var commands = []commandSpec{
 	{"show hardware capacity", "show-hardware-capacity", true},
-	{"show gre tunnel static", "show-gre-tunnel-static", true},
+	{"show interfaces description", "show-interfaces-description", true},
 	{"show processes top once", "show-processes-top-once", true},
 	{"show logging errors", "show-logging-errors", false},
 	{"show logging critical", "show-logging-critical", false},
@@ -61,12 +71,24 @@ func (s *Sampler) LatestCPUPercent() (float64, bool) {
 }
 
 // LatestTunnelCount returns the most recently observed number of user
-// tunnels on the device (`show gre tunnel static`'s greTunnels map
-// length). Returns (0, false) before the first successful parse. The
-// abort decider uses this to detect when the orchestrator's expected
-// active-user count diverges from what the agent has actually applied —
-// e.g. when the controller's per-device tunnel-slot cap silently
-// truncates the rendered device config.
+// tunnel interfaces on the device — i.e. interfaces whose description
+// starts with "USER-UCAST-" (the prefix the controller renders on
+// every per-user `interface TunnelN` block), counted from
+// `show interfaces description`. Returns (0, false) before the first
+// successful parse. The abort decider uses this to detect when the
+// orchestrator's expected active-user count diverges from what the
+// agent has actually applied — e.g. when the controller's per-device
+// tunnel-slot cap silently truncates the rendered device config.
+//
+// Earlier iterations used `show gre tunnel static` (only lists
+// statically-configured GRE-keyed routing-fabric tunnels) and
+// `show ip interface brief` filtered on a Tunnel-index >= 500
+// (worked while user tunnel IDs started at 500 but broke when the
+// controller started allocating from 1, overlapping the routing
+// fabric's low-numbered range). Filtering on the controller's
+// rendered description string is the most stable discriminator:
+// it tracks the controller's namespacing decisions regardless of
+// where in the Tunnel<N> ID space user tunnels happen to land.
 func (s *Sampler) LatestTunnelCount() (int, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -128,13 +150,13 @@ func (s *Sampler) runOne(c commandSpec, ts time.Time) error {
 				s.logger.Warn("could not parse CPU from show processes top once")
 			}
 		}
-		if c.cmd == "show gre tunnel static" {
+		if c.cmd == "show interfaces description" {
 			if n, ok := parseTunnelCount(raw); ok {
 				s.mu.Lock()
 				s.latestTunnelCount, s.tunnelCountValid = n, true
 				s.mu.Unlock()
 			} else {
-				s.logger.Warn("could not parse tunnel count from show gre tunnel static")
+				s.logger.Warn("could not parse tunnel count from show interfaces description")
 			}
 		}
 	} else {
@@ -183,23 +205,40 @@ func parseCPUPercent(raw json.RawMessage) (float64, bool) {
 	return total, true
 }
 
-// parseTunnelCount returns the number of entries in the `greTunnels` map
-// of the `show gre tunnel static | json` eAPI response, shaped as
-// `{"greTunnels": {"<idx>": {…}, …}}`. Returns (0, true) on an empty map
-// — a healthy device with no user tunnels — and (0, false) only when
-// `greTunnels` is missing entirely or the response is malformed, so the
-// abort decider can distinguish "zero confirmed" from "unknown".
+// parseTunnelCount returns the number of user-tunnel interfaces in the
+// `show interfaces description | json` eAPI response, shaped as
+// `{"interfaceDescriptions": {"<name>": {"description": "..."}, …}}`.
+// An interface is a user tunnel when its description begins with
+// `userTunnelDescriptionPrefix` — every per-user `interface TunnelN`
+// block the controller renders carries `description USER-UCAST-<idx>`,
+// so this filter is robust against changes in the Tunnel<N> id
+// range (legacy: 500+; current: 1+).
+//
+// Returns (0, true) on an empty interfaces map and (N, true) on a
+// populated one. Returns (0, false) only when the
+// `interfaceDescriptions` key is missing or the JSON is malformed, so
+// the abort decider can tell "zero confirmed" apart from "unknown" and
+// suppress the sentinel in the latter case.
 func parseTunnelCount(raw json.RawMessage) (int, bool) {
+	type desc struct {
+		Description string `json:"description"`
+	}
 	var env struct {
-		GreTunnels map[string]json.RawMessage `json:"greTunnels"`
+		InterfaceDescriptions map[string]desc `json:"interfaceDescriptions"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return 0, false
 	}
-	if env.GreTunnels == nil {
+	if env.InterfaceDescriptions == nil {
 		return 0, false
 	}
-	return len(env.GreTunnels), true
+	count := 0
+	for _, d := range env.InterfaceDescriptions {
+		if strings.HasPrefix(d.Description, userTunnelDescriptionPrefix) {
+			count++
+		}
+	}
+	return count, true
 }
 
 // fileTimestamp renders t as ISO 8601 UTC with `:` → `-` for filesystem

--- a/tools/stress/device-observer/internal/sample/eos_test.go
+++ b/tools/stress/device-observer/internal/sample/eos_test.go
@@ -62,9 +62,9 @@ func TestTickWritesAllFiles(t *testing.T) {
 	dir := t.TempDir()
 	runner := &fakeRunner{
 		jsonResp: map[string]json.RawMessage{
-			"show hardware capacity":  json.RawMessage(`{"capacity":1}`),
-			"show gre tunnel static":  json.RawMessage(`{"tunnels":[]}`),
-			"show processes top once": json.RawMessage(`{"processes":[]}`),
+			"show hardware capacity":      json.RawMessage(`{"capacity":1}`),
+			"show interfaces description": json.RawMessage(`{"interfaceDescriptions":{}}`),
+			"show processes top once":     json.RawMessage(`{"processes":[]}`),
 		},
 		textResp: map[string]string{
 			"show logging errors":   "errlog\n",
@@ -89,11 +89,11 @@ func TestTickWritesAllFiles(t *testing.T) {
 	}
 
 	expect := map[string]string{
-		"show-hardware-capacity":  `{"capacity":1}`,
-		"show-gre-tunnel-static":  `{"tunnels":[]}`,
-		"show-processes-top-once": `{"processes":[]}`,
-		"show-logging-errors":     "errlog\n",
-		"show-logging-critical":   "critlog\n",
+		"show-hardware-capacity":      `{"capacity":1}`,
+		"show-interfaces-description": `{"interfaceDescriptions":{}}`,
+		"show-processes-top-once":     `{"processes":[]}`,
+		"show-logging-errors":         "errlog\n",
+		"show-logging-critical":       "critlog\n",
 	}
 	for prefix, want := range expect {
 		matches, _ := filepath.Glob(filepath.Join(dir, prefix+"-*"))
@@ -118,7 +118,7 @@ func TestSingleCommandFailureContinues(t *testing.T) {
 	dir := t.TempDir()
 	runner := &fakeRunner{
 		errs: map[string]error{
-			"show gre tunnel static": errors.New("boom"),
+			"show interfaces description": errors.New("boom"),
 		},
 	}
 	frozen := time.Date(2026, 5, 29, 12, 34, 56, 0, time.UTC)
@@ -134,7 +134,7 @@ func TestSingleCommandFailureContinues(t *testing.T) {
 		t.Fatalf("expected 4 files after one failure, got %d", len(entries))
 	}
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "show-gre-tunnel-static") {
+		if strings.HasPrefix(e.Name(), "show-interfaces-description") {
 			t.Errorf("failing command should not have produced a file, got %s", e.Name())
 		}
 	}
@@ -290,10 +290,22 @@ type runnable interface {
 
 var _ runnable = (*Sampler)(nil)
 
-// TestParseTunnelCount covers the three shapes the parser must handle:
-// a populated greTunnels map, an empty map (healthy device with no users),
-// and a missing/malformed response (must signal ok=false so the decider
-// suppresses the device_tunnel_gap trigger).
+// TestParseTunnelCount covers the shapes the parser must handle for
+// `show interfaces description | json`:
+//
+//   - a populated map containing user tunnels (description begins
+//     "USER-UCAST-") mixed with non-user interfaces (Loopback,
+//     Ethernet, Management, inter-router fabric tunnels);
+//   - a map containing no user tunnels (the device has only routing
+//     fabric — valid state, not unknown);
+//   - an empty map;
+//   - a missing or malformed response (must signal ok=false so the
+//     decider suppresses the device_tunnel_gap trigger).
+//
+// Coverage explicitly includes the low-id case (Tunnel1, Tunnel2)
+// since the controller's gm/tunnel-id-start-1 fix allocates user
+// tunnels from index 1 — the previous numeric-range filter rejected
+// these but the description-prefix filter must accept them.
 func TestParseTunnelCount(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -302,19 +314,38 @@ func TestParseTunnelCount(t *testing.T) {
 		wantOK bool
 	}{
 		{
-			name:   "populated map",
-			body:   `{"greTunnels":{"500":{"name":"Tunnel500"},"501":{"name":"Tunnel501"},"502":{"name":"Tunnel502"}}}`,
+			name: "populated map filters by USER-UCAST- description",
+			body: `{"interfaceDescriptions":{
+				"Loopback255":{"description":""},
+				"Loopback256":{"description":""},
+				"Ethernet1":{"description":""},
+				"Management0":{"description":""},
+				"Tunnel19":{"description":"to-chi-dn-dzd9"},
+				"Tunnel1":{"description":"USER-UCAST-1"},
+				"Tunnel2":{"description":"USER-UCAST-2"},
+				"Tunnel500":{"description":"USER-UCAST-500"}
+			}}`,
 			wantN:  3,
 			wantOK: true,
 		},
 		{
-			name:   "empty map",
-			body:   `{"greTunnels":{}}`,
+			name: "only routing-fabric tunnels present (no USER-UCAST- description)",
+			body: `{"interfaceDescriptions":{
+				"Tunnel19":{"description":"to-chi-dn-dzd9"},
+				"Tunnel59":{"description":"to-chi-dn-dzd1"},
+				"Tunnel91":{"description":"to-chi-dn-dzd5"}
+			}}`,
 			wantN:  0,
 			wantOK: true,
 		},
 		{
-			name:   "missing greTunnels key",
+			name:   "empty interfaceDescriptions map",
+			body:   `{"interfaceDescriptions":{}}`,
+			wantN:  0,
+			wantOK: true,
+		},
+		{
+			name:   "missing interfaceDescriptions key",
 			body:   `{}`,
 			wantN:  0,
 			wantOK: false,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -43,6 +43,7 @@ type orchestratorConfig struct {
 	HoldSeconds                   int    `json:"hold_seconds"`
 	AgentQuietSeconds             int    `json:"agent_quiet_seconds"`
 	AgentQuiescenceTimeoutSeconds int    `json:"agent_quiescence_timeout_seconds"`
+	ApplyCatchUpTimeoutSeconds    int    `json:"apply_catch_up_timeout_seconds"`
 	DUTPubkey                     string `json:"dut_pubkey"`
 	DUTSSHHost                    string `json:"dut_ssh_host"`
 	DUTSSHKey                     string `json:"dut_ssh_key"`
@@ -98,6 +99,14 @@ func run() error {
 		// Default: 300 s — accommodates the 22k-line / ~650 KB final config
 		// commit at 1024 tunnels.
 		agentQuiescenceTimeoutSeconds = flag.Int("agent-quiescence-timeout-seconds", 300, "Hard cap on the post-deprovision agent quiescence wait, in seconds.")
+		// Default: 300 s — same cap as agent-quiescence-timeout-seconds.
+		// Aligns the provision→deprovision boundary wait with the
+		// post-deprovision one. The wait blocks until applied >= target
+		// (minus a small grace), which prevents deprovision from
+		// removing users before the agent has had time to add them.
+		// Set to 0 to disable; useful when reproducing pre-3796
+		// behavior or for --no-agent runs where applied never lands.
+		applyCatchUpTimeoutSeconds = flag.Int("apply-catch-up-timeout-seconds", 300, "Hard cap on the provision→deprovision wait for the agent's applied count to catch up to the provisioned-user count. 0 disables the wait.")
 		// The containerized harness ships a device-side wrapper (see
 		// tools/stress/docker/device/agent-wrapper.sh) that injects -pubkey from
 		// /etc/doublezero/agent/pubkey and re-execs through sudo, so the
@@ -144,6 +153,7 @@ func run() error {
 		HoldSeconds:                   *holdSeconds,
 		AgentQuietSeconds:             *agentQuietSeconds,
 		AgentQuiescenceTimeoutSeconds: *agentQuiescenceTimeoutSeconds,
+		ApplyCatchUpTimeoutSeconds:    *applyCatchUpTimeoutSeconds,
 		DUTPubkey:                     *dutPubkey,
 		DUTSSHHost:                    *dutSSHHost,
 		DUTSSHKey:                     *dutSSHKey,
@@ -253,6 +263,15 @@ func run() error {
 
 	agentRunner := selectAgentRunner(*noAgent, *dutSSHHost, *dutSSHKey, *dutSSHUser, *controllerAddr, *workingDir, *agentBinary, *agentCommandPrefix, *agentPubkey, *agentMetricsAddr, logger)
 
+	// With --no-agent there is no agent to emit Applied events, so the
+	// catch-up wait would pin to its full timeout on every run. Zero it
+	// out automatically rather than asking the operator to remember the
+	// matching flag.
+	if *noAgent && *applyCatchUpTimeoutSeconds > 0 {
+		logger.Info("sweep: --no-agent disables apply catch-up wait", "previous_timeout_seconds", *applyCatchUpTimeoutSeconds)
+		*applyCatchUpTimeoutSeconds = 0
+	}
+
 	cfg := sweep.Config{
 		RunID:                  *runID,
 		Target:                 *targetUserCount,
@@ -260,6 +279,7 @@ func run() error {
 		Hold:                   time.Duration(*holdSeconds) * time.Second,
 		AgentQuietWindow:       time.Duration(*agentQuietSeconds) * time.Second,
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
+		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -289,6 +289,7 @@ func run() error {
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
 		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
 		ApplyPerBatchCatchUp:   *applyPerBatchCatchUp,
+		NoAgent:                *noAgent,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
+++ b/tools/stress/device-orchestrator/cmd/device-orchestrator/main.go
@@ -44,6 +44,7 @@ type orchestratorConfig struct {
 	AgentQuietSeconds             int    `json:"agent_quiet_seconds"`
 	AgentQuiescenceTimeoutSeconds int    `json:"agent_quiescence_timeout_seconds"`
 	ApplyCatchUpTimeoutSeconds    int    `json:"apply_catch_up_timeout_seconds"`
+	ApplyPerBatchCatchUp          bool   `json:"apply_per_batch_catch_up"`
 	DUTPubkey                     string `json:"dut_pubkey"`
 	DUTSSHHost                    string `json:"dut_ssh_host"`
 	DUTSSHKey                     string `json:"dut_ssh_key"`
@@ -107,6 +108,12 @@ func run() error {
 		// Set to 0 to disable; useful when reproducing pre-3796
 		// behavior or for --no-agent runs where applied never lands.
 		applyCatchUpTimeoutSeconds = flag.Int("apply-catch-up-timeout-seconds", 300, "Hard cap on the provision→deprovision wait for the agent's applied count to catch up to the provisioned-user count. 0 disables the wait.")
+		// Off by default. Real production traffic adds users at
+		// human cadence, not in burst-fashion, so this flag is the
+		// closer match for measuring per-user latency under steady-
+		// state load. Off matches the default "stress the agent" shape
+		// the harness was originally built for.
+		applyPerBatchCatchUp = flag.Bool("apply-per-batch-catch-up", false, "Pause after each provision batch until the agent's applied count covers the cumulative target; honors --apply-catch-up-timeout-seconds per batch.")
 		// The containerized harness ships a device-side wrapper (see
 		// tools/stress/docker/device/agent-wrapper.sh) that injects -pubkey from
 		// /etc/doublezero/agent/pubkey and re-execs through sudo, so the
@@ -154,6 +161,7 @@ func run() error {
 		AgentQuietSeconds:             *agentQuietSeconds,
 		AgentQuiescenceTimeoutSeconds: *agentQuiescenceTimeoutSeconds,
 		ApplyCatchUpTimeoutSeconds:    *applyCatchUpTimeoutSeconds,
+		ApplyPerBatchCatchUp:          *applyPerBatchCatchUp,
 		DUTPubkey:                     *dutPubkey,
 		DUTSSHHost:                    *dutSSHHost,
 		DUTSSHKey:                     *dutSSHKey,
@@ -280,6 +288,7 @@ func run() error {
 		AgentQuietWindow:       time.Duration(*agentQuietSeconds) * time.Second,
 		AgentQuiescenceTimeout: time.Duration(*agentQuiescenceTimeoutSeconds) * time.Second,
 		ApplyCatchUpTimeout:    time.Duration(*applyCatchUpTimeoutSeconds) * time.Second,
+		ApplyPerBatchCatchUp:   *applyPerBatchCatchUp,
 		OwnerFilter:            signer.PublicKey(),
 		Executor:               liveExec,
 		Agent:                  agentRunner,

--- a/tools/stress/device-orchestrator/pkg/agent/agent.go
+++ b/tools/stress/device-orchestrator/pkg/agent/agent.go
@@ -33,6 +33,29 @@ const (
 	// otherwise see the agent as silent throughout the entire deprovision
 	// phase and skip the wait.
 	EventCommit
+	// EventConfigReceived marks the moment the agent finishes pulling a
+	// fresh config from the controller (the "Received N bytes of
+	// configuration from controller" log line). TunnelID is always 0;
+	// the event is purely an activity signal for the quiescence
+	// tracker, which would otherwise treat the agent as silent during
+	// the multi-second diff-check window between a config arrival and
+	// the next commit (~26 µs/byte → tens of seconds for the >1MB
+	// deprovision diff at 1k users). Without this signal, the post-
+	// deprovision quiescence wait can declare the agent "quiesced"
+	// while a deprovision diff is still being analyzed, and kill the
+	// SSH session before the commit lands on the device.
+	EventConfigReceived
+	// EventCommitAborted marks the moment the agent closes a
+	// configure-session with the `abort` command (the post-finalize
+	// log line ends `'...session-name abort'` rather than the more
+	// common `'...session-name commit'`). EOS emits an abort when the
+	// rendered config matches the running-config exactly — i.e. the
+	// agent saw a config it could ingest but found nothing to change.
+	// In steady state after deprovision the agent re-polls every 20s
+	// and aborts each one; the tracker uses this signal to clear the
+	// pending-commit flag set by EventConfigReceived so the quiescence
+	// wait doesn't time out on legitimate no-op poll loops.
+	EventCommitAborted
 )
 
 // Event is one observation emitted by the agent runner: a timestamped tunnel

--- a/tools/stress/device-orchestrator/pkg/agent/parser.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser.go
@@ -23,12 +23,30 @@ import (
 //   - "Configuration session finalized with command '... abort'"
 //     → close the block and clear the buffer with no Applied events.
 //
+// Two diff shapes need to be handled. The containerized cEOS path emits the
+// header itself as an addition ("+interface Tunnel500"), so one regex hit on
+// the header line is enough. Real EOS on chi-dn-dzd5 emits the diff against
+// the running-config: the "interface TunnelN" header lands unprefixed (or
+// space-prefixed as a unified-diff context line) and the additions appear
+// only on the property lines that follow ("+   description ..."). The parser
+// runs a small per-section state machine so both shapes resolve to one
+// EventPreCommitLog per tunnel section that contains any additions.
+//
 // A single Parser is goroutine-safe only against the calling Parse goroutine;
 // callers should funnel all lines through one Parse loop.
 type Parser struct {
 	pending []uint16
-	inDiff  bool             // open between a "Committing..." marker and its finalize line
-	now     func() time.Time // injectable for tests
+	inDiff  bool // open between a "Committing..." marker and its finalize line
+
+	// sectionTunnel is the most recently opened "interface TunnelN" section
+	// in the running diff (0 = no section open). sectionPromoted tracks
+	// whether the section has already produced an EventPreCommitLog; we
+	// only emit one per section even though the section contains many `+`
+	// property lines.
+	sectionTunnel   uint16
+	sectionPromoted bool
+
+	now func() time.Time // injectable for tests
 }
 
 // NewParser returns a Parser that stamps events with the current wallclock.
@@ -53,14 +71,26 @@ func WithClock(now func() time.Time) ParserOption {
 // The returned slice is freshly allocated per call and safe for the caller to
 // retain.
 func (p *Parser) Parse(line string) []Event {
+	// Receipt of a fresh config from the controller is an activity
+	// signal. We match the "bytes" line specifically (the agent emits
+	// both "lines" and "bytes" back-to-back per poll; one signal per
+	// cycle is enough) and emit an EventConfigReceived so the
+	// quiescence tracker doesn't time us out during the diff-check
+	// window that follows.
+	if configReceivedRE.MatchString(line) {
+		return []Event{{Kind: EventConfigReceived, TunnelID: 0, At: p.now()}}
+	}
 	if m := committingRE.FindStringSubmatch(line); m != nil {
-		// Open the diff block and scan the inline remainder of the marker line
-		// (the agent appends the first diff line after the colon).
+		// Open the diff block and scan the inline remainder of the marker line.
+		// cEOS appends the first diff line after the colon; real EOS appends
+		// the "--- file" header that we ignore.
 		p.inDiff = true
-		return p.scanAddedTunnels(m[1])
+		p.resetSection()
+		return p.scanInlineAdditions(m[1])
 	}
 	if finalizedCommitRE.MatchString(line) {
 		p.inDiff = false
+		p.resetSection()
 		now := p.now()
 		// Always emit EventCommit so the consumer can see commit activity
 		// during deprovision (pure-removal diffs leave p.pending empty).
@@ -73,23 +103,33 @@ func (p *Parser) Parse(line string) []Event {
 		return out
 	}
 	if finalizedAbortRE.MatchString(line) {
-		// Abort cleared the session — drop pending without emitting Applied.
+		// Abort cleared the session — drop pending Applieds without emitting,
+		// but emit one EventCommitAborted so the quiescence tracker can
+		// clear its pending-commit flag (set when the matching
+		// `Received N bytes` line arrived).
 		p.inDiff = false
+		p.resetSection()
 		p.pending = p.pending[:0]
-		return nil
+		return []Event{{Kind: EventCommitAborted, TunnelID: 0, At: p.now()}}
 	}
 	if p.inDiff {
-		// A diff-body line inside an open commit block: the "+ interface
-		// Tunnel<ID>" additions arrive here, one (or more) per line.
-		return p.scanAddedTunnels(line)
+		return p.parseDiffLine(line)
 	}
 	return nil
 }
 
-// scanAddedTunnels emits one EventPreCommitLog per "+ interface Tunnel<ID>"
-// found in s, recording the IDs as pending. Returns nil when s adds no tunnels
-// (context lines, "- interface" deletions, or unrelated diff text).
-func (p *Parser) scanAddedTunnels(s string) []Event {
+// resetSection clears the in-flight interface-section bookkeeping.
+func (p *Parser) resetSection() {
+	p.sectionTunnel = 0
+	p.sectionPromoted = false
+}
+
+// scanInlineAdditions handles the inline payload trailing the "Committing
+// config session due to diffs detected:" marker. This is the cEOS shape,
+// where the entire diff can land on one line. Real EOS only puts the
+// "--- file" unified-diff header here; the diff body itself arrives on
+// subsequent lines and is processed by parseDiffLine.
+func (p *Parser) scanInlineAdditions(s string) []Event {
 	ids := extractAddedTunnelIDs(s)
 	if len(ids) == 0 {
 		return nil
@@ -101,6 +141,63 @@ func (p *Parser) scanAddedTunnels(s string) []Event {
 		out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
 	}
 	return out
+}
+
+// parseDiffLine processes one line inside an open Committing diff block.
+// It handles three shapes:
+//
+//   - cEOS additive header  "+interface TunnelN" / "+ interface TunnelN"
+//     emits EventPreCommitLog directly and closes any open section.
+//   - Real-EOS section header  "interface TunnelN" or " interface TunnelN"
+//     (unified-diff context prefix) opens a section without emitting yet.
+//   - Property addition inside a section  "+   description ..."  promotes
+//     the section: emits EventPreCommitLog for the section's tunnel ID once.
+//
+// A " !" terminator (or the start of the next section) closes the current
+// section without emitting if it had no `+` lines (pure-removal section).
+func (p *Parser) parseDiffLine(line string) []Event {
+	// cEOS shape: the header line itself is an addition. The added-tunnel
+	// regex is anchored on `+\s*interface Tunnel`, so this only fires when
+	// the section *header* is in the diff body — not on `+   description ...`
+	// property lines (no "interface" token).
+	if ids := extractAddedTunnelIDs(line); len(ids) > 0 {
+		p.pending = append(p.pending, ids...)
+		now := p.now()
+		out := make([]Event, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, Event{Kind: EventPreCommitLog, TunnelID: id, At: now})
+		}
+		// The cEOS shape declares a new interface block in its entirety;
+		// any in-flight real-EOS section is no longer the relevant frame.
+		p.resetSection()
+		return out
+	}
+	// Real-EOS section header — context (space-prefixed) or unprefixed.
+	if m := sectionStartRE.FindStringSubmatch(line); m != nil {
+		id, err := strconv.ParseUint(m[1], 10, 16)
+		if err != nil {
+			// uint16 overflow on the section ID: drop it so we can't
+			// later promote the wrong tunnel into pending.
+			p.resetSection()
+			return nil
+		}
+		p.sectionTunnel = uint16(id)
+		p.sectionPromoted = false
+		return nil
+	}
+	// Section terminator ("!" as a context line). Closes without emitting.
+	if sectionTerminatorRE.MatchString(line) {
+		p.resetSection()
+		return nil
+	}
+	// Property addition inside an open section: promote once.
+	if p.sectionTunnel != 0 && !p.sectionPromoted && addedPropertyRE.MatchString(line) {
+		id := p.sectionTunnel
+		p.sectionPromoted = true
+		p.pending = append(p.pending, id)
+		return []Event{{Kind: EventPreCommitLog, TunnelID: id, At: p.now()}}
+	}
+	return nil
 }
 
 // Pending exposes the in-flight tunnel IDs awaiting an Applied event; tests
@@ -118,9 +215,36 @@ var (
 	// the multi-line diff arrives on subsequent lines (handled via inDiff).
 	committingRE = regexp.MustCompile(`Committing config session due to diffs detected:\s*(.*)$`)
 
-	// addedTunnelRE matches an additive interface-Tunnel diff line; the `\b` on
-	// the right keeps "Tunnel50001" out of a "Tunnel500" match.
+	// configReceivedRE matches the "Received N bytes of configuration"
+	// agent log line. The agent emits both a "lines" and a "bytes"
+	// counterpart back-to-back per poll cycle; we anchor on bytes so
+	// the EventConfigReceived signal fires exactly once per cycle.
+	configReceivedRE = regexp.MustCompile(`Received \d+ bytes of configuration from controller`)
+
+	// addedTunnelRE matches the cEOS additive header shape, where the
+	// "interface TunnelN" line is itself diff-added: "+interface TunnelN"
+	// or "+ interface TunnelN". The `\b` keeps "Tunnel50001" out of a
+	// "Tunnel500" match.
 	addedTunnelRE = regexp.MustCompile(`\+\s*interface Tunnel(\d+)\b`)
+
+	// sectionStartRE matches the real-EOS section header inside a diff
+	// body. EOS emits "interface TunnelN" with no prefix on the first
+	// section and " interface TunnelN" (a unified-diff context prefix) on
+	// subsequent sections when the interface already exists in
+	// running-config but has no properties yet.
+	sectionStartRE = regexp.MustCompile(`^[ ]?interface Tunnel(\d+)\b`)
+
+	// addedPropertyRE matches a "+   description ..." (or other property)
+	// addition line inside an interface section. The `\s+\S` rules out
+	// the "+++ session:/..." unified-diff file marker (no whitespace
+	// between the +s) and bare "+" lines.
+	addedPropertyRE = regexp.MustCompile(`^\+\s+\S`)
+
+	// sectionTerminatorRE matches the EOS "!" section terminator emitted
+	// as a context line (" !"). cEOS prefixes its terminator with "+", so
+	// it does not hit this regex — fine, because cEOS sections close
+	// implicitly via the next addedTunnelRE-matched header.
+	sectionTerminatorRE = regexp.MustCompile(`^[ ]!`)
 
 	// finalizedCommitRE matches the post-commit log line on a successful
 	// commit. The quoted command always ends in "...commit" for actual commits

--- a/tools/stress/device-orchestrator/pkg/agent/parser_test.go
+++ b/tools/stress/device-orchestrator/pkg/agent/parser_test.go
@@ -127,8 +127,13 @@ func TestParser_AbortClearsBufferWithoutAppliedEvents(t *testing.T) {
 	require.Len(t, events, 1)
 	require.Equal(t, []uint16{500}, p.Pending())
 
+	// Abort emits exactly one EventCommitAborted (so the quiescence
+	// tracker can clear its pending-commit flag) and drops the
+	// per-tunnel Applieds.
 	events = p.Parse(`Configuration session finalized with command 'configure session foo abort'`)
-	assert.Empty(t, events, "abort emits no events")
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventCommitAborted, events[0].Kind)
+	assert.Equal(t, uint16(0), events[0].TunnelID)
 	assert.Empty(t, p.Pending(), "abort still clears pending")
 }
 
@@ -177,6 +182,29 @@ func TestParser_UnrelatedLinesIgnored(t *testing.T) {
 	}
 }
 
+// TestParser_ReceivedBytesEmitsConfigReceived covers the activity-signal
+// shim the orchestrator's quiescence tracker uses to keep itself awake
+// during the multi-second diff-check window that follows a fresh config
+// pull. Without this, the agent can be silent for tens of seconds while
+// analyzing a >1 MB deprovision diff and the tracker will mistake the
+// silence for "agent quiesced" and tear down the SSH session.
+func TestParser_ReceivedBytesEmitsConfigReceived(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	p := agent.NewParser(agent.WithClock(fixedClock(now)))
+
+	// The "lines" sibling should not produce an event (we anchor on
+	// "bytes" so exactly one EventConfigReceived fires per poll cycle).
+	assert.Empty(t, p.Parse(`2026/06/04 22:00:00.000000 eapi.go:217: Received 51553 lines of configuration from controller`))
+
+	events := p.Parse(`2026/06/04 22:00:00.000010 eapi.go:218: Received 1622130 bytes of configuration from controller`)
+	require.Len(t, events, 1)
+	assert.Equal(t, agent.EventConfigReceived, events[0].Kind)
+	assert.Equal(t, uint16(0), events[0].TunnelID)
+	assert.Equal(t, now, events[0].At)
+}
+
 func TestParser_RejectsOversizedTunnelID(t *testing.T) {
 	t.Parallel()
 
@@ -196,4 +224,102 @@ func TestParser_DoesNotConfuseInterfaceNamePrefixes(t *testing.T) {
 	events := p.Parse(`Committing config session due to diffs detected: + interface Tunnel5000`)
 	require.Len(t, events, 1)
 	assert.Equal(t, uint16(5000), events[0].TunnelID)
+}
+
+// TestParser_RealEOSDiffFormat covers the shape real Arista EOS hardware
+// emits when diffing a session against running-config: the
+// "interface TunnelN" section header is a context line (no prefix on the
+// first section, space-prefixed on subsequent sections) and the additions
+// land on the property lines below it. cEOS containers don't do this —
+// they prefix the entire section, header included, with "+". The parser
+// must promote a section into pending the first time it sees a `+   ...`
+// property line inside it, and only once per section.
+func TestParser_RealEOSDiffFormat(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	lines := []string{
+		`2026/06/04 13:40:10 Committing config session due to diffs detected: --- system:/running-config`,
+		`+++ session:/doublezero-agent-1780580398-session-config`,
+		`interface Tunnel500`,
+		`+   description USER-UCAST-500`,
+		`+   mtu 9216`,
+		`+   vrf vrf1`,
+		`+   ip address 169.254.0.0/31`,
+		` !`,
+		` interface Tunnel501`,
+		`+   description USER-UCAST-501`,
+		`+   mtu 9216`,
+		` !`,
+		` interface Tunnel502`,
+		`+   description USER-UCAST-502`,
+		` !`,
+	}
+	var events []agent.Event
+	for _, l := range lines {
+		events = append(events, p.Parse(l)...)
+	}
+	require.Len(t, events, 3, "one EventPreCommitLog per real-EOS section, not per + line")
+	for i, want := range []uint16{500, 501, 502} {
+		assert.Equal(t, agent.EventPreCommitLog, events[i].Kind)
+		assert.Equal(t, want, events[i].TunnelID)
+	}
+	assert.Equal(t, []uint16{500, 501, 502}, p.Pending())
+
+	applied := p.Parse(`Configuration session finalized with command 'configure session doublezero-agent-1780580398 commit'`)
+	// One EventCommit + one EventApplied per pending tunnel.
+	require.Len(t, applied, 4)
+	assert.Equal(t, agent.EventCommit, applied[0].Kind)
+	assert.Equal(t, []uint16{500, 501, 502}, []uint16{applied[1].TunnelID, applied[2].TunnelID, applied[3].TunnelID})
+}
+
+// TestParser_RealEOSPureRemovalSectionEmitsNothing proves that a real-EOS
+// section that contains only "-   ..." lines (deprovision) does not get
+// promoted into pending — only `+` lines flip the section.
+func TestParser_RealEOSPureRemovalSectionEmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	lines := []string{
+		`Committing config session due to diffs detected: --- system:/running-config`,
+		`+++ session:/foo-config`,
+		` interface Tunnel500`,
+		`-   description USER-UCAST-500`,
+		`-   mtu 9216`,
+		` !`,
+	}
+	for _, l := range lines {
+		assert.Empty(t, p.Parse(l), "line=%q", l)
+	}
+	assert.Empty(t, p.Pending(), "pure-removal section must not pre-commit")
+
+	events := p.Parse(`Configuration session finalized with command 'configure session foo commit'`)
+	require.Len(t, events, 1, "commit fires EventCommit even with no pending")
+	assert.Equal(t, agent.EventCommit, events[0].Kind)
+}
+
+// TestParser_RealEOSEmitsOncePerSectionEvenWithManyAdditions enforces that
+// a section with many `+   ...` property lines produces exactly one
+// EventPreCommitLog (and exactly one entry in pending).
+func TestParser_RealEOSEmitsOncePerSectionEvenWithManyAdditions(t *testing.T) {
+	t.Parallel()
+
+	p := agent.NewParser()
+	require.Empty(t, p.Parse(`Committing config session due to diffs detected: --- system:/running-config`))
+	require.Empty(t, p.Parse(`+++ session:/foo-config`))
+	require.Empty(t, p.Parse(`interface Tunnel900`))
+
+	first := p.Parse(`+   description USER-UCAST-900`)
+	require.Len(t, first, 1, "first + line promotes the section")
+	assert.Equal(t, uint16(900), first[0].TunnelID)
+
+	for _, prop := range []string{
+		`+   mtu 9216`,
+		`+   vrf vrf1`,
+		`+   ip address 169.254.0.0/31`,
+		`+   tunnel mode gre`,
+	} {
+		assert.Empty(t, p.Parse(prop), "subsequent + lines in the same section must not re-emit")
+	}
+	assert.Equal(t, []uint16{900}, p.Pending())
 }

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -91,6 +91,20 @@ type Config struct {
 	AgentQuietWindow       time.Duration
 	AgentQuiescenceTimeout time.Duration
 
+	// ApplyCatchUpTimeout bounds how long Run waits between
+	// provision-complete and deprovision-start for the agent's
+	// `applied` event count to catch up to the provision-target
+	// count. With hold=0 and a slow agent (>1 MB configs take ~40s
+	// to diff-check) the orchestrator can finish provisioning all
+	// 1024 users and start deleting them before the agent ever
+	// applies the peak config — users get added and removed in the
+	// same diff and never show up on the device. The wait blocks
+	// until applied >= len(created) OR the timeout fires. Zero
+	// disables the wait (the legacy behavior). A small grace count
+	// (4) is allowed since the last batch's applied events lag by
+	// roughly one poll cycle even on a healthy agent.
+	ApplyCatchUpTimeout time.Duration
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -110,6 +124,8 @@ func (c *Config) validate() error {
 		return errors.New("sweep: AgentQuietWindow must be >= 0")
 	case c.AgentQuiescenceTimeout < 0:
 		return errors.New("sweep: AgentQuiescenceTimeout must be >= 0")
+	case c.ApplyCatchUpTimeout < 0:
+		return errors.New("sweep: ApplyCatchUpTimeout must be >= 0")
 	case c.AgentQuietWindow > 0 && c.AgentQuiescenceTimeout <= 0:
 		// The wait loop only enforces the deadline when timeout > 0. A zero
 		// timeout paired with a positive window would loop until ctx
@@ -144,24 +160,44 @@ func (c *Config) applyDefaults() {
 }
 
 // quiescenceTracker records the wall-clock time of the most recent observed
-// post-commit agent event (EventApplied or EventCommit). The orchestrator
-// polls it after deprovision returns to wait for the agent to finish
-// converging EOS to the new (post-deprovision) config before cancelling the
-// SSH session.
+// post-commit agent event AND whether the agent is currently mid-cycle
+// (a config has been received but not yet committed or aborted). The
+// orchestrator polls it after deprovision returns to wait for the agent
+// to finish converging EOS to the new (post-deprovision) config before
+// cancelling the SSH session.
 //
-// Both signals are post-commit: EventApplied fires per pending tunnel after
-// a successful commit-finalize; EventCommit fires once per successful
-// commit-finalize regardless of which tunnels (if any) changed. We need
-// both because deprovision diffs produce zero EventApplieds (the parser
-// only tracks `+ interface Tunnel<ID>` lines), so without EventCommit the
-// tracker would see the agent as silent through the entire deprovision
-// phase.
+// Why both: post-commit signals (EventApplied / EventCommit) alone are
+// insufficient because the agent goes silent during the diff-check
+// window between EventConfigReceived and the next EventCommit. At >1 MB
+// configs that window can exceed 30s — past the default 15s quiet
+// window — so the tracker would falsely declare quiescence mid-cycle
+// and the orchestrator would kill the SSH session before the
+// deprovision config was committed to EOS. The pending-commit flag
+// closes that gap: while it's true the wait blocks regardless of how
+// long the agent has been silent.
 type quiescenceTracker struct {
 	lastEventNanos atomic.Int64
+	// pendingCommit is true between an EventConfigReceived and the
+	// next terminal cycle event (EventCommit, EventApplied, or — as
+	// far as the tracker is concerned — a brand-new
+	// EventConfigReceived, which implies the previous cycle finished
+	// without an explicit commit).
+	pendingCommit atomic.Bool
+	// appliedCount counts EventApplied observations across the run.
+	// Used by waitForAppliedToCatchUp at the provision→deprovision
+	// boundary to ensure the agent has had time to apply the peak
+	// config before the orchestrator starts removing users.
+	appliedCount atomic.Int64
 }
 
-func (q *quiescenceTracker) markEvent(at time.Time) {
+// markEvent records an agent activity beat that resets the silence
+// timer. pending is true for events that *start* a new
+// commit cycle (EventConfigReceived) and false for events that close
+// it (EventCommit / EventApplied). The tracker uses pendingCommit to
+// decide whether quiescence is safe — see HasPendingCommit.
+func (q *quiescenceTracker) markEvent(at time.Time, pending bool) {
 	q.lastEventNanos.Store(at.UnixNano())
+	q.pendingCommit.Store(pending)
 }
 
 func (q *quiescenceTracker) lastEvent() (time.Time, bool) {
@@ -170,6 +206,24 @@ func (q *quiescenceTracker) lastEvent() (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return time.Unix(0, n), true
+}
+
+// HasPendingCommit reports whether the agent has received a config it
+// hasn't yet committed. While true the quiescence wait must block,
+// regardless of how long the agent has been silent.
+func (q *quiescenceTracker) HasPendingCommit() bool {
+	return q.pendingCommit.Load()
+}
+
+// markApplied increments the per-run EventApplied counter. Called
+// alongside markEvent for EventApplied observations.
+func (q *quiescenceTracker) markApplied() {
+	q.appliedCount.Add(1)
+}
+
+// AppliedCount returns the running total of EventApplied observations.
+func (q *quiescenceTracker) AppliedCount() int64 {
+	return q.appliedCount.Load()
 }
 
 // createdUser tracks an orchestrator-owned user so the deprovision phase can
@@ -261,6 +315,18 @@ func Run(ctx context.Context, cfg Config) error {
 
 	created, err := provision(runCtx, &cfg, registry)
 
+	// Wait for the agent to apply the peak config before tearing down.
+	// At 1k users / hold=0 the orchestrator's provision finishes ~40s
+	// ahead of the agent's slowest diff-check + commit, so without this
+	// wait deprovision starts removing users while the agent is still
+	// trying to add them — users get added and removed in the same
+	// running diff and never show up on the device. We only wait on
+	// the success path: a provision error or context cancel means
+	// we're aborting, and the goal there is to clean up quickly.
+	if err == nil && cfg.ApplyCatchUpTimeout > 0 {
+		waitForAppliedToCatchUp(runCtx, &cfg, tracker, len(created))
+	}
+
 	// Always attempt deprovision so a provision error (or an abort during
 	// provision) still cleans up what the sweep created; the consumer keeps
 	// draining in parallel so any straggling agent events for already-created
@@ -321,11 +387,30 @@ func Run(ctx context.Context, cfg Config) error {
 // is doing work" for the purpose of timing the SSH cancel.
 func consumeAgentEvents(cfg *Config, registry *tunnelRegistry, tracker *quiescenceTracker) {
 	for ev := range cfg.Agent.Events() {
-		if ev.Kind == agent.EventApplied || ev.Kind == agent.EventCommit {
-			tracker.markEvent(cfg.Clock.Now())
+		// All three "agent is doing work" signals reset the silence
+		// timer; only EventConfigReceived sets the pending-commit flag.
+		// EventCommit and EventApplied are terminal — receiving them
+		// means the commit cycle finished, so they clear pending.
+		// EventApplied is per-tunnel and redundant with EventCommit
+		// for tracker purposes, but feeding it through keeps the
+		// silence timer accurate even when a commit's per-tunnel
+		// Applieds arrive out-of-order with the Commit signal.
+		switch ev.Kind {
+		case agent.EventConfigReceived:
+			tracker.markEvent(cfg.Clock.Now(), true)
+		case agent.EventCommit, agent.EventApplied, agent.EventCommitAborted:
+			// All three close a commit cycle from the tracker's
+			// perspective: EventCommit and EventApplied report a
+			// successful finalize; EventCommitAborted reports the
+			// agent gave up on the session (no-op diff in steady-
+			// state polling, most commonly post-deprovision).
+			tracker.markEvent(cfg.Clock.Now(), false)
 		}
-		if ev.Kind == agent.EventCommit {
-			// Pure activity signal — no per-tunnel runlog row to emit.
+		if ev.Kind == agent.EventApplied {
+			tracker.markApplied()
+		}
+		if ev.Kind == agent.EventCommit || ev.Kind == agent.EventConfigReceived || ev.Kind == agent.EventCommitAborted {
+			// Pure activity signals — no per-tunnel runlog row to emit.
 			continue
 		}
 		u, ok := registry.lookup(ev.TunnelID)
@@ -400,7 +485,15 @@ func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenc
 		last, _ = tracker.lastEvent()
 		sinceLast := now.Sub(last)
 		elapsed := now.Sub(start)
-		if elapsed >= cfg.AgentQuietWindow && sinceLast >= cfg.AgentQuietWindow {
+		// Quiescence requires: silent for AgentQuietWindow AND wait
+		// has been running at least AgentQuietWindow AND no commit
+		// cycle is mid-flight (config received, not yet committed).
+		// The last predicate prevents declaring quiescence during a
+		// long diff-check window — the agent goes silent between
+		// `Received N bytes` and the subsequent `Committing config
+		// session` log line for the duration of the diff compute,
+		// which at >1 MB configs can exceed AgentQuietWindow.
+		if elapsed >= cfg.AgentQuietWindow && sinceLast >= cfg.AgentQuietWindow && !tracker.HasPendingCommit() {
 			cfg.Logger.Info("sweep: agent quiesced",
 				"quiet_for", sinceLast,
 				"wait_elapsed", elapsed)
@@ -416,6 +509,59 @@ func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenc
 		case <-cfg.Clock.After(time.Second):
 		case <-ctx.Done():
 			cfg.Logger.Warn("sweep: agent quiescence wait cancelled", "err", ctx.Err())
+			return
+		}
+	}
+}
+
+// waitForAppliedToCatchUp blocks at the provision→deprovision boundary
+// until either (a) the agent has emitted at least `target` EventApplied
+// observations OR (b) cfg.ApplyCatchUpTimeout elapses. The function is
+// a no-op when cfg.ApplyCatchUpTimeout == 0 (the legacy behavior).
+//
+// We allow a small grace (`applyCatchUpGrace`) so the last batch's
+// applied events, which lag by roughly one poll cycle even on a healthy
+// agent, don't pin the wait to its timeout. `target` is len(created):
+// the orchestrator's count of users it actually provisioned (excludes
+// users the executor declined to create).
+//
+// The wait returns silently on hit, warns on ctx cancel or timeout, and
+// never fails the run — deprovision still runs afterwards regardless.
+const applyCatchUpGrace = int64(4)
+
+func waitForAppliedToCatchUp(ctx context.Context, cfg *Config, tracker *quiescenceTracker, target int) {
+	if cfg.ApplyCatchUpTimeout <= 0 || target == 0 {
+		return
+	}
+	start := cfg.Clock.Now()
+	deadline := start.Add(cfg.ApplyCatchUpTimeout)
+	cfg.Logger.Info("sweep: waiting for agent applied to catch up to provision",
+		"target", target,
+		"applied", tracker.AppliedCount(),
+		"grace", applyCatchUpGrace,
+		"timeout", cfg.ApplyCatchUpTimeout)
+	for {
+		applied := tracker.AppliedCount()
+		if applied+applyCatchUpGrace >= int64(target) {
+			cfg.Logger.Info("sweep: applied caught up",
+				"applied", applied,
+				"target", target,
+				"elapsed", cfg.Clock.Now().Sub(start))
+			return
+		}
+		now := cfg.Clock.Now()
+		if !now.Before(deadline) {
+			cfg.Logger.Warn("sweep: apply catch-up timed out; proceeding with deprovision anyway",
+				"applied", applied,
+				"target", target,
+				"shortfall", int64(target)-applied,
+				"elapsed", now.Sub(start))
+			return
+		}
+		select {
+		case <-cfg.Clock.After(time.Second):
+		case <-ctx.Done():
+			cfg.Logger.Warn("sweep: apply catch-up wait cancelled", "err", ctx.Err())
 			return
 		}
 	}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -105,6 +105,26 @@ type Config struct {
 	// roughly one poll cycle even on a healthy agent.
 	ApplyCatchUpTimeout time.Duration
 
+	// ApplyPerBatchCatchUp, when true, makes the provision phase pause
+	// after every batch (not just at provision-complete) until the
+	// agent's applied count covers the cumulative user count submitted
+	// so far. This paces the orchestrator at the agent's throughput,
+	// which matches production better than the current "flood the
+	// agent" shape — users in real life arrive at human cadence, not
+	// in 32/64-user bursts.
+	//
+	// Trade-off: per-batch waits dramatically reduce the diff-check
+	// load per cycle (more, smaller cycles instead of fewer, larger
+	// ones), which is the load-bearing measurement the harness was
+	// built to surface. Off by default; flip on when measuring per-
+	// user latency under steady-state load rather than peak throughput
+	// under burst load.
+	//
+	// Each per-batch wait honors the same ApplyCatchUpTimeout as the
+	// provision-complete wait; that knob's grace (applyCatchUpGrace)
+	// still applies. With ApplyCatchUpTimeout == 0 this flag is a no-op.
+	ApplyPerBatchCatchUp bool
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -313,7 +333,7 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	}()
 
-	created, err := provision(runCtx, &cfg, registry)
+	created, err := provision(runCtx, &cfg, registry, tracker)
 
 	// Wait for the agent to apply the peak config before tearing down.
 	// At 1k users / hold=0 the orchestrator's provision finishes ~40s
@@ -575,7 +595,7 @@ func waitForAppliedToCatchUp(ctx context.Context, cfg *Config, tracker *quiescen
 // to ~14 s. Each created user is registered with the tunnel registry so
 // the agent-event consumer can attribute pre_commit_log / applied events
 // back to a user_index.
-func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry) ([]createdUser, error) {
+func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry, tracker *quiescenceTracker) ([]createdUser, error) {
 	if cfg.Target == 0 {
 		return nil, nil
 	}
@@ -611,6 +631,18 @@ func provision(ctx context.Context, cfg *Config, registry *tunnelRegistry) ([]cr
 		}
 
 		runningTarget = nextTarget
+		// Per-batch catch-up: pace the orchestrator at the agent's
+		// throughput so each batch's users land on the device before
+		// the next batch is submitted. Skipped on the final batch
+		// (the provision-complete wait covers it) and when the
+		// flag's off. Honors the same ApplyCatchUpTimeout as the
+		// provision-complete wait.
+		if cfg.ApplyPerBatchCatchUp && cfg.ApplyCatchUpTimeout > 0 && runningTarget < cfg.Target {
+			waitForAppliedToCatchUp(ctx, cfg, tracker, len(created))
+			if err := ctx.Err(); err != nil {
+				return created, err
+			}
+		}
 		if runningTarget >= cfg.Target {
 			break
 		}

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep.go
@@ -125,6 +125,17 @@ type Config struct {
 	// still applies. With ApplyCatchUpTimeout == 0 this flag is a no-op.
 	ApplyPerBatchCatchUp bool
 
+	// NoAgent declares that the run is being driven without a real
+	// agent (the caller wired up agent.NewNoop). Used by
+	// waitForAgentQuiescence to skip the wait without inferring the
+	// answer from tracker state — the previous inference races with
+	// the consumer goroutine that updates the tracker, and at high
+	// schedule pressure can fire even on a real-agent run that has
+	// emitted events that the consumer hasn't yet drained. main.go
+	// already turns this flag on when --no-agent is set, alongside
+	// zeroing ApplyCatchUpTimeout.
+	NoAgent bool
+
 	Executor Executor
 	Agent    agent.Runner
 	Runlog   *runlog.Writer
@@ -477,32 +488,42 @@ func consumeAgentEvents(cfg *Config, registry *tunnelRegistry, tracker *quiescen
 //
 // The wait returns early on cfg.AgentQuiescenceTimeout (warned) or
 // ctx.Done() (warned). It is a no-op when cfg.AgentQuietWindow is zero
-// (the library default) or when no agent event has ever been observed
-// (e.g. --no-agent runs).
+// (the library default) or when cfg.NoAgent is true (the caller wired a
+// noop runner). An older version of this function also skipped when
+// tracker.lastEvent() reported no events; that inference raced with
+// the consumer goroutine that updates the tracker (event sitting in
+// the channel buffer but not yet observed) and could falsely fast-path
+// during a real-agent run, killing the SSH session mid-commit. The
+// explicit NoAgent flag from main.go replaces that inference.
 //
 // The wait polls in 1s ticks. Polling avoids needing a separate
 // "applied observed" signal channel — the tracker's atomic.Int64 is
 // read each tick and compared against the current clock. At 1024
 // users / batch=32 the agent emits commits in clumps tens of seconds
 // apart, so a 1s poll is well below the natural event cadence.
+//
+// When tracker.lastEvent() reports no events yet (zero-time), the
+// loop still progresses correctly: sinceLast is "now - zero" which is
+// trivially larger than AgentQuietWindow, so the wait blocks for
+// AgentQuietWindow against the elapsed-since-start guard before
+// returning. That gives the consumer goroutine a generous window to
+// pick up any in-flight events before we declare quiescence.
 func waitForAgentQuiescence(ctx context.Context, cfg *Config, tracker *quiescenceTracker) {
 	if cfg.AgentQuietWindow <= 0 {
 		return
 	}
-	last, ok := tracker.lastEvent()
-	if !ok {
-		cfg.Logger.Info("sweep: no agent events observed; skipping agent quiescence wait")
+	if cfg.NoAgent {
+		cfg.Logger.Info("sweep: --no-agent set; skipping agent quiescence wait")
 		return
 	}
 	start := cfg.Clock.Now()
 	deadline := start.Add(cfg.AgentQuiescenceTimeout)
 	cfg.Logger.Info("sweep: waiting for agent to quiesce",
 		"quiet_window", cfg.AgentQuietWindow,
-		"timeout", cfg.AgentQuiescenceTimeout,
-		"last_event_at", last)
+		"timeout", cfg.AgentQuiescenceTimeout)
 	for {
 		now := cfg.Clock.Now()
-		last, _ = tracker.lastEvent()
+		last, _ := tracker.lastEvent()
 		sinceLast := now.Sub(last)
 		elapsed := now.Sub(start)
 		// Quiescence requires: silent for AgentQuietWindow AND wait

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -1008,10 +1008,13 @@ func TestRun_QuiescenceBlocksOnPendingCommit(t *testing.T) {
 	}
 }
 
-// TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved confirms the wait is a
-// no-op when the agent never emitted an Applied — common in --no-agent runs
-// and on early-failure paths where teardown shouldn't pay the wait cost.
-func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
+// TestRun_SkipsQuiescenceWaitWhenNoAgent confirms the wait is a no-op
+// when the caller declared the run as --no-agent (Config.NoAgent=true).
+// The wait used to skip on an inferred "no events observed" signal,
+// but that inference raced with the consumer goroutine; the explicit
+// flag replaces it. With a 30s quiet window the wait would dominate
+// the run if NoAgent did not short-circuit it.
+func TestRun_SkipsQuiescenceWaitWhenNoAgent(t *testing.T) {
 	t.Parallel()
 
 	owner := solana.NewWallet().PublicKey()
@@ -1032,6 +1035,7 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 		OwnerFilter:            owner,
 		Executor:               exec,
 		Agent:                  agent.NewNoop(nil),
+		NoAgent:                true,
 		Runlog:                 w,
 		Clock:                  sweep.RealClock{},
 	}
@@ -1040,7 +1044,7 @@ func TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved(t *testing.T) {
 	require.NoError(t, sweep.Run(context.Background(), cfg))
 	elapsed := time.Since(start)
 	assert.Less(t, elapsed, time.Second,
-		"Run took %v with a 30s quiet window but no Applied events — wait should have skipped", elapsed)
+		"Run took %v with a 30s quiet window and NoAgent=true — wait should have skipped", elapsed)
 }
 
 // TestRun_WaitsForAgentQuiescenceEvenOnAbort proves that the quiescence

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -742,6 +742,96 @@ func TestRun_WaitsForAgentQuiescenceAfterDeprovision(t *testing.T) {
 		"Run returned %v after gate release; expected ≥ %v (quiet window)", elapsed, quietWindow/2)
 }
 
+// TestRun_PerBatchCatchUpWaitsBetweenBatches proves that when
+// ApplyPerBatchCatchUp is set, the sweep blocks after each batch
+// until the agent has emitted enough Applied events to cover the
+// cumulative count submitted so far — i.e. the orchestrator stops
+// pre-creating batches faster than the agent can apply them. Without
+// this, batch 2 would start as soon as batch 1's onchain activates
+// land regardless of agent progress (the default behavior).
+func TestRun_PerBatchCatchUpWaitsBetweenBatches(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	// Signal when batch 2 starts (the 9th CreateUser call). We use a
+	// large enough batch size (8) and target (16) that batch 1's
+	// cumulative target (8) sits above the catch-up grace (4), so
+	// applied=0 actually blocks rather than passing-with-grace.
+	const batchSize = 8
+	const target = 16
+	batch2Reached := make(chan struct{})
+	var once sync.Once
+	exec.afterCreate = func(calls int) {
+		if calls == batchSize+1 {
+			once.Do(func() { close(batch2Reached) })
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:                "run-per-batch-catch-up",
+		Target:               target,
+		UsersPerBatch:        batchSize,
+		Hold:                 0,
+		ApplyCatchUpTimeout:  3 * time.Second,
+		ApplyPerBatchCatchUp: true,
+		OwnerFilter:          owner,
+		Executor:             exec,
+		Agent:                ag,
+		Runlog:               w,
+		Clock:                sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	// Wait for batch 1 to land (batchSize create calls), then confirm
+	// batch 2 hasn't started — the per-batch wait should block it.
+	deadline := time.Now().Add(2 * time.Second)
+	for exec.createN.Load() < batchSize {
+		if time.Now().After(deadline) {
+			t.Fatalf("batch 1 did not complete within 2s (got %d creates)", exec.createN.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-batch2Reached:
+		t.Fatal("batch 2 started before any Applied event — per-batch wait did not block")
+	default:
+	}
+
+	// Emit batchSize-grace+1 Applied events to push applied+grace
+	// past the cumulative target and unblock the wait.
+	for i := 0; i < batchSize; i++ {
+		ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: uint16(500 + i), At: time.Now()})
+	}
+
+	select {
+	case <-batch2Reached:
+		// Expected.
+	case <-time.After(3 * time.Second):
+		t.Fatal("batch 2 did not start within 3s of Applied events")
+	}
+
+	// Let the run finish; emit enough Applieds to clear remaining waits.
+	for i := 0; i < target; i++ {
+		ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: uint16(500 + batchSize + i), At: time.Now()})
+	}
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after all Applieds emitted")
+	}
+}
+
 // TestRun_BlocksDeprovisionUntilAppliedCatchesUp proves the
 // provision→deprovision wait blocks until enough EventApplied
 // observations have landed to cover the provisioned users. Without

--- a/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
+++ b/tools/stress/device-orchestrator/pkg/sweep/sweep_test.go
@@ -742,6 +742,182 @@ func TestRun_WaitsForAgentQuiescenceAfterDeprovision(t *testing.T) {
 		"Run returned %v after gate release; expected ≥ %v (quiet window)", elapsed, quietWindow/2)
 }
 
+// TestRun_BlocksDeprovisionUntilAppliedCatchesUp proves the
+// provision→deprovision wait blocks until enough EventApplied
+// observations have landed to cover the provisioned users. Without
+// this gate (hold=0) the orchestrator finishes provisioning ~40s
+// ahead of the agent's slowest commit at high user counts and starts
+// removing users before they've ever been added to the device.
+func TestRun_BlocksDeprovisionUntilAppliedCatchesUp(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:               "run-catch-up",
+		Target:              5,
+		UsersPerBatch:       5,
+		Hold:                0,
+		ApplyCatchUpTimeout: 2 * time.Second,
+		OwnerFilter:         owner,
+		Executor:            exec,
+		Agent:               ag,
+		Runlog:              w,
+		Clock:               sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	// Wait for provision to finish (5 create calls) but no deprovision
+	// yet — the catch-up wait should be blocking.
+	deadline := time.Now().Add(2 * time.Second)
+	for exec.createN.Load() < 5 {
+		if time.Now().After(deadline) {
+			t.Fatalf("provision did not reach 5 users in 2s (got %d)", exec.createN.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Give the wait a beat to enter the loop, then confirm deprovision
+	// hasn't started.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), exec.deleteN.Load(), "deprovision started before applied caught up")
+
+	// Emit enough Applied events to satisfy target - grace (5 - 4 = 1).
+	ag.Emit(agent.Event{Kind: agent.EventApplied, TunnelID: 500, At: time.Now()})
+
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s after Applied caught up")
+	}
+	assert.Equal(t, int32(5), exec.deleteN.Load(), "all 5 users should have been deprovisioned")
+}
+
+// TestRun_CatchUpWaitHonorsTimeout confirms the wait gives up and
+// proceeds with deprovision when ApplyCatchUpTimeout fires, instead of
+// pinning the orchestrator indefinitely on a stuck agent.
+func TestRun_CatchUpWaitHonorsTimeout(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	cfg := sweep.Config{
+		RunID:               "run-catch-up-timeout",
+		Target:              10,
+		UsersPerBatch:       10,
+		Hold:                0,
+		ApplyCatchUpTimeout: 200 * time.Millisecond,
+		OwnerFilter:         owner,
+		Executor:            exec,
+		Agent:               ag, // never emits Applied
+		Runlog:              w,
+		Clock:               sweep.RealClock{},
+	}
+	start := time.Now()
+	require.NoError(t, sweep.Run(context.Background(), cfg))
+	elapsed := time.Since(start)
+	// Wait should have taken roughly the timeout. The lower bound is
+	// timeout/2 (loose, absorbs scheduler jitter); the upper bound is
+	// timeout * 4 (loose enough to absorb the 1s tick interval).
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond,
+		"Run returned %v; expected at least the catch-up timeout floor", elapsed)
+	assert.Less(t, elapsed, 5*time.Second,
+		"Run took %v; expected catch-up wait to time out, not hang", elapsed)
+	assert.Equal(t, int32(10), exec.deleteN.Load(),
+		"deprovision should still run after the catch-up wait times out")
+}
+
+// TestRun_QuiescenceBlocksOnPendingCommit proves the wait does NOT
+// declare quiescence while the agent has a config received but not
+// yet committed. Without this, the wait could time out mid-diff-check
+// (which can run >30s at >1MB configs) and the orchestrator would
+// cancel the SSH session while the agent was still applying the
+// deprovision config.
+func TestRun_QuiescenceBlocksOnPendingCommit(t *testing.T) {
+	t.Parallel()
+
+	owner := solana.NewWallet().PublicKey()
+	exec := newFakeExecutor(owner)
+	// Block deprovision so we can emit a ConfigReceived during teardown
+	// and observe whether the wait honors the pending-commit flag.
+	gate := make(chan struct{})
+	exec.deleteGate = gate
+
+	ag := newScriptedAgent()
+
+	path := filepath.Join(t.TempDir(), "orchestrator-runlog.json")
+	w, err := runlog.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	const quietWindow = 100 * time.Millisecond
+	cfg := sweep.Config{
+		RunID:                  "run-pending-commit",
+		Target:                 1,
+		UsersPerBatch:          1,
+		Hold:                   0,
+		AgentQuietWindow:       quietWindow,
+		AgentQuiescenceTimeout: 2 * time.Second,
+		OwnerFilter:            owner,
+		Executor:               exec,
+		Agent:                  ag,
+		Runlog:                 w,
+		Clock:                  sweep.RealClock{},
+	}
+	done := make(chan error, 1)
+	go func() { done <- sweep.Run(context.Background(), cfg) }()
+
+	deadline := time.Now().Add(time.Second)
+	for exec.deleteN.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("sweep did not reach deprovision within 1s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Emit a ConfigReceived to set the pending-commit flag, then go
+	// silent. The wait MUST NOT declare quiescence until the matching
+	// EventCommit lands — even after multiple quietWindow durations
+	// have elapsed.
+	ag.Emit(agent.Event{Kind: agent.EventConfigReceived, TunnelID: 0, At: time.Now()})
+
+	close(gate)
+
+	// Stay quiet for several quiet windows; the wait must still be
+	// blocked because the pending-commit flag is sticky.
+	time.Sleep(5 * quietWindow)
+	select {
+	case <-done:
+		t.Fatal("Run returned while a config was pending commit — quiescence wait should block")
+	default:
+	}
+
+	// Emit the matching commit; only now should the wait complete.
+	ag.Emit(agent.Event{Kind: agent.EventCommit, TunnelID: 0, At: time.Now()})
+
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of EventCommit clearing the pending flag")
+	}
+}
+
 // TestRun_SkipsQuiescenceWaitWhenNoAppliedObserved confirms the wait is a
 // no-op when the agent never emitted an Applied — common in --no-agent runs
 // and on early-failure paths where teardown shouldn't pay the wait cost.

--- a/tools/stress/device-reporter/pkg/analyze/fit.go
+++ b/tools/stress/device-reporter/pkg/analyze/fit.go
@@ -1,0 +1,93 @@
+// Package analyze contains pure functions over parsed run data. It has no
+// I/O dependencies beyond the parser package so the same functions are
+// reusable from the CLI markdown writer, the CSV writer, and tests.
+package analyze
+
+import "math"
+
+// LinearFit is a simple ordinary-least-squares fit of y = slope*x + intercept.
+// R2 is the coefficient of determination (1.0 = perfect linear fit, 0.0 =
+// the mean predicts as well as the slope). N is the number of input points.
+type LinearFit struct {
+	Slope     float64
+	Intercept float64
+	R2        float64
+	N         int
+}
+
+// LinearLeastSquares returns the OLS fit of y on x. Returns a zero-value
+// LinearFit when len(x) != len(y), len(x) < 2, or x has zero variance
+// (vertical line — no meaningful slope).
+func LinearLeastSquares(x, y []float64) LinearFit {
+	if len(x) != len(y) || len(x) < 2 {
+		return LinearFit{}
+	}
+	n := float64(len(x))
+	var sumX, sumY float64
+	for i := range x {
+		sumX += x[i]
+		sumY += y[i]
+	}
+	meanX := sumX / n
+	meanY := sumY / n
+
+	var ssXY, ssXX float64
+	for i := range x {
+		dx := x[i] - meanX
+		dy := y[i] - meanY
+		ssXY += dx * dy
+		ssXX += dx * dx
+	}
+	if ssXX == 0 {
+		return LinearFit{N: len(x)}
+	}
+
+	slope := ssXY / ssXX
+	intercept := meanY - slope*meanX
+
+	// R² = 1 - SSres/SStot where SStot is the variance of y around its mean.
+	var ssRes, ssTot float64
+	for i := range x {
+		pred := slope*x[i] + intercept
+		ssRes += (y[i] - pred) * (y[i] - pred)
+		dy := y[i] - meanY
+		ssTot += dy * dy
+	}
+	r2 := 0.0
+	if ssTot > 0 {
+		r2 = 1 - ssRes/ssTot
+	}
+
+	return LinearFit{
+		Slope:     slope,
+		Intercept: intercept,
+		R2:        r2,
+		N:         len(x),
+	}
+}
+
+// Percentile returns the p-th percentile (0..1) of `values` using linear
+// interpolation between adjacent ranks (R-7 / numpy default). The input
+// must be sorted ascending; the caller is expected to copy + sort first.
+func Percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := p * float64(len(sorted)-1)
+	lo := int(math.Floor(idx))
+	hi := int(math.Ceil(idx))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := idx - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[hi]*frac
+}

--- a/tools/stress/device-reporter/pkg/analyze/fit_test.go
+++ b/tools/stress/device-reporter/pkg/analyze/fit_test.go
@@ -1,0 +1,76 @@
+package analyze
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLinearLeastSquares_PerfectLine(t *testing.T) {
+	// y = 2x + 1
+	x := []float64{1, 2, 3, 4, 5}
+	y := []float64{3, 5, 7, 9, 11}
+	f := LinearLeastSquares(x, y)
+	if math.Abs(f.Slope-2) > 1e-9 || math.Abs(f.Intercept-1) > 1e-9 {
+		t.Fatalf("expected slope=2 intercept=1, got slope=%g intercept=%g", f.Slope, f.Intercept)
+	}
+	if math.Abs(f.R2-1) > 1e-9 {
+		t.Fatalf("expected R²=1 for perfect line, got %g", f.R2)
+	}
+	if f.N != 5 {
+		t.Fatalf("expected N=5, got %d", f.N)
+	}
+}
+
+func TestLinearLeastSquares_RejectsTooFewPoints(t *testing.T) {
+	f := LinearLeastSquares([]float64{1}, []float64{2})
+	if f.N != 0 || f.Slope != 0 {
+		t.Fatalf("expected zero-value fit, got %+v", f)
+	}
+}
+
+func TestLinearLeastSquares_RejectsZeroVariance(t *testing.T) {
+	// All x's equal — vertical line, no slope.
+	f := LinearLeastSquares([]float64{2, 2, 2}, []float64{1, 2, 3})
+	if f.Slope != 0 || f.Intercept != 0 {
+		t.Fatalf("expected zero slope for zero-variance x, got %+v", f)
+	}
+	if f.N != 3 {
+		t.Fatalf("N still reflects input size; expected 3, got %d", f.N)
+	}
+}
+
+func TestLinearLeastSquares_NoisyR2(t *testing.T) {
+	// y = x + noise; R² should be < 1 but > 0.5.
+	x := []float64{1, 2, 3, 4, 5}
+	y := []float64{1.1, 2.2, 2.9, 4.1, 4.9}
+	f := LinearLeastSquares(x, y)
+	if f.R2 < 0.95 {
+		t.Fatalf("expected high R² for near-linear data, got %g", f.R2)
+	}
+}
+
+func TestPercentile_BasicCases(t *testing.T) {
+	v := []float64{1, 2, 3, 4, 5}
+	if got := Percentile(v, 0.5); got != 3 {
+		t.Errorf("p50 of [1..5] should be 3, got %g", got)
+	}
+	// p95 of 5 elements at indices [0..4] is 0.95*4 = 3.8 → 4 + 0.8*(5-4) = 4.8
+	if got := Percentile(v, 0.95); math.Abs(got-4.8) > 1e-9 {
+		t.Errorf("p95 should be 4.8, got %g", got)
+	}
+	if got := Percentile(v, 0); got != 1 {
+		t.Errorf("p0 should be 1, got %g", got)
+	}
+	if got := Percentile(v, 1); got != 5 {
+		t.Errorf("p100 should be 5, got %g", got)
+	}
+}
+
+func TestPercentile_EmptyAndSingle(t *testing.T) {
+	if Percentile(nil, 0.5) != 0 {
+		t.Error("empty percentile should be 0")
+	}
+	if Percentile([]float64{42}, 0.5) != 42 {
+		t.Error("single-element percentile should be that element")
+	}
+}

--- a/tools/stress/device-reporter/pkg/analyze/format.go
+++ b/tools/stress/device-reporter/pkg/analyze/format.go
@@ -1,0 +1,56 @@
+package analyze
+
+import (
+	"fmt"
+	"time"
+)
+
+// FormatInt formats with thousand-separators for readability in tables.
+// Exported so the format package's markdown writer can render the same
+// way the analyze-internal `compare` rows do.
+func FormatInt(n int) string {
+	if n < 0 {
+		return "-" + FormatInt(-n)
+	}
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	return FormatInt(n/1000) + "," + fmt.Sprintf("%03d", n%1000)
+}
+
+// FormatDuration renders a duration with units that fit the magnitude.
+// Zero durations render as "—" so empty cells are visually obvious in
+// tables. For fields where 0 is a deliberate operator choice (e.g. the
+// Hold knob), use FormatDurationOrZero instead.
+func FormatDuration(d time.Duration) string {
+	if d == 0 {
+		return "—"
+	}
+	return formatNonZeroDuration(d)
+}
+
+// FormatDurationOrZero renders 0 as "0s" rather than "—". Use this for
+// fields where the operator explicitly chose zero (e.g. `--hold 0`),
+// since the em-dash reads as "data missing" rather than "no hold".
+func FormatDurationOrZero(d time.Duration) string {
+	if d == 0 {
+		return "0s"
+	}
+	return formatNonZeroDuration(d)
+}
+
+func formatNonZeroDuration(d time.Duration) string {
+	if d < time.Microsecond {
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	}
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.1fµs", float64(d)/float64(time.Microsecond))
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.1fms", float64(d)/float64(time.Millisecond))
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+	return d.Truncate(time.Second).String()
+}

--- a/tools/stress/device-reporter/pkg/analyze/patterns.go
+++ b/tools/stress/device-reporter/pkg/analyze/patterns.go
@@ -1,0 +1,50 @@
+package analyze
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/parser"
+)
+
+// tunnelIDRE matches `TunnelN` (any tunnel-ID number) so we can normalize
+// command text like `interface Tunnel500` → `interface Tunnel<N>`. This
+// collapses per-tunnel error spam ("invalid command" on Tunnel500,
+// Tunnel501, ...) into one bucket.
+var tunnelIDRE = regexp.MustCompile(`Tunnel\d+`)
+
+// largeIntRE matches embedded integers ≥ 1000 (config session IDs, byte
+// counts, etc.) so unrelated errors don't fragment into one-bucket-per-run.
+var largeIntRE = regexp.MustCompile(`\b\d{4,}\b`)
+
+// normalizeCommand collapses run-variable bits of a CLI command so the
+// top-K aggregation buckets cleanly.
+func normalizeCommand(cmd string) string {
+	out := tunnelIDRE.ReplaceAllString(cmd, "Tunnel<N>")
+	out = largeIntRE.ReplaceAllString(out, "<N>")
+	return out
+}
+
+// topAgentErrors groups CLI failures by normalized command text and
+// returns the top k by count, ties broken alphabetically.
+func topAgentErrors(errs []parser.AgentCLIError, k int) []AgentErrorBucket {
+	counts := map[string]int{}
+	for _, e := range errs {
+		key := normalizeCommand(e.Command) + " :: " + e.Reason
+		counts[key]++
+	}
+	out := make([]AgentErrorBucket, 0, len(counts))
+	for k, v := range counts {
+		out = append(out, AgentErrorBucket{NormalizedCommand: k, Count: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].NormalizedCommand < out[j].NormalizedCommand
+	})
+	if len(out) > k {
+		out = out[:k]
+	}
+	return out
+}

--- a/tools/stress/device-reporter/pkg/analyze/summary.go
+++ b/tools/stress/device-reporter/pkg/analyze/summary.go
@@ -194,21 +194,38 @@ func BuildSummary(r *parser.Run) Summary {
 	}
 
 	// Outcome detection: an abort sentinel takes precedence; otherwise the
-	// run is "success" when every observed submit has a matching activate
-	// in both phases AND at least one event of any kind landed (so a run
-	// with zero recorded events is "unfinished", not vacuously successful).
-	// Guarding on `submit > 0` alone would mark a deprovision-only artifact
-	// (a re-run that only tore down a prior run's leftovers) as unfinished
-	// even though it converged.
+	// run is "success" only when both phases have fully converged.
+	// Concretely:
+	//
+	//   * every observed submit has a matching activate, and
+	//   * every observed deprovision_submit has a matching
+	//     deprovision_activate, and
+	//   * deprovision actually happened (deprovision_submit > 0), and
+	//   * either there was no provision in this run (deprovision-only
+	//     re-run that just tore down a prior run's leftovers) or every
+	//     provisioned user was deprovisioned.
+	//
+	// The deprovision_submit > 0 guard distinguishes a complete cycle
+	// from a provision-only mid-run snapshot (e.g. summary inspected
+	// before teardown starts) — without it the previous version of this
+	// branch labelled an in-progress run as `success`. The
+	// (submit == 0 || submit == deprovision_submit) guard preserves the
+	// deprovision-only artifact case (rerun teardown after a prior
+	// failed run) while keeping mid-deprovision out: a half-finished
+	// teardown has deprovision_submit < submit and falls through to
+	// "unfinished".
+	submits := s.EventCounts["submit"]
+	deprovSubmits := s.EventCounts["deprovision_submit"]
 	switch {
 	case r.Abort != nil:
 		s.Outcome = "aborted"
 		s.AbortReason = r.Abort.Reason
 		s.AbortTrigger = r.Abort.Trigger
 		s.AbortDetail = r.Abort.Detail
-	case s.EventCounts["activate"] == s.EventCounts["submit"] &&
-		s.EventCounts["deprovision_activate"] == s.EventCounts["deprovision_submit"] &&
-		(s.EventCounts["submit"]+s.EventCounts["deprovision_submit"]) > 0:
+	case s.EventCounts["activate"] == submits &&
+		s.EventCounts["deprovision_activate"] == deprovSubmits &&
+		deprovSubmits > 0 &&
+		(submits == 0 || submits == deprovSubmits):
 		s.Outcome = "success"
 	default:
 		s.Outcome = "unfinished"

--- a/tools/stress/device-reporter/pkg/analyze/summary.go
+++ b/tools/stress/device-reporter/pkg/analyze/summary.go
@@ -1,0 +1,589 @@
+package analyze
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/parser"
+)
+
+// Summary is the rolled-up view of a run that the markdown writer renders.
+// Every field is derived from the Run, so the summary itself stays a
+// dumb data carrier (easier to test against, easier to extend).
+type Summary struct {
+	// RunID, taken straight from orchestrator-config.json.
+	RunID string
+	// DUTName is the device-under-test identifier (hostname or IP)
+	// extracted from the orchestrator's ssh target, used in the
+	// summary header so multiple runs against different DUTs can be
+	// told apart at a glance.
+	DUTName string
+	// IsPhysical is true when the agent flags indicate a non-containerized
+	// DUT (orchestrator passes prefix/pubkey directly).
+	IsPhysical bool
+	// Target / Batch / Hold are the headline knobs from the config.
+	Target int
+	Batch  int
+	Hold   time.Duration
+	// StartedAt / EndedAt / Duration are pulled from runlog timestamps.
+	StartedAt time.Time
+	EndedAt   time.Time
+	Duration  time.Duration
+	// Outcome is one of "success", "aborted", "unfinished".
+	Outcome      string
+	AbortReason  string // populated when Outcome == "aborted"
+	AbortTrigger string
+	AbortDetail  string
+
+	// EventCounts is the per-event-type tally from the runlog.
+	EventCounts parser.EventCounts
+
+	// ProvisionDuration is the wall time from the first `submit` to the
+	// last `activate`. DeprovisionDuration mirrors for the deprovision phase.
+	ProvisionDuration   time.Duration
+	DeprovisionDuration time.Duration
+
+	// OnchainLatencies bundles per-user submit→activate stats for both phases.
+	OnchainLatencies OnchainLatencies
+
+	// AgentCommitStats summarizes the agent-side commit cycles.
+	AgentCommitStats AgentCommitStats
+
+	// CommitVsBytes / CommitVsLines fit commit duration against the
+	// received-config size. Empty fits (N < 2) indicate not enough cycles.
+	CommitVsBytes LinearFit
+	CommitVsLines LinearFit
+
+	// DiffCheckVsBytes / DiffCheckVsLines fit the per-cycle diff-check
+	// time (`Received N bytes` → `Committing config session`) against
+	// the received-config size. Diff-check tends to dominate the
+	// per-cycle wall time at scale, so the slope here is more
+	// load-bearing than the commit-vs-size fits.
+	DiffCheckVsBytes LinearFit
+	DiffCheckVsLines LinearFit
+
+	// AgentErrorTopK is up to k=8 most common CLI failure patterns
+	// (command-text with tunnel numbers normalized).
+	AgentErrorTopK []AgentErrorBucket
+
+	// CommitCycles is one row per agent commit cycle, joined against the
+	// runlog so each row knows how many users it actually pushed to the
+	// device. Used to render the per-cycle wall-time + onchain→on-device
+	// lag breakdown. Cycles with no matching `applied` event (e.g. config
+	// pushes that contained no user-tunnel additions) are still listed
+	// with UsersCommitted == 0 so the operator can see them.
+	CommitCycles []CommitCycle
+
+	// CommitCyclesJoinWarning is non-empty when the positional join
+	// between agent-log commit cycles and runlog applied-buckets failed
+	// to consume all of one side. The markdown writer surfaces it as a
+	// banner so silent off-by-one corruption in the per-cycle table is
+	// always visible to the operator.
+	CommitCyclesJoinWarning string
+
+	// OnchainToOnDeviceFit fits the per-user onchain→on-device gap (y, ns)
+	// against the active-user count when each user activated (x, count).
+	// Slope is duration / +1 user, so the operator can see whether the
+	// gap grows as the run progresses. Empty (N < 2) when fewer than two
+	// users had both `activate` and `applied`.
+	OnchainToOnDeviceFit LinearFit
+}
+
+// CommitCycle is the joined view of one agent commit cycle: the agent
+// log gives us the lines/bytes/duration; the runlog gives us the count
+// of users committed in that cycle plus the within-cycle onchain→on-device
+// gap distribution. Rows are ordered by commit-finalized time ascending.
+type CommitCycle struct {
+	// UsersCommitted is the count of `applied` runlog events that share
+	// this cycle's finalize timestamp. Zero for commit cycles that
+	// applied no user additions (e.g. controller pushed a no-op delta).
+	UsersCommitted int
+	ReceivedLines  int
+	ReceivedBytes  int
+	// DiffCheckDuration is the gap from `Received N bytes of
+	// configuration from controller` to `Committing config session due
+	// to diffs detected`. It covers the agent's diff-compute +
+	// decide-to-commit + configure-session-open time. Zero when the
+	// agent log did not emit a paired Received line before the commit
+	// (e.g. the agent restarted mid-cycle).
+	DiffCheckDuration time.Duration
+	// CommitDuration is the gap from `Committing config session ...` to
+	// `Configuration session finalized ...`. The wall-clock cost of the
+	// commit itself.
+	CommitDuration time.Duration
+	// OnchainToOnDeviceP50 / Max are within-cycle stats of the gap from
+	// each user's `activate` to this commit. They surface the spread —
+	// the just-activated user sees a small gap, the oldest user in the
+	// batch sees the largest. Both zero when UsersCommitted == 0.
+	OnchainToOnDeviceP50 time.Duration
+	OnchainToOnDeviceMax time.Duration
+}
+
+// OnchainLatencies collects per-user submit→activate timing stats for both
+// the provision and deprovision phases, plus the activate→applied gap that
+// measures how long it took for the agent to actually configure each
+// user's tunnel interface after the user account was activated onchain
+// (provision-only — deprovision has no `applied` event).
+type OnchainLatencies struct {
+	ProvisionSubmitToActivateP50   time.Duration
+	ProvisionSubmitToActivateP95   time.Duration
+	DeprovisionSubmitToActivateP50 time.Duration
+	DeprovisionSubmitToActivateP95 time.Duration
+	ProvisionUsers                 int
+	DeprovisionUsers               int
+
+	// ActivateToAppliedP50 / P95 are the per-user gap from `activate` to
+	// `applied` events in the provision phase. UsersApplied is the count
+	// of provision users that had both events (a user is dropped from the
+	// percentile inputs if either side is missing).
+	ActivateToAppliedP50 time.Duration
+	ActivateToAppliedP95 time.Duration
+	UsersApplied         int
+}
+
+// AgentCommitStats summarizes the agent-cycle table.
+type AgentCommitStats struct {
+	Cycles            int
+	CommitCount       int // Outcome == "commit"
+	AbortCount        int // Outcome == "abort" (commit-internal abort, NOT observer sentinel)
+	UnfinishedCount   int // Cycle that never finalized (agent killed mid-commit)
+	MaxLines          int
+	MaxBytes          int
+	AvgCommitDuration time.Duration
+}
+
+// AgentErrorBucket groups CLI-command failures by normalized command text.
+type AgentErrorBucket struct {
+	NormalizedCommand string
+	Count             int
+}
+
+// BuildSummary is the top-level analysis entry point.
+func BuildSummary(r *parser.Run) Summary {
+	s := Summary{
+		EventCounts: parser.CountEvents(r.Events),
+	}
+	if r.Config != nil {
+		s.RunID = r.Config.RunID
+		s.DUTName = r.Config.DUTName()
+		s.IsPhysical = r.Config.IsPhysical()
+		s.Target = r.Config.TargetUserCount
+		s.Batch = r.Config.UsersPerBatch
+		s.Hold = time.Duration(r.Config.HoldSeconds) * time.Second
+	}
+	if start, ok := r.StartedAt(); ok {
+		s.StartedAt = start
+	}
+	if end, ok := r.EndedAt(); ok {
+		s.EndedAt = end
+	}
+	s.Duration = r.Duration()
+
+	// Phase durations: submit → activate. We can be precise because each
+	// phase emits a final activate (or deprovision_activate) that closes it.
+	if first := firstEvent(r.Events, "submit"); first != nil {
+		if last := lastEvent(r.Events, "activate"); last != nil {
+			s.ProvisionDuration = last.Time().Sub(first.Time())
+		}
+	}
+	if first := firstEvent(r.Events, "deprovision_submit"); first != nil {
+		if last := lastEvent(r.Events, "deprovision_activate"); last != nil {
+			s.DeprovisionDuration = last.Time().Sub(first.Time())
+		}
+	}
+
+	// Outcome detection: an abort sentinel takes precedence; otherwise the
+	// run is "success" when every observed submit has a matching activate
+	// in both phases AND at least one event of any kind landed (so a run
+	// with zero recorded events is "unfinished", not vacuously successful).
+	// Guarding on `submit > 0` alone would mark a deprovision-only artifact
+	// (a re-run that only tore down a prior run's leftovers) as unfinished
+	// even though it converged.
+	switch {
+	case r.Abort != nil:
+		s.Outcome = "aborted"
+		s.AbortReason = r.Abort.Reason
+		s.AbortTrigger = r.Abort.Trigger
+		s.AbortDetail = r.Abort.Detail
+	case s.EventCounts["activate"] == s.EventCounts["submit"] &&
+		s.EventCounts["deprovision_activate"] == s.EventCounts["deprovision_submit"] &&
+		(s.EventCounts["submit"]+s.EventCounts["deprovision_submit"]) > 0:
+		s.Outcome = "success"
+	default:
+		s.Outcome = "unfinished"
+	}
+
+	s.OnchainLatencies = onchainLatencies(r.Events)
+	s.AgentCommitStats = agentCommitStats(r.Cycles)
+	s.CommitVsBytes, s.CommitVsLines = commitVsSizeFits(r.Cycles)
+	s.DiffCheckVsBytes, s.DiffCheckVsLines = diffCheckVsSizeFits(r.Cycles)
+	s.AgentErrorTopK = topAgentErrors(r.CliErrors, 8)
+	s.CommitCycles, s.CommitCyclesJoinWarning = commitCycles(r.Cycles, r.Events)
+	s.OnchainToOnDeviceFit = onchainToOnDeviceFit(r.Events)
+
+	return s
+}
+
+func firstEvent(events []parser.Event, kind string) *parser.Event {
+	for i := range events {
+		if events[i].Event == kind {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+func lastEvent(events []parser.Event, kind string) *parser.Event {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Event == kind {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// onchainLatencies computes per-user submit→activate gaps for both phases
+// and the per-user activate→applied gap for the provision phase. Pairs
+// are keyed by UserIndex. Missing-side events drop the user from the
+// corresponding percentile inputs (a user with `submit` but no `activate`
+// counts toward neither submit→activate population, for example).
+//
+// Activate→applied is provision-only because the agent emits `applied`
+// only when a `+ interface Tunnel<N>` shows up in the commit diff — pure
+// deprovision diffs (only removals) do not produce `applied` events.
+func onchainLatencies(events []parser.Event) OnchainLatencies {
+	type key struct {
+		phase string
+		idx   int
+	}
+	// Track whether each timestamp was observed explicitly rather than
+	// relying on TNs==0 as a "missing" sentinel — Unix epoch 0 is a
+	// theoretically valid timestamp and shouldn't be misclassified as
+	// absent.
+	type pair struct {
+		submitTNs, activateTNs int64
+		hasSubmit, hasActivate bool
+	}
+	pairs := map[key]*pair{}
+	// applied events are provision-only and keyed by UserIndex alone.
+	type appliedPair struct {
+		appliedTNs int64
+		hasApplied bool
+	}
+	applieds := map[int]*appliedPair{}
+	for _, e := range events {
+		if e.Event == "applied" {
+			p, ok := applieds[e.UserIndex]
+			if !ok {
+				p = &appliedPair{}
+				applieds[e.UserIndex] = p
+			}
+			// Take the first `applied` per user: a user can only be
+			// configured once per run, and a stray second event (e.g. an
+			// agent restart that re-applies the same diff) is the agent
+			// recovering, not a new device-creation moment.
+			if !p.hasApplied {
+				p.appliedTNs = e.TNs
+				p.hasApplied = true
+			}
+			continue
+		}
+		var phase, role string
+		switch e.Event {
+		case "submit":
+			phase, role = "provision", "submit"
+		case "activate":
+			phase, role = "provision", "activate"
+		case "deprovision_submit":
+			phase, role = "deprovision", "submit"
+		case "deprovision_activate":
+			phase, role = "deprovision", "activate"
+		default:
+			continue
+		}
+		k := key{phase, e.UserIndex}
+		p, ok := pairs[k]
+		if !ok {
+			p = &pair{}
+			pairs[k] = p
+		}
+		if role == "submit" {
+			p.submitTNs = e.TNs
+			p.hasSubmit = true
+		} else {
+			p.activateTNs = e.TNs
+			p.hasActivate = true
+		}
+	}
+
+	var provGaps, deprovGaps, applyGaps []float64
+	for k, p := range pairs {
+		if !p.hasSubmit || !p.hasActivate {
+			continue
+		}
+		gap := float64(p.activateTNs - p.submitTNs)
+		if k.phase == "provision" {
+			provGaps = append(provGaps, gap)
+			// activate→applied only makes sense when we know the activate
+			// timestamp. If the user also has an applied event, record it.
+			if ap, ok := applieds[k.idx]; ok && ap.hasApplied {
+				applyGaps = append(applyGaps, float64(ap.appliedTNs-p.activateTNs))
+			}
+		} else {
+			deprovGaps = append(deprovGaps, gap)
+		}
+	}
+	sort.Float64s(provGaps)
+	sort.Float64s(deprovGaps)
+	sort.Float64s(applyGaps)
+	return OnchainLatencies{
+		ProvisionSubmitToActivateP50:   time.Duration(Percentile(provGaps, 0.50)),
+		ProvisionSubmitToActivateP95:   time.Duration(Percentile(provGaps, 0.95)),
+		DeprovisionSubmitToActivateP50: time.Duration(Percentile(deprovGaps, 0.50)),
+		DeprovisionSubmitToActivateP95: time.Duration(Percentile(deprovGaps, 0.95)),
+		ProvisionUsers:                 len(provGaps),
+		DeprovisionUsers:               len(deprovGaps),
+		ActivateToAppliedP50:           time.Duration(Percentile(applyGaps, 0.50)),
+		ActivateToAppliedP95:           time.Duration(Percentile(applyGaps, 0.95)),
+		UsersApplied:                   len(applyGaps),
+	}
+}
+
+func agentCommitStats(cycles []parser.AgentCycle) AgentCommitStats {
+	stats := AgentCommitStats{Cycles: len(cycles)}
+	var total time.Duration
+	var counted int
+	for _, c := range cycles {
+		switch c.Outcome {
+		case "commit":
+			stats.CommitCount++
+		case "abort":
+			stats.AbortCount++
+		case "unfinished":
+			stats.UnfinishedCount++
+		}
+		if c.ReceivedLines > stats.MaxLines {
+			stats.MaxLines = c.ReceivedLines
+		}
+		if c.ReceivedBytes > stats.MaxBytes {
+			stats.MaxBytes = c.ReceivedBytes
+		}
+		if d := c.CommitDuration(); d > 0 {
+			total += d
+			counted++
+		}
+	}
+	if counted > 0 {
+		stats.AvgCommitDuration = total / time.Duration(counted)
+	}
+	return stats
+}
+
+// commitVsSizeFits returns (vs-bytes, vs-lines) linear fits. Only cycles
+// that committed successfully AND have a paired Received-line are
+// considered — abort/unfinished cycles or commits with no preceding
+// Received-pair would skew the slope.
+func commitVsSizeFits(cycles []parser.AgentCycle) (LinearFit, LinearFit) {
+	var bx, lx, y []float64
+	for _, c := range cycles {
+		if c.Outcome != "commit" {
+			continue
+		}
+		d := c.CommitDuration()
+		if d <= 0 {
+			continue
+		}
+		if c.ReceivedBytes == 0 && c.ReceivedLines == 0 {
+			continue
+		}
+		bx = append(bx, float64(c.ReceivedBytes))
+		lx = append(lx, float64(c.ReceivedLines))
+		y = append(y, float64(d))
+	}
+	return LinearLeastSquares(bx, y), LinearLeastSquares(lx, y)
+}
+
+// diffCheckVsSizeFits returns (vs-bytes, vs-lines) linear fits of the
+// agent's diff-check time against the received-config size. Same
+// inclusion rule as commitVsSizeFits — only successful commits with a
+// paired Received line and a positive diff-check gap contribute, so
+// agent restarts mid-cycle (zero ReceivedAt) and pure-noop polls don't
+// distort the slope.
+func diffCheckVsSizeFits(cycles []parser.AgentCycle) (LinearFit, LinearFit) {
+	var bx, lx, y []float64
+	for _, c := range cycles {
+		if c.Outcome != "commit" {
+			continue
+		}
+		if c.ReceivedAt.IsZero() || c.CommitStartedAt.IsZero() {
+			continue
+		}
+		gap := c.CommitStartedAt.Sub(c.ReceivedAt)
+		if gap <= 0 {
+			continue
+		}
+		if c.ReceivedBytes == 0 && c.ReceivedLines == 0 {
+			continue
+		}
+		bx = append(bx, float64(c.ReceivedBytes))
+		lx = append(lx, float64(c.ReceivedLines))
+		y = append(y, float64(gap))
+	}
+	return LinearLeastSquares(bx, y), LinearLeastSquares(lx, y)
+}
+
+// commitCycles joins each agent-log commit cycle with the runlog
+// `applied` events that share its finalize timestamp. All `applied`
+// events from one commit are emitted by the orchestrator at the same
+// instant (the parser stamps them with one wallclock read when the
+// "finalized ... commit" line is seen), so grouping the runlog by
+// `applied.TNs` yields a clean per-cycle bucket. Buckets are paired
+// with cycles in chronological order — the i-th cycle (by FinalizedAt)
+// pairs with the i-th distinct applied-TNs.
+//
+// Cycles whose Outcome is not "commit" (abort, unfinished) are still
+// emitted so the operator can see them; their UsersCommitted will be
+// zero by construction (the orchestrator doesn't emit Applied on
+// abort/unfinished cycles).
+func commitCycles(cycles []parser.AgentCycle, events []parser.Event) ([]CommitCycle, string) {
+	if len(cycles) == 0 {
+		return nil, ""
+	}
+
+	// Build per-user activate timestamps so we can compute the
+	// within-cycle onchain→on-device gap for each user.
+	activateAt := map[int]int64{}
+	for _, e := range events {
+		if e.Event == "activate" {
+			if _, seen := activateAt[e.UserIndex]; !seen {
+				activateAt[e.UserIndex] = e.TNs
+			}
+		}
+	}
+
+	// Group `applied` events by TNs. Events from the same commit cycle
+	// share an exact TNs, so a plain map suffices — no fuzzy bucketing.
+	type appliedBucket struct {
+		tNs   int64
+		gaps  []float64 // per-user onchain→on-device gaps (ns)
+		count int
+	}
+	bucketByTNs := map[int64]*appliedBucket{}
+	for _, e := range events {
+		if e.Event != "applied" {
+			continue
+		}
+		b, ok := bucketByTNs[e.TNs]
+		if !ok {
+			b = &appliedBucket{tNs: e.TNs}
+			bucketByTNs[e.TNs] = b
+		}
+		b.count++
+		if a, hasActivate := activateAt[e.UserIndex]; hasActivate {
+			b.gaps = append(b.gaps, float64(e.TNs-a))
+		}
+	}
+	buckets := make([]*appliedBucket, 0, len(bucketByTNs))
+	for _, b := range bucketByTNs {
+		buckets = append(buckets, b)
+	}
+	sort.Slice(buckets, func(i, j int) bool { return buckets[i].tNs < buckets[j].tNs })
+
+	// Cycles are already in chronological order from the agent-log
+	// parser, but make it explicit: sort by FinalizedAt with a stable
+	// fallback to CommitStartedAt so unfinished cycles (zero FinalizedAt)
+	// trail their finished neighbors instead of jumping to the front.
+	sorted := make([]parser.AgentCycle, len(cycles))
+	copy(sorted, cycles)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ti, tj := sorted[i].FinalizedAt, sorted[j].FinalizedAt
+		if ti.IsZero() {
+			ti = sorted[i].CommitStartedAt
+		}
+		if tj.IsZero() {
+			tj = sorted[j].CommitStartedAt
+		}
+		return ti.Before(tj)
+	})
+
+	out := make([]CommitCycle, 0, len(sorted))
+	commitCount := 0
+	bi := 0
+	for _, c := range sorted {
+		row := CommitCycle{
+			ReceivedLines:  c.ReceivedLines,
+			ReceivedBytes:  c.ReceivedBytes,
+			CommitDuration: c.CommitDuration(),
+		}
+		// Diff-check is Received → Committing. Skip when either side
+		// is missing (agent restart mid-cycle leaves ReceivedAt zero).
+		if !c.ReceivedAt.IsZero() && !c.CommitStartedAt.IsZero() {
+			if d := c.CommitStartedAt.Sub(c.ReceivedAt); d > 0 {
+				row.DiffCheckDuration = d
+			}
+		}
+		// Only successful commits should consume an applied bucket. Abort
+		// and unfinished cycles emit no applied events, so giving them
+		// a bucket would shift every later cycle's user-count off by one.
+		if c.Outcome == "commit" {
+			commitCount++
+			if bi < len(buckets) {
+				b := buckets[bi]
+				row.UsersCommitted = b.count
+				if len(b.gaps) > 0 {
+					sort.Float64s(b.gaps)
+					row.OnchainToOnDeviceP50 = time.Duration(Percentile(b.gaps, 0.50))
+					row.OnchainToOnDeviceMax = time.Duration(b.gaps[len(b.gaps)-1])
+				}
+				bi++
+			}
+		}
+		out = append(out, row)
+	}
+	// The positional join assumes one applied-bucket per "commit"-outcome
+	// cycle. A mismatch means either the runlog dropped some applied
+	// rows (off-by-one cascade: cycle i's bucket gets used for cycle
+	// i+1, etc.) or a cycle finalized at the same nanosecond as
+	// another and the buckets collapsed. Surface it so the markdown
+	// writer can warn the operator instead of silently rendering
+	// shifted per-cycle data.
+	var warning string
+	if commitCount != len(buckets) {
+		warning = fmt.Sprintf("commit-cycle/applied-bucket count mismatch: %d commit-outcome cycles vs %d applied buckets. Per-cycle UsersCommitted columns may be shifted.",
+			commitCount, len(buckets))
+	}
+	return out, warning
+}
+
+// onchainToOnDeviceFit fits the per-user onchain→on-device gap (y) in
+// nanoseconds against the count of users active when the user activated
+// (x — sourced from the runlog's NAfterEvent column at the activate
+// event). The slope tells the operator whether the gap grows as the
+// run progresses; R² indicates how linear the trend is.
+func onchainToOnDeviceFit(events []parser.Event) LinearFit {
+	activate := map[int]parser.Event{}
+	applied := map[int]parser.Event{}
+	for _, e := range events {
+		switch e.Event {
+		case "activate":
+			if _, seen := activate[e.UserIndex]; !seen {
+				activate[e.UserIndex] = e
+			}
+		case "applied":
+			if _, seen := applied[e.UserIndex]; !seen {
+				applied[e.UserIndex] = e
+			}
+		}
+	}
+	var xs, ys []float64
+	for idx, a := range activate {
+		ap, ok := applied[idx]
+		if !ok {
+			continue
+		}
+		xs = append(xs, float64(a.NAfterEvent))
+		ys = append(ys, float64(ap.TNs-a.TNs))
+	}
+	return LinearLeastSquares(xs, ys)
+}

--- a/tools/stress/device-reporter/pkg/analyze/summary_test.go
+++ b/tools/stress/device-reporter/pkg/analyze/summary_test.go
@@ -1,0 +1,267 @@
+package analyze
+
+import (
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/parser"
+)
+
+// TestOnchainLatencies_ActivateToApplied exercises the new metric: per-user
+// activate→applied gap (the "user account onchain → tunnel interface on
+// device" delay). The fixture includes:
+//
+//   - user 0: complete submit/activate/applied → contributes to all gaps
+//   - user 1: submit/activate but no applied (e.g. agent ran behind) →
+//     contributes to submit→activate but not activate→applied
+//   - user 2: submit/activate/applied → contributes to all gaps
+//
+// We assert UsersApplied counts only users with both activate AND applied,
+// and that the percentile inputs reflect just those users' gaps.
+func TestOnchainLatencies_ActivateToApplied(t *testing.T) {
+	// Times chosen so the activate→applied gap is 2s for user 0 and 4s for
+	// user 2 (and absent for user 1). p50 of {2s,4s} = 4s (the upper-half
+	// of the two-point sample under the Percentile helper); we only check
+	// p50 <= p95 and that both are in the {2s,4s} range to stay
+	// implementation-agnostic about percentile-interpolation choice.
+	base := time.Unix(1_700_000_000, 0).UnixNano()
+	events := []parser.Event{
+		{UserIndex: 0, Event: "submit", TNs: base},
+		{UserIndex: 0, Event: "activate", TNs: base + int64(1*time.Second)},
+		{UserIndex: 0, Event: "applied", TNs: base + int64(3*time.Second)}, // gap 2s
+		{UserIndex: 1, Event: "submit", TNs: base + int64(1*time.Second)},
+		{UserIndex: 1, Event: "activate", TNs: base + int64(2*time.Second)},
+		// user 1 deliberately has no `applied` event.
+		{UserIndex: 2, Event: "submit", TNs: base + int64(2*time.Second)},
+		{UserIndex: 2, Event: "activate", TNs: base + int64(3*time.Second)},
+		{UserIndex: 2, Event: "applied", TNs: base + int64(7*time.Second)}, // gap 4s
+	}
+
+	got := onchainLatencies(events)
+	if got.ProvisionUsers != 3 {
+		t.Errorf("ProvisionUsers = %d, want 3", got.ProvisionUsers)
+	}
+	if got.UsersApplied != 2 {
+		t.Errorf("UsersApplied = %d, want 2 (user 1 has no applied event)", got.UsersApplied)
+	}
+	if got.ActivateToAppliedP50 < 2*time.Second || got.ActivateToAppliedP50 > 4*time.Second {
+		t.Errorf("ActivateToAppliedP50 = %s, want in [2s, 4s]", got.ActivateToAppliedP50)
+	}
+	if got.ActivateToAppliedP95 < got.ActivateToAppliedP50 {
+		t.Errorf("p95 (%s) must be >= p50 (%s)", got.ActivateToAppliedP95, got.ActivateToAppliedP50)
+	}
+	if got.ActivateToAppliedP95 > 4*time.Second {
+		t.Errorf("ActivateToAppliedP95 = %s, want <= 4s", got.ActivateToAppliedP95)
+	}
+}
+
+// TestOnchainLatencies_NoAppliedEvents covers the --no-agent / pre-fix-run
+// case where no `applied` event ever fires. UsersApplied should be 0 and
+// the latency fields should stay at their zero values (the markdown writer
+// uses UsersApplied > 0 as the predicate for rendering the new table).
+func TestOnchainLatencies_NoAppliedEvents(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UnixNano()
+	events := []parser.Event{
+		{UserIndex: 0, Event: "submit", TNs: base},
+		{UserIndex: 0, Event: "activate", TNs: base + int64(time.Second)},
+		{UserIndex: 1, Event: "submit", TNs: base},
+		{UserIndex: 1, Event: "activate", TNs: base + int64(time.Second)},
+	}
+	got := onchainLatencies(events)
+	if got.UsersApplied != 0 {
+		t.Errorf("UsersApplied = %d, want 0", got.UsersApplied)
+	}
+	if got.ActivateToAppliedP50 != 0 || got.ActivateToAppliedP95 != 0 {
+		t.Errorf("activate→applied percentiles must be zero when no applied events present (got p50=%s p95=%s)",
+			got.ActivateToAppliedP50, got.ActivateToAppliedP95)
+	}
+}
+
+// TestOnchainLatencies_AppliedWithoutActivate guards against a malformed
+// runlog (an `applied` arriving for a user_index that has no `activate`
+// row). The user must not contribute to activate→applied since there's
+// no baseline timestamp to subtract from.
+func TestOnchainLatencies_AppliedWithoutActivate(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UnixNano()
+	events := []parser.Event{
+		{UserIndex: 0, Event: "applied", TNs: base + int64(3*time.Second)},
+	}
+	got := onchainLatencies(events)
+	if got.UsersApplied != 0 {
+		t.Errorf("UsersApplied = %d, want 0 (applied without activate must be ignored)", got.UsersApplied)
+	}
+}
+
+// TestCommitCycles_WarnsOnCountMismatch exercises the join-mismatch
+// guard added to surface silent off-by-one corruption in the per-cycle
+// table. Two commit cycles + one applied bucket → warning fires and
+// the second cycle's UsersCommitted is zero (it didn't consume a
+// bucket, which is the expected behavior).
+func TestCommitCycles_WarnsOnCountMismatch(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	cycles := []parser.AgentCycle{
+		{CommitStartedAt: base.Add(1 * time.Second), FinalizedAt: base.Add(2 * time.Second), Outcome: "commit"},
+		{CommitStartedAt: base.Add(11 * time.Second), FinalizedAt: base.Add(12 * time.Second), Outcome: "commit"},
+	}
+	// Only one applied bucket — the orchestrator's consumer dropped
+	// rows for cycle 2 (simulated).
+	events := []parser.Event{
+		{UserIndex: 0, Event: "activate", TNs: base.UnixNano()},
+		{UserIndex: 0, Event: "applied", TNs: base.Add(2 * time.Second).UnixNano()},
+	}
+	rows, warn := commitCycles(cycles, events)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows, got %d", len(rows))
+	}
+	if rows[0].UsersCommitted != 1 {
+		t.Errorf("cycle 1 should have consumed the single available bucket; UsersCommitted=%d", rows[0].UsersCommitted)
+	}
+	if rows[1].UsersCommitted != 0 {
+		t.Errorf("cycle 2 should report 0 users (no bucket left), got %d", rows[1].UsersCommitted)
+	}
+	if warn == "" {
+		t.Errorf("expected a join warning for 2-commit/1-bucket mismatch")
+	}
+}
+
+// TestCommitCycles_DiffCheckDuration verifies that the gap from
+// `Received N bytes ...` to `Committing config session ...` is computed
+// and emitted on each CommitCycle row.
+func TestCommitCycles_DiffCheckDuration(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	cycles := []parser.AgentCycle{
+		{
+			ReceivedAt:      base,
+			ReceivedLines:   100,
+			ReceivedBytes:   2000,
+			CommitStartedAt: base.Add(12 * time.Second),
+			FinalizedAt:     base.Add(14 * time.Second),
+			Outcome:         "commit",
+		},
+		{
+			// Mid-cycle agent restart: no paired Received line before commit.
+			CommitStartedAt: base.Add(20 * time.Second),
+			FinalizedAt:     base.Add(21 * time.Second),
+			Outcome:         "commit",
+		},
+	}
+	rows, _ := commitCycles(cycles, nil)
+	if got, want := rows[0].DiffCheckDuration, 12*time.Second; got != want {
+		t.Errorf("cycle 1 DiffCheckDuration = %s, want %s", got, want)
+	}
+	if rows[1].DiffCheckDuration != 0 {
+		t.Errorf("cycle 2 DiffCheckDuration = %s, want 0 (no Received pair)", rows[1].DiffCheckDuration)
+	}
+}
+
+// TestCommitCycles_JoinsAppliedEventsByTNs verifies that the agent-log
+// cycle list and the runlog `applied` events are paired correctly:
+//
+//   - cycles are listed chronologically by FinalizedAt;
+//   - applied events sharing a TNs collapse to one "users committed"
+//     count for the matching cycle;
+//   - non-commit cycles (abort, unfinished) get zero users and don't
+//     consume an applied bucket (which would shift later cycles).
+func TestCommitCycles_JoinsAppliedEventsByTNs(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	// Three agent cycles, finalized at base+10s, base+20s, base+30s.
+	cycles := []parser.AgentCycle{
+		{
+			CommitStartedAt: base.Add(8 * time.Second),
+			FinalizedAt:     base.Add(10 * time.Second),
+			ReceivedLines:   100,
+			ReceivedBytes:   2000,
+			Outcome:         "commit",
+		},
+		{
+			CommitStartedAt: base.Add(18 * time.Second),
+			FinalizedAt:     base.Add(20 * time.Second),
+			ReceivedLines:   150,
+			ReceivedBytes:   3500,
+			Outcome:         "abort", // mid-run abort, no applied events
+		},
+		{
+			CommitStartedAt: base.Add(28 * time.Second),
+			FinalizedAt:     base.Add(30 * time.Second),
+			ReceivedLines:   200,
+			ReceivedBytes:   5000,
+			Outcome:         "commit",
+		},
+	}
+	// Cycle 1: two users activated at base+0s, base+5s; both applied at
+	// base+10s. Gaps: 10s, 5s. Cycle 3: one user activated at base+25s,
+	// applied at base+30s. Gap: 5s.
+	events := []parser.Event{
+		{UserIndex: 0, Event: "activate", TNs: base.UnixNano()},
+		{UserIndex: 1, Event: "activate", TNs: base.Add(5 * time.Second).UnixNano()},
+		{UserIndex: 0, Event: "applied", TNs: base.Add(10 * time.Second).UnixNano()},
+		{UserIndex: 1, Event: "applied", TNs: base.Add(10 * time.Second).UnixNano()},
+		{UserIndex: 2, Event: "activate", TNs: base.Add(25 * time.Second).UnixNano()},
+		{UserIndex: 2, Event: "applied", TNs: base.Add(30 * time.Second).UnixNano()},
+	}
+
+	rows, warn := commitCycles(cycles, events)
+	if len(rows) != 3 {
+		t.Fatalf("want 3 rows (one per cycle, including the abort), got %d", len(rows))
+	}
+	if warn != "" {
+		t.Errorf("expected no join warning for balanced 2-commit/2-bucket input, got %q", warn)
+	}
+	// Cycle 1: 2 users, max gap = 10s.
+	if rows[0].UsersCommitted != 2 {
+		t.Errorf("cycle 1 UsersCommitted = %d, want 2", rows[0].UsersCommitted)
+	}
+	if rows[0].OnchainToOnDeviceMax != 10*time.Second {
+		t.Errorf("cycle 1 max gap = %s, want 10s", rows[0].OnchainToOnDeviceMax)
+	}
+	// Cycle 2: abort, must not consume the cycle-3 applied bucket.
+	if rows[1].UsersCommitted != 0 {
+		t.Errorf("cycle 2 (abort) UsersCommitted = %d, want 0 (abort cycles emit no applied events)", rows[1].UsersCommitted)
+	}
+	if rows[1].OnchainToOnDeviceMax != 0 {
+		t.Errorf("cycle 2 max gap should be zero, got %s", rows[1].OnchainToOnDeviceMax)
+	}
+	// Cycle 3: 1 user, gap 5s.
+	if rows[2].UsersCommitted != 1 {
+		t.Errorf("cycle 3 UsersCommitted = %d, want 1 (abort cycle must not have eaten this bucket)", rows[2].UsersCommitted)
+	}
+	if rows[2].OnchainToOnDeviceMax != 5*time.Second {
+		t.Errorf("cycle 3 max gap = %s, want 5s", rows[2].OnchainToOnDeviceMax)
+	}
+}
+
+// TestOnchainToOnDeviceFit_GrowsWithActiveUsers feeds a synthetic
+// dataset where the gap scales linearly with the active-user count and
+// asserts the slope comes back positive and R² is near 1.
+func TestOnchainToOnDeviceFit_GrowsWithActiveUsers(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UnixNano()
+	var events []parser.Event
+	// gap_ns = NAfterEvent * 1ms exactly — perfect linearity.
+	for i := 1; i <= 10; i++ {
+		activateT := base + int64(i)*int64(time.Second)
+		gap := int64(i) * int64(time.Millisecond)
+		events = append(events,
+			parser.Event{UserIndex: i, Event: "activate", TNs: activateT, NAfterEvent: i},
+			parser.Event{UserIndex: i, Event: "applied", TNs: activateT + gap},
+		)
+	}
+	fit := onchainToOnDeviceFit(events)
+	if fit.N != 10 {
+		t.Fatalf("fit.N = %d, want 10", fit.N)
+	}
+	// Slope is duration (ns) per +1 active user. We expect 1ms = 1e6 ns.
+	const wantSlope = float64(time.Millisecond)
+	if rel := abs((fit.Slope - wantSlope) / wantSlope); rel > 0.001 {
+		t.Errorf("fit.Slope = %v, want ≈ %v (rel err %v)", fit.Slope, wantSlope, rel)
+	}
+	if fit.R2 < 0.999 {
+		t.Errorf("fit.R2 = %v, want near 1.0 (perfectly linear input)", fit.R2)
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/tools/stress/device-reporter/pkg/analyze/summary_test.go
+++ b/tools/stress/device-reporter/pkg/analyze/summary_test.go
@@ -265,3 +265,89 @@ func abs(x float64) float64 {
 	}
 	return x
 }
+
+// TestBuildSummary_OutcomeClassification covers every shape the outcome
+// detector has to disambiguate. The cases that mattered for the bug:
+// a provision-only run (mid-flight, before teardown) used to be labelled
+// "success" because the previous predicate only required the two phase
+// counts to match each other and the sum to be > 0. Now we additionally
+// require that deprovision actually happened, with parity between
+// submit and deprovision_submit (so a half-finished teardown stays
+// "unfinished").
+func TestBuildSummary_OutcomeClassification(t *testing.T) {
+	cases := []struct {
+		name        string
+		events      []parser.Event
+		abort       *parser.AbortSentinel
+		wantOutcome string
+	}{
+		{
+			name:        "no events at all",
+			events:      nil,
+			wantOutcome: "unfinished",
+		},
+		{
+			name: "provision-only mid-run snapshot (the bug)",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "submit"}, {UserIndex: 0, Event: "activate"},
+				{UserIndex: 1, Event: "submit"}, {UserIndex: 1, Event: "activate"},
+				{UserIndex: 2, Event: "submit"}, {UserIndex: 2, Event: "activate"},
+			},
+			wantOutcome: "unfinished",
+		},
+		{
+			name: "complete provision + deprovision cycle",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "submit"}, {UserIndex: 0, Event: "activate"},
+				{UserIndex: 1, Event: "submit"}, {UserIndex: 1, Event: "activate"},
+				{UserIndex: 1, Event: "deprovision_submit"}, {UserIndex: 1, Event: "deprovision_activate"},
+				{UserIndex: 0, Event: "deprovision_submit"}, {UserIndex: 0, Event: "deprovision_activate"},
+			},
+			wantOutcome: "success",
+		},
+		{
+			name: "deprovision-only re-run (no provision in this run)",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "deprovision_submit"}, {UserIndex: 0, Event: "deprovision_activate"},
+				{UserIndex: 1, Event: "deprovision_submit"}, {UserIndex: 1, Event: "deprovision_activate"},
+			},
+			wantOutcome: "success",
+		},
+		{
+			name: "mid-provision (submit but no activate yet)",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "submit"}, {UserIndex: 0, Event: "activate"},
+				{UserIndex: 1, Event: "submit"},
+			},
+			wantOutcome: "unfinished",
+		},
+		{
+			name: "mid-deprovision (provision complete, teardown half done)",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "submit"}, {UserIndex: 0, Event: "activate"},
+				{UserIndex: 1, Event: "submit"}, {UserIndex: 1, Event: "activate"},
+				{UserIndex: 1, Event: "deprovision_submit"}, {UserIndex: 1, Event: "deprovision_activate"},
+				// User 0 not yet deprovisioned.
+			},
+			wantOutcome: "unfinished",
+		},
+		{
+			name: "abort sentinel takes precedence over a complete cycle",
+			events: []parser.Event{
+				{UserIndex: 0, Event: "submit"}, {UserIndex: 0, Event: "activate"},
+				{UserIndex: 0, Event: "deprovision_submit"}, {UserIndex: 0, Event: "deprovision_activate"},
+			},
+			abort:       &parser.AbortSentinel{Reason: "manual"},
+			wantOutcome: "aborted",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &parser.Run{Events: tc.events, Abort: tc.abort}
+			got := BuildSummary(r)
+			if got.Outcome != tc.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", got.Outcome, tc.wantOutcome)
+			}
+		})
+	}
+}

--- a/tools/stress/device-reporter/pkg/parser/agentlog.go
+++ b/tools/stress/device-reporter/pkg/parser/agentlog.go
@@ -1,0 +1,205 @@
+package parser
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// AgentCycle is one commit cycle as observed in orchestrator.agent.log:
+// the agent receives a config from the controller, opens a configure
+// session, then either commits or aborts. ReceivedAt / ReceivedLines /
+// ReceivedBytes are filled in from the immediately preceding "Received N
+// lines / N bytes" pair when one is present (the agent emits both lines
+// back-to-back on each poll cycle).
+type AgentCycle struct {
+	// ReceivedAt is the wall-clock time of the matched
+	// `Received N lines of configuration` line; zero if no pair preceded
+	// the commit marker (e.g. the agent restarted mid-cycle).
+	ReceivedAt    time.Time
+	ReceivedLines int
+	ReceivedBytes int
+	// CommitStartedAt is the wall-clock time of the
+	// `Committing config session due to diffs detected:` line.
+	CommitStartedAt time.Time
+	// FinalizedAt is the wall-clock time of the
+	// `Configuration session finalized with command '... commit'` (or
+	// `'... abort'`) line. Zero if the cycle never finalized (the agent
+	// process was killed mid-commit, which we model as Outcome="unfinished").
+	FinalizedAt time.Time
+	// Outcome is one of "commit", "abort", or "unfinished".
+	Outcome string
+}
+
+// CommitDuration is the gap from `Committing config session...` to
+// `Configuration session finalized...`. Returns 0 for unfinished cycles.
+func (c AgentCycle) CommitDuration() time.Duration {
+	if c.CommitStartedAt.IsZero() || c.FinalizedAt.IsZero() {
+		return 0
+	}
+	return c.FinalizedAt.Sub(c.CommitStartedAt)
+}
+
+// AgentCLIError is one `CLI command N of M '<cmd>' failed: <reason>` line.
+// These are commit-time EOS validation failures; reading them as a group
+// surfaces hardware-quirk patterns (e.g. all errors being
+// `default interface TunnelN invalid command` from chi-dn-dzd5's
+// Tunnel-name range cap). The N/M indices and timestamp are intentionally
+// not captured — the top-K bucketer in pkg/analyze only reads Command +
+// Reason after normalization, so the extra fields would just be unused
+// parser state.
+type AgentCLIError struct {
+	Command string // <cmd>
+	Reason  string // <reason>
+}
+
+var (
+	// EOS agent log timestamps look like "2026/06/04 00:32:01.930732".
+	// We accept either microsecond or nanosecond resolution, but the
+	// 6-digit microsecond form is what we've seen in practice.
+	agentTimeRE = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d+)\s`)
+	// Lines we care about (eapi.go line numbers are stable enough across
+	// agent builds that we anchor on them).
+	receivedLinesRE = regexp.MustCompile(`Received (\d+) lines of configuration from controller`)
+	receivedBytesRE = regexp.MustCompile(`Received (\d+) bytes of configuration from controller`)
+	committingRE    = regexp.MustCompile(`Committing config session due to diffs detected:`)
+	finalizedRE     = regexp.MustCompile(`Configuration session finalized with command '[^']*\s+(commit|abort)'`)
+	// The CLI-command failure shape, when seen inside the orchestrator's
+	// log, is doubly quoted: `'CLI command N of M '<cmd>' failed: <reason>' at line K`.
+	// The outer quotes belong to the orchestrator's error wrapper; the
+	// inner ones belong to the agent's reported failure. We stop <cmd> and
+	// <reason> at the next single quote to avoid capturing the outer
+	// closing quote into the reason field.
+	cliCommandFailRE = regexp.MustCompile(`CLI command (\d+) of (\d+) '([^']+)' failed:\s+([^']+)`)
+)
+
+const agentTimeLayout = "2006/01/02 15:04:05.000000"
+
+func parseAgentTime(s string) (time.Time, bool) {
+	// Accept variable-length fractional seconds by trimming or right-padding
+	// to the layout's 6-digit microsecond precision. The agentTimeRE already
+	// requires a `.<digits>` segment, so we always land on the dot branch.
+	m := agentTimeRE.FindStringSubmatch(s)
+	if m == nil {
+		return time.Time{}, false
+	}
+	stamp := m[1]
+	dot := strings.IndexByte(stamp, '.')
+	frac := stamp[dot+1:]
+	if len(frac) > 6 {
+		stamp = stamp[:dot+1+6]
+	} else if len(frac) < 6 {
+		stamp = stamp + strings.Repeat("0", 6-len(frac))
+	}
+	t, err := time.Parse(agentTimeLayout, stamp)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// loadAgentLog streams the file once, threading a small state machine that
+// builds AgentCycle records each time it sees `Committing config session`
+// followed by `Configuration session finalized`. It also collects every
+// `CLI command N of M ...` failure line.
+//
+// The pairing logic for received-lines/bytes is "most recent precedes the
+// Committing marker" — the agent emits both Received lines back-to-back per
+// poll cycle, so they always land just before the commit (or, on a no-op
+// poll, with no commit following them).
+func loadAgentLog(path string) ([]AgentCycle, []AgentCLIError, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	var cycles []AgentCycle
+	var errs []AgentCLIError
+
+	// Pending: the most recent Received-lines/Received-bytes pair that has
+	// not yet been matched to a Committing marker.
+	var pendingReceivedAt time.Time
+	var pendingLines, pendingBytes int
+
+	// Active: a Committing marker has been seen but not yet finalized.
+	var active *AgentCycle
+
+	s := bufio.NewScanner(f)
+	// Some lines are huge (the agent dumps the entire received config
+	// inline). Allow up to 4 MiB per line.
+	s.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for s.Scan() {
+		line := s.Text()
+		ts, _ := parseAgentTime(line)
+
+		switch {
+		case receivedLinesRE.MatchString(line):
+			pendingReceivedAt = ts
+			if m := receivedLinesRE.FindStringSubmatch(line); m != nil {
+				pendingLines, _ = strconv.Atoi(m[1])
+			}
+		case receivedBytesRE.MatchString(line):
+			if m := receivedBytesRE.FindStringSubmatch(line); m != nil {
+				pendingBytes, _ = strconv.Atoi(m[1])
+			}
+			// Bytes always immediately follows lines on the same poll, so
+			// leave pendingReceivedAt at the lines-line time (microsecond
+			// difference; the lines marker is the canonical "received").
+		case committingRE.MatchString(line):
+			// If a prior cycle was active but never finalized (e.g. the
+			// agent process exited between `Committing` and the matching
+			// `Configuration session finalized`, then restarted and began
+			// a fresh commit), record it as `unfinished` before replacing.
+			// Otherwise we'd silently drop it and skew commit counts +
+			// downstream stats.
+			if active != nil {
+				active.Outcome = "unfinished"
+				cycles = append(cycles, *active)
+			}
+			// Open a new cycle; absorb the pending received-pair into it
+			// (the most recent one is the closest match by construction).
+			active = &AgentCycle{
+				ReceivedAt:      pendingReceivedAt,
+				ReceivedLines:   pendingLines,
+				ReceivedBytes:   pendingBytes,
+				CommitStartedAt: ts,
+			}
+			pendingReceivedAt = time.Time{}
+			pendingLines, pendingBytes = 0, 0
+		case finalizedRE.MatchString(line):
+			if active != nil {
+				active.FinalizedAt = ts
+				m := finalizedRE.FindStringSubmatch(line)
+				if m != nil {
+					active.Outcome = m[1] // "commit" or "abort"
+				}
+				cycles = append(cycles, *active)
+				active = nil
+			}
+		}
+
+		// CLI command failures land scattered through the log; capture
+		// independently of the cycle state machine.
+		if m := cliCommandFailRE.FindStringSubmatch(line); m != nil {
+			errs = append(errs, AgentCLIError{
+				Command: m[3],
+				Reason:  m[4],
+			})
+		}
+	}
+	if err := s.Err(); err != nil {
+		return cycles, errs, fmt.Errorf("scan: %w", err)
+	}
+	// If a Committing was active but never finalized, record it as an
+	// unfinished cycle so callers can spot mid-commit kills.
+	if active != nil {
+		active.Outcome = "unfinished"
+		cycles = append(cycles, *active)
+	}
+	return cycles, errs, nil
+}

--- a/tools/stress/device-reporter/pkg/parser/agentlog_test.go
+++ b/tools/stress/device-reporter/pkg/parser/agentlog_test.go
@@ -1,0 +1,96 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleAgentLog = `2026/06/04 00:32:01.930732 eapi.go:217: Received 7551 lines of configuration from controller
+2026/06/04 00:32:01.930767 eapi.go:218: Received 167755 bytes of configuration from controller
+2026/06/04 00:32:15.605538 eapi.go:274: Committing config session due to diffs detected: --- system:/running-config
+2026/06/04 00:32:18.124050 eapi.go:295: Configuration session finalized with command 'configure session doublezero-agent-1780533121 commit'
+2026/06/04 00:32:18.222712 eapi.go:217: Received 6143 lines of configuration from controller
+2026/06/04 00:32:18.222734 eapi.go:218: Received 159258 bytes of configuration from controller
+2026/06/04 00:32:28.586218 eapi.go:274: Committing config session due to diffs detected: --- system:/running-config
+2026/06/04 00:32:30.618562 eapi.go:295: Configuration session finalized with command 'configure session doublezero-agent-1780533138 commit'
+2026/06/04 00:32:35.000000 eapi.go:139: ERROR: pollAndConfigureDevice returned error running eAPI cmd 'CLI command 67 of 253 ' interface Tunnel500' failed: invalid command' at line 1
+`
+
+func TestLoadAgentLog_PairsReceivedAndFinalized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(path, []byte(sampleAgentLog), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	cycles, errs, err := loadAgentLog(path)
+	if err != nil {
+		t.Fatalf("loadAgentLog: %v", err)
+	}
+	if len(cycles) != 2 {
+		t.Fatalf("expected 2 cycles, got %d (%+v)", len(cycles), cycles)
+	}
+	// Cycle 0 should pair the 7551/167755 receive with the first commit.
+	c0 := cycles[0]
+	if c0.ReceivedLines != 7551 || c0.ReceivedBytes != 167755 {
+		t.Errorf("cycle 0 receive sizes wrong: lines=%d bytes=%d", c0.ReceivedLines, c0.ReceivedBytes)
+	}
+	if c0.Outcome != "commit" {
+		t.Errorf("cycle 0 outcome should be commit, got %q", c0.Outcome)
+	}
+	if c0.CommitDuration() == 0 {
+		t.Error("cycle 0 commit duration should be > 0")
+	}
+	// Cycle 1 should pair the 6143/159258 receive with the second commit.
+	c1 := cycles[1]
+	if c1.ReceivedLines != 6143 || c1.ReceivedBytes != 159258 {
+		t.Errorf("cycle 1 receive sizes wrong: lines=%d bytes=%d", c1.ReceivedLines, c1.ReceivedBytes)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 CLI error, got %d", len(errs))
+	}
+	e := errs[0]
+	if e.Command != " interface Tunnel500" { // intentional leading space — preserved from EOS log shape
+		t.Errorf("CLI error command wrong: %q", e.Command)
+	}
+	if e.Reason != "invalid command" {
+		t.Errorf("CLI error reason wrong: %q", e.Reason)
+	}
+}
+
+func TestLoadAgentLog_UnfinishedCycle(t *testing.T) {
+	// Committing without a finalized line → "unfinished" cycle.
+	input := `2026/06/04 00:32:01.930732 eapi.go:217: Received 100 lines of configuration from controller
+2026/06/04 00:32:01.930767 eapi.go:218: Received 2000 bytes of configuration from controller
+2026/06/04 00:32:15.605538 eapi.go:274: Committing config session due to diffs detected: --- system:/running-config
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cycles, _, err := loadAgentLog(path)
+	if err != nil {
+		t.Fatalf("loadAgentLog: %v", err)
+	}
+	if len(cycles) != 1 || cycles[0].Outcome != "unfinished" {
+		t.Fatalf("expected one unfinished cycle, got %+v", cycles)
+	}
+}
+
+func TestParseAgentTime(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"2026/06/04 00:32:01.930732 eapi.go:217: foo", true},
+		{"not a timestamp", false},
+		{"2026/06/04 00:32:01 eapi.go:217: missing fractional", false}, // no `.` after seconds
+	}
+	for _, tc := range cases {
+		_, ok := parseAgentTime(tc.in)
+		if ok != tc.ok {
+			t.Errorf("parseAgentTime(%q) ok=%v, want %v", tc.in, ok, tc.ok)
+		}
+	}
+}

--- a/tools/stress/device-reporter/pkg/parser/config.go
+++ b/tools/stress/device-reporter/pkg/parser/config.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// OrchestratorConfig mirrors the subset of orchestrator-config.json that the
+// reporter actually reads. Extra fields the orchestrator dumps are tolerated
+// (json.Unmarshal ignores unknown keys); add typed fields here only when
+// something downstream needs to read them.
+type OrchestratorConfig struct {
+	RunID              string `json:"run_id"`
+	TargetUserCount    int    `json:"target_user_count"`
+	UsersPerBatch      int    `json:"users_per_batch"`
+	HoldSeconds        int    `json:"hold_seconds"`
+	AgentCommandPrefix string `json:"agent_command_prefix,omitempty"`
+	AgentPubkey        string `json:"agent_pubkey,omitempty"`
+	// DUTSSHHost is the ssh target the orchestrator drove (e.g.
+	// "chi-dn-dzd9:22" or "10.0.0.15:22"). The reporter strips the port
+	// to render a device name in the summary header.
+	DUTSSHHost string `json:"dut_ssh_host,omitempty"`
+}
+
+// DUTName returns the DUT identifier without the SSH port suffix, for
+// display in the summary header. Falls back to the raw value when no
+// colon is present.
+func (c *OrchestratorConfig) DUTName() string {
+	host, _, _ := strings.Cut(c.DUTSSHHost, ":")
+	return host
+}
+
+// IsPhysical heuristics off the presence of AgentCommandPrefix or
+// AgentPubkey, which the containerized harness leaves empty (the
+// device-side wrapper handles them) and the physical harness sets.
+func (c *OrchestratorConfig) IsPhysical() bool {
+	return c.AgentCommandPrefix != "" || c.AgentPubkey != ""
+}
+
+func loadOrchestratorConfig(path string) (*OrchestratorConfig, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c OrchestratorConfig
+	if err := json.Unmarshal(buf, &c); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &c, nil
+}

--- a/tools/stress/device-reporter/pkg/parser/observer.go
+++ b/tools/stress/device-reporter/pkg/parser/observer.go
@@ -1,0 +1,27 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// AbortSentinel is the JSON the observer writes to the run dir's `abort`
+// file when one of its triggers fires.
+type AbortSentinel struct {
+	Reason  string `json:"reason"`
+	Detail  string `json:"detail"`
+	Trigger string `json:"trigger"`
+}
+
+func loadAbortSentinel(path string) (*AbortSentinel, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var a AbortSentinel
+	if err := json.Unmarshal(buf, &a); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &a, nil
+}

--- a/tools/stress/device-reporter/pkg/parser/run.go
+++ b/tools/stress/device-reporter/pkg/parser/run.go
@@ -1,0 +1,116 @@
+// Package parser loads a single stress-test run directory into structured
+// data. A run directory is whatever `tools/stress/scripts/run-stress-*.sh`
+// drops under `dev/.deploy/.../run/<UTC>/`: the orchestrator's config dump,
+// per-event runlog, agent log capture, plus observer artifacts and the abort
+// sentinel if the run aborted.
+//
+// The parser is intentionally lenient: missing files leave the corresponding
+// field nil/empty rather than failing the load, since not every run produces
+// every artifact (e.g. --no-agent runs have no agent log, runs that didn't
+// abort have no sentinel).
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Run is the in-memory representation of a single run directory.
+type Run struct {
+	// Path is the absolute path to the run directory on disk.
+	Path string
+	// Config is the orchestrator's resolved CLI inputs, or nil if the
+	// config file is missing.
+	Config *OrchestratorConfig
+	// Events is every row from orchestrator-runlog.jsonl in file order.
+	Events []Event
+	// Cycles is the parsed agent commit cycles, one per
+	// `Committing config session...` / `Configuration session finalized...`
+	// pair. The most-recent received-config sizes are paired in when they
+	// precede the commit marker.
+	Cycles []AgentCycle
+	// CliErrors is every `CLI command X of Y '...' failed: ...` line from
+	// the agent log, in file order. These are commit-time validation
+	// failures from EOS, not orchestrator-side errors.
+	CliErrors []AgentCLIError
+	// Abort holds the abort sentinel JSON if it was written, else nil.
+	Abort *AbortSentinel
+}
+
+// LoadRun reads every artifact present under `dir` into a Run. Missing
+// individual artifacts leave the matching field nil/empty; the directory
+// itself, however, must exist — a typo'd path is a hard error so callers
+// don't silently get an empty Run + a near-empty markdown summary.
+// Unparseable artifacts surface as errors so callers can decide whether to
+// skip the run or fail.
+func LoadRun(dir string) (*Run, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve run dir: %w", err)
+	}
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("stat run dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("not a directory: %s", absDir)
+	}
+	r := &Run{Path: absDir}
+
+	if cfg, err := loadOrchestratorConfig(filepath.Join(absDir, "orchestrator-config.json")); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("orchestrator-config.json: %w", err)
+	} else if cfg != nil {
+		r.Config = cfg
+	}
+
+	if events, err := loadRunlog(filepath.Join(absDir, "orchestrator-runlog.jsonl")); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("orchestrator-runlog.jsonl: %w", err)
+	} else {
+		r.Events = events
+	}
+
+	if cycles, cliErrors, err := loadAgentLog(filepath.Join(absDir, "orchestrator.agent.log")); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("orchestrator.agent.log: %w", err)
+	} else {
+		r.Cycles = cycles
+		r.CliErrors = cliErrors
+	}
+
+	if ab, err := loadAbortSentinel(filepath.Join(absDir, "abort")); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("abort: %w", err)
+	} else if ab != nil {
+		r.Abort = ab
+	}
+
+	return r, nil
+}
+
+// StartedAt returns the earliest timestamp observed in the runlog, falling
+// back to the orchestrator config's RunID timestamp parsing isn't trivial
+// (the orchestrator config has no explicit started-at field).
+func (r *Run) StartedAt() (time.Time, bool) {
+	if len(r.Events) == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(0, r.Events[0].TNs), true
+}
+
+// EndedAt returns the latest timestamp observed in the runlog.
+func (r *Run) EndedAt() (time.Time, bool) {
+	if len(r.Events) == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(0, r.Events[len(r.Events)-1].TNs), true
+}
+
+// Duration is end - start; zero if either side is missing.
+func (r *Run) Duration() time.Duration {
+	start, ok1 := r.StartedAt()
+	end, ok2 := r.EndedAt()
+	if !ok1 || !ok2 {
+		return 0
+	}
+	return end.Sub(start)
+}

--- a/tools/stress/device-reporter/pkg/parser/runlog.go
+++ b/tools/stress/device-reporter/pkg/parser/runlog.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Event mirrors one row in orchestrator-runlog.jsonl. The orchestrator emits
+// at most 8 distinct kinds (submit/confirm/activate × {provision, deprovision}
+// plus pre_commit_log / applied for tunnels the agent finished applying).
+type Event struct {
+	UserIndex   int    `json:"user_index"`
+	TunnelID    uint16 `json:"tunnel_id"`
+	Event       string `json:"event"`
+	TNs         int64  `json:"t_ns"`
+	NAfterEvent int    `json:"n_after_event"`
+}
+
+// Time returns the event's wall-clock instant.
+func (e Event) Time() time.Time { return time.Unix(0, e.TNs) }
+
+// EventCounts groups events by .Event for headline figures.
+type EventCounts map[string]int
+
+// CountEvents returns a per-event-type tally.
+func CountEvents(events []Event) EventCounts {
+	out := make(EventCounts)
+	for _, e := range events {
+		out[e.Event]++
+	}
+	return out
+}
+
+func loadRunlog(path string) ([]Event, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []Event
+	s := bufio.NewScanner(f)
+	// Some runs at high user counts produce >64 KB lines if pubkeys grow
+	// (they don't today, but safer to allow). Cap at 1 MiB.
+	s.Buffer(make([]byte, 64*1024), 1024*1024)
+	line := 0
+	for s.Scan() {
+		line++
+		if len(s.Bytes()) == 0 {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal(s.Bytes(), &e); err != nil {
+			return nil, fmt.Errorf("line %d: %w", line, err)
+		}
+		out = append(out, e)
+	}
+	if err := s.Err(); err != nil {
+		return out, fmt.Errorf("scan: %w", err)
+	}
+	return out, nil
+}

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -30,10 +30,11 @@ tools/stress/scripts/run-stress-local.sh --no-build
 tools/stress/scripts/run-stress-local.sh --target-users 8 --hold 60
 ```
 
-The script ends by printing the orchestrator/observer PIDs and the run
-working directory (under `dev/.deploy/dz-local/stress/run/<UTC timestamp>/`).
-Both processes keep running in the background. Stop them with the
-`kill $(cat …)` snippet the script prints.
+The script ends by printing the orchestrator/observer PIDs and the
+run working directory (under
+`dev/.deploy/dz-local/stress/run/<UTC timestamp>/`). Both keep
+running in the background. Stop them with the `kill $(cat …)` snippet
+the script prints.
 
 ## What the stress device differs from the e2e device
 
@@ -119,31 +120,43 @@ SDK checks or the agent will run but fail to apply config:
    doublezero-agent ./controlplane/agent/cmd/agent` on a host with the
    repo checked out.
 
-3. **EOS SDK RPC agent (`eapilocal`)** running in the management VRF —
-   the agent dials its local SDK at `127.0.0.1:9543`. cEOS provides
-   this implicitly via `management api eos-sdk-rpc / transport grpc
-   foo / localhost loopback`; physical EOS requires an explicit
-   `daemon eapilocal` block plus a VRF qualifier on the transport:
+3. **EOS native gNMI provider** running in the management VRF — the
+   doublezero-agent always dials its local EOS API at
+   `127.0.0.1:9543` (see `controlplane/agent/cmd/agent/main.go`, the
+   `--device` default). On real Arista EOS, the `provider eos-native`
+   knob inside the gNMI block exposes that listener (cEOS containers
+   ship with it on by default; real hardware does not). Tested
+   stanza — substitute the device's own management IP for
+   `listen-addresses`:
    ```
-   daemon eapilocal
-      exec /usr/bin/EosSdkRpcAgent --daemon-name eapilocal
-      no shutdown
-   !
-   management api eos-sdk-rpc
-      transport grpc eapilocal
-         localhost loopback vrf management
-         service all
-         no disabled
-   !
+   management api gnmi
+      transport grpc default
+         port 57400
+         vrf management
+         listen-addresses 10.0.0.X
+      provider eos-native
    ```
-   Verify with `show management api eos-sdk-rpc` — `Server: running`,
-   `Listening on: ... port: 9543, VRF: management`.
+   Verify the agent's target is reachable: `bash sudo ip netns exec
+   ns-management ss -ltn | grep 9543` from the device should show a
+   LISTEN entry. If the run aborts with `apply_config_errors` and the
+   agent log shows `dial tcp 127.0.0.1:9543: connect: connection
+   refused`, this stanza is missing or misconfigured.
 
-4. **eAPI HTTP-commands enabled.** The device-observer scrapes `show
-   gre tunnel static`, `show processes top once`, etc. via eAPI. Make
-   sure `management api http-commands` is `no shutdown` and an admin
-   user with a password the harness can use exists. Export
-   `EAPI_USER` / `EAPI_PASS` before running.
+4. **eAPI HTTP-commands enabled + a stress user.** The device-observer
+   scrapes `show interfaces description`, `show processes top once`, etc.
+   over HTTP basic auth on each sample. Add a dedicated stress user
+   (so the harness doesn't share the `admin` password) and enable
+   the HTTP transport:
+   ```
+   username stress secret 0 stress
+   !
+   management api http-commands
+      no shutdown
+   ```
+   The harness defaults `EAPI_USER=stress`; export `EAPI_PASS` before
+   running (the script bails out fast if it's unset, since an empty
+   password silently produces 401s and leaves the run dir with zero
+   `show-*.{json,log}` captures).
 
 5. **Management netns.** The orchestrator wraps the agent command in
    `ip netns exec <netns>` so it can reach the controller via the
@@ -165,10 +178,10 @@ SDK checks or the agent will run but fail to apply config:
 # private infra repo, not here. Export it before running.
 export DZ_PROGRAM_ID='<stress-program-id-from-infra-repo>'
 
-# Required: eAPI credentials for the observer. EAPI_USER defaults to
-# $DUT_SSH_USER; password must be supplied (no plaintext default).
-export EAPI_USER=admin
-read -s EAPI_PASS; export EAPI_PASS
+# Required: eAPI password for the observer. EAPI_USER defaults to
+# `stress` (the username the README's prerequisite step adds to the
+# device); password has no default — the script fails fast if unset.
+export EAPI_PASS=stress
 
 # Optional overrides (defaults shown in the script header):
 # export DZ_RPC_URL='https://...'
@@ -189,8 +202,8 @@ The script:
 4. Launches the controller on the host with
    `--max-user-tunnel-slots $TARGET_USERS` and waits for the gRPC port.
 5. Sets up access passes in parallel against the devnet RPC.
-6. Builds the orchestrator + observer binaries and launches them in the
-   background, pointing at the physical DUT.
+6. Builds the orchestrator + observer binaries.
+7. Launches the orchestrator + observer in the background.
 
 The controller pid is recorded in `dev/.deploy/stress-physical/run/controller.pid`;
 the orchestrator + observer pids land in the per-run subdirectory
@@ -214,8 +227,9 @@ All knobs are env vars (defaults in the script header):
 | `CONTROLLER_BIND_ADDR`    | Controller listen address (default `0.0.0.0`)             |
 | `CONTROLLER_ADVERTISE_ADDR` | Address advertised to the device (default: auto-detect) |
 | `CONTROLLER_LISTEN_PORT`  | Controller listen port (default `7000`)                   |
+| `CONTROLLER_BINARY`       | Path to a prebuilt controller binary (default: `go run` from local checkout) |
 | `SOLANA_KEYPAIR`          | Operator keypair (signs init + access-passes)             |
-| `EAPI_USER`               | eAPI HTTP basic-auth user (default `admin`)               |
+| `EAPI_USER`               | eAPI HTTP basic-auth user (default `stress`)              |
 | `EAPI_PASS`               | eAPI HTTP basic-auth password (no default — required)     |
 | `DEVICE_CODE`             | Device code onchain (default `chi-dn-dzd5`)               |
 | `DEVICE_DZ_PREFIX`        | Device's dz-prefix /29 (carved from the tunnel block)     |

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -60,8 +60,14 @@ AGENT_METRICS_PORT="${AGENT_METRICS_PORT:-50100}"
 # via env on physical hardware. The containerized harness uses a hardcoded
 # admin/admin pair baked into its rendered startup-config; this script does
 # not control the physical device's user table, so the operator supplies it.
-EAPI_USER="${EAPI_USER:-admin}"
-EAPI_PASS="${EAPI_PASS:-}"
+EAPI_USER="${EAPI_USER:-stress}"
+# EAPI_PASS has no default: the observer authenticates over HTTP basic
+# auth on each `show ...` poll, and an empty password silently yields
+# 401-Unauthorized for every sample, producing an empty observer
+# capture set (no show-*.{json,log} files in the run dir). Fail fast
+# at startup so the operator notices before a 4-minute run finishes
+# with nothing to analyze.
+: "${EAPI_PASS:?EAPI_PASS is required — export it (and optionally EAPI_USER) before running. See README.md.}"
 
 DEVICE_CODE="${DZ_STRESS_DEVICE_CODE:-chi-dn-dzd5}"
 DEVICE_LOCATION="${DZ_STRESS_DEVICE_LOCATION:-ewr}"
@@ -149,6 +155,13 @@ solana_cli() {
 }
 
 mkdir -p "$DEPLOY_DIR" "$WORKING_DIR"
+
+# Stamp the per-run directory up front so the controller (phase 4) can drop
+# its log alongside the orchestrator/observer artifacts in the same dir,
+# rather than into a shared file at $WORKING_DIR/controller.log that every
+# subsequent run truncates.
+RUN_DIR="${WORKING_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$RUN_DIR"
 
 # ---------------------------------------------------------------------------
 # Phase 1: connectivity sanity checks
@@ -276,7 +289,9 @@ done
 # `go run` is intentional per the user spec — convenient for iteration; the
 # operator can later swap to a built binary if startup time matters.
 # ---------------------------------------------------------------------------
-CONTROLLER_LOG="${WORKING_DIR}/controller.log"
+CONTROLLER_LOG="${RUN_DIR}/controller.log"
+# Pid file stays at the parent level so the leftover-process detection in
+# the next run can find it even after $RUN_DIR has been pruned/archived.
 CONTROLLER_PID_FILE="${WORKING_DIR}/controller.pid"
 
 # Fail fast if something is already listening on the controller port. Without
@@ -316,9 +331,20 @@ cleanup_controller() {
 }
 trap cleanup_controller EXIT
 
+# By default we `go run` the controller from the current checkout so the
+# operator iterates without a separate build step. Set CONTROLLER_BINARY
+# to a prebuilt path (e.g. from another branch's worktree) to swap in an
+# alternate controller for an experiment.
+if [ -n "${CONTROLLER_BINARY:-}" ]; then
+    [ -x "$CONTROLLER_BINARY" ] || die "CONTROLLER_BINARY is not executable: $CONTROLLER_BINARY"
+    log "controller binary (override): $CONTROLLER_BINARY"
+    CONTROLLER_CMD=("$CONTROLLER_BINARY")
+else
+    CONTROLLER_CMD=(go run ./controlplane/controller/cmd/controller)
+fi
 (
     cd "$WORKSPACE_DIR"
-    nohup go run ./controlplane/controller/cmd/controller start \
+    nohup "${CONTROLLER_CMD[@]}" start \
         --program-id "$DZ_PROGRAM_ID" \
         --solana-rpc-endpoint "$DZ_RPC_URL" \
         --device-local-asn 65000 \
@@ -329,11 +355,12 @@ trap cleanup_controller EXIT
         > "$CONTROLLER_LOG" 2>&1 &
     echo $! > "$CONTROLLER_PID_FILE"
 )
-# Provisionally tracks the `go run` parent PID. `go run` compiles a temp
-# binary then exec's it as a child process; the actual port listener is
-# the child. We overwrite this once the port is up.
+# Provisionally tracks the controller's parent PID. With `go run` this is
+# the `go` wrapper which exec's the compiled binary as a child; with a
+# prebuilt binary it is the listener itself. We overwrite once the port
+# is up so the recorded pid always points at the actual listener.
 CONTROLLER_PARENT_PID="$(cat "$CONTROLLER_PID_FILE")"
-log "controller (go run) pid: $CONTROLLER_PARENT_PID (log: $CONTROLLER_LOG)"
+log "controller parent pid: $CONTROLLER_PARENT_PID (log: $CONTROLLER_LOG)"
 
 # Wait for the controller's listen port to accept connections (gRPC handshake).
 # The cleanup trap stays armed through every following phase (access-pass
@@ -424,8 +451,6 @@ OBS_BIN="${DEPLOY_DIR}/device-observer"
 # ---------------------------------------------------------------------------
 # Phase 7: launch orchestrator + observer
 # ---------------------------------------------------------------------------
-RUN_DIR="${WORKING_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
-mkdir -p "$RUN_DIR"
 log "run working-dir: $RUN_DIR"
 
 ORCH_ARGS=(

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -115,6 +115,12 @@ ACCESS_PASS_PARALLEL="${DZ_STRESS_ACCESS_PASS_PARALLEL:-16}"
 CLIENT_IP_BASE="${DZ_STRESS_CLIENT_IP_BASE:-9.200.0.0}"
 
 NO_AGENT=false
+# Off by default — matches the orchestrator's default 'stress the agent'
+# shape. When set, the orchestrator pauses after every provision batch
+# until the agent's applied count covers the cumulative target. Slows
+# the run but yields per-cycle data that better matches production
+# (where users arrive at human cadence, not in burst-fashion).
+APPLY_PER_BATCH_CATCH_UP=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --no-agent) NO_AGENT=true; shift ;;
@@ -122,6 +128,7 @@ while [[ $# -gt 0 ]]; do
         --users-per-batch) USERS_PER_BATCH="$2"; shift 2 ;;
         --hold) HOLD_SECONDS="$2"; shift 2 ;;
         --sample-interval) SAMPLE_INTERVAL="$2"; shift 2 ;;
+        --apply-per-batch-catch-up) APPLY_PER_BATCH_CATCH_UP=true; shift ;;
         -h|--help) sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) echo "unknown flag: $1" >&2; exit 2 ;;
     esac
@@ -475,6 +482,9 @@ ORCH_ARGS=(
 )
 if [ "$NO_AGENT" = true ]; then
     ORCH_ARGS+=(--no-agent)
+fi
+if [ "$APPLY_PER_BATCH_CATCH_UP" = true ]; then
+    ORCH_ARGS+=(--apply-per-batch-catch-up)
 fi
 
 log "launching orchestrator (background)"


### PR DESCRIPTION
**Stack:** 3 of 4 — base [#3842](https://github.com/malbeclabs/doublezero/pull/3842). Followed by [#stress-reporter-cli].

This PR is the data-analysis foundation for the new \`device-reporter\` binary. It contains no I/O surface (no CLI, no markdown writer, no script integration) — those land in #4 of the stack. Split this way so the analyzer's data model can be reviewed without rendering pulling focus.

## Summary of Changes
- **\`pkg/parser\`** — \`LoadRun\` aggregates one stress-run directory: \`orchestrator-config.json\`, \`orchestrator-runlog.jsonl\`, the captured agent log (state machine that builds \`AgentCycle\` records from \`Received N lines/bytes\` / \`Committing config session\` / \`Configuration session finalized\` markers), and the abort sentinel. Missing individual artifacts are tolerated; a missing run directory is a hard error.
- **\`pkg/analyze\`** — \`BuildSummary\` turns one \`parser.Run\` into the rolled-up view callers render. Two non-trivial joins: activate↔applied pairing by \`user_index\` (for the per-user onchain→on-device gap) and agent-cycle↔applied-bucket pairing by shared finalize timestamp (for the per-cycle table). Three linearity fits: commit-duration vs config size, diff-check-duration vs config size, onchain→on-device-gap vs active-user count. \`commitCycles\` surfaces a join-mismatch warning when the positional cycle↔bucket join is unbalanced.

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net   |
|-------------|-------|-------------|-------|
| Core logic  |     6 | +1130 / -0  | +1130 |
| Scaffolding |     2 | +122  / -0  | +122  |
| Tests       |     4 | +439  / -0  | +439  |
| **Total**   |    12 | +1691 / -0  | +1691 |

Pure additive — twelve new files, no edits to existing code. Densest PR in the stack but all in one mental space (pure data manipulation).

<details>
<summary>Key files (click to expand)</summary>

- [\`tools/stress/device-reporter/pkg/analyze/summary.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-analyze/files) — top-level \`BuildSummary\`, the two joins, the three fits, the join-mismatch warning.
- [\`tools/stress/device-reporter/pkg/parser/agentlog.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-analyze/files) — state machine that walks the orchestrator's captured agent log.
- [\`tools/stress/device-reporter/pkg/parser/run.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-analyze/files) — \`LoadRun\` aggregator.
- [\`tools/stress/device-reporter/pkg/analyze/fit.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-analyze/files) — \`LinearLeastSquares\` + percentile helpers shared by all three fits.

</details>

## Testing Verification
- Unit tests cover: parser shapes for both cEOS and real-EOS agent logs; the activate↔applied pairing edge cases (missing applied, applied-without-activate, --no-agent runs with no applied at all); the per-cycle join across commit/abort/unfinished cycle outcomes; the join-mismatch warning; the diff-check duration computation; the onchain→on-device linearity fit against a perfectly-linear synthetic dataset.