### PR TITLE
tools/stress/device-reporter: CLI + markdown writer + auto-summary

### DIFF
--- a/tools/stress/device-reporter/README.md
+++ b/tools/stress/device-reporter/README.md
@@ -1,0 +1,70 @@
+# device-reporter
+
+Post-run analysis for the stress-test harnesses
+(`tools/stress/scripts/run-stress-local.sh`,
+`tools/stress/scripts/run-stress-physical.sh`).
+
+Reads a run directory (`dev/.deploy/.../run/<UTC>/`), produces a
+markdown summary.
+
+## Build
+
+```bash
+go build -o /tmp/device-reporter ./tools/stress/device-reporter/cmd/device-reporter
+```
+
+## Usage
+
+```
+device-reporter summary <run-dir>     # markdown to stdout
+```
+
+## What the summary covers
+
+- **Run knobs**: target users, batch size, hold, containerized vs physical.
+- **Onchain phase timings**: provision / deprovision wall time, plus p50 and p95
+  submit→activate gaps per phase.
+- **Agent commit stats**: how many cycles ran, how many committed cleanly
+  vs internally-aborted vs left unfinished, max config size seen, average
+  commit duration.
+- **Commit duration vs config size**: linear least-squares fit of commit
+  duration against received-config bytes and lines, with R² so you can
+  tell at a glance whether the relationship is roughly linear, loosely
+  linear, or not well-fit by a line.
+- **Agent CLI errors**: top normalized command patterns (tunnel IDs are
+  collapsed so per-tunnel error spam buckets cleanly).
+- **Abort detail**: trigger / reason / human-readable detail when an abort
+  sentinel was written.
+
+## Example
+
+```bash
+/tmp/device-reporter summary dev/.deploy/stress-physical/run/20260604T003155Z
+```
+
+```
+# Stress run summary
+
+**Run ID**: `run-cabb684ace4d58de`
+**Target**: 512 users, batch=32, hold=—, dut=physical EOS
+**Wall clock**: 6m22s
+**Outcome**: **ABORTED** — trigger=`device_tunnel_gap` (...)
+
+## Onchain
+
+| Phase | Users | Wall time | p50 submit→activate | p95 |
+|---|---|---|---|---|
+| Provision | 512 | 3m12s | 11.82s | 12.09s |
+| Deprovision | 512 | 3m10s | 11.85s | 12.10s |
+
+## Agent
+
+- Cycles: 13 (commits=13, internal aborts=0, unfinished=0)
+- Avg commit duration: **2.48s**
+- Max config received: **27,263 lines / 861,711 bytes**
+
+### Commit duration vs config size
+
+- vs **bytes**: slope = **1.83 µs/byte**, R² = **0.616** (loosely linear, n=13)
+- vs **lines**: slope = **62.33 µs/line**, R² = **0.637** (loosely linear, n=13)
+```

--- a/tools/stress/device-reporter/cmd/device-reporter/main.go
+++ b/tools/stress/device-reporter/cmd/device-reporter/main.go
@@ -1,0 +1,68 @@
+// device-reporter consumes a stress-test run directory and emits a
+// markdown summary suitable for paste-into-PR / standups.
+//
+// Usage:
+//
+//	device-reporter summary <run-dir>
+//
+// Output goes to stdout; pipe or redirect at will.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/analyze"
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/format"
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/parser"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		return fmt.Errorf("missing subcommand")
+	}
+	switch os.Args[1] {
+	case "summary":
+		return cmdSummary(os.Args[2:])
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		return nil
+	default:
+		usage(os.Stderr)
+		return fmt.Errorf("unknown subcommand %q", os.Args[1])
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprintf(w, `device-reporter — stress-run analysis
+
+Usage:
+  device-reporter summary <run-dir>
+`)
+}
+
+func cmdSummary(args []string) error {
+	fs := flag.NewFlagSet("summary", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("summary takes exactly one <run-dir>")
+	}
+	run, err := parser.LoadRun(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	s := analyze.BuildSummary(run)
+	format.Summary(os.Stdout, s, run)
+	return nil
+}

--- a/tools/stress/device-reporter/pkg/format/markdown.go
+++ b/tools/stress/device-reporter/pkg/format/markdown.go
@@ -1,0 +1,208 @@
+// Package format renders Summary / Comparison values into the strings that
+// `device-reporter summary` and `device-reporter compare` write to stdout.
+// Kept separate from `analyze` so the analyzer stays I/O-free.
+package format
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/analyze"
+	"github.com/malbeclabs/doublezero/tools/stress/device-reporter/pkg/parser"
+)
+
+// Summary writes a markdown report for one run to w.
+func Summary(w io.Writer, s analyze.Summary, r *parser.Run) {
+	bw := &writer{w: w}
+
+	bw.printf("# Stress run summary\n\n")
+	if s.RunID != "" {
+		bw.printf("**Run ID**: `%s`\n", s.RunID)
+	}
+	if r.Path != "" {
+		bw.printf("**Path**: `%s`\n", r.Path)
+	}
+	dut := "containerized cEOS"
+	if s.IsPhysical {
+		dut = "physical EOS"
+	}
+	if s.DUTName != "" {
+		dut = fmt.Sprintf("%s (%s)", s.DUTName, dut)
+	}
+	bw.printf("**Target**: %s users, batch=%d, hold=%s, dut=%s\n", fmtInt(s.Target), s.Batch, analyze.FormatDurationOrZero(s.Hold), dut)
+	if !s.StartedAt.IsZero() {
+		bw.printf("**Started**: %s UTC\n", s.StartedAt.UTC().Format("2006-01-02 15:04:05"))
+	}
+	bw.printf("**Wall clock**: %s\n", fmtDur(s.Duration))
+	bw.printf("**Outcome**: **%s**", strings.ToUpper(s.Outcome))
+	if s.Outcome == "aborted" {
+		bw.printf(" — trigger=`%s` (%s)", s.AbortTrigger, s.AbortDetail)
+	}
+	bw.printf("\n\n")
+
+	bw.printf("## Onchain\n\n")
+	bw.printf("| Phase | Users | Wall time | p50 submit→activate | p95 |\n")
+	bw.printf("|---|---|---|---|---|\n")
+	bw.printf("| Provision | %s | %s | %s | %s |\n",
+		fmtInt(s.OnchainLatencies.ProvisionUsers),
+		fmtDur(s.ProvisionDuration),
+		fmtDur(s.OnchainLatencies.ProvisionSubmitToActivateP50),
+		fmtDur(s.OnchainLatencies.ProvisionSubmitToActivateP95))
+	bw.printf("| Deprovision | %s | %s | %s | %s |\n",
+		fmtInt(s.OnchainLatencies.DeprovisionUsers),
+		fmtDur(s.DeprovisionDuration),
+		fmtDur(s.OnchainLatencies.DeprovisionSubmitToActivateP50),
+		fmtDur(s.OnchainLatencies.DeprovisionSubmitToActivateP95))
+	bw.printf("\n")
+
+	// onchain→on-device is the gap from `activate` (user account written
+	// onchain) to `applied` (first commit cycle whose diff includes the
+	// user's tunnel interface). Render only when at least one user
+	// produced both events so that runs without agent data (`--no-agent`,
+	// device-side path broken) don't leave an empty table behind.
+	if s.OnchainLatencies.UsersApplied > 0 {
+		bw.printf("| Phase | Users on device | p50 onchain→on-device | p95 |\n")
+		bw.printf("|---|---|---|---|\n")
+		bw.printf("| Provision | %s | %s | %s |\n",
+			fmtInt(s.OnchainLatencies.UsersApplied),
+			fmtDur(s.OnchainLatencies.ActivateToAppliedP50),
+			fmtDur(s.OnchainLatencies.ActivateToAppliedP95))
+		bw.printf("\n")
+		// Linearity hint: does the gap grow as the run progresses?
+		// `+X ms / user` means each additional active user pushes the
+		// next user's onchain→on-device by that much.
+		writeFit(bw, "active users", s.OnchainToOnDeviceFit, time.Millisecond, "ms/user")
+		bw.printf("\n")
+	}
+
+	bw.printf("**Event counts**: ")
+	keys := []string{"submit", "confirm", "activate", "deprovision_submit", "deprovision_confirm", "deprovision_activate", "pre_commit_log", "applied"}
+	var parts []string
+	for _, k := range keys {
+		if v, ok := s.EventCounts[k]; ok && v > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, v))
+		}
+	}
+	bw.printf("%s\n\n", strings.Join(parts, " · "))
+
+	if s.AgentCommitStats.Cycles > 0 {
+		bw.printf("## Agent\n\n")
+		st := s.AgentCommitStats
+		bw.printf("- Cycles: %d (commits=%d, internal aborts=%d, unfinished=%d)\n",
+			st.Cycles, st.CommitCount, st.AbortCount, st.UnfinishedCount)
+		bw.printf("- Avg commit duration: **%s**\n", fmtDur(st.AvgCommitDuration))
+		bw.printf("- Max config received: **%s lines / %s bytes**\n", fmtInt(st.MaxLines), fmtInt(st.MaxBytes))
+		bw.printf("\n")
+
+		// Per-cycle breakdown: one row per agent commit cycle, joined
+		// with the runlog so each row knows how many users it pushed and
+		// the within-cycle onchain→on-device lag distribution. Skip when
+		// the join produced nothing useful (e.g. --no-agent runs where
+		// the cycle list is empty already).
+		if len(s.CommitCycles) > 0 {
+			bw.printf("### Per-cycle wall time\n\n")
+			if s.CommitCyclesJoinWarning != "" {
+				bw.printf("> ⚠️ %s\n\n", s.CommitCyclesJoinWarning)
+			}
+			// Columns: Cycle | users(cycle) | users(cumulative) | lines | bytes | diff check | commit | p50 onchain→on-device | max
+			// "Diff check" is the gap from `Received N bytes` to `Committing
+			// config session` (diff compute + decide + session-open);
+			// "Commit time" is the gap from Committing to Finalized.
+			bw.printf("| Cycle | Users (cycle) | Users (cumulative) | Lines | Bytes | Diff check | Commit time | p50 onchain→on-device | Max |\n")
+			bw.printf("|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+			cumulative := 0
+			for i, c := range s.CommitCycles {
+				cumulative += c.UsersCommitted
+				p50, maxv := "—", "—"
+				if c.OnchainToOnDeviceMax > 0 {
+					p50 = fmtDur(c.OnchainToOnDeviceP50)
+					maxv = fmtDur(c.OnchainToOnDeviceMax)
+				}
+				bw.printf("| %d | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+					i+1,
+					fmtInt(c.UsersCommitted),
+					fmtInt(cumulative),
+					fmtInt(c.ReceivedLines),
+					fmtInt(c.ReceivedBytes),
+					fmtDur(c.DiffCheckDuration),
+					fmtDur(c.CommitDuration),
+					p50, maxv)
+			}
+			bw.printf("\n")
+		}
+
+		bw.printf("### Commit duration vs config size\n\n")
+		writeFit(bw, "bytes", s.CommitVsBytes, time.Microsecond, "µs/byte")
+		writeFit(bw, "lines", s.CommitVsLines, time.Microsecond, "µs/line")
+		bw.printf("\n")
+
+		bw.printf("### Diff-check duration vs config size\n\n")
+		writeFit(bw, "bytes", s.DiffCheckVsBytes, time.Microsecond, "µs/byte")
+		writeFit(bw, "lines", s.DiffCheckVsLines, time.Microsecond, "µs/line")
+		bw.printf("\n")
+	}
+
+	if len(s.AgentErrorTopK) > 0 {
+		bw.printf("## Agent CLI errors (top patterns)\n\n")
+		bw.printf("| Count | Normalized command :: reason |\n|---|---|\n")
+		for _, e := range s.AgentErrorTopK {
+			bw.printf("| %d | `%s` |\n", e.Count, e.NormalizedCommand)
+		}
+		bw.printf("\n")
+	}
+
+	if s.Outcome == "aborted" {
+		bw.printf("## Abort\n\n")
+		bw.printf("- **Reason**: `%s`\n", s.AbortReason)
+		bw.printf("- **Trigger**: `%s`\n", s.AbortTrigger)
+		bw.printf("- **Detail**: %s\n", s.AbortDetail)
+		bw.printf("\n")
+	}
+}
+
+// writeFit prints a one-line summary of a LinearFit. The slope is
+// re-expressed in the unit the reader actually wants (µs per byte, etc.),
+// and R² is rendered as a 0-1 number plus a verdict.
+func writeFit(bw *writer, axis string, f analyze.LinearFit, unit time.Duration, slopeUnit string) {
+	if f.N < 2 {
+		bw.printf("- vs %s: not enough data (n=%d)\n", axis, f.N)
+		return
+	}
+	// Slope is duration/unit-of-x in nanoseconds, convert to caller units.
+	slopeInUnit := f.Slope / float64(unit)
+	verdict := classifyR2(f.R2)
+	bw.printf("- vs **%s**: slope = **%.2f %s**, R² = **%.3f** (%s, n=%d)\n",
+		axis, slopeInUnit, slopeUnit, f.R2, verdict, f.N)
+}
+
+func classifyR2(r2 float64) string {
+	if math.IsNaN(r2) {
+		return "indeterminate"
+	}
+	switch {
+	case r2 >= 0.95:
+		return "essentially linear"
+	case r2 >= 0.85:
+		return "roughly linear"
+	case r2 >= 0.6:
+		return "loosely linear"
+	default:
+		return "not well-fit by a line"
+	}
+}
+
+// writer wraps an io.Writer with a printf shortcut that swallows the error
+// (the markdown writer outputs to stdout / a file the caller owns; a write
+// error is reported when the caller calls Sync/Close on it).
+type writer struct{ w io.Writer }
+
+func (w *writer) printf(f string, a ...any) { fmt.Fprintf(w.w, f, a...) }
+
+// fmtInt / fmtDur are thin wrappers around the exported analyze helpers
+// so the markdown writer doesn't duplicate their definitions. Kept
+// unexported here so call sites read naturally inside this file.
+func fmtInt(n int) string           { return analyze.FormatInt(n) }
+func fmtDur(d time.Duration) string { return analyze.FormatDuration(d) }

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -30,11 +30,18 @@ tools/stress/scripts/run-stress-local.sh --no-build
 tools/stress/scripts/run-stress-local.sh --target-users 8 --hold 60
 ```
 
-The script ends by printing the orchestrator/observer PIDs and the
-run working directory (under
-`dev/.deploy/dz-local/stress/run/<UTC timestamp>/`). Both keep
+The script ends by printing the orchestrator/observer/watcher PIDs and
+the run working directory (under
+`dev/.deploy/dz-local/stress/run/<UTC timestamp>/`). All three keep
 running in the background. Stop them with the `kill $(cat …)` snippet
 the script prints.
+
+When the orchestrator exits (sweep finished or aborted), a background
+**watcher** stops the observer and emits a post-run markdown summary
+via [`tools/stress/device-reporter`](../device-reporter/) at
+`<run-dir>/summary.md`. `tail -F summary.md` to read it as soon as it
+lands, or invoke `device-reporter summary <run-dir>` ad hoc at any
+point during the run for a partial view.
 
 ## What the stress device differs from the e2e device
 
@@ -202,13 +209,18 @@ The script:
 4. Launches the controller on the host with
    `--max-user-tunnel-slots $TARGET_USERS` and waits for the gRPC port.
 5. Sets up access passes in parallel against the devnet RPC.
-6. Builds the orchestrator + observer binaries.
-7. Launches the orchestrator + observer in the background.
+6. Builds the orchestrator + observer + reporter binaries.
+7. Launches the orchestrator + observer in the background, plus a
+   background watcher that waits for the orchestrator to exit, then
+   stops the observer and emits a markdown summary at
+   `<run-dir>/summary.md` via
+   [`tools/stress/device-reporter`](../device-reporter/).
 
 The controller pid is recorded in `dev/.deploy/stress-physical/run/controller.pid`;
-the orchestrator + observer pids land in the per-run subdirectory
+the orchestrator + observer + watcher pids land in the per-run subdirectory
 (`run/<UTC timestamp>/`). Stop everything with the `kill $(cat …)`
-snippet the script prints.
+snippet the script prints. `tail -F <run-dir>/summary.md` to watch the
+post-run summary land.
 
 ## Overrides
 
@@ -227,9 +239,8 @@ All knobs are env vars (defaults in the script header):
 | `CONTROLLER_BIND_ADDR`    | Controller listen address (default `0.0.0.0`)             |
 | `CONTROLLER_ADVERTISE_ADDR` | Address advertised to the device (default: auto-detect) |
 | `CONTROLLER_LISTEN_PORT`  | Controller listen port (default `7000`)                   |
-| `CONTROLLER_BINARY`       | Path to a prebuilt controller binary (default: `go run` from local checkout) |
 | `SOLANA_KEYPAIR`          | Operator keypair (signs init + access-passes)             |
-| `EAPI_USER`               | eAPI HTTP basic-auth user (default `stress`)              |
+| `EAPI_USER`               | eAPI HTTP basic-auth user (default `admin`)               |
 | `EAPI_PASS`               | eAPI HTTP basic-auth password (no default — required)     |
 | `DEVICE_CODE`             | Device code onchain (default `chi-dn-dzd5`)               |
 | `DEVICE_DZ_PREFIX`        | Device's dz-prefix /29 (carved from the tunnel block)     |

--- a/tools/stress/scripts/README.md
+++ b/tools/stress/scripts/README.md
@@ -239,8 +239,9 @@ All knobs are env vars (defaults in the script header):
 | `CONTROLLER_BIND_ADDR`    | Controller listen address (default `0.0.0.0`)             |
 | `CONTROLLER_ADVERTISE_ADDR` | Address advertised to the device (default: auto-detect) |
 | `CONTROLLER_LISTEN_PORT`  | Controller listen port (default `7000`)                   |
+| `CONTROLLER_BINARY`       | Path to a prebuilt controller binary (default: `go run` from local checkout) |
 | `SOLANA_KEYPAIR`          | Operator keypair (signs init + access-passes)             |
-| `EAPI_USER`               | eAPI HTTP basic-auth user (default `admin`)               |
+| `EAPI_USER`               | eAPI HTTP basic-auth user (default `stress`)              |
 | `EAPI_PASS`               | eAPI HTTP basic-auth password (no default — required)     |
 | `DEVICE_CODE`             | Device code onchain (default `chi-dn-dzd5`)               |
 | `DEVICE_DZ_PREFIX`        | Device's dz-prefix /29 (carved from the tunnel block)     |

--- a/tools/stress/scripts/run-stress-local.sh
+++ b/tools/stress/scripts/run-stress-local.sh
@@ -567,7 +567,7 @@ cat <<EOF
     working dir      : ${RUN_DIR}
     abort sentinel   : ${RUN_DIR}/abort
 
-To stop both: kill \$(cat ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid ${RUN_DIR}/watcher.pid)
+To stop everything: kill \$(cat ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid ${RUN_DIR}/watcher.pid)
 To follow:    tail -F ${RUN_DIR}/orchestrator.stderr ${RUN_DIR}/observer.stderr
 To read the post-run summary (once ready): tail -F ${SUMMARY_PATH}
 Or invoke it ad-hoc:                       ${REPORTER_BIN} summary ${RUN_DIR}

--- a/tools/stress/scripts/run-stress-local.sh
+++ b/tools/stress/scripts/run-stress-local.sh
@@ -476,12 +476,14 @@ seq 0 $((TARGET_USERS - 1)) | xargs -P "$ACCESS_PASS_PARALLEL" -I{} bash -c '
 # ---------------------------------------------------------------------------
 # Phase 8: build orchestrator + observer
 # ---------------------------------------------------------------------------
-log "building orchestrator + observer binaries"
+log "building orchestrator + observer + reporter binaries"
 ORCH_BIN="${DEPLOY_DIR}/device-orchestrator"
 OBS_BIN="${DEPLOY_DIR}/device-observer"
+REPORTER_BIN="${DEPLOY_DIR}/device-reporter"
 ( cd "$WORKSPACE_DIR" && \
-  go build -o "$ORCH_BIN" ./tools/stress/device-orchestrator/cmd/device-orchestrator && \
-  go build -o "$OBS_BIN"  ./tools/stress/device-observer/cmd/device-observer )
+  go build -o "$ORCH_BIN"     ./tools/stress/device-orchestrator/cmd/device-orchestrator && \
+  go build -o "$OBS_BIN"      ./tools/stress/device-observer/cmd/device-observer && \
+  go build -o "$REPORTER_BIN" ./tools/stress/device-reporter/cmd/device-reporter )
 
 # ---------------------------------------------------------------------------
 # Phase 9: launch orchestrator + observer
@@ -537,15 +539,37 @@ nohup "$OBS_BIN" \
 OBS_PID=$!
 echo "$OBS_PID" > "${RUN_DIR}/observer.pid"
 
+# Background watcher: when the orchestrator exits (sweep finished or
+# aborted), tear down the observer and emit a markdown summary into
+# the run dir. See run-stress-physical.sh for the same pattern.
+SUMMARY_PATH="${RUN_DIR}/summary.md"
+SUMMARY_ERR_PATH="${RUN_DIR}/summary.stderr"
+(
+    while kill -0 "$ORCH_PID" 2>/dev/null; do
+        sleep 5
+    done
+    sleep 2
+    kill "$OBS_PID" 2>/dev/null || true
+    sleep 2
+    if [ -x "$REPORTER_BIN" ]; then
+        "$REPORTER_BIN" summary "$RUN_DIR" >"$SUMMARY_PATH" 2>"$SUMMARY_ERR_PATH" || true
+    fi
+) >/dev/null 2>&1 &
+WATCHER_PID=$!
+echo "$WATCHER_PID" > "${RUN_DIR}/watcher.pid"
+
 cat <<EOF
 
 ==> stress test launched
     orchestrator pid : $ORCH_PID  (logs: ${RUN_DIR}/orchestrator.std{out,err})
     observer     pid : $OBS_PID  (logs: ${RUN_DIR}/observer.std{out,err})
+    watcher      pid : $WATCHER_PID  (writes ${SUMMARY_PATH} when orchestrator exits)
     working dir      : ${RUN_DIR}
     abort sentinel   : ${RUN_DIR}/abort
 
-To stop both: kill \$(cat ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid)
+To stop both: kill \$(cat ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid ${RUN_DIR}/watcher.pid)
 To follow:    tail -F ${RUN_DIR}/orchestrator.stderr ${RUN_DIR}/observer.stderr
+To read the post-run summary (once ready): tail -F ${SUMMARY_PATH}
+Or invoke it ad-hoc:                       ${REPORTER_BIN} summary ${RUN_DIR}
 To tear down: ${WORKSPACE_DIR}/dev/dzctl destroy -y && docker rm -f ${CONTAINER_NAME}
 EOF

--- a/tools/stress/scripts/run-stress-physical.sh
+++ b/tools/stress/scripts/run-stress-physical.sh
@@ -448,12 +448,14 @@ seq 0 $((TARGET_USERS - 1)) | xargs -P "$ACCESS_PASS_PARALLEL" -I{} bash -c '
 # ---------------------------------------------------------------------------
 # Phase 6: build orchestrator + observer
 # ---------------------------------------------------------------------------
-log "building orchestrator + observer binaries"
+log "building orchestrator + observer + reporter binaries"
 ORCH_BIN="${DEPLOY_DIR}/device-orchestrator"
 OBS_BIN="${DEPLOY_DIR}/device-observer"
+REPORTER_BIN="${DEPLOY_DIR}/device-reporter"
 ( cd "$WORKSPACE_DIR" && \
-  go build -o "$ORCH_BIN" ./tools/stress/device-orchestrator/cmd/device-orchestrator && \
-  go build -o "$OBS_BIN"  ./tools/stress/device-observer/cmd/device-observer )
+  go build -o "$ORCH_BIN"     ./tools/stress/device-orchestrator/cmd/device-orchestrator && \
+  go build -o "$OBS_BIN"      ./tools/stress/device-observer/cmd/device-observer && \
+  go build -o "$REPORTER_BIN" ./tools/stress/device-reporter/cmd/device-reporter )
 
 # ---------------------------------------------------------------------------
 # Phase 7: launch orchestrator + observer
@@ -513,15 +515,45 @@ nohup "$OBS_BIN" \
 OBS_PID=$!
 echo "$OBS_PID" > "${RUN_DIR}/observer.pid"
 
+# Background watcher: when the orchestrator exits (sweep finished or
+# aborted), tear down the observer and emit a markdown summary into
+# the run dir. Polls every 5s with `kill -0` so we don't depend on
+# `wait` having access to a non-child pid. The summary is written to
+# `$RUN_DIR/summary.md`; an empty file means the reporter run failed
+# (stderr captured next to it).
+SUMMARY_PATH="${RUN_DIR}/summary.md"
+SUMMARY_ERR_PATH="${RUN_DIR}/summary.stderr"
+(
+    while kill -0 "$ORCH_PID" 2>/dev/null; do
+        sleep 5
+    done
+    # Orchestrator has exited. Give the observer a moment to flush its
+    # final sample, then stop it. Pid is best-effort; absent processes
+    # are silently skipped.
+    sleep 2
+    kill "$OBS_PID" 2>/dev/null || true
+    # Give the observer time to actually shut down before reading its
+    # working dir (it writes sample files mid-cycle).
+    sleep 2
+    if [ -x "$REPORTER_BIN" ]; then
+        "$REPORTER_BIN" summary "$RUN_DIR" >"$SUMMARY_PATH" 2>"$SUMMARY_ERR_PATH" || true
+    fi
+) >/dev/null 2>&1 &
+WATCHER_PID=$!
+echo "$WATCHER_PID" > "${RUN_DIR}/watcher.pid"
+
 cat <<EOF
 
 ==> stress test launched against $DUT_HOST
     controller   pid : ${CONTROLLER_LISTENER_PID:-$CONTROLLER_PARENT_PID}  (log: $CONTROLLER_LOG)
     orchestrator pid : $ORCH_PID  (logs: ${RUN_DIR}/orchestrator.std{out,err})
     observer     pid : $OBS_PID  (logs: ${RUN_DIR}/observer.std{out,err})
+    watcher      pid : $WATCHER_PID  (writes ${SUMMARY_PATH} when orchestrator exits)
     working dir      : ${RUN_DIR}
     abort sentinel   : ${RUN_DIR}/abort
 
-To stop everything:  kill \$(cat ${CONTROLLER_PID_FILE} ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid)
+To stop everything:  kill \$(cat ${CONTROLLER_PID_FILE} ${RUN_DIR}/orchestrator.pid ${RUN_DIR}/observer.pid ${RUN_DIR}/watcher.pid)
 To follow:           tail -F ${RUN_DIR}/orchestrator.stderr ${RUN_DIR}/observer.stderr ${CONTROLLER_LOG}
+To read the post-run summary (once ready): tail -F ${SUMMARY_PATH}
+Or invoke it ad-hoc:                       ${REPORTER_BIN} summary ${RUN_DIR}
 EOF


### PR DESCRIPTION
**Stack:** 4 of 4 — base [#3843](https://github.com/malbeclabs/doublezero/pull/3843). Final PR in the stack.

The reporter's user-facing surface, layered on top of #3843's parser + analyzer foundation. After this lands, both \`run-stress-local.sh\` and \`run-stress-physical.sh\` automatically emit a \`summary.md\` at the end of every run.

## Summary of Changes
- **\`device-reporter\` binary** — a single \`device-reporter summary <run-dir>\` subcommand that loads the run, builds the summary, and renders markdown to stdout.
- **Markdown writer in \`pkg/format\`** — header with DUT name + outcome, onchain phase tables (provision/deprovision wall time + p50/p95 submit→activate), onchain→on-device latency table with trend-line slope/R², per-cycle wall-time table (users-cycle / users-cumulative / lines / bytes / diff-check / commit time / within-cycle p50+max), and the two linearity-fit blocks. Surfaces the analyzer's join-mismatch warning as a banner above the per-cycle table.
- **Auto-emit at run completion** — both \`run-stress-{local,physical}.sh\` build the reporter binary alongside the orchestrator and observer, and launch a background watcher that, when the orchestrator exits, stops the observer and runs \`device-reporter summary <run-dir>\` into \`<run-dir>/summary.md\`. Script farewell banner points at the summary path.

## Diff Breakdown
| Category    | Files | Lines (+/-) | Net   |
|-------------|-------|-------------|-------|
| Core logic  |     1 | +208  / -0  | +208  |
| Scaffolding |     3 | +140  / -9  | +131  |
| Docs        |     2 | +82   / -0  | +82   |
| **Total**   |     6 | +430  / -9  | +421  |

Small final PR — mostly "does the rendered output look right?"

<details>
<summary>Key files (click to expand)</summary>

- [\`tools/stress/device-reporter/pkg/format/markdown.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-cli/files) — markdown rendering.
- [\`tools/stress/device-reporter/cmd/device-reporter/main.go\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-cli/files) — CLI front-end.
- [\`tools/stress/scripts/run-stress-physical.sh\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-cli/files) + [\`run-stress-local.sh\`](https://github.com/malbeclabs/doublezero/pull/new/nikw9944/stress-reporter-cli/files) — build reporter, launch watcher subprocess.

</details>

## Testing Verification
- End-to-end on physical hardware (1023-user runs on chi-dn-dzd5 + chi-dn-dzd9): \`summary.md\` lands ~10 s after sweep completion; the diff-check linearity fit comes back essentially linear at 22.89 µs/byte (R² 0.981) on dzd5 and 32.49 µs/byte (R² 0.932) on dzd9 — confirming the curve is real per-device hardware behavior.
- Containerized harness (524-user cEOS sweep): \`summary.md\` lands cleanly; agent stats match the parser's understanding of the runlog.