### PR TITLE
e2e/qa: dedupe repeated device tests in failure-rate aggregation

### DIFF
--- a/e2e/internal/qa/device_assignment.go
+++ b/e2e/internal/qa/device_assignment.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 )
@@ -298,4 +300,118 @@ func AssignDevicesToClients(devices []*Device, clients []*Client, clientLatencie
 		}
 	}
 	return batchData
+}
+
+// HostFailureStats aggregates per-host failure information after deduping
+// repeated tests of the same (host, device) pair.
+type HostFailureStats struct {
+	Total         int      // unique devices assigned to this host
+	Failed        int      // unique devices that never succeeded on this host
+	FailedDevices []string // sorted, deduped device codes
+}
+
+// DeviceRetest describes a (host, device) pair that was tested more than once.
+type DeviceRetest struct {
+	Host       string
+	DeviceCode string
+	Attempts   int
+	Successes  int
+	Failures   int
+}
+
+// FailureStats summarizes the outcome of a QA all-devices run after applying
+// the "any success counts as success" rule:
+//   - A device that succeeded at least once is treated as a success overall.
+//   - A device that never succeeded counts as a single failure, regardless of
+//     how many times it was retested.
+//
+// DeviceResults is sorted by DeviceCode. Each HostFailureStats.FailedDevices
+// slice is sorted by device code. Retests is sorted by (Host, DeviceCode).
+type FailureStats struct {
+	DeviceResults []DeviceTestResult          // one per unique device code
+	PerHost       map[string]HostFailureStats // keyed by host
+	Retests       []DeviceRetest              // entries where Attempts > 1
+}
+
+// ComputeFailureStats walks batchData once and applies the "any success
+// counts as success" rule per device. Repeated tests of the same
+// (host, device) collapse into a single result for both the overall device
+// list and per-host stats.
+func ComputeFailureStats(batchData BatchData) FailureStats {
+	// hostDeviceAttempts[host][code] = number of attempts
+	hostDeviceAttempts := make(map[string]map[string]int)
+	// hostDeviceSuccesses[host][code] = number of successful attempts
+	hostDeviceSuccesses := make(map[string]map[string]int)
+	deviceSucceeded := make(map[string]bool)
+	devicePubkey := make(map[string]string)
+
+	batchNums := slices.Sorted(maps.Keys(batchData))
+	for _, batchNum := range batchNums {
+		hosts := slices.Sorted(maps.Keys(batchData[batchNum]))
+		for _, host := range hosts {
+			assignment := batchData[batchNum][host]
+			code := assignment.Device.Code
+			if hostDeviceAttempts[host] == nil {
+				hostDeviceAttempts[host] = make(map[string]int)
+				hostDeviceSuccesses[host] = make(map[string]int)
+			}
+			hostDeviceAttempts[host][code]++
+			devicePubkey[code] = assignment.Device.PubKey
+			if assignment.Success() {
+				hostDeviceSuccesses[host][code]++
+				deviceSucceeded[code] = true
+			} else if _, seen := deviceSucceeded[code]; !seen {
+				deviceSucceeded[code] = false
+			}
+		}
+	}
+
+	deviceCodes := slices.Sorted(maps.Keys(deviceSucceeded))
+	deviceResults := make([]DeviceTestResult, 0, len(deviceCodes))
+	for _, code := range deviceCodes {
+		deviceResults = append(deviceResults, DeviceTestResult{
+			DeviceCode:   code,
+			DevicePubkey: devicePubkey[code],
+			Success:      deviceSucceeded[code],
+		})
+	}
+
+	perHost := make(map[string]HostFailureStats, len(hostDeviceAttempts))
+	for host, attempts := range hostDeviceAttempts {
+		stats := HostFailureStats{Total: len(attempts)}
+		codes := slices.Sorted(maps.Keys(attempts))
+		for _, code := range codes {
+			if hostDeviceSuccesses[host][code] == 0 {
+				stats.Failed++
+				stats.FailedDevices = append(stats.FailedDevices, code)
+			}
+		}
+		perHost[host] = stats
+	}
+
+	var retests []DeviceRetest
+	hosts := slices.Sorted(maps.Keys(hostDeviceAttempts))
+	for _, host := range hosts {
+		codes := slices.Sorted(maps.Keys(hostDeviceAttempts[host]))
+		for _, code := range codes {
+			n := hostDeviceAttempts[host][code]
+			if n <= 1 {
+				continue
+			}
+			successes := hostDeviceSuccesses[host][code]
+			retests = append(retests, DeviceRetest{
+				Host:       host,
+				DeviceCode: code,
+				Attempts:   n,
+				Successes:  successes,
+				Failures:   n - successes,
+			})
+		}
+	}
+
+	return FailureStats{
+		DeviceResults: deviceResults,
+		PerHost:       perHost,
+		Retests:       retests,
+	}
 }

--- a/e2e/internal/qa/device_assignment_test.go
+++ b/e2e/internal/qa/device_assignment_test.go
@@ -664,25 +664,6 @@ func TestComputeFailureStats(t *testing.T) {
 		}
 	})
 
-	t.Run("device succeeds on host A, fails on host B", func(t *testing.T) {
-		// Overall: device succeeded somewhere, so it counts as success.
-		// Per-host: A 0/1, B 1/1 (per-host dedupe is (host, device), not global).
-		batchData := BatchData{
-			0: {"hostA": pass(dev1), "hostB": fail(dev1)},
-		}
-		stats := ComputeFailureStats(batchData)
-
-		if len(stats.DeviceResults) != 1 || !stats.DeviceResults[0].Success {
-			t.Errorf("expected device marked success overall, got %+v", stats.DeviceResults)
-		}
-		if stats.PerHost["hostA"].Failed != 0 || stats.PerHost["hostA"].Total != 1 {
-			t.Errorf("hostA per-host: got %+v, want 0/1", stats.PerHost["hostA"])
-		}
-		if stats.PerHost["hostB"].Failed != 1 || stats.PerHost["hostB"].Total != 1 {
-			t.Errorf("hostB per-host: got %+v, want 1/1", stats.PerHost["hostB"])
-		}
-	})
-
 	t.Run("multiple devices on one host with mixed outcomes", func(t *testing.T) {
 		// hostA tests three distinct devices: dev1 passes, dev2 fails, dev3 passes.
 		batchData := BatchData{

--- a/e2e/internal/qa/device_assignment_test.go
+++ b/e2e/internal/qa/device_assignment_test.go
@@ -3,6 +3,7 @@ package qa
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 )
 
@@ -538,6 +539,215 @@ func TestComputeRouteTargets(t *testing.T) {
 
 		if len(result) != 0 {
 			t.Errorf("expected 0 targets for single client, got %d", len(result))
+		}
+	})
+}
+
+func TestComputeFailureStats(t *testing.T) {
+	// pass marks a BatchResult as a successful test (Success() returns true
+	// when FailedTests == 0 && PacketsSent > 0 && PacketsReceived > 0).
+	pass := func(d *Device) *BatchResult {
+		return &BatchResult{Device: d, PacketsSent: 10, PacketsReceived: 10}
+	}
+	// fail marks a BatchResult as a failed test.
+	fail := func(d *Device) *BatchResult {
+		return &BatchResult{Device: d, PacketsSent: 10, PacketsReceived: 0, FailedTests: 1}
+	}
+
+	dev1 := &Device{Code: "dev1", PubKey: "pk1"}
+	dev2 := &Device{Code: "dev2", PubKey: "pk2"}
+	dev3 := &Device{Code: "dev3", PubKey: "pk3"}
+
+	t.Run("empty batch data", func(t *testing.T) {
+		stats := ComputeFailureStats(BatchData{})
+		if len(stats.DeviceResults) != 0 {
+			t.Errorf("expected no device results, got %d", len(stats.DeviceResults))
+		}
+		if len(stats.PerHost) != 0 {
+			t.Errorf("expected no per-host stats, got %d", len(stats.PerHost))
+		}
+		if len(stats.Retests) != 0 {
+			t.Errorf("expected no retests, got %d", len(stats.Retests))
+		}
+	})
+
+	t.Run("single device single host fail", func(t *testing.T) {
+		batchData := BatchData{
+			0: {"hostA": fail(dev1)},
+		}
+		stats := ComputeFailureStats(batchData)
+
+		wantDevice := []DeviceTestResult{
+			{DeviceCode: "dev1", DevicePubkey: "pk1", Success: false},
+		}
+		if !reflect.DeepEqual(stats.DeviceResults, wantDevice) {
+			t.Errorf("device results: got %+v, want %+v", stats.DeviceResults, wantDevice)
+		}
+		host := stats.PerHost["hostA"]
+		if host.Total != 1 || host.Failed != 1 {
+			t.Errorf("per-host: got total=%d failed=%d, want 1/1", host.Total, host.Failed)
+		}
+		if len(stats.Retests) != 0 {
+			t.Errorf("expected no retests, got %d", len(stats.Retests))
+		}
+	})
+
+	t.Run("single device single host pass", func(t *testing.T) {
+		batchData := BatchData{
+			0: {"hostA": pass(dev1)},
+		}
+		stats := ComputeFailureStats(batchData)
+
+		if len(stats.DeviceResults) != 1 || !stats.DeviceResults[0].Success {
+			t.Errorf("expected one successful device, got %+v", stats.DeviceResults)
+		}
+		host := stats.PerHost["hostA"]
+		if host.Total != 1 || host.Failed != 0 {
+			t.Errorf("per-host: got total=%d failed=%d, want 1/0", host.Total, host.Failed)
+		}
+	})
+
+	t.Run("device retested 11 times with 3 successes", func(t *testing.T) {
+		// Mirrors the scenario from the issue: tyo-mn-qa01 tests tyo001-dz002
+		// 11 times, 3 of which succeeded and 8 failed. Expected: one
+		// unique device, marked success; per-host 0/1; one retest entry.
+		batch := BatchData{}
+		// 3 successes
+		for i := 0; i < 3; i++ {
+			batch[i] = map[string]*BatchResult{"hostA": pass(dev1)}
+		}
+		// 8 failures
+		for i := 3; i < 11; i++ {
+			batch[i] = map[string]*BatchResult{"hostA": fail(dev1)}
+		}
+
+		stats := ComputeFailureStats(batch)
+
+		if len(stats.DeviceResults) != 1 || !stats.DeviceResults[0].Success {
+			t.Errorf("expected single device marked success, got %+v", stats.DeviceResults)
+		}
+		host := stats.PerHost["hostA"]
+		if host.Total != 1 || host.Failed != 0 || len(host.FailedDevices) != 0 {
+			t.Errorf("per-host: got total=%d failed=%d failedDevices=%v, want 1/0/[]", host.Total, host.Failed, host.FailedDevices)
+		}
+		wantRetests := []DeviceRetest{
+			{Host: "hostA", DeviceCode: "dev1", Attempts: 11, Successes: 3, Failures: 8},
+		}
+		if !reflect.DeepEqual(stats.Retests, wantRetests) {
+			t.Errorf("retests: got %+v, want %+v", stats.Retests, wantRetests)
+		}
+	})
+
+	t.Run("device retested 11 times with 0 successes", func(t *testing.T) {
+		batch := BatchData{}
+		for i := 0; i < 11; i++ {
+			batch[i] = map[string]*BatchResult{"hostA": fail(dev1)}
+		}
+
+		stats := ComputeFailureStats(batch)
+
+		if len(stats.DeviceResults) != 1 || stats.DeviceResults[0].Success {
+			t.Errorf("expected single device marked failure, got %+v", stats.DeviceResults)
+		}
+		host := stats.PerHost["hostA"]
+		if host.Total != 1 || host.Failed != 1 {
+			t.Errorf("per-host: got total=%d failed=%d, want 1/1", host.Total, host.Failed)
+		}
+		if !reflect.DeepEqual(host.FailedDevices, []string{"dev1"}) {
+			t.Errorf("failedDevices: got %v, want [dev1]", host.FailedDevices)
+		}
+		wantRetests := []DeviceRetest{
+			{Host: "hostA", DeviceCode: "dev1", Attempts: 11, Successes: 0, Failures: 11},
+		}
+		if !reflect.DeepEqual(stats.Retests, wantRetests) {
+			t.Errorf("retests: got %+v, want %+v", stats.Retests, wantRetests)
+		}
+	})
+
+	t.Run("device succeeds on host A, fails on host B", func(t *testing.T) {
+		// Overall: device succeeded somewhere, so it counts as success.
+		// Per-host: A 0/1, B 1/1 (per-host dedupe is (host, device), not global).
+		batchData := BatchData{
+			0: {"hostA": pass(dev1), "hostB": fail(dev1)},
+		}
+		stats := ComputeFailureStats(batchData)
+
+		if len(stats.DeviceResults) != 1 || !stats.DeviceResults[0].Success {
+			t.Errorf("expected device marked success overall, got %+v", stats.DeviceResults)
+		}
+		if stats.PerHost["hostA"].Failed != 0 || stats.PerHost["hostA"].Total != 1 {
+			t.Errorf("hostA per-host: got %+v, want 0/1", stats.PerHost["hostA"])
+		}
+		if stats.PerHost["hostB"].Failed != 1 || stats.PerHost["hostB"].Total != 1 {
+			t.Errorf("hostB per-host: got %+v, want 1/1", stats.PerHost["hostB"])
+		}
+	})
+
+	t.Run("multiple devices on one host with mixed outcomes", func(t *testing.T) {
+		// hostA tests three distinct devices: dev1 passes, dev2 fails, dev3 passes.
+		batchData := BatchData{
+			0: {"hostA": pass(dev1)},
+			1: {"hostA": fail(dev2)},
+			2: {"hostA": pass(dev3)},
+		}
+		stats := ComputeFailureStats(batchData)
+
+		wantDevices := []DeviceTestResult{
+			{DeviceCode: "dev1", DevicePubkey: "pk1", Success: true},
+			{DeviceCode: "dev2", DevicePubkey: "pk2", Success: false},
+			{DeviceCode: "dev3", DevicePubkey: "pk3", Success: true},
+		}
+		if !reflect.DeepEqual(stats.DeviceResults, wantDevices) {
+			t.Errorf("device results: got %+v, want %+v", stats.DeviceResults, wantDevices)
+		}
+		host := stats.PerHost["hostA"]
+		if host.Total != 3 || host.Failed != 1 {
+			t.Errorf("per-host: got total=%d failed=%d, want 3/1", host.Total, host.Failed)
+		}
+		if !reflect.DeepEqual(host.FailedDevices, []string{"dev2"}) {
+			t.Errorf("failedDevices: got %v, want [dev2]", host.FailedDevices)
+		}
+		if len(stats.Retests) != 0 {
+			t.Errorf("expected no retests, got %+v", stats.Retests)
+		}
+	})
+
+	t.Run("multiple hosts and devices with sorted retests", func(t *testing.T) {
+		// hostA: dev1 attempted twice (one pass, one fail) — should be success.
+		// hostB: dev2 attempted twice, both fail — should be failure.
+		// hostA also tests dev3 once, passes.
+		batchData := BatchData{
+			0: {"hostA": pass(dev1), "hostB": fail(dev2)},
+			1: {"hostA": fail(dev1), "hostB": fail(dev2)},
+			2: {"hostA": pass(dev3), "hostB": fail(dev2)},
+		}
+		stats := ComputeFailureStats(batchData)
+
+		wantDevices := []DeviceTestResult{
+			{DeviceCode: "dev1", DevicePubkey: "pk1", Success: true},
+			{DeviceCode: "dev2", DevicePubkey: "pk2", Success: false},
+			{DeviceCode: "dev3", DevicePubkey: "pk3", Success: true},
+		}
+		if !reflect.DeepEqual(stats.DeviceResults, wantDevices) {
+			t.Errorf("device results: got %+v, want %+v", stats.DeviceResults, wantDevices)
+		}
+		hostA := stats.PerHost["hostA"]
+		if hostA.Total != 2 || hostA.Failed != 0 {
+			t.Errorf("hostA: got %+v, want total=2 failed=0", hostA)
+		}
+		hostB := stats.PerHost["hostB"]
+		if hostB.Total != 1 || hostB.Failed != 1 {
+			t.Errorf("hostB: got %+v, want total=1 failed=1", hostB)
+		}
+		if !reflect.DeepEqual(hostB.FailedDevices, []string{"dev2"}) {
+			t.Errorf("hostB failedDevices: got %v, want [dev2]", hostB.FailedDevices)
+		}
+		wantRetests := []DeviceRetest{
+			{Host: "hostA", DeviceCode: "dev1", Attempts: 2, Successes: 1, Failures: 1},
+			{Host: "hostB", DeviceCode: "dev2", Attempts: 3, Successes: 0, Failures: 3},
+		}
+		if !reflect.DeepEqual(stats.Retests, wantRetests) {
+			t.Errorf("retests: got %+v, want %+v", stats.Retests, wantRetests)
 		}
 	})
 }

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -191,7 +191,6 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 
 	var totalSent, totalReceived uint32
 	batchesWithLoss := 0
-	deviceResults := make(map[string]*qa.DeviceTestResult)
 	for _, batch := range batchData {
 		for _, assignment := range batch {
 			totalSent += assignment.PacketsSent
@@ -199,29 +198,35 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 			if assignment.PacketsReceived < assignment.PacketsSent {
 				batchesWithLoss++
 			}
-
-			if _, seen := deviceResults[assignment.Device.Code]; !seen {
-				deviceResults[assignment.Device.Code] = &qa.DeviceTestResult{
-					DeviceCode:   assignment.Device.Code,
-					DevicePubkey: assignment.Device.PubKey,
-					Success:      true,
-				}
-			}
-			if !assignment.Success() {
-				deviceResults[assignment.Device.Code].Success = false
-			}
 		}
 	}
 	log.Debug("Test summary", "packetsReceived", totalReceived, "packetsSent", totalSent, "batchesWithLoss", batchesWithLoss, "totalBatches", batchCount)
 
+	// Aggregate device results with the "any success counts as success" rule:
+	// a device tested multiple times that succeeded at least once is treated as a
+	// success; a device that never succeeded counts as a single failure regardless
+	// of how many times it was retested. See `AssignDevicesToClients` for why the
+	// same (host, device) pair may appear in multiple batches.
+	stats := qa.ComputeFailureStats(batchData)
+
+	for _, r := range stats.Retests {
+		log.Debug("Device retested",
+			"host", r.Host,
+			"device", r.DeviceCode,
+			"attempts", r.Attempts,
+			"successes", r.Successes,
+			"failures", r.Failures,
+		)
+	}
+
 	// Evaluate failure rates against threshold
-	totalDevices := len(deviceResults)
+	totalDevices := len(stats.DeviceResults)
 	failedDevices := 0
 	var failedDeviceCodes []string
-	for code, result := range deviceResults {
+	for _, result := range stats.DeviceResults {
 		if !result.Success {
 			failedDevices++
-			failedDeviceCodes = append(failedDeviceCodes, code)
+			failedDeviceCodes = append(failedDeviceCodes, result.DeviceCode)
 		}
 	}
 
@@ -233,54 +238,31 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 		"threshold", fmt.Sprintf("%.1f%%", *failureThreshold*100),
 	)
 	if overallRate > *failureThreshold {
-		slices.Sort(failedDeviceCodes)
 		t.Errorf("Overall device failure rate %.1f%% (%d/%d) exceeds threshold %.1f%%. Failed devices: %s",
 			overallRate*100, failedDevices, totalDevices, *failureThreshold*100,
 			strings.Join(failedDeviceCodes, ", "))
 	}
 
-	type hostStats struct {
-		total         int
-		failed        int
-		failedDevices []string
-	}
-	perHost := make(map[string]*hostStats)
-	for _, batch := range batchData {
-		for host, assignment := range batch {
-			if perHost[host] == nil {
-				perHost[host] = &hostStats{}
-			}
-			perHost[host].total++
-			if !assignment.Success() {
-				perHost[host].failed++
-				perHost[host].failedDevices = append(perHost[host].failedDevices, assignment.Device.Code)
-			}
-		}
-	}
-	for host, stats := range perHost {
-		hostRate := float64(stats.failed) / float64(stats.total)
+	for _, host := range slices.Sorted(maps.Keys(stats.PerHost)) {
+		hs := stats.PerHost[host]
+		hostRate := float64(hs.Failed) / float64(hs.Total)
 		log.Debug("Per-host failure rate",
 			"host", host,
-			"failed", stats.failed,
-			"total", stats.total,
+			"failed", hs.Failed,
+			"total", hs.Total,
 			"rate", fmt.Sprintf("%.1f%%", hostRate*100),
 		)
 		if hostRate > *perHostFailureThreshold {
-			slices.Sort(stats.failedDevices)
 			t.Errorf("Host %s failure rate %.1f%% (%d/%d) exceeds threshold %.1f%%. Failed devices: %s",
-				host, hostRate*100, stats.failed, stats.total, *perHostFailureThreshold*100,
-				strings.Join(stats.failedDevices, ", "))
+				host, hostRate*100, hs.Failed, hs.Total, *perHostFailureThreshold*100,
+				strings.Join(hs.FailedDevices, ", "))
 		}
 	}
 
-	results := make([]qa.DeviceTestResult, 0, len(deviceResults))
-	for _, result := range deviceResults {
-		results = append(results, *result)
-	}
-	if err := qa.PublishMetrics(ctx, log, qa.MetricsConfigFromEnv(), envArg, results, time.Since(startTime)); err != nil {
+	if err := qa.PublishMetrics(ctx, log, qa.MetricsConfigFromEnv(), envArg, stats.DeviceResults, time.Since(startTime)); err != nil {
 		log.Error("Failed to publish metrics", "error", err)
 	}
-	if err := qa.PublishToClickhouse(ctx, log, qa.ClickhouseConfigFromEnv(), envArg, results, time.Since(startTime)); err != nil {
+	if err := qa.PublishToClickhouse(ctx, log, qa.ClickhouseConfigFromEnv(), envArg, stats.DeviceResults, time.Since(startTime)); err != nil {
 		log.Error("Failed to publish metrics to ClickHouse", "error", err)
 	}
 }


### PR DESCRIPTION
## Summary of Changes

* `AssignDevicesToClients` pads each client's device list so every client has an entry in every batch. Hosts with fewer unique devices end up retesting the same `(host, device)` pair multiple times. The old failure-rate aggregation conflated those repeats with independent failures, which is what's been flaking `qa.alldevices.mainnet-beta` — e.g. run `26967321854` saw `tyo-mn-qa01` test `tyo001-dz002` 11 times (3 pass / 8 fail) and got reported as 8 host failures.
* Introduce `ComputeFailureStats` in `e2e/internal/qa/device_assignment.go` to centralize the aggregation. New rules per the issue:
  * A device that succeeds in **any** attempt counts as a success overall.
  * A device that never succeeded counts as a **single** failure on a host, regardless of how many times it was retested.
* Emit a `Device retested` debug log line per `(host, device)` with attempts > 1 so future flakes are easier to triage.
* Refactor `TestQA_AllDevices_UnicastConnectivity` to use the helper.
* Semantic shift worth flagging: `DeviceTestResult.Success` published to InfluxDB / ClickHouse now means "any attempt succeeded" rather than "every attempt succeeded". Strictly looser; matches the threshold logic.
* Fixes malbeclabs/infra#1512

## Testing Verification

* New table-driven unit tests in `e2e/internal/qa/device_assignment_test.go` cover the scenarios called out in the issue plus surrounding edge cases:
  * Device retested 11x with 3 successes (the issue's `tyo001-dz002` case) collapses to 1 success, per-host 0/1, retest entry of attempts=11/successes=3/failures=8.
  * Device retested 11x with 0 successes collapses to 1 failure, per-host 1/1.
  * Same device succeeds on host A but fails on host B: overall success, per-host A 0/1 / B 1/1.
  * Empty `BatchData`, single-host pass/fail, multiple-device-multiple-host mixed outcomes.
* `go vet -tags qa ./e2e/...` and `go test -count=1 ./e2e/internal/qa/` both pass.
* No workflow / threshold changes; thresholds (`-failure-threshold=0.1`, `-per-host-failure-threshold=0.2`) stay as-is.