### PR TITLE
telemetry: retry metrics-listener bind on EADDRNOTAVAIL/EADDRINUSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Telemetry
+  - Retry `EADDRNOTAVAIL` / `EADDRINUSE` failures on the device-telemetry-agent's Prometheus metrics-listener bind with capped exponential backoff (1s → 30s, indefinite until context cancel), so a startup race against `ns-management` IP assignment no longer leaves the agent running silently without a `/metrics` endpoint ([malbeclabs/infra#1542](https://github.com/malbeclabs/infra/issues/1542))
+
 ## [v0.26.0](https://github.com/malbeclabs/doublezero/compare/client/v0.25.1...client/v0.26.0) - 2026-06-05
 
 ### Breaking

--- a/controlplane/telemetry/cmd/telemetry/main.go
+++ b/controlplane/telemetry/cmd/telemetry/main.go
@@ -230,25 +230,18 @@ func main() {
 	if *metricsEnable {
 		metrics.BuildInfo.WithLabelValues(version, commit, date).Set(1)
 		go func() {
-			var listener net.Listener
+			var listen listenFunc
 			if *managementNamespace != "" {
-				// If the management namespace is provided, we need to run the metrics server in that namespace.
-				listener, err = netns.RunInNamespace(*managementNamespace, func() (net.Listener, error) {
-					return net.Listen("tcp", *metricsAddr)
-				})
-				if err != nil {
-					log.Error("Failed to start prometheus metrics server listener in namespace", "error", err, "namespace", *managementNamespace)
-					return
-				}
-				log.Info("Prometheus metrics server listening", "namespace", *managementNamespace, "address", listener.Addr().String())
+				listen = namespacedListen(*metricsAddr, *managementNamespace)
 			} else {
-				listener, err = net.Listen("tcp", *metricsAddr)
-				if err != nil {
-					log.Error("Failed to start prometheus metrics server listener", "error", err)
-					return
-				}
-				log.Info("Prometheus metrics server listening", "address", listener.Addr().String())
+				listen = plainListen(*metricsAddr)
 			}
+			listener, err := listenWithRetry(ctx, log, listen)
+			if err != nil {
+				log.Error("Failed to start prometheus metrics server listener", "error", err, "namespace", *managementNamespace)
+				return
+			}
+			log.Info("Prometheus metrics server listening", "namespace", *managementNamespace, "address", listener.Addr().String())
 			http.Handle("/metrics", promhttp.Handler())
 			if err := http.Serve(listener, nil); err != nil {
 				log.Error("Failed to start prometheus metrics server", "error", err)

--- a/controlplane/telemetry/cmd/telemetry/metrics_listener.go
+++ b/controlplane/telemetry/cmd/telemetry/metrics_listener.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"syscall"
+	"time"
+
+	"github.com/malbeclabs/doublezero/controlplane/telemetry/internal/netns"
+)
+
+// metricsListenerInitialBackoff is the first sleep between retry attempts; the
+// delay doubles after each failure and is capped at metricsListenerMaxBackoff.
+// Picked small so that a startup race against namespace-IP assignment (the case
+// from the incident) recovers in ~1s without burning startup time.
+const (
+	metricsListenerInitialBackoff = 1 * time.Second
+	metricsListenerMaxBackoff     = 30 * time.Second
+)
+
+// listenFunc is the surface listenWithRetry uses to open the metrics-server
+// socket. In production it is plainListen / namespacedListen below; tests inject
+// a fake so the retry/classifier logic can be exercised without root.
+type listenFunc func() (net.Listener, error)
+
+// isRetryableBindError reports whether err is a transient bind failure that
+// should be retried. EADDRNOTAVAIL is the incident's failure mode: the
+// namespace exists but its IP has not been assigned yet, and self-heals within
+// seconds. EADDRINUSE is also retried because a fresh restart can race the
+// kernel's teardown of the previous listener's socket (TIME_WAIT can take up
+// to 2*MSL). The trade-off: a genuine port conflict (e.g., two daemons
+// configured for the same metrics-addr) will retry forever, surfacing only as
+// repeating WARN log lines rather than a hard exit — operators should monitor
+// for sustained warnings on this path. Everything else surfaces immediately
+// so a real configuration problem (parse error, unknown namespace, etc.) is
+// not silently retried.
+func isRetryableBindError(err error) bool {
+	return errors.Is(err, syscall.EADDRNOTAVAIL) || errors.Is(err, syscall.EADDRINUSE)
+}
+
+// listenWithRetry opens the metrics-server listener, retrying transient bind
+// failures with capped exponential backoff. It returns when the bind succeeds,
+// when a non-retryable error occurs, or when ctx is cancelled.
+//
+// Backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s, ... until ctx.Done().
+//
+// Retries are unbounded by design. The agent has no useful action it can take
+// if the namespace IP never appears; giving up would only restore the pre-fix
+// behavior of running silently without /metrics.
+func listenWithRetry(ctx context.Context, log *slog.Logger, listen listenFunc) (net.Listener, error) {
+	delay := metricsListenerInitialBackoff
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		listener, err := listen()
+		if err == nil {
+			return listener, nil
+		}
+		if !isRetryableBindError(err) {
+			return nil, err
+		}
+		lastErr = err
+		log.Warn("Failed to bind prometheus metrics listener, retrying",
+			"attempt", attempt, "delay", delay, "error", err)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("context cancelled while retrying metrics listener bind (last error: %w): %w", lastErr, ctx.Err())
+		case <-timer.C:
+		}
+		delay = nextBackoff(delay)
+	}
+}
+
+// nextBackoff returns the next backoff delay: double the current one, clamped
+// at metricsListenerMaxBackoff. Once the cap is reached, subsequent calls
+// return the cap unchanged.
+func nextBackoff(current time.Duration) time.Duration {
+	if current >= metricsListenerMaxBackoff {
+		return metricsListenerMaxBackoff
+	}
+	doubled := current * 2
+	if doubled > metricsListenerMaxBackoff {
+		return metricsListenerMaxBackoff
+	}
+	return doubled
+}
+
+// plainListen returns a listenFunc that binds addr in the current network
+// namespace.
+func plainListen(addr string) listenFunc {
+	return func() (net.Listener, error) {
+		return net.Listen("tcp", addr)
+	}
+}
+
+// namespacedListen returns a listenFunc that binds addr inside nsName via
+// netns.RunInNamespace.
+func namespacedListen(addr, nsName string) listenFunc {
+	return func() (net.Listener, error) {
+		return netns.RunInNamespace(nsName, func() (net.Listener, error) {
+			return net.Listen("tcp", addr)
+		})
+	}
+}

--- a/controlplane/telemetry/cmd/telemetry/metrics_listener_test.go
+++ b/controlplane/telemetry/cmd/telemetry/metrics_listener_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// newTestLogger returns a slog.Logger that discards output, so tests do not
+// pollute stdout/stderr.
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// fakeListener is a minimal net.Listener used to assert the success path
+// without actually binding a socket.
+type fakeListener struct{}
+
+func (fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }
+func (fakeListener) Close() error              { return nil }
+func (fakeListener) Addr() net.Addr            { return &net.TCPAddr{IP: net.IPv4zero, Port: 0} }
+
+// wrapEADDRNOTAVAIL builds an error that errors.Is detects as EADDRNOTAVAIL,
+// matching how net.Listen surfaces bind failures in production.
+func wrapEADDRNOTAVAIL() error {
+	return &net.OpError{Op: "listen", Err: &os.SyscallError{Syscall: "bind", Err: syscall.EADDRNOTAVAIL}}
+}
+
+func wrapEADDRINUSE() error {
+	return &net.OpError{Op: "listen", Err: &os.SyscallError{Syscall: "bind", Err: syscall.EADDRINUSE}}
+}
+
+func TestListenWithRetry_SucceedsAfterTransientEADDRNOTAVAIL(t *testing.T) {
+	var attempts int32
+	listen := func() (net.Listener, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return nil, wrapEADDRNOTAVAIL()
+		}
+		return fakeListener{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	listener, err := listenWithRetry(ctx, newTestLogger(), listen)
+	if err != nil {
+		t.Fatalf("expected success after transient failures, got %v", err)
+	}
+	if listener == nil {
+		t.Fatal("expected non-nil listener")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestListenWithRetry_RetriesEADDRINUSE(t *testing.T) {
+	var attempts int32
+	listen := func() (net.Listener, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			return nil, wrapEADDRINUSE()
+		}
+		return fakeListener{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := listenWithRetry(ctx, newTestLogger(), listen); err != nil {
+		t.Fatalf("expected success after EADDRINUSE retry, got %v", err)
+	}
+}
+
+func TestListenWithRetry_SurfaceNonRetryableErrorImmediately(t *testing.T) {
+	want := errors.New("nope: config wrong")
+	var attempts int32
+	listen := func() (net.Listener, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, want
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	listener, err := listenWithRetry(ctx, newTestLogger(), listen)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected non-retryable error to be returned as-is, got %v", err)
+	}
+	if listener != nil {
+		t.Fatal("expected nil listener on error")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected exactly 1 attempt, got %d", got)
+	}
+}
+
+func TestListenWithRetry_ReturnsOnContextCancel(t *testing.T) {
+	listen := func() (net.Listener, error) {
+		return nil, wrapEADDRNOTAVAIL()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay so the loop is mid-backoff.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	listener, err := listenWithRetry(ctx, newTestLogger(), listen)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if listener != nil {
+		t.Fatal("expected nil listener on cancel")
+	}
+	// The initial backoff is 1s but the cancel must short-circuit it; bound the
+	// elapsed time to well under the initial backoff to confirm the select on
+	// ctx.Done() is reached.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected prompt return on context cancel, took %v", elapsed)
+	}
+}
+
+func TestNextBackoff(t *testing.T) {
+	cases := []struct {
+		current time.Duration
+		want    time.Duration
+	}{
+		{1 * time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, metricsListenerMaxBackoff}, // 32s -> clamped to 30s
+		{metricsListenerMaxBackoff, metricsListenerMaxBackoff},
+		{2 * metricsListenerMaxBackoff, metricsListenerMaxBackoff}, // never exceeds cap
+	}
+	for _, tc := range cases {
+		if got := nextBackoff(tc.current); got != tc.want {
+			t.Errorf("nextBackoff(%v) = %v, want %v", tc.current, got, tc.want)
+		}
+	}
+}
+
+func TestIsRetryableBindError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"EADDRNOTAVAIL", wrapEADDRNOTAVAIL(), true},
+		{"EADDRINUSE", wrapEADDRINUSE(), true},
+		{"generic", errors.New("nope"), false},
+		{"ECONNREFUSED", &os.SyscallError{Syscall: "bind", Err: syscall.ECONNREFUSED}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableBindError(tc.err); got != tc.want {
+				t.Fatalf("isRetryableBindError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary of Changes

* Wrap the device-telemetry-agent's Prometheus metrics-listener bind in a context-aware retry loop with capped exponential backoff (1s → 30s, indefinite until shutdown).
* `EADDRNOTAVAIL` and `EADDRINUSE` are retried (transient classes); all other errors surface immediately so a real configuration problem is not silently retried.
* Fixes the silent-failure mode from the 2026-05-18 incident on `chi-dn-dzd1`/`dzd2`/`dzd3` where the agent lost a race against `ns-management` IP assignment, the bind returned `EADDRNOTAVAIL`, and the daemon kept running for ~18 days with `up{component="device_telemetry_agent"} == 0`.
* Fixes malbeclabs/infra#1542

Companion docs PR with the design rationale: malbeclabs/infra#1546 (work plan in `docs/work-plan-1542.md`).

## Testing Verification

* `go test ./controlplane/telemetry/cmd/telemetry/` — all tests pass, including new ones in `metrics_listener_test.go`:
  * `TestListenWithRetry_SucceedsAfterTransientEADDRNOTAVAIL` — recovers after 2 transient EADDRNOTAVAIL failures, then succeeds.
  * `TestListenWithRetry_RetriesEADDRINUSE` — recovers after a transient EADDRINUSE failure.
  * `TestListenWithRetry_SurfaceNonRetryableErrorImmediately` — non-bind errors surface on attempt 1 (no silent retry).
  * `TestListenWithRetry_ReturnsOnContextCancel` — cancellation during backoff short-circuits within 500ms; cancel-path error wraps both the last bind error and `ctx.Err()`.
  * `TestNextBackoff` — verifies the documented 1s, 2s, 4s, 8s, 16s, 30s, 30s, ... sequence including the cap clamp.
  * `TestIsRetryableBindError` — classifier table covers nil, EADDRNOTAVAIL, EADDRINUSE, generic, and ECONNREFUSED.
* `go build ./controlplane/telemetry/cmd/telemetry/` and `go vet ./controlplane/telemetry/...` both clean.
* Manual e2e exercise (racing the namespace IP on real Arista cEOS) is not part of the unit-test harness — that path will be observed in prod after the next agent release rolls out, watching `up{component="device_telemetry_agent"}` and the `Component: Service Down` alert on the previously affected DZD devices.