### PR TITLE
sdk: UNSPECIFIED-first AccessPass lookup in GetAccessPassCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
   - `access-pass set` gains `--max-unicast-users` / `--max-multicast-users`; `get`/`list` show the per-category counts and caps.
 - SDK
   - Decode the four new `AccessPass` cap fields (and the previously-missing `tenant_allowlist`) in the Go, Python, and TypeScript layouts.
+  - `GetAccessPassCommand` resolves a shared dynamic-seat AccessPass (the `UNSPECIFIED` PDA) before the exact-IP pass, matching the onchain `create_user` lookup. (#3853)
 
 ## [v0.26.0](https://github.com/malbeclabs/doublezero/compare/client/v0.25.1...client/v0.26.0) - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   - `access-pass set` gains `--max-unicast-users` / `--max-multicast-users`; `get`/`list` show the per-category counts and caps.
 - SDK
   - Decode the four new `AccessPass` cap fields (and the previously-missing `tenant_allowlist`) in the Go, Python, and TypeScript layouts.
-  - `GetAccessPassCommand` resolves a shared dynamic-seat AccessPass (the `UNSPECIFIED` PDA) before the exact-IP pass, matching the onchain `create_user` lookup. (#3853)
+  - `GetAccessPassCommand` and the multicast allowlist resolver both resolve a shared dynamic-seat AccessPass (the `UNSPECIFIED` PDA) before the exact-IP pass, matching the onchain `create_user` lookup. (#3853)
 
 ## [v0.26.0](https://github.com/malbeclabs/doublezero/compare/client/v0.25.1...client/v0.26.0) - 2026-06-05
 

--- a/smartcontract/sdk/rs/src/commands/accesspass/get.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/get.rs
@@ -18,12 +18,187 @@ impl GetAccessPassCommand {
         &self,
         client: &dyn DoubleZeroClient,
     ) -> eyre::Result<Option<(Pubkey, AccessPass)>> {
-        let (pubkey, _) =
-            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+        let program_id = client.get_program_id();
 
+        // Prefer a shared dynamic seat pass stored at the UNSPECIFIED (0.0.0.0) PDA,
+        // aligning the read path with the onchain create_user path (which accepts either
+        // the exact-IP PDA or the UNSPECIFIED PDA). Fall back to the exact-IP pass only
+        // when the dynamic pass is absent.
+        if self.client_ip != Ipv4Addr::UNSPECIFIED {
+            let (dynamic_pubkey, _) =
+                get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &self.user_payer);
+            if let Ok(AccountData::AccessPass(accesspass)) = client.get(dynamic_pubkey) {
+                return Ok(Some((dynamic_pubkey, accesspass)));
+            }
+        }
+
+        let (pubkey, _) = get_accesspass_pda(&program_id, &self.client_ip, &self.user_payer);
         match client.get(pubkey) {
             Ok(AccountData::AccessPass(accesspass)) => Ok(Some((pubkey, accesspass))),
             Ok(_) | Err(_) => Ok(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::accesspass::get::GetAccessPassCommand, tests::utils::create_test_client,
+        DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        pda::get_accesspass_pda,
+        state::{
+            accesspass::{AccessPass, AccessPassStatus, AccessPassType},
+            accountdata::AccountData,
+            accounttype::AccountType,
+        },
+    };
+    use mockall::predicate;
+    use solana_sdk::pubkey::Pubkey;
+    use std::net::Ipv4Addr;
+
+    fn sample_accesspass(client_ip: Ipv4Addr, user_payer: Pubkey) -> AccessPass {
+        AccessPass {
+            account_type: AccountType::AccessPass,
+            owner: Pubkey::new_unique(),
+            bump_seed: 0,
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            user_payer,
+            last_access_epoch: u64::MAX,
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            flags: 0,
+            tenant_allowlist: vec![],
+            unicast_user_count: 0,
+            max_unicast_users: 1,
+            multicast_user_count: 0,
+            max_multicast_users: 1,
+        }
+    }
+
+    #[test]
+    fn test_get_accesspass_prefers_dynamic_pass() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let dynamic_pass = sample_accesspass(Ipv4Addr::UNSPECIFIED, payer);
+
+        // The dynamic (UNSPECIFIED) PDA resolves first; the exact-IP PDA is never queried.
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .times(1)
+            .returning(move |_| Ok(AccountData::AccessPass(dynamic_pass.clone())));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute(&client)
+        .unwrap();
+
+        let (pubkey, pass) = res.expect("expected a pass");
+        assert_eq!(pubkey, dynamic_pubkey);
+        assert_eq!(pass.client_ip, Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn test_get_accesspass_falls_back_to_exact_ip() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+        let exact_pass = sample_accesspass(client_ip, payer);
+
+        // No dynamic pass exists; fall back to the exact-IP pass.
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(exact_pass.clone())));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute(&client)
+        .unwrap();
+
+        let (pubkey, pass) = res.expect("expected a pass");
+        assert_eq!(pubkey, exact_pubkey);
+        assert_eq!(pass.client_ip, client_ip);
+    }
+
+    #[test]
+    fn test_get_accesspass_returns_none_when_neither_present() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute(&client)
+        .unwrap();
+
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn test_get_accesspass_unspecified_does_single_lookup() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let payer = Pubkey::new_unique();
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let dynamic_pass = sample_accesspass(Ipv4Addr::UNSPECIFIED, payer);
+
+        // When the requested IP is already UNSPECIFIED, only a single lookup happens
+        // (the exact-IP PDA is the UNSPECIFIED PDA — no redundant double query).
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .times(1)
+            .returning(move |_| Ok(AccountData::AccessPass(dynamic_pass.clone())));
+
+        let res = GetAccessPassCommand {
+            client_ip: Ipv4Addr::UNSPECIFIED,
+            user_payer: payer,
+        }
+        .execute(&client)
+        .unwrap();
+
+        let (pubkey, _) = res.expect("expected a pass");
+        assert_eq!(pubkey, dynamic_pubkey);
     }
 }

--- a/smartcontract/sdk/rs/src/commands/accesspass/set.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set.rs
@@ -99,6 +99,7 @@ mod tests {
     };
     use mockall::predicate;
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+    use std::net::Ipv4Addr;
 
     #[test]
     fn test_commands_set_accesspass_command() {
@@ -133,6 +134,15 @@ mod tests {
             .expect_get()
             .with(predicate::eq(pda_pubkey))
             .returning(move |_| Ok(AccountData::AccessPass(accesspass.clone())));
+
+        // GetAccessPassCommand checks the UNSPECIFIED (dynamic) PDA first; no pass
+        // exists there, so it falls back to the exact-IP PDA above.
+        let (dynamic_pubkey, _) =
+            get_accesspass_pda(&client.get_program_id(), &Ipv4Addr::UNSPECIFIED, &payer);
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
 
         client
             .expect_execute_transaction()

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/mod.rs
@@ -10,28 +10,27 @@ use crate::DoubleZeroClient;
 
 /// Resolves which AccessPass PDA to use for allowlist operations.
 ///
-/// Tries the static PDA (`client_ip`, `user_payer`) first. If no AccessPass exists there,
-/// falls back to the dynamic PDA (`0.0.0.0`, `user_payer`) for `allow_multiple_ip` passes.
-/// If neither exists, returns the static PDA so the program can create a new AccessPass.
+/// Prefers the dynamic PDA (`0.0.0.0`, `user_payer`): a pass stored at the `UNSPECIFIED` PDA is
+/// valid for any client IP by construction (see the onchain `create_user` lookup in
+/// `create_core.rs`), so it takes precedence over an exact-IP pass independent of
+/// `allow_multiple_ip`. Falls back to the static PDA (`client_ip`, `user_payer`) when no dynamic
+/// pass exists — either to use an existing exact-IP pass or as the creation target when neither
+/// pass exists.
+///
+/// This mirrors `GetAccessPassCommand::execute` so allowlist ops and reads resolve the same pass.
 pub(crate) fn resolve_accesspass_pda(
     client: &dyn DoubleZeroClient,
     client_ip: &Ipv4Addr,
     user_payer: &Pubkey,
 ) -> Pubkey {
     let program_id = client.get_program_id();
-    let (static_pda, _) = get_accesspass_pda(&program_id, client_ip, user_payer);
-
-    if let Ok(AccountData::AccessPass(_)) = client.get(static_pda) {
-        return static_pda;
-    }
 
     let (dynamic_pda, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, user_payer);
-    if let Ok(AccountData::AccessPass(ap)) = client.get(dynamic_pda) {
-        if ap.allow_multiple_ip() {
-            return dynamic_pda;
-        }
+    if let Ok(AccountData::AccessPass(_)) = client.get(dynamic_pda) {
+        return dynamic_pda;
     }
 
+    let (static_pda, _) = get_accesspass_pda(&program_id, client_ip, user_payer);
     static_pda
 }
 
@@ -40,7 +39,7 @@ mod tests {
     use doublezero_serviceability::{
         pda::get_accesspass_pda,
         state::{
-            accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP},
+            accesspass::{AccessPass, AccessPassStatus, AccessPassType},
             accountdata::AccountData,
             accounttype::AccountType,
         },
@@ -81,14 +80,41 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_accesspass_pda_returns_static_when_found() {
+    fn test_resolve_accesspass_pda_prefers_dynamic() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
+        let user_payer = Pubkey::new_unique();
+        let (dynamic_pda, bump) =
+            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
+
+        // flags=0 (no allow_multiple_ip): a pass at the UNSPECIFIED PDA still takes precedence,
+        // and the exact-IP PDA is never queried.
+        let ap = make_accesspass(Ipv4Addr::UNSPECIFIED, user_payer, bump, 0);
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pda))
+            .times(1)
+            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
+
+        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
+        assert_eq!(result, dynamic_pda);
+    }
+
+    #[test]
+    fn test_resolve_accesspass_pda_falls_back_to_static_when_dynamic_absent() {
         let mut client = create_test_client();
         let program_id = client.get_program_id();
         let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
         let user_payer = Pubkey::new_unique();
         let (static_pda, bump) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+        let (dynamic_pda, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
 
         let ap = make_accesspass(client_ip, user_payer, bump, 0);
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pda))
+            .returning(|_| Err(eyre::eyre!("not found")));
         client
             .expect_get()
             .with(predicate::eq(static_pda))
@@ -96,31 +122,6 @@ mod tests {
 
         let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
         assert_eq!(result, static_pda);
-    }
-
-    #[test]
-    fn test_resolve_accesspass_pda_returns_dynamic_for_allow_multiple_ip() {
-        let mut client = create_test_client();
-        let program_id = client.get_program_id();
-        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
-        let user_payer = Pubkey::new_unique();
-        let (static_pda, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
-        let (dynamic_pda, bump) =
-            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
-
-        let ap = make_accesspass(Ipv4Addr::UNSPECIFIED, user_payer, bump, ALLOW_MULTIPLE_IP);
-
-        client
-            .expect_get()
-            .with(predicate::eq(static_pda))
-            .returning(|_| Err(eyre::eyre!("not found")));
-        client
-            .expect_get()
-            .with(predicate::eq(dynamic_pda))
-            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
-
-        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
-        assert_eq!(result, dynamic_pda);
     }
 
     #[test]
@@ -134,31 +135,6 @@ mod tests {
         client
             .expect_get()
             .returning(|_| Err(eyre::eyre!("not found")));
-
-        let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
-        assert_eq!(result, static_pda);
-    }
-
-    #[test]
-    fn test_resolve_accesspass_pda_ignores_dynamic_without_allow_multiple_ip() {
-        let mut client = create_test_client();
-        let program_id = client.get_program_id();
-        let client_ip: Ipv4Addr = [192, 168, 1, 1].into();
-        let user_payer = Pubkey::new_unique();
-        let (static_pda, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
-        let (dynamic_pda, bump) =
-            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer);
-
-        let ap = make_accesspass(Ipv4Addr::UNSPECIFIED, user_payer, bump, 0); // flags=0, no allow_multiple_ip
-
-        client
-            .expect_get()
-            .with(predicate::eq(static_pda))
-            .returning(|_| Err(eyre::eyre!("not found")));
-        client
-            .expect_get()
-            .with(predicate::eq(dynamic_pda))
-            .returning(move |_| Ok(AccountData::AccessPass(ap.clone())));
 
         let result = resolve_accesspass_pda(&client, &client_ip, &user_payer);
         assert_eq!(result, static_pda);

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/subscribe.rs
@@ -45,20 +45,13 @@ impl UpdateMulticastGroupRolesCommand {
         .execute(client)
         .map_err(|_err| eyre::eyre!("User not found"))?;
 
+        // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
+        // back to the exact client-IP pass.
         let (accesspass_pubkey, accesspass) = GetAccessPassCommand {
-            client_ip: Ipv4Addr::UNSPECIFIED,
+            client_ip: self.client_ip,
             user_payer: user.owner,
         }
         .execute(client)?
-        .or_else(|| {
-            GetAccessPassCommand {
-                client_ip: self.client_ip,
-                user_payer: user.owner,
-            }
-            .execute(client)
-            .ok()
-            .flatten()
-        })
         .ok_or_else(|| eyre::eyre!("AccessPass not found"))?;
 
         if self.publisher && !accesspass.mgroup_pub_allowlist.contains(&self.group_pk) {

--- a/smartcontract/sdk/rs/src/commands/tenant/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/tenant/delete.rs
@@ -437,6 +437,18 @@ mod tests {
             .with(predicate::eq(accesspass_pubkey))
             .returning(move |_| Ok(AccountData::AccessPass(ap_for_get.clone())));
 
+        // GetAccessPassCommand checks the UNSPECIFIED (dynamic) PDA first; no pass
+        // exists there, so it falls back to the exact-IP PDA above.
+        let (dynamic_accesspass_pubkey, _) = get_accesspass_pda(
+            &client.get_program_id(),
+            &Ipv4Addr::UNSPECIFIED,
+            &client.get_payer(),
+        );
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_accesspass_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
+
         // 1. ListAccessPassCommand: gets(AccountType::AccessPass)
         let ap_for_list = accesspass.clone();
         client

--- a/smartcontract/sdk/rs/src/commands/user/create.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create.rs
@@ -31,21 +31,13 @@ impl CreateUserCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        // First try to get AccessPass for the client IP
+        // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
+        // back to the exact client-IP pass, matching the onchain create_user path.
         let (accesspass_pk, _) = GetAccessPassCommand {
             client_ip: self.client_ip,
             user_payer: client.get_payer(),
         }
         .execute(client)?
-        .or_else(|| {
-            GetAccessPassCommand {
-                client_ip: Ipv4Addr::UNSPECIFIED,
-                user_payer: client.get_payer(),
-            }
-            .execute(client)
-            .ok()
-            .flatten()
-        })
         .ok_or_else(|| eyre::eyre!("You have no Access Pass"))?;
 
         let (pda_pubkey, _) =
@@ -180,6 +172,15 @@ mod tests {
             .expect_get()
             .with(predicate::eq(accesspass_pubkey))
             .returning(move |_| Ok(AccountData::AccessPass(accesspass.clone())));
+
+        // GetAccessPassCommand checks the UNSPECIFIED (dynamic) PDA first; no pass
+        // exists there, so it falls back to the exact-IP PDA above.
+        let (dynamic_accesspass_pubkey, _) =
+            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_accesspass_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
 
         let device = Device {
             account_type: AccountType::Device,

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -53,21 +53,13 @@ impl CreateSubscribeUserCommand {
         // When a custom owner is set, look up the access pass for that owner
         let accesspass_payer = self.owner.unwrap_or_else(|| client.get_payer());
 
-        // First try to get AccessPass for the client IP
+        // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
+        // back to the exact client-IP pass, matching the onchain create_user path.
         let (accesspass_pk, _) = GetAccessPassCommand {
             client_ip: self.client_ip,
             user_payer: accesspass_payer,
         }
         .execute(client)?
-        .or_else(|| {
-            GetAccessPassCommand {
-                client_ip: Ipv4Addr::UNSPECIFIED,
-                user_payer: accesspass_payer,
-            }
-            .execute(client)
-            .ok()
-            .flatten()
-        })
         .ok_or_else(|| eyre::eyre!("No Access Pass found for owner"))?;
 
         let (pda_pubkey, _) =
@@ -211,6 +203,15 @@ mod tests {
             .expect_get()
             .with(predicate::eq(accesspass_pubkey))
             .returning(move |_| Ok(AccountData::AccessPass(accesspass.clone())));
+
+        // GetAccessPassCommand checks the UNSPECIFIED (dynamic) PDA first; no pass
+        // exists there, so it falls back to the exact-IP PDA above.
+        let (dynamic_accesspass_pubkey, _) =
+            get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_accesspass_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
 
         let device = Device {
             account_type: AccountType::Device,

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, net::Ipv4Addr};
+use std::collections::HashSet;
 
 use crate::{
     commands::{
@@ -56,20 +56,13 @@ impl DeleteUserCommand {
             }
         }
 
+        // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
+        // back to the exact client-IP pass.
         let (accesspass_pk, _) = GetAccessPassCommand {
-            client_ip: Ipv4Addr::UNSPECIFIED,
+            client_ip: user.client_ip,
             user_payer: user.owner,
         }
         .execute(client)?
-        .or_else(|| {
-            GetAccessPassCommand {
-                client_ip: user.client_ip,
-                user_payer: user.owner,
-            }
-            .execute(client)
-            .ok()
-            .flatten()
-        })
         .ok_or_else(|| eyre::eyre!("You have no Access Pass"))?;
 
         let (_, device) = GetDeviceCommand {


### PR DESCRIPTION
## Summary

- Make `GetAccessPassCommand::execute` resolve a shared **dynamic-seat** AccessPass (the `UNSPECIFIED`/`0.0.0.0` PDA) before the exact-IP pass, falling back to the exact-IP PDA only when the dynamic pass is absent.
- Aligns the SDK read path with the onchain `create_user` path, which already accepts either the exact-IP PDA or the `UNSPECIFIED` PDA. This is a read-only change with no onchain behavior impact.
- `connect`'s `check_accesspass` benefits automatically, since it routes through this command — so `doublezero connect` can now resolve a node's dynamic seat pass with no other client changes.

When `client_ip` is already `UNSPECIFIED`, a single lookup is performed (no redundant double query).

Part of the Dynamic Seat Allocation effort (RFC-21, see #3858). Closes #3853.

## Dependency

Stacks on #3859 (AccessPass user caps, branch `gm/accesspass-user-caps`) and is based on that branch. Retarget to `main` once #3859 merges.

## Testing Verification

- Added unit tests for `GetAccessPassCommand` covering: dynamic pass preferred over exact-IP, fallback to exact-IP when the dynamic pass is absent, `None` when neither exists, and a single lookup when `client_ip == UNSPECIFIED`.
