### PR TITLE
client: add thin doublezero docker image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,49 @@
+# Thin DoubleZero client image.
+#
+# Installs the `doublezero` package (CLI + `doublezerod` daemon) from the official
+# Cloudsmith apt repo on top of a minimal Ubuntu base. The entrypoint starts the
+# daemon and passes any arguments through to the `doublezero` CLI, e.g.:
+#
+#   docker run --rm --network host \
+#     --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/net/tun \
+#     ghcr.io/malbeclabs/doublezero status
+#
+# See client/docker-README.md for the full runtime contract.
+#
+# The doublezero deb is published for linux/amd64 only, so the platform defaults to
+# amd64 (via an ARG, to avoid the const-platform build warning) to keep builds
+# reproducible on arm64 hosts such as Apple Silicon. Override with
+# --build-arg BASE_PLATFORM=... if needed.
+ARG BASE_PLATFORM=linux/amd64
+FROM --platform=${BASE_PLATFORM} ubuntu:24.04
+
+# Empty DZ_VERSION installs the latest published client. Release CI pins the exact
+# released version (e.g. DZ_VERSION=1.2.3) for reproducible images.
+ARG DZ_VERSION=
+# Image provenance, supplied by CI; sensible defaults for local builds.
+ARG BUILD_VERSION=dev
+ARG BUILD_COMMIT=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/malbeclabs/doublezero" \
+      org.opencontainers.image.title="doublezero" \
+      org.opencontainers.image.description="Thin DoubleZero client (doublezero CLI + doublezerod daemon)" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add the Cloudsmith apt repo via the official scripted installer, install the
+# client, then drop the now-unneeded curl and apt lists to keep the image thin.
+# ca-certificates is installed explicitly so it survives the curl auto-remove.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    curl -1sLf 'https://dl.cloudsmith.io/public/malbeclabs/doublezero/setup.deb.sh' | bash; \
+    apt-get install -y --no-install-recommends "doublezero${DZ_VERSION:+=$DZ_VERSION}"; \
+    apt-get purge -y --auto-remove curl; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/client/docker-README.md
+++ b/client/docker-README.md
@@ -1,0 +1,48 @@
+# DoubleZero client Docker image
+
+A thin Ubuntu image with the DoubleZero client (`doublezero` CLI + `doublezerod`
+daemon) installed from the official Cloudsmith apt repo. Published as
+`ghcr.io/malbeclabs/doublezero`.
+
+## Build
+
+```bash
+# latest published client
+docker build -t doublezero client/
+
+# pin a specific released version
+docker build --build-arg DZ_VERSION=1.2.3 -t doublezero:1.2.3 client/
+```
+
+## Run
+
+The client manages GRE tunnels and routes, so the container needs network
+capabilities and a tun device:
+
+```bash
+docker run --rm \
+  --network host \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  ghcr.io/malbeclabs/doublezero status
+```
+
+The entrypoint starts `doublezerod`, waits for its socket, then:
+
+- **with arguments** — runs `doublezero <args>` (e.g. `status`, `latency`,
+  `connect ...`) and exits.
+- **without arguments** — prints `doublezero status` and stays running on the
+  daemon, so you can `docker exec -it <container> doublezero <args>`.
+
+### Configuration
+
+| Env var   | Default                              | Purpose                                  |
+| --------- | ------------------------------------ | ---------------------------------------- |
+| `DZ_ENV`  | `mainnet-beta`                       | DoubleZero environment for the daemon and CLI |
+| `DZ_SOCK` | `/run/doublezerod/doublezerod.sock`  | doublezerod Unix socket path             |
+
+## Not yet wired up
+
+- **Publishing**: a `release.docker.client.yml` workflow (modeled on
+  `release.docker.core.yml`) will build and push the image after `client/v*.*.*`
+  releases land in Cloudsmith.

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the thin DoubleZero client image.
+#
+# Starts the doublezerod daemon (the deb's systemd unit does not run inside a
+# container) and then hands off to the `doublezero` CLI:
+#
+#   * with arguments  -> exec `doublezero <args>` (e.g. connect / status)
+#   * without args    -> print status and stay alive on the daemon so the
+#                        container can be `docker exec`'d into for manual commands
+#
+set -euo pipefail
+
+# mainnet-beta matches the compiled default of the doublezero package published to
+# the public Cloudsmith repo; the daemon and CLI must use the same environment.
+DZ_ENV="${DZ_ENV:-mainnet-beta}"
+DZ_SOCK="${DZ_SOCK:-/run/doublezerod/doublezerod.sock}"
+
+# doublezerod creates its Unix socket in this directory.
+mkdir -p "$(dirname "$DZ_SOCK")"
+
+# Persist the environment into the CLI config (~/.config/doublezero/cli/config.yml)
+# so every `doublezero` invocation in this container -- the entrypoint, a
+# `docker exec`, or an interactive shell -- uses the same env as the daemon and
+# avoids the "client and daemon are using different environments" mismatch.
+echo "[entrypoint] setting CLI config env=$DZ_ENV" >&2
+doublezero config set --env "$DZ_ENV" >/dev/null
+
+echo "[entrypoint] starting doublezerod (env=$DZ_ENV sock=$DZ_SOCK)" >&2
+doublezerod -sock-file "$DZ_SOCK" -env "$DZ_ENV" &
+DZD_PID=$!
+
+# Forward termination so `docker stop` shuts the daemon down cleanly.
+trap 'kill -TERM "$DZD_PID" 2>/dev/null || true' TERM INT
+
+# Wait (up to ~10s) for the daemon socket before issuing any CLI command.
+for _ in $(seq 1 50); do
+    [ -S "$DZ_SOCK" ] && break
+    if ! kill -0 "$DZD_PID" 2>/dev/null; then
+        echo "[entrypoint] doublezerod exited before its socket was ready" >&2
+        wait "$DZD_PID"
+        exit 1
+    fi
+    sleep 0.2
+done
+
+if [ ! -S "$DZ_SOCK" ]; then
+    echo "[entrypoint] timed out waiting for $DZ_SOCK" >&2
+    kill -TERM "$DZD_PID" 2>/dev/null || true
+    exit 1
+fi
+echo "[entrypoint] doublezerod ready" >&2
+
+# (Optional startup hooks -- e.g. auto-running a `doublezero connect ...` on
+# boot -- would go here.)
+
+if [ "$#" -gt 0 ]; then
+    exec doublezero --sock-file "$DZ_SOCK" --env "$DZ_ENV" "$@"
+fi
+
+# No command given: show status, then stay attached to the daemon.
+doublezero --sock-file "$DZ_SOCK" --env "$DZ_ENV" status || true
+wait "$DZD_PID"


### PR DESCRIPTION
## Summary of Changes
- Add a thin Ubuntu 24.04 `Dockerfile` that installs the `doublezero` client (CLI + `doublezerod` daemon) from the official Cloudsmith apt repo, pinnable to an exact release via a `DZ_VERSION` build arg.
- Add an entrypoint that starts the daemon, waits for its socket, and passes arguments through to the CLI — keeping the CLI and daemon on the same DoubleZero environment so they never report an "environments differ" mismatch.
- Persist `DZ_ENV` into the CLI config at startup so every invocation (entrypoint, `docker exec`, or an interactive shell) inherits the daemon's environment, not just the entrypoint's own calls.
- Document the build, the `docker run` flags required for connectivity (`--network host`, `NET_ADMIN`/`NET_RAW`, `/dev/net/tun`), and the `DZ_ENV`/`DZ_SOCK` knobs.

Plumbing only; publishing the image to `ghcr.io/malbeclabs/doublezero` is a follow-up.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +63 / -0    | +63  |
| Scaffolding  |     1 | +49 / -0    | +49  |
| Docs         |     1 | +48 / -0    | +48  |
| **Total**    |     3 | +160 / -0   | +160 |

Small and purely additive — no existing files touched; a new image build, its entrypoint, and operator docs.

<details>
<summary>Key files (click to expand)</summary>

- `client/docker-entrypoint.sh` — starts `doublezerod`, waits for the socket, persists `DZ_ENV` to the CLI config, forwards signals, then execs the CLI (or stays alive on the daemon when no command is given).
- `client/Dockerfile` — `ubuntu:24.04` base (platform pinned to amd64, the only arch the deb publishes), Cloudsmith repo via the scripted installer, `DZ_VERSION` pin, and image cleanup to stay thin.
- `client/docker-README.md` — build/run instructions, required capabilities/networking, and configuration env vars.

</details>

## Testing Verification
- Built the image and ran it on a clean Ubuntu 24.04 amd64 EC2 instance: `doublezerod` starts, the socket becomes ready, and `doublezero status` reports cleanly (exit 0).
- Verified `-e DZ_ENV=testnet` brings the daemon and CLI up on testnet with no environment-mismatch error; default (`mainnet-beta`) likewise.
- Verified the config-persistence behavior: a `docker exec … doublezero status` with no `--env` reads the daemon's environment back from the persisted `config.yml`, confirming the client and daemon stay in lockstep.
- Confirmed the image is amd64 and stays thin (curl and apt lists removed post-install).
