### PR TITLE
removes restrictive accesspass client_ip check

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/subscribe.rs
@@ -207,15 +207,6 @@ pub fn process_update_multicastgroup_roles(
         "Invalid AccessPass PDA",
     );
 
-    if !accesspass.allow_multiple_ip() && accesspass.client_ip != user.client_ip {
-        msg!(
-            "AccessPass client_ip does not match. accesspass.client_ip: {} user.client_ip: {}",
-            accesspass.client_ip,
-            user.client_ip
-        );
-        return Err(DoubleZeroError::Unauthorized.into());
-    }
-
     // The access pass must belong to the payer. If the payer differs, the payer
     // must be in the foundation allowlist.
     if accesspass.user_payer != *payer_account.key


### PR DESCRIPTION
## Summary of Changes
* accesspass.client_ip may equal 0.0.0.0 and a user.client_ip may be set. There is no need to verify the client_ip on the accesspass so long as the user_payer is validated.
