### PR TITLE
client: auto-join authorized multicast groups on connect with no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Client
   - Auto-enable allocated-IP mode for `doublezero connect ibrl` when the daemon detects a private RFC1918 default-route source (behind NAT), unless `-a` or `--client-ip` is set.
+  - `doublezero connect multicast` with no groups now auto-joins every group authorized in the caller's AccessPass — publishing to `mgroup_pub_allowlist` and subscribing to `mgroup_sub_allowlist`. An AccessPass with no authorized groups is a no-op.
 - Onchain programs
   - Add per-category seat caps to `EdgeSeat` access passes (errors 89/90 on overflow), scale the `SetAccessPass` airdrop by the cap sum when `allow_multiple_ip` is set, and drop the dynamic-pass IP-lock and `IS_DYNAMIC` flag. (#3859)
 - CLI

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -2059,6 +2059,171 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// `connect multicast` with no groups auto-joins every group authorized in the
+    /// AccessPass: publishes to mgroup_pub_allowlist and subscribes to mgroup_sub_allowlist.
+    #[tokio::test]
+    async fn test_connect_command_multicast_autojoin_from_accesspass() {
+        let mut fixture = TestFixture::new();
+
+        let (g1_pk, _) = fixture.add_multicast_group("group-1", "239.0.0.1");
+        let (g2_pk, _) = fixture.add_multicast_group("group-2", "239.0.0.2");
+
+        // Authorize publishing to g1 and subscribing to g1 + g2.
+        {
+            let mut ap = fixture.accesspass.lock().unwrap();
+            ap.mgroup_pub_allowlist = vec![g1_pk];
+            ap.mgroup_sub_allowlist = vec![g1_pk, g2_pk];
+        }
+
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+        let user = fixture.create_user(UserType::Multicast, device1_pk, "1.2.3.4");
+
+        // First group (g1) created via create_subscribe_user as publisher + subscriber.
+        let user_pk = Pubkey::new_unique();
+        fixture.expect_create_subscribe_user(user_pk, &user, g1_pk, true, true);
+        // Remaining group (g2) added via update_multicastgroup_roles as subscriber-only.
+        fixture.expect_update_multicastgroup_roles(
+            user_pk,
+            g2_pk,
+            Ipv4Addr::new(1, 2, 3, 4),
+            false,
+            true,
+        );
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec![],
+            },
+            client_ip: None,
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "auto-join from access pass must succeed: {:?}",
+            result.err()
+        );
+    }
+
+    /// Auto-join is a no-op success when the AccessPass authorizes no groups: no user
+    /// is created and no subscriptions are issued.
+    #[tokio::test]
+    async fn test_connect_command_multicast_autojoin_empty_allowlist_is_noop() {
+        let mut fixture = TestFixture::new();
+        // AccessPass has empty allowlists by default; a device exists but must not be used.
+        fixture.add_device(DeviceType::Hybrid, 100, true);
+
+        // No expect_create_subscribe_user / expect_update_multicastgroup_roles: any such
+        // call would panic the mock.
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec![],
+            },
+            client_ip: None,
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "empty allowlist must be a no-op success: {:?}",
+            result.err()
+        );
+    }
+
+    /// Allowlist entries that no longer resolve to a known multicast group are dropped
+    /// during auto-join; only the still-valid groups are used.
+    #[tokio::test]
+    async fn test_connect_command_multicast_autojoin_filters_stale_allowlist_pubkeys() {
+        let mut fixture = TestFixture::new();
+
+        let (g1_pk, _) = fixture.add_multicast_group("group-1", "239.0.0.1");
+        // Not registered in list_multicastgroup — simulates a deleted group.
+        let stale_pk = Pubkey::new_unique();
+
+        {
+            let mut ap = fixture.accesspass.lock().unwrap();
+            ap.mgroup_sub_allowlist = vec![stale_pk, g1_pk];
+        }
+
+        let (device1_pk, _device1) = fixture.add_device(DeviceType::Hybrid, 100, true);
+        let user = fixture.create_user(UserType::Multicast, device1_pk, "1.2.3.4");
+
+        // Only g1 survives filtering → single create_subscribe_user as subscriber-only,
+        // no further update calls.
+        let user_pk = Pubkey::new_unique();
+        fixture.expect_create_subscribe_user(user_pk, &user, g1_pk, false, true);
+
+        println!();
+
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec![],
+            },
+            client_ip: None,
+            device: None,
+            verbose: false,
+        };
+
+        let result = command
+            .execute_with_service_controller(&fixture.client, &fixture.controller)
+            .await;
+        assert!(
+            result.is_ok(),
+            "stale allowlist pubkeys must be filtered: {:?}",
+            result.err()
+        );
+    }
+
+    /// `parse_dz_mode` accepts multicast with no groups, yielding empty pub/sub vectors
+    /// that trigger the AccessPass-driven auto-join downstream.
+    #[test]
+    fn test_parse_dz_mode_multicast_no_args_yields_empty_groups() {
+        let command = ProvisioningCliCommand {
+            dz_mode: DzMode::Multicast {
+                mode: None,
+                multicast_groups: vec![],
+                pub_groups: vec![],
+                sub_groups: vec![],
+            },
+            client_ip: None,
+            device: None,
+            verbose: false,
+        };
+
+        match command.parse_dz_mode().unwrap() {
+            ParsedDzMode::Multicast {
+                pub_groups,
+                sub_groups,
+            } => {
+                assert!(pub_groups.is_empty());
+                assert!(sub_groups.is_empty());
+            }
+            ParsedDzMode::Ibrl(..) => panic!("expected ParsedDzMode::Multicast, got Ibrl"),
+        }
+    }
+
     /// Multicast connect succeeds when the AccessPass has last_access_epoch = 0 (expired).
     /// Multicast access is gated by mgroup_*_allowlist, not by epoch.
     #[tokio::test]

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -167,10 +167,11 @@ impl ProvisioningCliCommand {
         spinner.println(format!("    DoubleZero ID: {}", client.get_payer()));
         spinner.println(format!("⚡  Provisioning for IP: {client_ip_str}"));
 
-        match parsed_mode {
+        let provisioned = match parsed_mode {
             ParsedDzMode::Ibrl(user_type, tenant) => {
                 self.execute_ibrl(client, controller, user_type, client_ip, tenant, &spinner)
-                    .await
+                    .await?;
+                true
             }
             ParsedDzMode::Multicast {
                 pub_groups,
@@ -184,11 +185,13 @@ impl ProvisioningCliCommand {
                     client_ip,
                     &spinner,
                 )
-                .await
+                .await?
             }
-        }?;
+        };
 
-        spinner.println("✅  User Provisioned");
+        if provisioned {
+            spinner.println("✅  User Provisioned");
+        }
         spinner.finish_and_clear();
 
         Ok(())
@@ -226,34 +229,100 @@ impl ProvisioningCliCommand {
         sub_groups: &[String],
         client_ip: Ipv4Addr,
         spinner: &ProgressBar,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<bool> {
         let mcast_groups = client.list_multicastgroup(ListMulticastGroupCommand)?;
 
-        // Resolve pub group codes to pubkeys
-        let mut pub_group_pks = Vec::new();
-        for group_code in pub_groups {
-            let (pk, _) = mcast_groups
-                .iter()
-                .find(|(_, g)| g.code == *group_code)
-                .ok_or_else(|| eyre::eyre!("Multicast group not found: {}", group_code))?;
-            if pub_group_pks.contains(pk) {
-                eyre::bail!("Duplicate multicast pub group: {}", group_code);
-            }
-            pub_group_pks.push(*pk);
-        }
+        let (pub_group_pks, sub_group_pks) = if pub_groups.is_empty() && sub_groups.is_empty() {
+            // No groups specified: auto-join every group authorized in the caller's
+            // AccessPass — publish to its publisher allowlist and subscribe to its
+            // subscriber allowlist. The pass is guaranteed to exist (validated by
+            // check_accesspass before dispatch); the ok_or_else is defensive.
+            let (_, accesspass) = client
+                .get_accesspass(GetAccessPassCommand {
+                    client_ip,
+                    user_payer: client.get_payer(),
+                })?
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "No valid AccessPass found for IP: {} user_payer: {}",
+                        client_ip,
+                        client.get_payer()
+                    )
+                })?;
 
-        // Resolve sub group codes to pubkeys
-        let mut sub_group_pks = Vec::new();
-        for group_code in sub_groups {
-            let (pk, _) = mcast_groups
+            // Keep only allowlist entries that still resolve to a known group; drop
+            // pubkeys left over from deleted groups.
+            let pub_group_pks: Vec<Pubkey> = accesspass
+                .mgroup_pub_allowlist
                 .iter()
-                .find(|(_, g)| g.code == *group_code)
-                .ok_or_else(|| eyre::eyre!("Multicast group not found: {}", group_code))?;
-            if sub_group_pks.contains(pk) {
-                eyre::bail!("Duplicate multicast sub group: {}", group_code);
+                .filter(|pk| mcast_groups.contains_key(pk))
+                .copied()
+                .collect();
+            let sub_group_pks: Vec<Pubkey> = accesspass
+                .mgroup_sub_allowlist
+                .iter()
+                .filter(|pk| mcast_groups.contains_key(pk))
+                .copied()
+                .collect();
+
+            if pub_group_pks.is_empty() && sub_group_pks.is_empty() {
+                spinner.println(
+                    "ℹ️  The AccessPass has no authorized multicast groups; nothing to connect to.",
+                );
+                return Ok(false);
             }
-            sub_group_pks.push(*pk);
-        }
+
+            let code_of = |pk: &Pubkey| {
+                mcast_groups
+                    .get(pk)
+                    .map(|g| g.code.clone())
+                    .unwrap_or_else(|| pk.to_string())
+            };
+            if !pub_group_pks.is_empty() {
+                let codes: Vec<String> = pub_group_pks.iter().map(code_of).collect();
+                spinner.println(format!(
+                    "    Publishing to (from AccessPass): {}",
+                    codes.join(", ")
+                ));
+            }
+            if !sub_group_pks.is_empty() {
+                let codes: Vec<String> = sub_group_pks.iter().map(code_of).collect();
+                spinner.println(format!(
+                    "    Subscribing to (from AccessPass): {}",
+                    codes.join(", ")
+                ));
+            }
+
+            (pub_group_pks, sub_group_pks)
+        } else {
+            // Resolve pub group codes to pubkeys
+            let mut pub_group_pks = Vec::new();
+            for group_code in pub_groups {
+                let (pk, _) = mcast_groups
+                    .iter()
+                    .find(|(_, g)| g.code == *group_code)
+                    .ok_or_else(|| eyre::eyre!("Multicast group not found: {}", group_code))?;
+                if pub_group_pks.contains(pk) {
+                    eyre::bail!("Duplicate multicast pub group: {}", group_code);
+                }
+                pub_group_pks.push(*pk);
+            }
+
+            // Resolve sub group codes to pubkeys
+            let mut sub_group_pks = Vec::new();
+            for group_code in sub_groups {
+                let (pk, _) = mcast_groups
+                    .iter()
+                    .find(|(_, g)| g.code == *group_code)
+                    .ok_or_else(|| eyre::eyre!("Multicast group not found: {}", group_code))?;
+                if sub_group_pks.contains(pk) {
+                    eyre::bail!("Duplicate multicast sub group: {}", group_code);
+                }
+                sub_group_pks.push(*pk);
+            }
+
+            (pub_group_pks, sub_group_pks)
+        };
 
         // Look for user and subscribe to all groups
         let (_user_pubkey, user) = self
@@ -271,7 +340,7 @@ impl ProvisioningCliCommand {
             UserStatus::Activated => {
                 self.user_activated(controller, UserType::Multicast, spinner)
                     .await;
-                Ok(())
+                Ok(true)
             }
             _ => eyre::bail!("User status not expected"),
         }
@@ -326,7 +395,12 @@ impl ProvisioningCliCommand {
                         sub_groups: sub_groups.clone(),
                     })
                 } else {
-                    eyre::bail!("At least one of --publish or --subscribe is required, or use legacy syntax: multicast <publisher|subscriber> <groups...>")
+                    // No groups specified: auto-join every group authorized in the
+                    // caller's AccessPass (resolved in execute_multicast).
+                    Ok(ParsedDzMode::Multicast {
+                        pub_groups: vec![],
+                        sub_groups: vec![],
+                    })
                 }
             }
         }

--- a/e2e/multicast_autojoin_test.go
+++ b/e2e/multicast_autojoin_test.go
@@ -44,18 +44,26 @@ func TestE2E_Multicast_AutoJoinFromAccessPass(t *testing.T) {
 	serviceabilityClient, err := dn.Ledger.GetServiceabilityClient()
 	require.NoError(t, err)
 
-	// Resolve the onchain pubkeys for the two groups by code.
+	// Resolve the onchain pubkeys for the two groups by code. The `group create`
+	// commands above confirm their transactions, but the program data read can
+	// still race ahead of ledger propagation, so poll until the group appears.
 	groupPubKeyByCode := func(t *testing.T, code string) [32]byte {
 		t.Helper()
-		data, err := serviceabilityClient.GetProgramData(t.Context())
-		require.NoError(t, err)
-		for _, g := range data.MulticastGroups {
-			if g.Code == code {
-				return g.PubKey
+		var pk [32]byte
+		require.Eventually(t, func() bool {
+			data, err := serviceabilityClient.GetProgramData(t.Context())
+			if err != nil {
+				return false
 			}
-		}
-		t.Fatalf("multicast group %q not found in program data", code)
-		return [32]byte{}
+			for _, g := range data.MulticastGroups {
+				if g.Code == code {
+					pk = g.PubKey
+					return true
+				}
+			}
+			return false
+		}, 30*time.Second, 2*time.Second, "multicast group %q not found in program data", code)
+		return pk
 	}
 	pubGroupPK := groupPubKeyByCode(t, pubGroup)
 	subGroupPK := groupPubKeyByCode(t, subGroup)

--- a/e2e/multicast_autojoin_test.go
+++ b/e2e/multicast_autojoin_test.go
@@ -1,0 +1,107 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	serviceability "github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_Multicast_AutoJoinFromAccessPass verifies that `doublezero connect
+// multicast` invoked with NO group arguments auto-joins every group authorized
+// in the caller's AccessPass: it publishes to the groups in mgroup_pub_allowlist
+// and subscribes to the groups in mgroup_sub_allowlist.
+//
+// The test authorizes the client for publishing on one group and subscribing on
+// a different group, then runs the bare connect command and asserts the
+// resulting onchain Multicast user holds exactly those roles.
+func TestE2E_Multicast_AutoJoinFromAccessPass(t *testing.T) {
+	t.Parallel()
+
+	// Single device + single client. Start() also sets a prepaid access pass for
+	// the client at (client.CYOANetworkIP, client.Pubkey).
+	dn, _, client := NewSingleDeviceSingleClientTestDevnet(t)
+
+	const pubGroup = "autojoin-pub"
+	const subGroup = "autojoin-sub"
+
+	// Create two groups and authorize the client for publishing on one and
+	// subscribing on the other (distinct roles, distinct groups). The allowlist
+	// adds target the same access pass PDA created by Start().
+	_, err := dn.Manager.Exec(t.Context(), []string{"bash", "-c", `
+		set -e
+		doublezero multicast group create --code ` + pubGroup + ` --max-bandwidth 10Gbps --owner me -w
+		doublezero multicast group create --code ` + subGroup + ` --max-bandwidth 10Gbps --owner me -w
+		doublezero multicast group allowlist publisher add --code ` + pubGroup + ` --user-payer ` + client.Pubkey + ` --client-ip ` + client.CYOANetworkIP + `
+		doublezero multicast group allowlist subscriber add --code ` + subGroup + ` --user-payer ` + client.Pubkey + ` --client-ip ` + client.CYOANetworkIP + `
+	`})
+	require.NoError(t, err)
+
+	serviceabilityClient, err := dn.Ledger.GetServiceabilityClient()
+	require.NoError(t, err)
+
+	// Resolve the onchain pubkeys for the two groups by code.
+	groupPubKeyByCode := func(t *testing.T, code string) [32]byte {
+		t.Helper()
+		data, err := serviceabilityClient.GetProgramData(t.Context())
+		require.NoError(t, err)
+		for _, g := range data.MulticastGroups {
+			if g.Code == code {
+				return g.PubKey
+			}
+		}
+		t.Fatalf("multicast group %q not found in program data", code)
+		return [32]byte{}
+	}
+	pubGroupPK := groupPubKeyByCode(t, pubGroup)
+	subGroupPK := groupPubKeyByCode(t, subGroup)
+
+	clientIPBytes := func(ip string) [4]uint8 {
+		parsed := net.ParseIP(ip).To4()
+		require.NotNil(t, parsed, "could not parse client IP: %s", ip)
+		return [4]uint8{parsed[0], parsed[1], parsed[2], parsed[3]}
+	}
+	wantClientIP := clientIPBytes(client.CYOANetworkIP)
+
+	containsPubKey := func(list [][32]uint8, want [32]byte) bool {
+		for _, pk := range list {
+			if pk == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Run the bare connect command — no publisher/subscriber, no group codes.
+	// The CLI must look up the access pass and auto-join the authorized groups.
+	_, err = client.Exec(t.Context(), []string{"bash", "-c", "doublezero connect multicast"})
+	require.NoError(t, err, "bare `doublezero connect multicast` failed")
+
+	err = client.WaitForTunnelUp(t.Context(), 90*time.Second)
+	require.NoError(t, err)
+
+	// The resulting Multicast user must publish to pubGroup and subscribe to
+	// subGroup, and to nothing else.
+	require.Eventually(t, func() bool {
+		data, err := serviceabilityClient.GetProgramData(t.Context())
+		if err != nil {
+			return false
+		}
+		for _, u := range data.Users {
+			if u.UserType != serviceability.UserTypeMulticast || u.ClientIp != wantClientIP {
+				continue
+			}
+			if u.Status != serviceability.UserStatusActivated {
+				return false
+			}
+			return len(u.Publishers) == 1 && containsPubKey(u.Publishers, pubGroupPK) &&
+				len(u.Subscribers) == 1 && containsPubKey(u.Subscribers, subGroupPK)
+		}
+		return false
+	}, 90*time.Second, 2*time.Second,
+		"multicast user did not auto-join the access-pass-authorized publish and subscribe groups")
+}


### PR DESCRIPTION
## Summary of Changes

- `doublezero connect multicast` invoked with **no groups** now auto-joins every multicast group authorized in the caller's AccessPass: it publishes to `mgroup_pub_allowlist` and subscribes to `mgroup_sub_allowlist`. The AccessPass is resolved via the existing `GetAccessPassCommand`, which already tries the shared dynamic-seat pass (`UNSPECIFIED`/`0.0.0.0` PDA) first and falls back to the exact client-IP pass.
- Allowlist entries that no longer resolve to a known group (deleted groups) are dropped; an AccessPass with no authorized groups is a no-op success (no user/tunnel created), and the generic "User Provisioned" footer is suppressed in that case.
- Explicit `--publish`/`--subscribe` and the legacy positional syntax are unchanged.

## Diff Breakdown

| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     1 | +103 / -29   | +74  |
| Tests        |     1 | +165 / -0    | +165 |
| Docs         |     1 | +1 / -0      | +1   |
| **Total**    |     2 | +269 / -29   | +240 |

Mostly tests; the core change is a single new branch in `execute_multicast` plus relaxing `parse_dz_mode`.

<details>
<summary>Key files (click to expand)</summary>

- `client/doublezero/src/command/connect.rs` — `parse_dz_mode` accepts multicast with no groups (empty vectors instead of erroring); `execute_multicast` derives pub/sub group pubkeys from the AccessPass allowlists when none are passed, filters stale pubkeys, and returns whether anything was provisioned so the success footer is conditional.
- `CHANGELOG.md` — Client entry for the new auto-join behavior.

</details>

## Testing Verification

- Added unit tests in `command::connect::tests`: auto-join publishes + subscribes from both allowlists; empty allowlist is a no-op with no onchain calls; stale allowlist pubkeys are filtered out; `parse_dz_mode` yields empty groups for no-args multicast.
- Full `command::connect::tests` module passes (42 tests); clippy clean with `-Dclippy::all -Dwarnings`.
