### PR TITLE
ci: publish doublezero client docker image on release

### DIFF
--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -1,0 +1,104 @@
+name: release.docker.client
+
+# Builds and publishes the thin doublezero client image
+# (ghcr.io/<owner>/doublezero). The image installs the released client from the
+# Cloudsmith apt repo, so publishing is chained off a successful `releaser.client`
+# run (which publishes that deb) rather than building from source on main.
+on:
+  workflow_run:
+    workflows: ["releaser.client"]
+    types: [completed]
+  pull_request:
+    paths:
+      - "client/Dockerfile"
+      - "client/docker-entrypoint.sh"
+      - ".github/workflows/release.docker.client.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/doublezero
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  # Release path: a client release just published its deb to Cloudsmith. Build the
+  # image (which installs that now-latest client) and push :<version> and :latest.
+  publish:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0 # need tags to resolve the released version
+
+      - name: Resolve released version
+        id: v
+        shell: bash
+        run: |
+          # releaser.client is triggered by a client/v*.*.* tag; find it on the
+          # commit that triggered this run.
+          TAG="$(git tag --points-at "${{ github.event.workflow_run.head_sha }}" | grep '^client/v' | head -n1 || true)"
+          if [[ -z "$TAG" ]]; then
+            echo "No client/v* tag points at ${{ github.event.workflow_run.head_sha }}; nothing to publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${TAG#client/v}" >> "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Resolved version: ${TAG#client/v}"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.v.outputs.publish == 'true'
+
+      - uses: docker/login-action@v3
+        if: steps.v.outputs.publish == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The image installs the latest client from Cloudsmith, which IS the version
+      # releaser.client just published. We tag with the resolved version rather than
+      # pinning DZ_VERSION (the deb revision suffix isn't derivable from the tag).
+      - name: Build & push (:version + :latest)
+        if: steps.v.outputs.publish == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_VERSION=${{ steps.v.outputs.version }}
+            BUILD_COMMIT=${{ github.event.workflow_run.head_sha }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.v.outputs.version }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.v.outputs.version }}
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha }}
+
+  # Validation path: on PRs touching the image, build for amd64 but do NOT push,
+  # to catch Dockerfile/entrypoint regressions before they reach a release.
+  build-only:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary of Changes
- Add `release.docker.client.yml`, which builds and publishes the thin client image to `ghcr.io/<owner>/doublezero`.
- **Release path:** chained off a successful `releaser.client` run (which publishes the client deb to Cloudsmith) via `workflow_run`, so the image build never races ahead of the apt package it installs. It resolves the released version from the `client/v*.*.*` tag and pushes `:<version>` and `:latest`.
- **Validation path:** on PRs touching `client/Dockerfile`, the entrypoint, or this workflow, it builds the image for `linux/amd64` **without pushing**, to catch Dockerfile/entrypoint regressions before a release.
- Pushes to GHCR with the built-in `GITHUB_TOKEN` (no extra secrets), mirroring `release.docker.core.yml`.

This completes the publish half of the thin client image added in #3862.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| CI/build     |     1 | +104 / -0   | +104 |
| **Total**    |     1 | +104 / -0   | +104 |

A single additive CI workflow; no application code touched.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/release.docker.client.yml` — `workflow_run` publish job (resolves version from tag, pushes `:version`/`:latest`) plus a push-free `pull_request` build job for validation.

</details>

## Testing Verification
- Workflow passes `actionlint` (clean) and parses as valid YAML.
- The image build itself was validated out-of-band: built from `client/Dockerfile` and run on a clean Ubuntu 24.04 amd64 host, where the daemon starts and `doublezero status` reports correctly.
- The `pull_request` build-only job exercises the build path on this PR. The `workflow_run` publish path can only fire from the default branch, so it activates after merge (first real run on the next `releaser.client` release).
