### PR TITLE
client: revert auto-allocate IP on connect when behind NAT (#3861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Client
+  - Revert auto-enabling allocated-IP mode on `doublezero connect ibrl` behind NAT (#3861): the RFC1918 heuristic misfires on 1:1 NAT hosts where plain IBRL works, silently changing the user type.
+
 ## [v0.27.0](https://github.com/malbeclabs/doublezero/compare/client/v0.26.0...client/v0.27.0) - 2026-06-10
 
 ### Breaking

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -122,34 +122,11 @@ impl ProvisioningCliCommand {
             );
         }
 
-        // Get public IP from daemon, along with whether the daemon detected a
-        // private (RFC1918) default-route source (i.e. the host is behind NAT).
-        let (client_ip, behind_nat) =
-            super::helpers::resolve_client_ip_with_nat(controller).await?;
+        // Get public IP from daemon
+        let client_ip = super::helpers::resolve_client_ip(controller).await?;
         let client_ip_str = client_ip.to_string();
 
-        let mut parsed_mode = self.parse_dz_mode()?;
-
-        // When behind NAT the client cannot advertise its own (private) address,
-        // so plain IBRL won't work — default to an allocated DoubleZero address
-        // as if `-a`/`--allocate-addr` were passed. `behind_nat` is only set
-        // when the daemon auto-discovered the IP (it is false whenever an
-        // explicit IP was supplied to the daemon), so the legitimate
-        // "use my own IP" override is already handled daemon-side. The only
-        // no-op case left is `-a` already set, which the user_type guard covers.
-        if behind_nat {
-            if let ParsedDzMode::Ibrl(user_type, _) = &mut parsed_mode {
-                if *user_type == UserType::IBRL {
-                    spinner.println(
-                        "ℹ️  Local address is private (RFC1918); you appear to be behind NAT. \
-                         Enabling --allocate-addr (-a) so DoubleZero assigns a routable IP. \
-                         Pass -a explicitly to silence this, or set --client-ip on the daemon to override.",
-                    );
-                    *user_type = UserType::IBRLWithAllocatedIP;
-                }
-            }
-        }
-
+        let parsed_mode = self.parse_dz_mode()?;
         // Multicast users are not subject to epoch expiry — only verify the AccessPass exists.
         let enforce_epoch = !matches!(parsed_mode, ParsedDzMode::Multicast { .. });
 
@@ -1093,24 +1070,13 @@ mod tests {
 
     impl TestFixture {
         pub fn new() -> Self {
-            Self::new_with_nat(false)
-        }
-
-        /// Like [`TestFixture::new`], but the daemon's v2_status reports
-        /// `behind_nat`, exercising the auto-allocate-on-NAT path.
-        pub fn new_behind_nat() -> Self {
-            Self::new_with_nat(true)
-        }
-
-        fn new_with_nat(behind_nat: bool) -> Self {
             let mut fixture = Self::new_base();
             fixture.setup_enable(|| Ok(()));
-            fixture.controller.expect_v2_status().returning(move || {
+            fixture.controller.expect_v2_status().returning(|| {
                 Ok(V2StatusResponse {
                     reconciler_enabled: false,
                     client_ip: "1.2.3.4".to_string(),
                     network: String::new(),
-                    behind_nat,
                     services: vec![],
                 })
             });
@@ -1129,7 +1095,6 @@ mod tests {
                     reconciler_enabled: false,
                     client_ip: "1.2.3.4".to_string(),
                     network: String::new(),
-                    behind_nat: false,
                     services: vec![],
                 })
             });
@@ -1873,94 +1838,6 @@ mod tests {
                 allocate_addr: true,
             },
             client_ip: Some(user.client_ip.to_string()),
-            device: None,
-            verbose: false,
-        };
-
-        let result = command
-            .execute_with_service_controller(&fixture.client, &fixture.controller)
-            .await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_connect_command_ibrl_behind_nat_auto_allocates() {
-        // Daemon reports behind_nat=true and no client IP is supplied, so a
-        // plain `ibrl` connect should be steered to IBRLWithAllocatedIP.
-        let mut fixture = TestFixture::new_behind_nat();
-
-        let (tenant_pk, tenant) = fixture.add_tenant("nat-tenant");
-        let (device1_pk, _device1) = fixture.add_device(DeviceType::Edge, 100, true);
-        let user = fixture.create_user(UserType::IBRLWithAllocatedIP, device1_pk, "1.2.3.4");
-        fixture.expect_create_user_with_tenant(Pubkey::new_unique(), &user, Some(tenant_pk));
-
-        println!();
-
-        let command = ProvisioningCliCommand {
-            dz_mode: DzMode::IBRL {
-                tenant: Some(tenant.code.clone()),
-                allocate_addr: false,
-            },
-            client_ip: None,
-            device: None,
-            verbose: false,
-        };
-
-        let result = command
-            .execute_with_service_controller(&fixture.client, &fixture.controller)
-            .await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_connect_command_ibrl_behind_nat_ignores_deprecated_cli_client_ip() {
-        // The deprecated CLI --client-ip flag is otherwise ignored, so it must
-        // not suppress the NAT upgrade: behind_nat (which the daemon only sets
-        // when it auto-discovered the IP) still steers to IBRLWithAllocatedIP.
-        let mut fixture = TestFixture::new_behind_nat();
-
-        let (tenant_pk, tenant) = fixture.add_tenant("nat-tenant");
-        let (device1_pk, _device1) = fixture.add_device(DeviceType::Edge, 100, true);
-        let user = fixture.create_user(UserType::IBRLWithAllocatedIP, device1_pk, "1.2.3.4");
-        fixture.expect_create_user_with_tenant(Pubkey::new_unique(), &user, Some(tenant_pk));
-
-        println!();
-
-        let command = ProvisioningCliCommand {
-            dz_mode: DzMode::IBRL {
-                tenant: Some(tenant.code.clone()),
-                allocate_addr: false,
-            },
-            client_ip: Some("1.2.3.4".to_string()),
-            device: None,
-            verbose: false,
-        };
-
-        let result = command
-            .execute_with_service_controller(&fixture.client, &fixture.controller)
-            .await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_connect_command_ibrl_behind_nat_with_explicit_allocate() {
-        // behind_nat=true and -a already set: stays IBRLWithAllocatedIP (the
-        // auto-enable guard is a no-op when allocate is already requested).
-        let mut fixture = TestFixture::new_behind_nat();
-
-        let (tenant_pk, tenant) = fixture.add_tenant("nat-tenant");
-        let (device1_pk, _device1) = fixture.add_device(DeviceType::Edge, 100, true);
-        let user = fixture.create_user(UserType::IBRLWithAllocatedIP, device1_pk, "1.2.3.4");
-        fixture.expect_create_user_with_tenant(Pubkey::new_unique(), &user, Some(tenant_pk));
-
-        println!();
-
-        let command = ProvisioningCliCommand {
-            dz_mode: DzMode::IBRL {
-                tenant: Some(tenant.code.clone()),
-                allocate_addr: true,
-            },
-            client_ip: None,
             device: None,
             verbose: false,
         };

--- a/client/doublezero/src/command/disable.rs
+++ b/client/doublezero/src/command/disable.rs
@@ -58,7 +58,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: String::new(),
-                behind_nat: false,
                 services: vec![],
             })
         });

--- a/client/doublezero/src/command/disconnect.rs
+++ b/client/doublezero/src/command/disconnect.rs
@@ -406,7 +406,6 @@ mod tests {
             reconciler_enabled: true,
             client_ip: client_ip.to_string(),
             network: "mainnet".to_string(),
-            behind_nat: false,
             services: vec![],
         }
     }

--- a/client/doublezero/src/command/enable.rs
+++ b/client/doublezero/src/command/enable.rs
@@ -51,7 +51,6 @@ mod tests {
                 reconciler_enabled: false,
                 client_ip: String::new(),
                 network: String::new(),
-                behind_nat: false,
                 services: vec![],
             })
         });

--- a/client/doublezero/src/command/helpers.rs
+++ b/client/doublezero/src/command/helpers.rs
@@ -1,24 +1,9 @@
 use std::net::Ipv4Addr;
 
-use crate::servicecontroller::{ServiceController, V2StatusResponse};
+use crate::servicecontroller::ServiceController;
 
 pub async fn resolve_client_ip<T: ServiceController>(controller: &T) -> eyre::Result<Ipv4Addr> {
     let v2_status = controller.v2_status().await?;
-    parse_client_ip(&v2_status)
-}
-
-/// Like [`resolve_client_ip`], but also returns the daemon's `behind_nat`
-/// signal (true when the auto-discovered default-route source was a private
-/// RFC1918 address). Fetches `/v2/status` once.
-pub async fn resolve_client_ip_with_nat<T: ServiceController>(
-    controller: &T,
-) -> eyre::Result<(Ipv4Addr, bool)> {
-    let v2_status = controller.v2_status().await?;
-    let ip = parse_client_ip(&v2_status)?;
-    Ok((ip, v2_status.behind_nat))
-}
-
-fn parse_client_ip(v2_status: &V2StatusResponse) -> eyre::Result<Ipv4Addr> {
     if v2_status.client_ip.is_empty() {
         return Err(eyre::eyre!(
             "Daemon has not discovered its client IP. Ensure the daemon is running \

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -208,7 +208,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![make_v2_service(
                     "BGP Session Up",
                     Some("tunnel_name"),
@@ -258,7 +257,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![V2ServiceStatus {
                     status: StatusResponse {
                         doublezero_status: DoubleZeroStatus {
@@ -314,7 +312,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![make_v2_service(
                     "BGP Session Up",
                     Some("tunnel_name"),
@@ -351,7 +348,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![V2ServiceStatus {
                     status: StatusResponse {
                         doublezero_status: DoubleZeroStatus {
@@ -575,7 +571,6 @@ mod tests {
                 reconciler_enabled: false,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![make_v2_service(
                     "BGP Session Up",
                     Some("doublezero1"),
@@ -611,7 +606,6 @@ mod tests {
                 reconciler_enabled: false,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![],
             })
         });
@@ -648,7 +642,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![make_v2_service(
                     "BGP Session Up",
                     Some("doublezero1"),
@@ -678,7 +671,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![make_v2_service(
                     "BGP Session Up",
                     Some("doublezero1"),
@@ -710,7 +702,6 @@ mod tests {
                 reconciler_enabled: true,
                 client_ip: String::new(),
                 network: "testnet".to_string(),
-                behind_nat: false,
                 services: vec![V2ServiceStatus {
                     status: StatusResponse {
                         doublezero_status: DoubleZeroStatus {
@@ -836,7 +827,6 @@ mod tests {
                     reconciler_enabled: true,
                     client_ip: String::new(),
                     network: "testnet".to_string(),
-                    behind_nat: false,
                     services: vec![make_v2_service(
                         "BGP Session Up",
                         Some("doublezero1"),

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -179,11 +179,6 @@ pub struct V2StatusResponse {
     pub client_ip: String,
     #[serde(default)]
     pub network: String,
-    /// True when the daemon auto-discovered its client IP and the default-route
-    /// source was a private RFC1918 address (i.e. the host is behind NAT).
-    /// `serde(default)` keeps the CLI compatible with older daemons that omit it.
-    #[serde(default)]
-    pub behind_nat: bool,
     pub services: Vec<V2ServiceStatus>,
 }
 

--- a/client/doublezerod/internal/manager/http.go
+++ b/client/doublezerod/internal/manager/http.go
@@ -37,7 +37,6 @@ type V2StatusResponse struct {
 	ReconcilerEnabled bool              `json:"reconciler_enabled"`
 	ClientIP          string            `json:"client_ip"`
 	Network           string            `json:"network"`
-	BehindNAT         bool              `json:"behind_nat"`
 	Services          []V2ServiceStatus `json:"services"`
 }
 
@@ -175,7 +174,6 @@ func (n *NetlinkManager) ServeV2Status(w http.ResponseWriter, _ *http.Request) {
 		ReconcilerEnabled: n.enabled.Load(),
 		ClientIP:          n.clientIP.String(),
 		Network:           n.network,
-		BehindNAT:         n.behindNAT,
 		Services:          enriched,
 	})
 }

--- a/client/doublezerod/internal/manager/manager.go
+++ b/client/doublezerod/internal/manager/manager.go
@@ -68,14 +68,6 @@ func WithClientIP(ip net.IP) Option {
 	}
 }
 
-// WithBehindNAT sets whether the client's default-route source is a private
-// RFC1918 address (i.e. the host is behind NAT).
-func WithBehindNAT(behindNAT bool) Option {
-	return func(n *NetlinkManager) {
-		n.behindNAT = behindNAT
-	}
-}
-
 // WithFetcher sets the onchain data fetcher for the reconciler.
 func WithFetcher(f Fetcher) Option {
 	return func(n *NetlinkManager) {
@@ -150,11 +142,6 @@ type NetlinkManager struct {
 	// Status enrichment fields
 	latencyProvider LatencyProvider
 	network         string
-
-	// behindNAT is true when the client IP was auto-discovered and the
-	// default-route source was a private RFC1918 address. Exposed via
-	// /v2/status so the CLI can default to an allocated DoubleZero address.
-	behindNAT bool
 }
 
 // CreateService creates the appropriate service based on the provisioned

--- a/client/doublezerod/internal/manager/reconciler_test.go
+++ b/client/doublezerod/internal/manager/reconciler_test.go
@@ -1203,45 +1203,6 @@ func TestServeV2Status_Disabled_NoServices(t *testing.T) {
 	}
 }
 
-func TestServeV2Status_BehindNAT(t *testing.T) {
-	dir := t.TempDir()
-	fetcher := &mockFetcher{data: &serviceability.ProgramData{GlobalConfig: testGlobalConfig()}}
-	req := httptest.NewRequest(http.MethodGet, "/v2/status", nil)
-
-	// Default: behind_nat is false.
-	def := newTestNLM(fetcher,
-		WithClientIP(net.IPv4(1, 2, 3, 4).To4()),
-		WithPollInterval(time.Hour),
-		WithStateDir(dir),
-	)
-	w := httptest.NewRecorder()
-	def.ServeV2Status(w, req)
-	var defResp V2StatusResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &defResp); err != nil {
-		t.Fatal(err)
-	}
-	if defResp.BehindNAT {
-		t.Fatal("expected behind_nat=false by default")
-	}
-
-	// With WithBehindNAT(true): behind_nat is reported true.
-	nat := newTestNLM(fetcher,
-		WithClientIP(net.IPv4(1, 2, 3, 4).To4()),
-		WithBehindNAT(true),
-		WithPollInterval(time.Hour),
-		WithStateDir(dir),
-	)
-	w = httptest.NewRecorder()
-	nat.ServeV2Status(w, req)
-	var natResp V2StatusResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &natResp); err != nil {
-		t.Fatal(err)
-	}
-	if !natResp.BehindNAT {
-		t.Fatal("expected behind_nat=true")
-	}
-}
-
 func TestServeV2Status_Enrichment(t *testing.T) {
 	devicePK := [32]byte{1}
 	exchangePK := [32]byte{2}

--- a/client/doublezerod/internal/runtime/clientip.go
+++ b/client/doublezerod/internal/runtime/clientip.go
@@ -27,10 +27,6 @@ var (
 	externalDiscoveryURL = "https://ifconfig.me/ip"
 )
 
-// defaultRouteSource returns the default route's source IP. It is a package
-// var so tests can inject a source without performing a real route lookup.
-var defaultRouteSource = discoverDefaultRouteSource
-
 func init() {
 	for _, cidr := range []string{
 		"0.0.0.0/8",       // "this" network (RFC 1122)
@@ -84,43 +80,24 @@ func IsPublicIPv4(ip net.IP) bool {
 // pick an address on an interface that doesn't match the default route,
 // causing a mismatch with the onchain User's ClientIp.
 //
-// The second return value describes the discovery method for logging. The
-// third return value (behindNAT) is true when the IP was auto-discovered and
-// the default-route source was a private RFC1918 address — i.e. the host sits
-// behind NAT. It is always false when an explicit IP was supplied, so callers
-// can use it to decide whether to default to an allocated DoubleZero address.
-func DiscoverClientIP(explicit string) (net.IP, string, bool, error) {
+// The second return value describes the discovery method for logging.
+func DiscoverClientIP(explicit string) (net.IP, string, error) {
 	// 1. Explicit flag.
 	if explicit != "" {
 		ip := net.ParseIP(explicit)
 		if ip == nil {
-			return nil, "", false, fmt.Errorf("invalid client-ip flag value: %s", explicit)
+			return nil, "", fmt.Errorf("invalid client-ip flag value: %s", explicit)
 		}
 		ip = ip.To4()
 		if ip == nil {
-			return nil, "", false, fmt.Errorf("client-ip must be IPv4: %s", explicit)
+			return nil, "", fmt.Errorf("client-ip must be IPv4: %s", explicit)
 		}
-		return ip, "explicit flag", false, nil
+		return ip, "explicit flag", nil
 	}
 
 	// 2. Default route source hint.
-	behindNAT := false
-	if src, err := defaultRouteSource(); err == nil {
-		if IsPublicIPv4(src) {
-			return src, "default route", false, nil
-		}
-		// The default-route source is not publicly routable. If it is a
-		// private RFC1918 address the host is behind NAT; record that so the
-		// caller can default to an allocated address. The public IP itself
-		// still comes from external discovery below.
-		//
-		// Scoped to RFC1918 deliberately: IsPrivate excludes CGNAT
-		// (100.64.0.0/10) and other reserved ranges. CGNAT hosts can't run
-		// plain IBRL either, but flagging them is a separate product decision;
-		// widen the predicate here if we choose to cover them later.
-		behindNAT = src.IsPrivate()
-		slog.Debug("client-ip: default route source not publicly routable, falling back to external",
-			"source", src.String(), "behind_nat", behindNAT)
+	if ip, err := discoverFromDefaultRoute(); err == nil {
+		return ip, "default route", nil
 	} else {
 		slog.Debug("client-ip: default route discovery failed, falling back to external", "error", err)
 	}
@@ -128,17 +105,16 @@ func DiscoverClientIP(explicit string) (net.IP, string, bool, error) {
 	// 3. External discovery.
 	ip, err := discoverFromExternal()
 	if err != nil {
-		return nil, "", false, fmt.Errorf("client IP discovery failed: %w", err)
+		return nil, "", fmt.Errorf("client IP discovery failed: %w", err)
 	}
-	return ip, "external discovery (ifconfig.me)", behindNAT, nil
+	return ip, "external discovery (ifconfig.me)", nil
 }
 
-// discoverDefaultRouteSource performs a kernel route lookup by dialing a
+// discoverFromDefaultRoute performs a kernel route lookup by dialing a
 // well-known public IP over UDP (no packets are actually sent). The local
 // address chosen by the kernel reflects the default route's source hint,
-// which is the address that outbound traffic would actually use. It returns
-// the raw IPv4 source without judging whether it is publicly routable.
-func discoverDefaultRouteSource() (net.IP, error) {
+// which is the address that outbound traffic would actually use.
+func discoverFromDefaultRoute() (net.IP, error) {
 	conn, err := net.Dial("udp4", "8.8.8.8:80")
 	if err != nil {
 		return nil, fmt.Errorf("route lookup failed: %w", err)
@@ -153,6 +129,9 @@ func discoverDefaultRouteSource() (net.IP, error) {
 	ip := localAddr.IP.To4()
 	if ip == nil {
 		return nil, fmt.Errorf("default route source is not IPv4: %v", localAddr.IP)
+	}
+	if !IsPublicIPv4(ip) {
+		return nil, fmt.Errorf("default route source %s is not publicly routable", ip)
 	}
 	return ip, nil
 }

--- a/client/doublezerod/internal/runtime/clientip_test.go
+++ b/client/doublezerod/internal/runtime/clientip_test.go
@@ -114,7 +114,7 @@ func TestDiscoverClientIP_Explicit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ip, method, behindNAT, err := DiscoverClientIP(tt.explicit)
+			ip, method, err := DiscoverClientIP(tt.explicit)
 			if tt.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got ip=%v method=%s", ip, method)
@@ -126,9 +126,6 @@ func TestDiscoverClientIP_Explicit(t *testing.T) {
 			}
 			if method != "explicit flag" {
 				t.Errorf("method = %q, want %q", method, "explicit flag")
-			}
-			if behindNAT {
-				t.Errorf("behindNAT = true, want false for explicit flag")
 			}
 			if ip.String() != tt.expectIP {
 				t.Errorf("ip = %s, want %s", ip.String(), tt.expectIP)
@@ -142,80 +139,6 @@ func withTestExternalURL(t *testing.T, url string) {
 	orig := externalDiscoveryURL
 	externalDiscoveryURL = url
 	t.Cleanup(func() { externalDiscoveryURL = orig })
-}
-
-func withTestDefaultRouteSource(t *testing.T, src net.IP, err error) {
-	t.Helper()
-	orig := defaultRouteSource
-	defaultRouteSource = func() (net.IP, error) { return src, err }
-	t.Cleanup(func() { defaultRouteSource = orig })
-}
-
-func TestDiscoverClientIP_AutoDiscovery(t *testing.T) {
-	const publicIP = "93.184.216.34"
-
-	tests := []struct {
-		name         string
-		source       net.IP
-		sourceErr    error
-		expectIP     string
-		expectMethod string
-		expectBehind bool
-	}{
-		{
-			name:         "public default-route source used directly",
-			source:       net.ParseIP("44.0.0.1"),
-			expectIP:     "44.0.0.1",
-			expectMethod: "default route",
-			expectBehind: false,
-		},
-		{
-			name:         "rfc1918 source falls back to external and flags NAT",
-			source:       net.ParseIP("192.168.1.50"),
-			expectIP:     publicIP,
-			expectMethod: "external discovery (ifconfig.me)",
-			expectBehind: true,
-		},
-		{
-			name:         "cgnat source falls back but does not flag NAT",
-			source:       net.ParseIP("100.64.0.1"),
-			expectIP:     publicIP,
-			expectMethod: "external discovery (ifconfig.me)",
-			expectBehind: false,
-		},
-		{
-			name:         "no default route falls back without flagging NAT",
-			sourceErr:    fmt.Errorf("no route"),
-			expectIP:     publicIP,
-			expectMethod: "external discovery (ifconfig.me)",
-			expectBehind: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			withTestDefaultRouteSource(t, tt.source, tt.sourceErr)
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, publicIP)
-			}))
-			defer srv.Close()
-			withTestExternalURL(t, srv.URL)
-
-			ip, method, behindNAT, err := DiscoverClientIP("")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if ip.String() != tt.expectIP {
-				t.Errorf("ip = %s, want %s", ip, tt.expectIP)
-			}
-			if method != tt.expectMethod {
-				t.Errorf("method = %q, want %q", method, tt.expectMethod)
-			}
-			if behindNAT != tt.expectBehind {
-				t.Errorf("behindNAT = %v, want %v", behindNAT, tt.expectBehind)
-			}
-		})
-	}
 }
 
 func TestDiscoverFromExternal_Success(t *testing.T) {

--- a/client/doublezerod/internal/runtime/run.go
+++ b/client/doublezerod/internal/runtime/run.go
@@ -79,11 +79,11 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 	svcClient := serviceability.New(rpc.New(networkConfig.LedgerPublicRPCURL), pid)
 	cachingFetcher := onchain.NewCachingFetcher(svcClient, onchain.DefaultCacheTTL, onchainRPCTimeout)
 
-	ip, method, behindNAT, err := DiscoverClientIP(clientIP)
+	ip, method, err := DiscoverClientIP(clientIP)
 	if err != nil {
 		return fmt.Errorf("client IP discovery failed: %w", err)
 	}
-	slog.Info("reconciler: discovered client IP", "ip", ip.String(), "method", method, "behind_nat", behindNAT)
+	slog.Info("reconciler: discovered client IP", "ip", ip.String(), "method", method)
 
 	reconcilerEnabled, err := manager.LoadOrMigrateState(stateDir)
 	if err != nil {
@@ -116,7 +116,6 @@ func Run(ctx context.Context, sockFile string, routeConfigPath string, enableLat
 	fetchTimeout := time.Duration(reconcilerFetchTimeout) * time.Second
 	nlmOpts := []manager.Option{
 		manager.WithClientIP(ip),
-		manager.WithBehindNAT(behindNAT),
 		manager.WithFetcher(cachingFetcher),
 		manager.WithPollInterval(pollInterval),
 		manager.WithFetchTimeout(fetchTimeout),


### PR DESCRIPTION
## Summary of Changes
- Reverts #3861 (`105d9035`): `doublezero connect ibrl` no longer auto-flips to `IBRLWithAllocatedIP` when the daemon's default-route source is an RFC1918 address.
- The heuristic misfires on hosts behind 1:1 NAT — e.g. the chi-dn devnet QA hosts — where plain IBRL works. After today's daily deploy picked up the change, those hosts silently connected as a different user type with an allocated `dz_ip`, and devnet QA `TestQA_MultiTunnel/unicast_connectivity` failed deterministically (route waits expect public-IP routes).
- Beyond QA, the same silent user-type change would hit any NAT'd production client on the next release, so the detection needs to distinguish 1:1 NAT from address-translating NAT before re-landing.
- Removes the `behind_nat` field from the daemon's `/v2/status` response and the CLI's NAT-aware connect path; explicit `-a` / `--client-ip` behavior is unchanged.
- Targeted for a standalone v0.27.1 release (v0.27.0 is already tagged with the feature included).

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net   |
|--------------|-------|--------------|-------|
| Core logic   |     2 | +19 / -163   |  -144 |
| Scaffolding  |     9 | +3  / -52    |   -49 |
| Tests        |     2 | +1  / -117   |  -116 |
| Docs         |     1 | +3  / -0     |    +3 |
| **Total**    |    14 | +26 / -332   |  -306 |

Pure revert: net -306 lines, mostly removing the NAT-detection logic and its tests.

<details>
<summary>Key files (click to expand)</summary>

- `client/doublezero/src/command/connect.rs` — remove the behind-NAT auto-allocate decision and its tests
- `client/doublezerod/internal/runtime/clientip.go` — `DiscoverClientIP` no longer reports `behindNAT`; restores the pre-#3861 signature

</details>

## Testing Verification
- `cargo test -p doublezero`: 145 tests pass (includes the connect command suite the revert touches).
- `go test ./client/doublezerod/internal/runtime/... ./client/doublezerod/internal/manager/...`: pass.
- `make rust-lint` clean in the dev container.
- The revert auto-merged around #3864 (auto-join multicast groups), which landed in `connect.rs` afterward; only `CHANGELOG.md` needed manual resolution (v0.27.0 section kept as shipped history, revert noted under Unreleased).