### PR TITLE
client: make installer attendantless with DZ_ secret token

### DIFF
--- a/client/install.sh
+++ b/client/install.sh
@@ -8,7 +8,7 @@
 #
 # It checks for Docker (offering to install it), preps the host for GRE, loads the
 # access secret, runs the thin doublezero client container
-# (ghcr.io/malbeclabs/doublezero), and runs `doublezero connect multicast`.
+# (ghcr.io/malbeclabs-latam/doublezero-edge-connect), and runs `doublezero connect multicast`.
 #
 # Attendantless: the only input is the access secret. Provide it via DZ_SECRET to
 # run with no prompts at all; otherwise you're prompted once. Everything else has
@@ -18,7 +18,7 @@
 #   DZ_SECRET=<DZ_token|path> base64 keypair token (always prefixed with 'DZ_')
 #                             OR a path to a keypair file. If set, runs non-interactively.
 #   DZ_ENV=testnet|devnet|mainnet-beta   default: testnet
-#   DZ_IMAGE=ghcr.io/malbeclabs/doublezero:latest
+#   DZ_IMAGE=ghcr.io/malbeclabs-latam/doublezero-edge-connect:latest
 #   DZ_NAME=doublezero                   container name
 #   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
 #
@@ -35,7 +35,7 @@ set -euo pipefail
 # ----------------------------------------------------------------------------
 # config / defaults
 # ----------------------------------------------------------------------------
-DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs/doublezero:latest}"
+DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs-latam/doublezero-edge-connect:latest}"
 DZ_NAME="${DZ_NAME:-doublezero}"
 DZ_ENV="${DZ_ENV:-testnet}"
 DZ_SECRET="${DZ_SECRET:-}"

--- a/client/install.sh
+++ b/client/install.sh
@@ -166,20 +166,25 @@ fi
 
 case "$SECRET" in
   DZ_*)
-    # base64 keypair token: strip the 'DZ_' prefix, decode + validate, and install
-    # to the client's standard keypair location.
+    # 'DZ_' + base64url(raw 64 keypair bytes). Restore the base64 alphabet and
+    # padding, decode to raw bytes, render the Solana keypair JSON array, and
+    # install it to the client's standard keypair location.
+    b64="$(printf '%s' "${SECRET#DZ_}" | tr '_-' '/+')"
+    case $(( ${#b64} % 4 )) in
+      2) b64="${b64}==" ;;
+      3) b64="${b64}=" ;;
+      1) die "Invalid DZ_ token (bad base64url length)." ;;
+    esac
+    # raw bytes -> single-line "[b1,b2,...]" (collapse od's multi-line output)
+    arr="$(printf '%s' "$b64" | base64 -d 2>/dev/null | od -An -v -t u1 | tr -s ' \n' ' ' | sed 's/^ //; s/ $//; s/ /,/g')"
+    case "$arr" in [0-9]*) : ;; *) die "DZ_ token did not decode to a valid keypair." ;; esac
+    n=$(printf '%s' "$arr" | tr ',' '\n' | grep -c .)
+    [ "$n" -eq 64 ] || die "DZ_ token decoded to $n bytes, expected 64 (not a Solana keypair)."
     KEYFILE="$REAL_HOME/.config/doublezero/id.json"
-    tmp_key="$(mktemp)"
-    if printf '%s' "${SECRET#DZ_}" | tr -d '[:space:]' | base64 -d > "$tmp_key" 2>/dev/null \
-       && grep -qE '^[[:space:]]*\[[0-9]+,' "$tmp_key"; then
-      mkdir -p "$(dirname "$KEYFILE")"
-      mv "$tmp_key" "$KEYFILE"
-      chmod 600 "$KEYFILE"
-      info "Decoded token to $KEYFILE"
-    else
-      rm -f "$tmp_key"
-      die "DZ_ token did not decode to a valid keypair."
-    fi
+    mkdir -p "$(dirname "$KEYFILE")"
+    printf '[%s]' "$arr" > "$KEYFILE"
+    chmod 600 "$KEYFILE"
+    info "Decoded token to $KEYFILE ($n-byte keypair)"
     ;;
   *)
     # otherwise it's a path to an existing keypair file

--- a/client/install.sh
+++ b/client/install.sh
@@ -6,14 +6,18 @@
 #
 #     curl -fsSL https://get.doublezero.xyz/install | bash
 #
-# It checks for Docker (offering to install it), preps the host for GRE,
-# loads the user's keypair, runs the thin doublezero client container
-# (ghcr.io/malbeclabs/doublezero), and connects.
+# It checks for Docker (offering to install it), preps the host for GRE, loads the
+# access secret, runs the thin doublezero client container
+# (ghcr.io/malbeclabs/doublezero), and runs `doublezero connect multicast`.
 #
-# Non-interactive overrides (env vars):
-#   DZ_ENV=testnet|devnet|mainnet-beta   default: prompt (falls back to mainnet-beta)
-#   DZ_KEYPAIR=/abs/path/to/id.json      default: prompt
-#   DZ_CONNECT="connect multicast"       connect args to run (default: "connect multicast")
+# Attendantless: the only input is the access secret. Provide it via DZ_SECRET to
+# run with no prompts at all; otherwise you're prompted once. Everything else has
+# a default.
+#
+# Env vars:
+#   DZ_SECRET=<DZ_token|path> base64 keypair token (always prefixed with 'DZ_')
+#                             OR a path to a keypair file. If set, runs non-interactively.
+#   DZ_ENV=testnet|devnet|mainnet-beta   default: testnet
 #   DZ_IMAGE=ghcr.io/malbeclabs/doublezero:latest
 #   DZ_NAME=doublezero                   container name
 #   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
@@ -29,9 +33,8 @@ set -euo pipefail
 # ----------------------------------------------------------------------------
 DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs/doublezero:latest}"
 DZ_NAME="${DZ_NAME:-doublezero}"
-DZ_ENV="${DZ_ENV:-}"
-DZ_KEYPAIR="${DZ_KEYPAIR:-}"
-DZ_CONNECT="${DZ_CONNECT:-}"
+DZ_ENV="${DZ_ENV:-testnet}"
+DZ_SECRET="${DZ_SECRET:-}"
 DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
 KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)
 LIVENESS_UDP_PORT=44880
@@ -147,18 +150,45 @@ case "$CLOUD" in
 esac
 
 # ----------------------------------------------------------------------------
-# 5. inputs: keypair + environment + connect target
+# 5. input: the access secret (the only thing we ask for)
 # ----------------------------------------------------------------------------
-# environment
-if [ -z "$DZ_ENV" ]; then DZ_ENV="$(ask 'DoubleZero environment (testnet/devnet/mainnet-beta)' 'mainnet-beta')"; fi
-case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV'";; esac
+# Environment: default testnet, override via DZ_ENV; never prompted.
+case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV' (testnet|devnet|mainnet-beta)";; esac
 
-# keypair
-if [ -z "$DZ_KEYPAIR" ]; then DZ_KEYPAIR="$(ask 'Path to your DoubleZero keypair (id.json)' "$REAL_HOME/.config/doublezero/id.json")"; fi
-# expand ~ and relativize to absolute (against the human user's home)
-case "$DZ_KEYPAIR" in "~"*) DZ_KEYPAIR="${REAL_HOME}${DZ_KEYPAIR#\~}";; esac
-DZ_KEYPAIR="$(realpath -m "$DZ_KEYPAIR" 2>/dev/null || echo "$DZ_KEYPAIR")"
-[ -f "$DZ_KEYPAIR" ] || die "No keypair file at: $DZ_KEYPAIR (a wrong path makes Docker mount an empty dir over id.json)."
+# The secret is either a base64 keypair token (always prefixed with 'DZ_') or a
+# path to an existing keypair file. Provide via DZ_SECRET (no prompt) or once at
+# the prompt.
+SECRET="$DZ_SECRET"
+if [ -z "$SECRET" ]; then
+  SECRET="$(ask 'Access secret (DZ_-prefixed token, or path to a keypair file)' '')"
+fi
+[ -n "$SECRET" ] || die "No secret provided. Set DZ_SECRET or supply one when prompted."
+
+case "$SECRET" in
+  DZ_*)
+    # base64 keypair token: strip the 'DZ_' prefix, decode + validate, and install
+    # to the client's standard keypair location.
+    KEYFILE="$REAL_HOME/.config/doublezero/id.json"
+    tmp_key="$(mktemp)"
+    if printf '%s' "${SECRET#DZ_}" | tr -d '[:space:]' | base64 -d > "$tmp_key" 2>/dev/null \
+       && grep -qE '^[[:space:]]*\[[0-9]+,' "$tmp_key"; then
+      mkdir -p "$(dirname "$KEYFILE")"
+      mv "$tmp_key" "$KEYFILE"
+      chmod 600 "$KEYFILE"
+      info "Decoded token to $KEYFILE"
+    else
+      rm -f "$tmp_key"
+      die "DZ_ token did not decode to a valid keypair."
+    fi
+    ;;
+  *)
+    # otherwise it's a path to an existing keypair file
+    case "$SECRET" in "~"*) SECRET_PATH="${REAL_HOME}${SECRET#\~}";; *) SECRET_PATH="$SECRET";; esac
+    [ -f "$SECRET_PATH" ] || die "Secret is not a DZ_-prefixed token, and no keypair file exists at: $SECRET"
+    KEYFILE="$(realpath -m "$SECRET_PATH")"
+    info "Using keypair file: $KEYFILE"
+    ;;
+esac
 
 # SELinux relabel for the bind mount
 MNT_OPT=ro
@@ -178,7 +208,7 @@ $SUDO docker run -d --name "$DZ_NAME" \
   --cap-add NET_ADMIN --cap-add NET_RAW \
   --device /dev/net/tun \
   -e DZ_ENV="$DZ_ENV" \
-  -v "$DZ_KEYPAIR":"$KEYPAIR_DEST":"$MNT_OPT" \
+  -v "$KEYFILE":"$KEYPAIR_DEST":"$MNT_OPT" \
   "$DZ_IMAGE" >/dev/null
 
 # wait for the daemon socket
@@ -190,22 +220,17 @@ for _ in $(seq 1 30); do
 done
 
 # ----------------------------------------------------------------------------
-# 7. connect  (TODO: finalize the verb/args + access-pass flow)
+# 7. connect (always `doublezero connect multicast`)
 # ----------------------------------------------------------------------------
-if [ -z "$DZ_CONNECT" ]; then
-  DZ_CONNECT="$(ask 'Connect command to run now (Enter to accept, blank-then-Enter to skip)' 'connect multicast')"
-fi
-if [ -n "$DZ_CONNECT" ]; then
-  info "Connecting: doublezero $DZ_CONNECT"
-  # Allocate a pseudo-TTY when our stdout is a terminal so the CLI streams its
-  # normal output to the screen (without -t, docker exec gives it no TTY and the
-  # command's progress/result output is suppressed).
-  EXEC_TTY=""; [ -t 1 ] && EXEC_TTY="-t"
-  # NOTE: connect requires the host's public IP to have an access pass / allowlisted
-  # user onchain for $DZ_ENV. If this errors with an access-pass message, that
-  # provisioning step still needs to happen.
-  $SUDO docker exec $EXEC_TTY "$DZ_NAME" doublezero $DZ_CONNECT || warn "connect failed (often: no access pass for this IP, or provider firewall/NAT). See notes above."
-fi
+info "Connecting: doublezero connect multicast"
+# Allocate a pseudo-TTY when our stdout is a terminal so the CLI streams its
+# normal output to the screen (without -t, docker exec gives it no TTY and the
+# command's output is suppressed).
+EXEC_TTY=""; [ -t 1 ] && EXEC_TTY="-t"
+# NOTE: connect requires the host's public IP to have an access pass / allowlisted
+# user onchain for $DZ_ENV. If this errors with an access-pass message, that
+# provisioning step still needs to happen.
+$SUDO docker exec $EXEC_TTY "$DZ_NAME" doublezero connect multicast || warn "connect failed (often: no access pass for this IP, or provider firewall/NAT). See notes above."
 
 # ----------------------------------------------------------------------------
 # 8. status + management hints

--- a/client/install.sh
+++ b/client/install.sh
@@ -120,7 +120,7 @@ $SUDO docker info >/dev/null 2>&1 || die "Docker is installed but the daemon isn
 # ----------------------------------------------------------------------------
 # 3. host kernel / network prep (host-side; safe to attempt)
 # ----------------------------------------------------------------------------
-info "Preparing host for GRE tunnels..."
+info "Preparing host for DoubleZero Edge Connect"
 $SUDO modprobe tun 2>/dev/null    || warn "Could not load 'tun' module (may be built-in)."
 $SUDO modprobe ip_gre 2>/dev/null || warn "Could not load 'ip_gre' module (will auto-load on tunnel create)."
 [ -e /dev/net/tun ] || warn "/dev/net/tun is missing; tunnel creation may fail."

--- a/client/install.sh
+++ b/client/install.sh
@@ -22,6 +22,10 @@
 #   DZ_NAME=doublezero                   container name
 #   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
 #
+# A DZ_-token-derived keypair is injected straight into the container and is never
+# written to the host disk; a keypair supplied as a file path is bind-mounted
+# read-only. Either way the plaintext key is not printed.
+#
 # NOTE: connecting requires the host's public IP to have an access pass / allowlisted
 # user onchain for the chosen environment. That provisioning is a separate step; if
 # `connect` reports an access-pass error, the rest of the setup is still in place.
@@ -167,8 +171,9 @@ fi
 case "$SECRET" in
   DZ_*)
     # 'DZ_' + base64url(raw 64 keypair bytes). Restore the base64 alphabet and
-    # padding, decode to raw bytes, render the Solana keypair JSON array, and
-    # install it to the client's standard keypair location.
+    # padding, decode to raw bytes, and build the Solana keypair JSON array in
+    # memory. It is injected into the container after start and is NEVER written
+    # to the host disk.
     b64="$(printf '%s' "${SECRET#DZ_}" | tr '_-' '/+')"
     case $(( ${#b64} % 4 )) in
       2) b64="${b64}==" ;;
@@ -176,21 +181,18 @@ case "$SECRET" in
       1) die "Invalid DZ_ token (bad base64url length)." ;;
     esac
     # raw bytes -> single-line "[b1,b2,...]" (collapse od's multi-line output)
-    arr="$(printf '%s' "$b64" | base64 -d 2>/dev/null | od -An -v -t u1 | tr -s ' \n' ' ' | sed 's/^ //; s/ $//; s/ /,/g')"
-    case "$arr" in [0-9]*) : ;; *) die "DZ_ token did not decode to a valid keypair." ;; esac
-    n=$(printf '%s' "$arr" | tr ',' '\n' | grep -c .)
-    [ "$n" -eq 64 ] || die "DZ_ token decoded to $n bytes, expected 64 (not a Solana keypair)."
-    KEYFILE="$REAL_HOME/.config/doublezero/id.json"
-    mkdir -p "$(dirname "$KEYFILE")"
-    printf '[%s]' "$arr" > "$KEYFILE"
-    chmod 600 "$KEYFILE"
-    info "Decoded token to $KEYFILE ($n-byte keypair)"
+    KEY_JSON="[$(printf '%s' "$b64" | base64 -d 2>/dev/null | od -An -v -t u1 | tr -s ' \n' ' ' | sed 's/^ //; s/ $//; s/ /,/g')]"
+    n=$(printf '%s' "$KEY_JSON" | tr ',' '\n' | grep -c '[0-9]')
+    [ "$n" -eq 64 ] || die "DZ_ token did not decode to a 64-byte keypair (got $n)."
+    KEY_SRC=token
+    info "Decoded token to a $n-byte keypair (held in memory; not written to host disk)."
     ;;
   *)
-    # otherwise it's a path to an existing keypair file
+    # otherwise it's a path to an existing keypair file (bind-mounted read-only)
     case "$SECRET" in "~"*) SECRET_PATH="${REAL_HOME}${SECRET#\~}";; *) SECRET_PATH="$SECRET";; esac
     [ -f "$SECRET_PATH" ] || die "Secret is not a DZ_-prefixed token, and no keypair file exists at: $SECRET"
     KEYFILE="$(realpath -m "$SECRET_PATH")"
+    KEY_SRC=file
     info "Using keypair file: $KEYFILE"
     ;;
 esac
@@ -207,13 +209,17 @@ $SUDO docker pull -q "$DZ_IMAGE" >/dev/null
 
 info "Starting doublezero client (env=$DZ_ENV)..."
 $SUDO docker rm -f "$DZ_NAME" >/dev/null 2>&1 || true
+# Bind-mount the keypair only when the secret was a file; a token-derived key is
+# injected into the container after it starts (so it never touches the host disk).
+mount_args=()
+[ "$KEY_SRC" = file ] && mount_args=(-v "$KEYFILE":"$KEYPAIR_DEST":"$MNT_OPT")
 $SUDO docker run -d --name "$DZ_NAME" \
   --restart unless-stopped \
   --network host \
   --cap-add NET_ADMIN --cap-add NET_RAW \
   --device /dev/net/tun \
   -e DZ_ENV="$DZ_ENV" \
-  -v "$KEYFILE":"$KEYPAIR_DEST":"$MNT_OPT" \
+  "${mount_args[@]}" \
   "$DZ_IMAGE" >/dev/null
 
 # wait for the daemon socket
@@ -223,6 +229,15 @@ for _ in $(seq 1 30); do
   $SUDO docker ps -q --filter "name=^${DZ_NAME}$" | grep -q . || die "Container exited early. Logs: sudo docker logs $DZ_NAME"
   sleep 1
 done
+
+# Deliver a token-derived key by piping it straight into the container's
+# filesystem, so the plaintext keypair lives only in the container (and is gone
+# when the container is removed). A file secret is already bind-mounted above.
+if [ "$KEY_SRC" = token ]; then
+  printf '%s' "$KEY_JSON" | $SUDO docker exec -i "$DZ_NAME" \
+    sh -c 'umask 077; mkdir -p /root/.config/doublezero && cat > /root/.config/doublezero/id.json'
+  info "Installed keypair into the container (not stored on the host)."
+fi
 
 # ----------------------------------------------------------------------------
 # 7. connect (always `doublezero connect multicast`)


### PR DESCRIPTION
## Summary of Changes
- Make the installer **attendantless**: the only input is the access secret. Set `DZ_SECRET` to run with no prompts at all; otherwise it prompts exactly once.
- The secret is either a **`DZ_`-prefixed base64url token** (the raw keypair bytes) or a **path to a keypair file**, disambiguated by the `DZ_` prefix.
- A token-derived keypair is **decoded in memory and injected into the running container** (`docker exec -i`), so the plaintext key **never touches the host disk** and lives only in the container (gone when it's removed). A file-path secret is bind-mounted read-only as before.
- **Default environment is now `testnet`** (override via `DZ_ENV`), and the installer **always runs `doublezero connect multicast`** — the environment and connect prompts are gone.

Behavior change vs. the previous installer: no env/keypair/connect prompts; `DZ_KEYPAIR`/`DZ_CONNECT` are replaced by `DZ_SECRET`; default env flips `mainnet-beta` → `testnet`.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +82 / -37   | +45  |
| **Total**    |     1 | +82 / -37   | +45  |

A single-file change to the installer's input handling, secret decoding, and key delivery.

<details>
<summary>Key files (click to expand)</summary>

- `client/install.sh` — one secret input (`DZ_SECRET` or single prompt); `DZ_`-prefixed tokens are base64url-decoded to a Solana keypair JSON array and piped into the container (never written to host); file-path secrets bind-mount read-only; env defaults to `testnet`; always runs `connect multicast`.

</details>

## Testing Verification
- Ran attendantless on a clean Ubuntu 24.04 amd64 EC2 host with `DZ_SECRET=DZ_<token>`: no prompts, env resolved to `testnet`, and `doublezero connect multicast` ran automatically; daemon healthy (`status=running`, `restarts=0`).
- **Secret handling verified by round-trip:** a real `DZ_` token decoded to an `id.json` that byte-exactly matches the source keypair (64 bytes); confirmed the host has **no** keyfile afterward while the container's copy matches.
- `connect` reaches the expected onchain gate (`account has no available credits`) for an unfunded test key — i.e. the flow completes through to the real check.
- Validated `bash -n` and the `DZ_`-prefix vs. file-path detection locally.
