### PR TITLE
release: refresh onchain program version after devnet smartcontract deploy

### DIFF
--- a/.github/workflows/release.devnet.smartcontract.daily.yml
+++ b/.github/workflows/release.devnet.smartcontract.daily.yml
@@ -53,3 +53,32 @@ jobs:
             --program-id program-keypair.json \
             -k id.json \
             target/deploy/${{ matrix.binary }}
+      - name: Build doublezero CLI
+        if: matrix.program == 'serviceability'
+        run: cargo build --release -p doublezero
+      # `init` refreshes ProgramConfig.version to the just-deployed binary's
+      # compiled-in version (and min_compatible_version to the program's
+      # MIN_COMPATIBLE_VERSION constant). GlobalState is untouched when it
+      # already exists, so this is safe to run on every deploy.
+      - name: Refresh onchain program version
+        if: matrix.program == 'serviceability'
+        run: |
+          target/release/doublezero init \
+            --url https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16 \
+            --ws wss://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16/whirligig \
+            --program-id "$(solana address -k program-keypair.json)" \
+            --keypair id.json
+      - name: Verify onchain program version matches build
+        if: matrix.program == 'serviceability'
+        run: |
+          expected="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          target/release/doublezero version \
+            --url https://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16 \
+            --ws wss://doublezerolocalnet.rpcpool.com/8a4fd3f4-0977-449f-88c7-63d4b0f10f16/whirligig \
+            --program-id "$(solana address -k program-keypair.json)" \
+            | tee version.txt
+          actual="$(awk '/^program version:/ {print $3}' version.txt)"
+          if [ "$actual" != "$expected" ]; then
+            echo "onchain program version '$actual' does not match built version '$expected'"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary of Changes
- The daily devnet deploy runs `solana program deploy` but never updates `ProgramConfig` onchain, so the program version reported by `doublezero -V` has been frozen at 0.21.0 (with min required version 0.12.0) since `doublezero init` was last run manually in early May, despite the bytecode being redeployed every weekday.
- Adds post-deploy steps to the serviceability matrix job: build the `doublezero` CLI and run `doublezero init` against the just-deployed program. `init` stamps the deployed binary's compiled-in version into `ProgramConfig` and resets `min_compatible_version` to the program's `MIN_COMPATIBLE_VERSION` constant (currently 0.15.0); `GlobalState` is untouched when it already exists, so the step is safe to repeat on every deploy.
- Adds a verification step that fails the job if the onchain program version doesn't match the workspace version — the check that would have caught this staleness within a day.

Note: this raises devnet's enforced min compatible client version from the stale 0.12.0 to the repo's 0.15.0, and future deploys will keep it tracking the constant rather than manual `global-config set-version` calls.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Config/build |     1 | +30 / -1    |  +29 |

Workflow-only change; no Rust/Go code touched.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/release.devnet.smartcontract.daily.yml` — build `doublezero` CLI, run `init` after the serviceability deploy, verify onchain version matches the build

</details>

## Testing Verification
- Smoke-tested the exact commands the workflow runs from a worktree build: `doublezero version --env devnet` reaches devnet and reproduces the stale state (client 0.27.0, program 0.21.0, min 0.12.0), confirming the verify step's parsing works against real output.
- Confirmed in `initialize_global_state` that re-running `init` overwrites only `ProgramConfig` and early-returns without touching an existing `GlobalState`.
- actionlint passes (only pre-existing finding on an untouched step).