### PR TITLE
Bump to 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+## [v0.27.1](https://github.com/malbeclabs/doublezero/compare/client/v0.27.0...client/v0.27.1) - 2026-06-10
+
+### Breaking
+
+### Changes
+
 - Client
   - Revert auto-enabling allocated-IP mode on `doublezero connect ibrl` behind NAT (#3861): the RFC1918 heuristic misfires on 1:1 NAT hosts where plain IBRL works, silently changing the user type.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "doublezero"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-admin"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bitflags",
  "clap",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "eyre",
  "serde",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation-cli"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "clap",
  "doublezero-cli-core",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability-cli"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh 1.5.7",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -2115,7 +2115,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-accounts"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Malbec Labs <dev@malbeclabs.com>"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
## Summary of Changes
- Version bump to 0.27.1 for a standalone patch release carrying the revert of the NAT auto-allocate behavior (#3861, reverted in #3870).
- Moves the revert note from Unreleased into a v0.27.1 changelog section.

## Testing Verification
- Cargo.lock regenerated via `cargo update --workspace`; same 13/13 line shape as the 0.27.0 bump.