### PR TITLE
ci(e2e): skip e2e on docs and version-bump-only PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,13 +43,75 @@ jobs:
     permissions:
       packages: write
       contents: read
+      checks: write
     outputs:
       run-e2e: ${{ steps.gate.outputs.run-e2e }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
+      # A version-bump PR changes only version lines in Cargo.toml/Cargo.lock
+      # plus CHANGELOG.md; e2e adds no signal there. When skipping, report the
+      # required shard checks as successful on the PR head, because the gated
+      # matrix job never creates its check runs and branch protection would
+      # otherwise block the merge. Keep in sync with shreds-e2e.yml.
+      - name: Check for version-bump-only PR
+        id: bump
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          CHECK_NAME: e2e
+          # SHARD_COUNT round-robin shards + 1 dedicated shard; must match the
+          # required status check contexts in the main ruleset.
+          CHECK_SHARDS: "5"
+        with:
+          script: |
+            try {
+              const allowed = new Set(['CHANGELOG.md', 'Cargo.toml', 'Cargo.lock']);
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              // Missing patch (diff too large) fails closed: e2e runs.
+              const versionLinesOnly = (patch) => typeof patch === 'string' && patch
+                .split('\n')
+                .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
+                .every((l) => /^[+-]version = "/.test(l));
+              const isBump = files.length > 0 && files.every((f) =>
+                f.status === 'modified' &&
+                allowed.has(f.filename) &&
+                (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
+              core.setOutput('skip', String(isBump));
+              if (!isBump) return;
+              core.notice('Version-bump-only PR; skipping e2e and reporting shard checks as successful.');
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              for (let shard = 1; shard <= Number(process.env.CHECK_SHARDS); shard++) {
+                await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: `${process.env.CHECK_NAME} (shard ${shard})`,
+                  head_sha: context.payload.pull_request.head.sha,
+                  status: 'completed',
+                  conclusion: 'success',
+                  details_url: runUrl,
+                  output: {
+                    title: 'Skipped: version-bump-only PR',
+                    summary: 'Only version lines in Cargo.toml/Cargo.lock and CHANGELOG.md changed, so e2e was skipped.',
+                  },
+                });
+              }
+            } catch (err) {
+              core.warning(`Version-bump gate failed; running e2e: ${err}`);
+              core.setOutput('skip', 'false');
+            }
       - name: Decide whether privileged e2e can run
         id: gate
         run: |
+          if [ "${{ steps.bump.outputs.skip }}" = "true" ]; then
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping e2e: version-bump-only PR."
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             echo "run-e2e=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping privileged e2e on an external fork PR. A maintainer can comment /run-e2e to start a trusted run."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,10 +77,16 @@ jobs:
                 .split('\n')
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
-              const isBump = files.length > 0 && files.every((f) =>
-                f.status === 'modified' &&
-                allowed.has(f.filename) &&
-                (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
+              const names = new Set(files.map((f) => f.filename));
+              // Cargo.toml and Cargo.lock must change together: a requirement
+              // change that leaves the lock untouched can still alter what
+              // unlocked CI builds resolve, and is not a version bump.
+              const isBump = files.length > 0 &&
+                names.has('Cargo.toml') === names.has('Cargo.lock') &&
+                files.every((f) =>
+                  f.status === 'modified' &&
+                  allowed.has(f.filename) &&
+                  (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
               core.setOutput('skip', String(isBump));
               if (!isBump) return;
               core.notice('Version-bump-only PR; skipping e2e and reporting shard checks as successful.');

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,13 +48,14 @@ jobs:
       run-e2e: ${{ steps.gate.outputs.run-e2e }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
-      # A version-bump PR changes only version lines in Cargo.toml/Cargo.lock
-      # plus CHANGELOG.md; e2e adds no signal there. When skipping, report the
-      # required shard checks as successful on the PR head, because the gated
-      # matrix job never creates its check runs and branch protection would
-      # otherwise block the merge. Keep in sync with shreds-e2e.yml.
-      - name: Check for version-bump-only PR
-        id: bump
+      # Version-bump PRs (only version lines change in Cargo.toml/Cargo.lock)
+      # and markdown-only PRs (docs, RFCs) get no signal from e2e. When
+      # skipping, report the required shard checks as successful on the PR
+      # head, because the gated matrix job never creates its check runs and
+      # branch protection would otherwise block the merge. Keep in sync with
+      # shreds-e2e.yml.
+      - name: Check for docs/version-bump-only PR
+        id: skip-check
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
@@ -65,7 +66,6 @@ jobs:
         with:
           script: |
             try {
-              const allowed = new Set(['CHANGELOG.md', 'Cargo.toml', 'Cargo.lock']);
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -77,19 +77,27 @@ jobs:
                 .split('\n')
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
+              const isMd = (name) => typeof name === 'string' && name.endsWith('.md');
+              // Markdown is inert for e2e; a rename/copy must come from
+              // markdown too, since a rename also deletes the source path.
+              const fileOk = (f) => {
+                if (isMd(f.filename)) {
+                  return (f.status !== 'renamed' && f.status !== 'copied') || isMd(f.previous_filename);
+                }
+                return (f.filename === 'Cargo.toml' || f.filename === 'Cargo.lock') &&
+                  f.status === 'modified' &&
+                  versionLinesOnly(f.patch);
+              };
               const names = new Set(files.map((f) => f.filename));
               // Cargo.toml and Cargo.lock must change together: a requirement
               // change that leaves the lock untouched can still alter what
               // unlocked CI builds resolve, and is not a version bump.
-              const isBump = files.length > 0 &&
+              const skippable = files.length > 0 &&
                 names.has('Cargo.toml') === names.has('Cargo.lock') &&
-                files.every((f) =>
-                  f.status === 'modified' &&
-                  allowed.has(f.filename) &&
-                  (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
-              core.setOutput('skip', String(isBump));
-              if (!isBump) return;
-              core.notice('Version-bump-only PR; skipping e2e and reporting shard checks as successful.');
+                files.every(fileOk);
+              core.setOutput('skip', String(skippable));
+              if (!skippable) return;
+              core.notice('Docs/version-bump-only PR; skipping e2e and reporting shard checks as successful.');
               const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
               for (let shard = 1; shard <= Number(process.env.CHECK_SHARDS); shard++) {
                 await github.rest.checks.create({
@@ -101,21 +109,21 @@ jobs:
                   conclusion: 'success',
                   details_url: runUrl,
                   output: {
-                    title: 'Skipped: version-bump-only PR',
-                    summary: 'Only version lines in Cargo.toml/Cargo.lock and CHANGELOG.md changed, so e2e was skipped.',
+                    title: 'Skipped: docs/version-bump-only PR',
+                    summary: 'Only markdown files and version lines in Cargo.toml/Cargo.lock changed, so e2e was skipped.',
                   },
                 });
               }
             } catch (err) {
-              core.warning(`Version-bump gate failed; running e2e: ${err}`);
+              core.warning(`Skip gate failed; running e2e: ${err}`);
               core.setOutput('skip', 'false');
             }
       - name: Decide whether privileged e2e can run
         id: gate
         run: |
-          if [ "${{ steps.bump.outputs.skip }}" = "true" ]; then
+          if [ "${{ steps.skip-check.outputs.skip }}" = "true" ]; then
             echo "run-e2e=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping e2e: version-bump-only PR."
+            echo "::notice::Skipping e2e: docs/version-bump-only PR."
             exit 0
           fi
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -36,14 +36,76 @@ jobs:
     permissions:
       packages: write
       contents: read
+      checks: write
     outputs:
       run-e2e: ${{ steps.gate.outputs.run-e2e }}
       shreds-sha: ${{ steps.checkout-shreds.outputs.commit }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
+      # A version-bump PR changes only version lines in Cargo.toml/Cargo.lock
+      # plus CHANGELOG.md; e2e adds no signal there. When skipping, report the
+      # required shard checks as successful on the PR head, because the gated
+      # matrix job never creates its check runs and branch protection would
+      # otherwise block the merge. Keep in sync with e2e.yml.
+      - name: Check for version-bump-only PR
+        id: bump
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          CHECK_NAME: shard-e2e
+          # 2 pinned shards + 2 round-robin shards; must match the required
+          # status check contexts in the main ruleset.
+          CHECK_SHARDS: "4"
+        with:
+          script: |
+            try {
+              const allowed = new Set(['CHANGELOG.md', 'Cargo.toml', 'Cargo.lock']);
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              // Missing patch (diff too large) fails closed: e2e runs.
+              const versionLinesOnly = (patch) => typeof patch === 'string' && patch
+                .split('\n')
+                .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
+                .every((l) => /^[+-]version = "/.test(l));
+              const isBump = files.length > 0 && files.every((f) =>
+                f.status === 'modified' &&
+                allowed.has(f.filename) &&
+                (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
+              core.setOutput('skip', String(isBump));
+              if (!isBump) return;
+              core.notice('Version-bump-only PR; skipping shreds e2e and reporting shard checks as successful.');
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              for (let shard = 1; shard <= Number(process.env.CHECK_SHARDS); shard++) {
+                await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: `${process.env.CHECK_NAME} (shard ${shard})`,
+                  head_sha: context.payload.pull_request.head.sha,
+                  status: 'completed',
+                  conclusion: 'success',
+                  details_url: runUrl,
+                  output: {
+                    title: 'Skipped: version-bump-only PR',
+                    summary: 'Only version lines in Cargo.toml/Cargo.lock and CHANGELOG.md changed, so shreds e2e was skipped.',
+                  },
+                });
+              }
+            } catch (err) {
+              core.warning(`Version-bump gate failed; running shreds e2e: ${err}`);
+              core.setOutput('skip', 'false');
+            }
       - name: Decide whether privileged shreds e2e can run
         id: gate
         run: |
+          if [ "${{ steps.bump.outputs.skip }}" = "true" ]; then
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping shreds e2e: version-bump-only PR."
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             echo "run-e2e=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping privileged shreds e2e on an external fork PR. A maintainer can comment /run-e2e to start a trusted run."

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -71,10 +71,16 @@ jobs:
                 .split('\n')
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
-              const isBump = files.length > 0 && files.every((f) =>
-                f.status === 'modified' &&
-                allowed.has(f.filename) &&
-                (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
+              const names = new Set(files.map((f) => f.filename));
+              // Cargo.toml and Cargo.lock must change together: a requirement
+              // change that leaves the lock untouched can still alter what
+              // unlocked CI builds resolve, and is not a version bump.
+              const isBump = files.length > 0 &&
+                names.has('Cargo.toml') === names.has('Cargo.lock') &&
+                files.every((f) =>
+                  f.status === 'modified' &&
+                  allowed.has(f.filename) &&
+                  (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
               core.setOutput('skip', String(isBump));
               if (!isBump) return;
               core.notice('Version-bump-only PR; skipping shreds e2e and reporting shard checks as successful.');

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -42,13 +42,14 @@ jobs:
       shreds-sha: ${{ steps.checkout-shreds.outputs.commit }}
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
-      # A version-bump PR changes only version lines in Cargo.toml/Cargo.lock
-      # plus CHANGELOG.md; e2e adds no signal there. When skipping, report the
-      # required shard checks as successful on the PR head, because the gated
-      # matrix job never creates its check runs and branch protection would
-      # otherwise block the merge. Keep in sync with e2e.yml.
-      - name: Check for version-bump-only PR
-        id: bump
+      # Version-bump PRs (only version lines change in Cargo.toml/Cargo.lock)
+      # and markdown-only PRs (docs, RFCs) get no signal from e2e. When
+      # skipping, report the required shard checks as successful on the PR
+      # head, because the gated matrix job never creates its check runs and
+      # branch protection would otherwise block the merge. Keep in sync with
+      # e2e.yml.
+      - name: Check for docs/version-bump-only PR
+        id: skip-check
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
@@ -59,7 +60,6 @@ jobs:
         with:
           script: |
             try {
-              const allowed = new Set(['CHANGELOG.md', 'Cargo.toml', 'Cargo.lock']);
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -71,19 +71,27 @@ jobs:
                 .split('\n')
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
+              const isMd = (name) => typeof name === 'string' && name.endsWith('.md');
+              // Markdown is inert for e2e; a rename/copy must come from
+              // markdown too, since a rename also deletes the source path.
+              const fileOk = (f) => {
+                if (isMd(f.filename)) {
+                  return (f.status !== 'renamed' && f.status !== 'copied') || isMd(f.previous_filename);
+                }
+                return (f.filename === 'Cargo.toml' || f.filename === 'Cargo.lock') &&
+                  f.status === 'modified' &&
+                  versionLinesOnly(f.patch);
+              };
               const names = new Set(files.map((f) => f.filename));
               // Cargo.toml and Cargo.lock must change together: a requirement
               // change that leaves the lock untouched can still alter what
               // unlocked CI builds resolve, and is not a version bump.
-              const isBump = files.length > 0 &&
+              const skippable = files.length > 0 &&
                 names.has('Cargo.toml') === names.has('Cargo.lock') &&
-                files.every((f) =>
-                  f.status === 'modified' &&
-                  allowed.has(f.filename) &&
-                  (f.filename === 'CHANGELOG.md' || versionLinesOnly(f.patch)));
-              core.setOutput('skip', String(isBump));
-              if (!isBump) return;
-              core.notice('Version-bump-only PR; skipping shreds e2e and reporting shard checks as successful.');
+                files.every(fileOk);
+              core.setOutput('skip', String(skippable));
+              if (!skippable) return;
+              core.notice('Docs/version-bump-only PR; skipping shreds e2e and reporting shard checks as successful.');
               const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
               for (let shard = 1; shard <= Number(process.env.CHECK_SHARDS); shard++) {
                 await github.rest.checks.create({
@@ -95,21 +103,21 @@ jobs:
                   conclusion: 'success',
                   details_url: runUrl,
                   output: {
-                    title: 'Skipped: version-bump-only PR',
-                    summary: 'Only version lines in Cargo.toml/Cargo.lock and CHANGELOG.md changed, so shreds e2e was skipped.',
+                    title: 'Skipped: docs/version-bump-only PR',
+                    summary: 'Only markdown files and version lines in Cargo.toml/Cargo.lock changed, so shreds e2e was skipped.',
                   },
                 });
               }
             } catch (err) {
-              core.warning(`Version-bump gate failed; running shreds e2e: ${err}`);
+              core.warning(`Skip gate failed; running shreds e2e: ${err}`);
               core.setOutput('skip', 'false');
             }
       - name: Decide whether privileged shreds e2e can run
         id: gate
         run: |
-          if [ "${{ steps.bump.outputs.skip }}" = "true" ]; then
+          if [ "${{ steps.skip-check.outputs.skip }}" = "true" ]; then
             echo "run-e2e=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping shreds e2e: version-bump-only PR."
+            echo "::notice::Skipping shreds e2e: docs/version-bump-only PR."
             exit 0
           fi
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then


### PR DESCRIPTION
## Summary of Changes
- Skip the e2e and shreds-e2e suites on PRs where the suites add no signal — version bumps and docs/RFC-only changes — so they don't burn ~20 minutes of self-hosted runner time building images and running the full suite.
- A new gate step in each workflow's `setup` job inspects the PR's changed files via the API. A PR qualifies only if every file is either markdown (`*.md`, any path; renames/copies must come from markdown too, since a rename also deletes the source path) or `Cargo.toml`/`Cargo.lock` with diffs touching nothing but `version = "..."` lines, with the two Cargo files changing together. A dependency bump fails the check — `cargo update` changes Cargo.lock checksum/source lines, an inline requirement change in Cargo.toml doesn't match the version-line shape, and a requirement change that leaves the lock untouched fails the pairing rule — as does any code file or an API-truncated patch. All of those fall through to a normal e2e run. Markdown is verified inert: no `.md` files are used as test fixtures, embedded via `include_str!`, or read by e2e code.
- Because the gated matrix jobs never create their shard check runs, the gate reports the required `e2e (shard 1-5)` / `shard-e2e (shard 1-4)` contexts as successful on the PR head via the checks API (same pattern the trusted fork-PR flow already uses), so branch protection doesn't block the merge.
- The gate runs only on same-repo `pull_request` events; fork PRs, pushes to main/hotfix, and trusted `workflow_dispatch` runs are unaffected. Any gate error fails open to running e2e.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Config/build |     2 | +152 / -0   | +152 |

Workflow-only change; the same gate logic is added to both e2e workflows.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/e2e.yml` — skip-gate step + early exit in the existing `run-e2e` gate; reports `e2e (shard 1-5)` checks when skipping
- `.github/workflows/shreds-e2e.yml` — same gate; reports `shard-e2e (shard 1-4)` checks when skipping

</details>

## Testing Verification
- Ran the gate's file-classification logic (extracted verbatim into a node harness) against real PR data: #3874 (0.27.1 version bump) correctly classifies as skippable; #3870 (code change) correctly runs e2e.
- Synthetic dependency-bump cases all run e2e: `cargo update`-shaped Cargo.lock diff (checksum lines); dependency requirement change in Cargo.toml, both inline and multi-line-table form with the lock untouched; lock-only version-line change.
- Synthetic markdown cases: new RFC added, RFC+README edits, markdown deleted, markdown renamed from markdown, and version bump + RFC edit all skip; markdown plus a code file, a file renamed from `.rs` to `.md`, and a Cargo.lock with an API-omitted patch all run e2e.
- `actionlint` passes on both workflows.