### PR TITLE
client: add per-environment docker image variants and installers

### DIFF
--- a/.github/workflows/release.docker.client.cleanup.yml
+++ b/.github/workflows/release.docker.client.cleanup.yml
@@ -1,7 +1,8 @@
 name: release.docker.client.cleanup
 
 # Weekly retention for the client images. Deletes orphaned untagged versions and
-# keeps the last 10 pinned versions per env family, never touching moving tags.
+# keeps the last 10 pinned versions per env family (testnet-* and mainnet-beta-*
+# each get their own 10-slot budget), never touching moving tags.
 on:
   schedule:
     - cron: "17 4 * * 1" # Mondays 04:17 UTC
@@ -14,15 +15,30 @@ jobs:
   cleanup-public:
     runs-on: ubuntu-latest
     steps:
-      - name: Prune ghcr.io/${{ github.repository_owner }}/doublezero
+      # Each step scopes keep-n-tagged to one family by combining delete-tags
+      # (which restricts what the action considers) with exclude-tags (which
+      # hard-protects the other family and all moving tags from deletion).
+      - name: Prune testnet-* tags in ghcr.io/${{ github.repository_owner }}/doublezero
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           package: doublezero
           owner: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-untagged: true
+          delete-tags: testnet-*
           keep-n-tagged: 10
-          exclude-tags: latest,testnet,mainnet-beta
+          exclude-tags: latest,testnet,mainnet-beta,mainnet-beta-*
+
+      - name: Prune mainnet-beta-* tags in ghcr.io/${{ github.repository_owner }}/doublezero
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: doublezero
+          owner: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-untagged: false
+          delete-tags: mainnet-beta-*
+          keep-n-tagged: 10
+          exclude-tags: latest,testnet,mainnet-beta,testnet-*
 
   cleanup-devnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.docker.client.cleanup.yml
+++ b/.github/workflows/release.docker.client.cleanup.yml
@@ -1,0 +1,38 @@
+name: release.docker.client.cleanup
+
+# Weekly retention for the client images. Deletes orphaned untagged versions and
+# keeps the last 10 pinned versions per env family, never touching moving tags.
+on:
+  schedule:
+    - cron: "17 4 * * 1" # Mondays 04:17 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup-public:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune ghcr.io/${{ github.repository_owner }}/doublezero
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: doublezero
+          owner: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-untagged: true
+          keep-n-tagged: 10
+          exclude-tags: latest,testnet,mainnet-beta
+
+  cleanup-devnet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune ghcr.io/${{ github.repository_owner }}/doublezero-devnet
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: doublezero-devnet
+          owner: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-untagged: true
+          keep-n-tagged: 10
+          exclude-tags: latest

--- a/.github/workflows/release.docker.client.cleanup.yml
+++ b/.github/workflows/release.docker.client.cleanup.yml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: "17 4 * * 1" # Mondays 04:17 UTC
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted without deleting"
+        type: boolean
+        default: true
 
 permissions:
   packages: write
@@ -15,9 +20,11 @@ jobs:
   cleanup-public:
     runs-on: ubuntu-latest
     steps:
-      # Each step scopes keep-n-tagged to one family by combining delete-tags
-      # (which restricts what the action considers) with exclude-tags (which
-      # hard-protects the other family and all moving tags from deletion).
+      # Two passes to scope keep-n-tagged independently per tag family.
+      # delete-tags + keep-n-tagged limits retention within that family;
+      # exclude-tags hard-protects moving tags and the other family.
+      # Note: delete-untagged: true (first step only) removes ALL untagged
+      # manifests package-wide — it is not scoped by delete-tags.
       - name: Prune testnet-* tags in ghcr.io/${{ github.repository_owner }}/doublezero
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
@@ -28,6 +35,7 @@ jobs:
           delete-tags: testnet-*
           keep-n-tagged: 10
           exclude-tags: latest,testnet,mainnet-beta,mainnet-beta-*
+          dry-run: ${{ inputs.dry_run || false }}
 
       - name: Prune mainnet-beta-* tags in ghcr.io/${{ github.repository_owner }}/doublezero
         uses: dataaxiom/ghcr-cleanup-action@v1
@@ -39,6 +47,7 @@ jobs:
           delete-tags: mainnet-beta-*
           keep-n-tagged: 10
           exclude-tags: latest,testnet,mainnet-beta,testnet-*
+          dry-run: ${{ inputs.dry_run || false }}
 
   cleanup-devnet:
     runs-on: ubuntu-latest
@@ -52,3 +61,4 @@ jobs:
           delete-untagged: true
           keep-n-tagged: 10
           exclude-tags: latest
+          dry-run: ${{ inputs.dry_run || false }}

--- a/.github/workflows/release.docker.client.devnet.yml
+++ b/.github/workflows/release.docker.client.devnet.yml
@@ -35,7 +35,7 @@ jobs:
             apt-get update -qq >/dev/null 2>&1
             apt-cache madison doublezero | head -1 | awk "{print \$3}"')"
           [[ -n "$RAW" ]] || { echo "could not resolve devnet version"; exit 1; }
-          TAG="$(printf '%s' "$RAW" | tr '~' '-')"
+          TAG="$(printf '%s' "$RAW" | tr '~:' '--')"
           echo "version=$RAW" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved devnet version: $RAW (tag: $TAG)"

--- a/.github/workflows/release.docker.client.devnet.yml
+++ b/.github/workflows/release.docker.client.devnet.yml
@@ -1,0 +1,69 @@
+name: release.docker.client.devnet
+
+# Builds and publishes the PRIVATE devnet client image
+# (ghcr.io/<owner>/doublezero-devnet) after the nightly devnet client deb is
+# published. Triggered manually or chained off the nightly devnet client release.
+on:
+  workflow_run:
+    workflows: ["release.devnet.client.daily"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/doublezero-devnet
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve devnet nightly version + tag
+        id: v
+        shell: bash
+        run: |
+          RAW="$(docker run --rm --entrypoint bash ubuntu:24.04 -c '
+            apt-get update -qq >/dev/null 2>&1
+            apt-get install -y -qq --no-install-recommends ca-certificates curl >/dev/null 2>&1
+            curl -1sLf "https://dl.cloudsmith.io/public/malbeclabs/doublezero-devnet/setup.deb.sh" | bash >/dev/null 2>&1
+            apt-get update -qq >/dev/null 2>&1
+            apt-cache madison doublezero | head -1 | awk "{print \$3}"')"
+          [[ -n "$RAW" ]] || { echo "could not resolve devnet version"; exit 1; }
+          TAG="$(printf '%s' "$RAW" | tr '~' '-')"
+          echo "version=$RAW" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved devnet version: $RAW (tag: $TAG)"
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push devnet (:latest + sanitized version)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero-devnet
+            DZ_DEP_REPO=doublezero-testnet
+            DZ_DEFAULT_ENV=devnet
+            DZ_VERSION=${{ steps.v.outputs.version }}
+            BUILD_VERSION=${{ steps.v.outputs.version }}
+            BUILD_COMMIT=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ steps.v.outputs.tag }}

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -80,7 +80,6 @@ jobs:
           build-args: |
             DZ_CLOUDSMITH_REPO=doublezero-testnet
             DZ_DEFAULT_ENV=testnet
-            DZ_VERSION=${{ steps.v.outputs.version }}-1
             BUILD_VERSION=${{ steps.v.outputs.version }}
             BUILD_COMMIT=${{ github.event.workflow_run.head_sha }}
           tags: |

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -66,6 +66,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve exact testnet deb version
+        id: deb
+        if: steps.v.outputs.publish == 'true'
+        shell: bash
+        run: |
+          SEMVER='${{ steps.v.outputs.version }}'
+          DEB="$(docker run --rm --entrypoint bash ubuntu:24.04 -c "
+            apt-get update -qq >/dev/null 2>&1
+            apt-get install -y -qq --no-install-recommends ca-certificates curl >/dev/null 2>&1
+            curl -1sLf 'https://dl.cloudsmith.io/public/malbeclabs/doublezero-testnet/setup.deb.sh' | bash >/dev/null 2>&1
+            apt-get update -qq >/dev/null 2>&1
+            apt-cache madison doublezero | awk '{print \$3}' | grep -E '^${SEMVER}-' | head -1")"
+          [ -n "$DEB" ] || { echo "no doublezero-testnet deb found for ${SEMVER}"; exit 1; }
+          echo "debversion=$DEB" >> "$GITHUB_OUTPUT"
+          echo "Pinned testnet deb: $DEB"
+
       - name: Build & push (:testnet + :testnet-version)
         if: steps.v.outputs.publish == 'true'
         uses: docker/build-push-action@v6
@@ -80,6 +96,7 @@ jobs:
           build-args: |
             DZ_CLOUDSMITH_REPO=doublezero-testnet
             DZ_DEFAULT_ENV=testnet
+            DZ_VERSION=${{ steps.deb.outputs.debversion }}
             BUILD_VERSION=${{ steps.v.outputs.version }}
             BUILD_COMMIT=${{ github.event.workflow_run.head_sha }}
           tags: |
@@ -109,6 +126,7 @@ jobs:
           fi
           [[ -n "$VERSION" ]] || { echo "could not resolve mainnet-beta version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$(printf '%s' "$VERSION" | tr '~:' '--')" >> "$GITHUB_OUTPUT"
           echo "Resolved mainnet-beta version: $VERSION"
 
       - uses: docker/setup-buildx-action@v3
@@ -136,7 +154,7 @@ jobs:
             BUILD_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.IMAGE }}:mainnet-beta
-            ${{ env.IMAGE }}:mainnet-beta-${{ steps.v.outputs.version }}
+            ${{ env.IMAGE }}:mainnet-beta-${{ steps.v.outputs.tag }}
             ${{ env.IMAGE }}:latest
 
   # Validation path: on PRs touching the image, build all three variants for

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -13,6 +13,12 @@ on:
       - "client/Dockerfile"
       - "client/docker-entrypoint.sh"
       - ".github/workflows/release.docker.client.yml"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "mainnet-beta version to tag (blank = resolve public repo latest)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -23,8 +29,8 @@ env:
   DOCKER_BUILDKIT: 1
 
 jobs:
-  # Release path: a client release just published its deb to Cloudsmith. Build the
-  # image (which installs that now-latest client) and push :<version> and :latest.
+  # Release path: a client release just published its testnet deb to Cloudsmith.
+  # Build the image (which installs that now-latest client) and push testnet tags.
   publish:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
@@ -60,10 +66,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The image installs the latest client from Cloudsmith, which IS the version
-      # releaser.client just published. We tag with the resolved version rather than
-      # pinning DZ_VERSION (the deb revision suffix isn't derivable from the tag).
-      - name: Build & push (:version + :latest)
+      - name: Build & push (:testnet + :testnet-version)
         if: steps.v.outputs.publish == 'true'
         uses: docker/build-push-action@v6
         with:
@@ -75,25 +78,78 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero-testnet
+            DZ_DEFAULT_ENV=testnet
+            DZ_VERSION=${{ steps.v.outputs.version }}-1
             BUILD_VERSION=${{ steps.v.outputs.version }}
             BUILD_COMMIT=${{ github.event.workflow_run.head_sha }}
           tags: |
-            ${{ env.IMAGE }}:${{ steps.v.outputs.version }}
-            ${{ env.IMAGE }}:latest
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.v.outputs.version }}
-            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha }}
+            ${{ env.IMAGE }}:testnet
+            ${{ env.IMAGE }}:testnet-${{ steps.v.outputs.version }}
 
-  # Validation path: on PRs touching the image, build for amd64 but do NOT push,
-  # to catch Dockerfile/entrypoint regressions before they reach a release.
+  # Manual dispatch path: publish mainnet-beta tags (:mainnet-beta, :version, :latest).
+  # The version can be supplied directly or resolved from the public Cloudsmith repo.
+  publish-mainnet-beta:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve mainnet-beta version
+        id: v
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="$(docker run --rm --entrypoint bash ubuntu:24.04 -c '
+              apt-get update -qq >/dev/null 2>&1
+              apt-get install -y -qq --no-install-recommends ca-certificates curl >/dev/null 2>&1
+              curl -1sLf "https://dl.cloudsmith.io/public/malbeclabs/doublezero/setup.deb.sh" | bash >/dev/null 2>&1
+              apt-get update -qq >/dev/null 2>&1
+              apt-cache madison doublezero | head -1 | awk "{print \$3}"')"
+          fi
+          [[ -n "$VERSION" ]] || { echo "could not resolve mainnet-beta version"; exit 1; }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved mainnet-beta version: $VERSION"
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (:mainnet-beta + version + :latest)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero
+            DZ_DEFAULT_ENV=mainnet-beta
+            DZ_VERSION=${{ steps.v.outputs.version }}
+            BUILD_VERSION=${{ steps.v.outputs.version }}
+            BUILD_COMMIT=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE }}:mainnet-beta
+            ${{ env.IMAGE }}:mainnet-beta-${{ steps.v.outputs.version }}
+            ${{ env.IMAGE }}:latest
+
+  # Validation path: on PRs touching the image, build all three variants for
+  # amd64 but do NOT push, to catch Dockerfile/entrypoint regressions before
+  # they reach a release.
   build-only:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - name: Build (no push)
+      - name: Build testnet (no push)
         uses: docker/build-push-action@v6
         with:
           context: ./client
@@ -102,3 +158,31 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero-testnet
+            DZ_DEFAULT_ENV=testnet
+      - name: Build mainnet-beta (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero
+            DZ_DEFAULT_ENV=mainnet-beta
+      - name: Build devnet (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DZ_CLOUDSMITH_REPO=doublezero-devnet
+            DZ_DEP_REPO=doublezero-testnet
+            DZ_DEFAULT_ENV=devnet

--- a/.github/workflows/release.install-script.yml
+++ b/.github/workflows/release.install-script.yml
@@ -9,6 +9,8 @@ on:
     branches: [main]
     paths:
       - "client/install.sh"
+      - "client/install-testnet.sh"
+      - "client/install-devnet.sh"
       - ".github/workflows/release.install-script.yml"
   workflow_dispatch:
 
@@ -33,11 +35,14 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload install.sh and invalidate cache
+      - name: Upload install scripts and invalidate cache
         run: |
-          aws s3 cp client/install.sh "s3://${BUCKET}/install" \
-            --content-type text/x-shellscript \
-            --cache-control "public,max-age=120"
+          for variant in "install:install.sh" "install-testnet:install-testnet.sh" "install-devnet:install-devnet.sh"; do
+            key="${variant%%:*}"; file="client/${variant##*:}"
+            aws s3 cp "$file" "s3://${BUCKET}/${key}" \
+              --content-type text/x-shellscript \
+              --cache-control "public,max-age=120"
+          done
           aws cloudfront create-invalidation \
             --distribution-id "$DISTRIBUTION_ID" \
-            --paths '/install'
+            --paths '/install' '/install-testnet' '/install-devnet'

--- a/.github/workflows/release.install-script.yml
+++ b/.github/workflows/release.install-script.yml
@@ -35,7 +35,7 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload install scripts and invalidate cache
+      - name: Upload install scripts
         run: |
           for variant in "install:install.sh" "install-testnet:install-testnet.sh" "install-devnet:install-devnet.sh"; do
             key="${variant%%:*}"; file="client/${variant##*:}"
@@ -43,6 +43,9 @@ jobs:
               --content-type text/x-shellscript \
               --cache-control "public,max-age=120"
           done
+
+      - name: Invalidate CloudFront cache
+        run: |
           aws cloudfront create-invalidation \
             --distribution-id "$DISTRIBUTION_ID" \
             --paths '/install' '/install-testnet' '/install-devnet'

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -13,12 +13,28 @@
 # The doublezero deb is published for linux/amd64 only, so the platform defaults to
 # amd64 (via an ARG, to avoid the const-platform build warning) to keep builds
 # reproducible on arm64 hosts such as Apple Silicon. Override with
-# --build-arg BASE_PLATFORM=... if needed.
+# --build-arg BASE_PLATFORM=... if needed. Override the release-train repo with
+# --build-arg DZ_CLOUDSMITH_REPO=<repo>, where <repo> is one of:
+# doublezero (mainnet-beta), doublezero-testnet, doublezero-devnet.
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=${BASE_PLATFORM} ubuntu:24.04
 
-# Empty DZ_VERSION installs the latest published client. Release CI pins the exact
-# released version (e.g. DZ_VERSION=1.2.3) for reproducible images.
+# Which Cloudsmith apt repo to install the client from. Selects the environment's
+# release train:
+#   doublezero          -> mainnet-beta (public/promoted repo)
+#   doublezero-testnet  -> testnet
+#   doublezero-devnet   -> devnet (nightly; see DZ_DEP_REPO for its solana dep)
+ARG DZ_CLOUDSMITH_REPO=doublezero
+# Optional second Cloudsmith repo added only to satisfy dependencies that the
+# primary repo lacks (the devnet repo has no doublezero-solana). Empty for the
+# self-contained testnet/mainnet-beta repos.
+ARG DZ_DEP_REPO=
+# Default environment baked into the image so `docker run` with no -e DZ_ENV
+# still selects the right env. The entrypoint honors DZ_ENV.
+ARG DZ_DEFAULT_ENV=mainnet-beta
+# Empty installs the repo's latest. CI pins the exact resolved version for
+# reproducible images (required for devnet, whose nightly version is ambiguous
+# once the dep repo is also present).
 ARG DZ_VERSION=
 # Image provenance, supplied by CI; sensible defaults for local builds.
 ARG BUILD_VERSION=dev
@@ -31,14 +47,21 @@ LABEL org.opencontainers.image.source="https://github.com/malbeclabs/doublezero"
       org.opencontainers.image.revision="${BUILD_COMMIT}"
 
 ENV DEBIAN_FRONTEND=noninteractive
+# Baked default environment for the entrypoint; overridable at runtime with -e DZ_ENV.
+ENV DZ_ENV=${DZ_DEFAULT_ENV}
 
-# Add the Cloudsmith apt repo via the official scripted installer, install the
-# client, then drop the now-unneeded curl and apt lists to keep the image thin.
-# ca-certificates is installed explicitly so it survives the curl auto-remove.
+# Add the primary Cloudsmith apt repo (and an optional dependency repo) via the
+# official scripted installer, install the client, then drop the now-unneeded
+# curl and apt lists to keep the image thin. ca-certificates is installed
+# explicitly so it survives the curl auto-remove.
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends ca-certificates curl; \
-    curl -1sLf 'https://dl.cloudsmith.io/public/malbeclabs/doublezero/setup.deb.sh' | bash; \
+    curl -1sLf "https://dl.cloudsmith.io/public/malbeclabs/${DZ_CLOUDSMITH_REPO}/setup.deb.sh" | bash; \
+    if [ -n "${DZ_DEP_REPO}" ]; then \
+      curl -1sLf "https://dl.cloudsmith.io/public/malbeclabs/${DZ_DEP_REPO}/setup.deb.sh" | bash; \
+    fi; \
+    apt-get update; \
     apt-get install -y --no-install-recommends "doublezero${DZ_VERSION:+=$DZ_VERSION}"; \
     apt-get purge -y --auto-remove curl; \
     rm -rf /var/lib/apt/lists/*

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -11,8 +11,9 @@
 #
 set -euo pipefail
 
-# mainnet-beta matches the compiled default of the doublezero package published to
-# the public Cloudsmith repo; the daemon and CLI must use the same environment.
+# Default environment. Baked into the image via `ENV DZ_ENV` per variant
+# (testnet / mainnet-beta / devnet); overridable at runtime with -e DZ_ENV. The
+# daemon and CLI must use the same environment.
 DZ_ENV="${DZ_ENV:-mainnet-beta}"
 DZ_SOCK="${DZ_SOCK:-/run/doublezerod/doublezerod.sock}"
 

--- a/client/install-devnet.sh
+++ b/client/install-devnet.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# DoubleZero Edge installer (devnet)
+# ------------------------------------
+# Served from https://get.doublezero.xyz/install-devnet and run as:
+#
+#     curl -fsSL https://get.doublezero.xyz/install-devnet | bash
+#
+# It checks for Docker (offering to install it), preps the host for GRE, loads the
+# access secret, runs the thin doublezero client container
+# (ghcr.io/malbeclabs/doublezero-devnet:latest), and runs `doublezero connect multicast`.
+#
+# Attendantless: the only input is the access secret. Provide it via DZ_SECRET to
+# run with no prompts at all; otherwise you're prompted once. Everything else has
+# a default.
+#
+# Env vars:
+#   DZ_SECRET=<DZ_token|path> base64 keypair token (always prefixed with 'DZ_')
+#                             OR a path to a keypair file. If set, runs non-interactively.
+#   DZ_ENV=testnet|devnet|mainnet-beta   default: devnet
+#   DZ_IMAGE=ghcr.io/malbeclabs/doublezero-devnet:latest
+#   DZ_NAME=doublezero                   container name
+#   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
+#   DZ_GHCR_TOKEN=<token>   ghcr token with read:packages (required: the devnet
+#                           image is private). DZ_GHCR_USER defaults to the token owner.
+#   DZ_GHCR_USER=<user>     optional; ghcr username for the login
+#
+# A DZ_-token-derived keypair is injected straight into the container and is never
+# written to the host disk; a keypair supplied as a file path is bind-mounted
+# read-only. Either way the plaintext key is not printed.
+#
+# NOTE: connecting requires the host's public IP to have an access pass / allowlisted
+# user onchain for the chosen environment. That provisioning is a separate step; if
+# `connect` reports an access-pass error, the rest of the setup is still in place.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# config / defaults
+# ----------------------------------------------------------------------------
+DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs/doublezero-devnet:latest}"
+DZ_NAME="${DZ_NAME:-doublezero}"
+DZ_ENV="${DZ_ENV:-devnet}"
+DZ_SECRET="${DZ_SECRET:-}"
+DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
+KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)
+LIVENESS_UDP_PORT=44880
+
+# ----------------------------------------------------------------------------
+# pretty output + prompts (read from the terminal, not the curl pipe)
+# ----------------------------------------------------------------------------
+if [ -t 1 ]; then BOLD=$'\033[1m'; RED=$'\033[31m'; YEL=$'\033[33m'; GRN=$'\033[32m'; RST=$'\033[0m'
+else BOLD=; RED=; YEL=; GRN=; RST=; fi
+info() { printf '%s==>%s %s\n' "$GRN" "$RST" "$*"; }
+warn() { printf '%s!! %s%s\n' "$YEL" "$*" "$RST" >&2; }
+die()  { printf '%sxx %s%s\n' "$RED" "$*" "$RST" >&2; exit 1; }
+
+# /dev/tty so prompts work under `curl | bash` (where stdin is the script)
+TTY=/dev/tty
+ask() {  # ask "Question" "default" -> echoes answer
+  local q="$1" def="${2:-}" ans=""
+  if [ ! -r "$TTY" ]; then echo "$def"; return; fi
+  if [ -n "$def" ]; then printf '%s%s%s [%s]: ' "$BOLD" "$q" "$RST" "$def" >"$TTY"
+  else printf '%s%s%s: ' "$BOLD" "$q" "$RST" >"$TTY"; fi
+  read -r ans <"$TTY" || true
+  echo "${ans:-$def}"
+}
+confirm() {  # confirm "Question" -> returns 0 if yes
+  [ "$DZ_ASSUME_YES" = 1 ] && return 0
+  [ -r "$TTY" ] || return 1
+  local ans; printf '%s%s%s [y/N]: ' "$BOLD" "$1" "$RST" >"$TTY"
+  read -r ans <"$TTY" || true
+  case "$ans" in y|Y|yes|YES) return 0;; *) return 1;; esac
+}
+
+# ----------------------------------------------------------------------------
+# 1. preconditions
+# ----------------------------------------------------------------------------
+[ "$(uname -s)" = Linux ] || die "This installer supports Linux hosts only (got $(uname -s)). The client needs host networking + kernel tunnels."
+
+case "$(uname -m)" in
+  x86_64|amd64) : ;;
+  *) die "The doublezero image is published for amd64 only; this host is $(uname -m). Run on an x86_64 Linux box." ;;
+esac
+
+# root / sudo: run as a normal user and self-elevate only the privileged steps.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  command -v sudo >/dev/null 2>&1 || die "Need root (for Docker + network capabilities) but sudo is not installed. Re-run as root."
+  SUDO="sudo"
+fi
+
+# Resolve the *human* user's home so the keypair default points at their files
+# whether this is invoked as `... | bash` (self-sudo) or `... | sudo bash` (all root).
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != root ]; then
+  REAL_HOME="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+fi
+REAL_HOME="${REAL_HOME:-$HOME}"
+
+# Prime sudo once up front so later privileged commands don't re-prompt mid-run,
+# but only ask for a password if one is actually required ('sudo -n true' succeeds
+# silently for NOPASSWD or an already-cached timestamp).
+if [ -n "$SUDO" ] && ! $SUDO -n true 2>/dev/null; then
+  info "Some steps need root; you may be prompted for your password once."
+  $SUDO -v || die "Could not obtain sudo. Re-run as root, or configure passwordless sudo."
+fi
+
+# ----------------------------------------------------------------------------
+# 2. docker present? offer install
+# ----------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  warn "Docker is not installed."
+  if confirm "Install Docker now via get.docker.com?"; then
+    info "Installing Docker..."
+    curl -fsSL https://get.docker.com | $SUDO sh
+    $SUDO systemctl enable --now docker 2>/dev/null || true
+  else
+    die "Docker is required. Install it and re-run."
+  fi
+fi
+$SUDO docker info >/dev/null 2>&1 || die "Docker is installed but the daemon isn't reachable. Start it (e.g. 'sudo systemctl start docker') and re-run."
+
+# ----------------------------------------------------------------------------
+# 3. host kernel / network prep (host-side; safe to attempt)
+# ----------------------------------------------------------------------------
+info "Preparing host for DoubleZero Edge Connect"
+$SUDO modprobe tun 2>/dev/null    || warn "Could not load 'tun' module (may be built-in)."
+$SUDO modprobe ip_gre 2>/dev/null || warn "Could not load 'ip_gre' module (will auto-load on tunnel create)."
+[ -e /dev/net/tun ] || warn "/dev/net/tun is missing; tunnel creation may fail."
+
+# best-effort firewall hints (don't auto-edit the user's firewall)
+if command -v ufw >/dev/null 2>&1 && $SUDO ufw status 2>/dev/null | grep -qi "Status: active"; then
+  warn "ufw is active: ensure IP protocol 47 (GRE) and UDP $LIVENESS_UDP_PORT are allowed."
+fi
+if command -v firewall-cmd >/dev/null 2>&1 && $SUDO firewall-cmd --state 2>/dev/null | grep -qi running; then
+  warn "firewalld is running: ensure GRE (protocol 47) and UDP $LIVENESS_UDP_PORT are allowed."
+fi
+
+# ----------------------------------------------------------------------------
+# 4. cloud detection -> warn about provider-level firewall (script can't fix)
+# ----------------------------------------------------------------------------
+detect_cloud() {
+  local md="http://169.254.169.254"
+  # AWS IMDSv2
+  local tok
+  tok=$(curl -fsS -m 1 -X PUT "$md/latest/api/token" -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' 2>/dev/null || true)
+  if [ -n "$tok" ] && curl -fsS -m 1 -H "X-aws-ec2-metadata-token: $tok" "$md/latest/meta-data/instance-id" >/dev/null 2>&1; then echo aws; return; fi
+  if curl -fsS -m 1 -H 'Metadata-Flavor: Google' "$md/computeMetadata/v1/instance/id" >/dev/null 2>&1; then echo gcp; return; fi
+  if curl -fsS -m 1 -H 'Metadata: true' "$md/metadata/instance?api-version=2021-02-01" >/dev/null 2>&1; then echo azure; return; fi
+  echo none
+}
+CLOUD="$(detect_cloud)"
+case "$CLOUD" in
+  aws)   warn "AWS detected. GRE will not work until you (in AWS, NOT on this host): 1) allow inbound IP protocol 47 in the Security Group; 2) DISABLE the ENI source/dest check.";;
+  gcp)   warn "GCP detected. Add a firewall rule allowing IP protocol 47 (gre) to this instance.";;
+  azure) warn "Azure detected. Add an NSG rule allowing IP protocol 47 to this VM.";;
+esac
+
+# ----------------------------------------------------------------------------
+# 5. input: the access secret (the only thing we ask for)
+# ----------------------------------------------------------------------------
+# Environment: default testnet, override via DZ_ENV; never prompted.
+case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV' (testnet|devnet|mainnet-beta)";; esac
+
+# The secret is either a base64 keypair token (always prefixed with 'DZ_') or a
+# path to an existing keypair file. Provide via DZ_SECRET (no prompt) or once at
+# the prompt.
+SECRET="$DZ_SECRET"
+if [ -z "$SECRET" ]; then
+  SECRET="$(ask 'Access secret (DZ_-prefixed token, or path to a keypair file)' '')"
+fi
+[ -n "$SECRET" ] || die "No secret provided. Set DZ_SECRET or supply one when prompted."
+
+case "$SECRET" in
+  DZ_*)
+    # 'DZ_' + base64url(raw 64 keypair bytes). Restore the base64 alphabet and
+    # padding, decode to raw bytes, and build the Solana keypair JSON array in
+    # memory. It is injected into the container after start and is NEVER written
+    # to the host disk.
+    b64="$(printf '%s' "${SECRET#DZ_}" | tr '_-' '/+')"
+    case $(( ${#b64} % 4 )) in
+      2) b64="${b64}==" ;;
+      3) b64="${b64}=" ;;
+      1) die "Invalid DZ_ token (bad base64url length)." ;;
+    esac
+    # raw bytes -> single-line "[b1,b2,...]" (collapse od's multi-line output)
+    KEY_JSON="[$(printf '%s' "$b64" | base64 -d 2>/dev/null | od -An -v -t u1 | tr -s ' \n' ' ' | sed 's/^ //; s/ $//; s/ /,/g')]"
+    n=$(printf '%s' "$KEY_JSON" | tr ',' '\n' | grep -c '[0-9]')
+    [ "$n" -eq 64 ] || die "DZ_ token did not decode to a 64-byte keypair (got $n)."
+    KEY_SRC=token
+    info "Decoded token to a $n-byte keypair (held in memory; not written to host disk)."
+    ;;
+  *)
+    # otherwise it's a path to an existing keypair file (bind-mounted read-only)
+    case "$SECRET" in "~"*) SECRET_PATH="${REAL_HOME}${SECRET#\~}";; *) SECRET_PATH="$SECRET";; esac
+    [ -f "$SECRET_PATH" ] || die "Secret is not a DZ_-prefixed token, and no keypair file exists at: $SECRET"
+    KEYFILE="$(realpath -m "$SECRET_PATH")"
+    KEY_SRC=file
+    info "Using keypair file: $KEYFILE"
+    ;;
+esac
+
+# SELinux relabel for the bind mount
+MNT_OPT=ro
+if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" = Enforcing ]; then MNT_OPT=ro,Z; fi
+
+# ----------------------------------------------------------------------------
+# 6. run the container (detached, long-lived daemon)
+# ----------------------------------------------------------------------------
+# The devnet image is private; authenticate to ghcr before pulling.
+DZ_GHCR_TOKEN="${DZ_GHCR_TOKEN:-}"
+DZ_GHCR_USER="${DZ_GHCR_USER:-doublezero}"
+if [ -z "$DZ_GHCR_TOKEN" ]; then
+  die "The devnet image is private. Set DZ_GHCR_TOKEN (a ghcr token with read:packages) and re-run."
+fi
+info "Logging in to ghcr.io as $DZ_GHCR_USER ..."
+printf '%s' "$DZ_GHCR_TOKEN" | $SUDO docker login ghcr.io -u "$DZ_GHCR_USER" --password-stdin >/dev/null \
+  || die "ghcr login failed. Check DZ_GHCR_TOKEN/DZ_GHCR_USER."
+
+info "Pulling $DZ_IMAGE ..."
+$SUDO docker pull -q "$DZ_IMAGE" >/dev/null
+
+info "Starting doublezero client (env=$DZ_ENV)..."
+$SUDO docker rm -f "$DZ_NAME" >/dev/null 2>&1 || true
+# Bind-mount the keypair only when the secret was a file; a token-derived key is
+# injected into the container after it starts (so it never touches the host disk).
+mount_args=()
+[ "$KEY_SRC" = file ] && mount_args=(-v "$KEYFILE":"$KEYPAIR_DEST":"$MNT_OPT")
+$SUDO docker run -d --name "$DZ_NAME" \
+  --restart unless-stopped \
+  --network host \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  -e DZ_ENV="$DZ_ENV" \
+  "${mount_args[@]}" \
+  "$DZ_IMAGE" >/dev/null
+
+# wait for the daemon socket
+info "Waiting for the daemon..."
+for _ in $(seq 1 30); do
+  $SUDO docker logs "$DZ_NAME" 2>&1 | grep -q "doublezerod ready" && break
+  $SUDO docker ps -q --filter "name=^${DZ_NAME}$" | grep -q . || die "Container exited early. Logs: sudo docker logs $DZ_NAME"
+  sleep 1
+done
+
+# Deliver a token-derived key by piping it straight into the container's
+# filesystem, so the plaintext keypair lives only in the container (and is gone
+# when the container is removed). A file secret is already bind-mounted above.
+if [ "$KEY_SRC" = token ]; then
+  printf '%s' "$KEY_JSON" | $SUDO docker exec -i "$DZ_NAME" \
+    sh -c 'umask 077; mkdir -p /root/.config/doublezero && cat > /root/.config/doublezero/id.json'
+  info "Installed keypair into the container (not stored on the host)."
+fi
+
+# ----------------------------------------------------------------------------
+# 7. connect (always `doublezero connect multicast`)
+# ----------------------------------------------------------------------------
+info "Connecting: doublezero connect multicast"
+# Allocate a pseudo-TTY when our stdout is a terminal so the CLI streams its
+# normal output to the screen (without -t, docker exec gives it no TTY and the
+# command's output is suppressed).
+EXEC_TTY=""; [ -t 1 ] && EXEC_TTY="-t"
+# NOTE: connect requires the host's public IP to have an access pass / allowlisted
+# user onchain for $DZ_ENV. If this errors with an access-pass message, that
+# provisioning step still needs to happen.
+$SUDO docker exec $EXEC_TTY "$DZ_NAME" doublezero connect multicast || warn "connect failed (often: no access pass for this IP, or provider firewall/NAT). See notes above."
+
+# ----------------------------------------------------------------------------
+# 8. status + management hints
+# ----------------------------------------------------------------------------
+echo
+$SUDO docker exec "$DZ_NAME" doublezero status || true
+echo
+info "Done. Manage with:"
+echo "  sudo docker exec -it $DZ_NAME doublezero status      # tunnel status"
+echo "  sudo docker exec -it $DZ_NAME doublezero latency     # device latencies"
+echo "  sudo docker logs -f $DZ_NAME                         # daemon logs"
+echo "  sudo docker rm -f $DZ_NAME                           # stop & remove"

--- a/client/install-devnet.sh
+++ b/client/install-devnet.sh
@@ -43,6 +43,8 @@ DZ_NAME="${DZ_NAME:-doublezero}"
 DZ_ENV="${DZ_ENV:-devnet}"
 DZ_SECRET="${DZ_SECRET:-}"
 DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
+DZ_GHCR_TOKEN="${DZ_GHCR_TOKEN:-}"
+DZ_GHCR_USER="${DZ_GHCR_USER:-doublezero}"
 KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)
 LIVENESS_UDP_PORT=44880
 
@@ -159,7 +161,7 @@ esac
 # ----------------------------------------------------------------------------
 # 5. input: the access secret (the only thing we ask for)
 # ----------------------------------------------------------------------------
-# Environment: default testnet, override via DZ_ENV; never prompted.
+# Environment: default devnet, override via DZ_ENV; never prompted.
 case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV' (testnet|devnet|mainnet-beta)";; esac
 
 # The secret is either a base64 keypair token (always prefixed with 'DZ_') or a
@@ -208,8 +210,6 @@ if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" = Enfo
 # 6. run the container (detached, long-lived daemon)
 # ----------------------------------------------------------------------------
 # The devnet image is private; authenticate to ghcr before pulling.
-DZ_GHCR_TOKEN="${DZ_GHCR_TOKEN:-}"
-DZ_GHCR_USER="${DZ_GHCR_USER:-doublezero}"
 if [ -z "$DZ_GHCR_TOKEN" ]; then
   die "The devnet image is private. Set DZ_GHCR_TOKEN (a ghcr token with read:packages) and re-run."
 fi

--- a/client/install-devnet.sh
+++ b/client/install-devnet.sh
@@ -23,7 +23,7 @@
 #   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
 #   DZ_GHCR_TOKEN=<token>   ghcr token with read:packages (required: the devnet
 #                           image is private). DZ_GHCR_USER defaults to the token owner.
-#   DZ_GHCR_USER=<user>     optional; ghcr username for the login
+#   DZ_GHCR_USER=<user>     optional; ghcr username for the login (default: malbeclabs)
 #
 # A DZ_-token-derived keypair is injected straight into the container and is never
 # written to the host disk; a keypair supplied as a file path is bind-mounted
@@ -44,7 +44,7 @@ DZ_ENV="${DZ_ENV:-devnet}"
 DZ_SECRET="${DZ_SECRET:-}"
 DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
 DZ_GHCR_TOKEN="${DZ_GHCR_TOKEN:-}"
-DZ_GHCR_USER="${DZ_GHCR_USER:-doublezero}"
+DZ_GHCR_USER="${DZ_GHCR_USER:-malbeclabs}"
 KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)
 LIVENESS_UDP_PORT=44880
 

--- a/client/install-testnet.sh
+++ b/client/install-testnet.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# DoubleZero Edge installer (testnet)
+# ------------------------------------
+# Served from https://get.doublezero.xyz/install-testnet and run as:
+#
+#     curl -fsSL https://get.doublezero.xyz/install-testnet | bash
+#
+# It checks for Docker (offering to install it), preps the host for GRE, loads the
+# access secret, runs the thin doublezero client container
+# (ghcr.io/malbeclabs/doublezero:testnet), and runs `doublezero connect multicast`.
+#
+# Attendantless: the only input is the access secret. Provide it via DZ_SECRET to
+# run with no prompts at all; otherwise you're prompted once. Everything else has
+# a default.
+#
+# Env vars:
+#   DZ_SECRET=<DZ_token|path> base64 keypair token (always prefixed with 'DZ_')
+#                             OR a path to a keypair file. If set, runs non-interactively.
+#   DZ_ENV=testnet|devnet|mainnet-beta   default: testnet
+#   DZ_IMAGE=ghcr.io/malbeclabs/doublezero:testnet
+#   DZ_NAME=doublezero                   container name
+#   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
+#
+# A DZ_-token-derived keypair is injected straight into the container and is never
+# written to the host disk; a keypair supplied as a file path is bind-mounted
+# read-only. Either way the plaintext key is not printed.
+#
+# NOTE: connecting requires the host's public IP to have an access pass / allowlisted
+# user onchain for the chosen environment. That provisioning is a separate step; if
+# `connect` reports an access-pass error, the rest of the setup is still in place.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# config / defaults
+# ----------------------------------------------------------------------------
+DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs/doublezero:testnet}"
+DZ_NAME="${DZ_NAME:-doublezero}"
+DZ_ENV="${DZ_ENV:-testnet}"
+DZ_SECRET="${DZ_SECRET:-}"
+DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
+KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)
+LIVENESS_UDP_PORT=44880
+
+# ----------------------------------------------------------------------------
+# pretty output + prompts (read from the terminal, not the curl pipe)
+# ----------------------------------------------------------------------------
+if [ -t 1 ]; then BOLD=$'\033[1m'; RED=$'\033[31m'; YEL=$'\033[33m'; GRN=$'\033[32m'; RST=$'\033[0m'
+else BOLD=; RED=; YEL=; GRN=; RST=; fi
+info() { printf '%s==>%s %s\n' "$GRN" "$RST" "$*"; }
+warn() { printf '%s!! %s%s\n' "$YEL" "$*" "$RST" >&2; }
+die()  { printf '%sxx %s%s\n' "$RED" "$*" "$RST" >&2; exit 1; }
+
+# /dev/tty so prompts work under `curl | bash` (where stdin is the script)
+TTY=/dev/tty
+ask() {  # ask "Question" "default" -> echoes answer
+  local q="$1" def="${2:-}" ans=""
+  if [ ! -r "$TTY" ]; then echo "$def"; return; fi
+  if [ -n "$def" ]; then printf '%s%s%s [%s]: ' "$BOLD" "$q" "$RST" "$def" >"$TTY"
+  else printf '%s%s%s: ' "$BOLD" "$q" "$RST" >"$TTY"; fi
+  read -r ans <"$TTY" || true
+  echo "${ans:-$def}"
+}
+confirm() {  # confirm "Question" -> returns 0 if yes
+  [ "$DZ_ASSUME_YES" = 1 ] && return 0
+  [ -r "$TTY" ] || return 1
+  local ans; printf '%s%s%s [y/N]: ' "$BOLD" "$1" "$RST" >"$TTY"
+  read -r ans <"$TTY" || true
+  case "$ans" in y|Y|yes|YES) return 0;; *) return 1;; esac
+}
+
+# ----------------------------------------------------------------------------
+# 1. preconditions
+# ----------------------------------------------------------------------------
+[ "$(uname -s)" = Linux ] || die "This installer supports Linux hosts only (got $(uname -s)). The client needs host networking + kernel tunnels."
+
+case "$(uname -m)" in
+  x86_64|amd64) : ;;
+  *) die "The doublezero image is published for amd64 only; this host is $(uname -m). Run on an x86_64 Linux box." ;;
+esac
+
+# root / sudo: run as a normal user and self-elevate only the privileged steps.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  command -v sudo >/dev/null 2>&1 || die "Need root (for Docker + network capabilities) but sudo is not installed. Re-run as root."
+  SUDO="sudo"
+fi
+
+# Resolve the *human* user's home so the keypair default points at their files
+# whether this is invoked as `... | bash` (self-sudo) or `... | sudo bash` (all root).
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != root ]; then
+  REAL_HOME="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+fi
+REAL_HOME="${REAL_HOME:-$HOME}"
+
+# Prime sudo once up front so later privileged commands don't re-prompt mid-run,
+# but only ask for a password if one is actually required ('sudo -n true' succeeds
+# silently for NOPASSWD or an already-cached timestamp).
+if [ -n "$SUDO" ] && ! $SUDO -n true 2>/dev/null; then
+  info "Some steps need root; you may be prompted for your password once."
+  $SUDO -v || die "Could not obtain sudo. Re-run as root, or configure passwordless sudo."
+fi
+
+# ----------------------------------------------------------------------------
+# 2. docker present? offer install
+# ----------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  warn "Docker is not installed."
+  if confirm "Install Docker now via get.docker.com?"; then
+    info "Installing Docker..."
+    curl -fsSL https://get.docker.com | $SUDO sh
+    $SUDO systemctl enable --now docker 2>/dev/null || true
+  else
+    die "Docker is required. Install it and re-run."
+  fi
+fi
+$SUDO docker info >/dev/null 2>&1 || die "Docker is installed but the daemon isn't reachable. Start it (e.g. 'sudo systemctl start docker') and re-run."
+
+# ----------------------------------------------------------------------------
+# 3. host kernel / network prep (host-side; safe to attempt)
+# ----------------------------------------------------------------------------
+info "Preparing host for DoubleZero Edge Connect"
+$SUDO modprobe tun 2>/dev/null    || warn "Could not load 'tun' module (may be built-in)."
+$SUDO modprobe ip_gre 2>/dev/null || warn "Could not load 'ip_gre' module (will auto-load on tunnel create)."
+[ -e /dev/net/tun ] || warn "/dev/net/tun is missing; tunnel creation may fail."
+
+# best-effort firewall hints (don't auto-edit the user's firewall)
+if command -v ufw >/dev/null 2>&1 && $SUDO ufw status 2>/dev/null | grep -qi "Status: active"; then
+  warn "ufw is active: ensure IP protocol 47 (GRE) and UDP $LIVENESS_UDP_PORT are allowed."
+fi
+if command -v firewall-cmd >/dev/null 2>&1 && $SUDO firewall-cmd --state 2>/dev/null | grep -qi running; then
+  warn "firewalld is running: ensure GRE (protocol 47) and UDP $LIVENESS_UDP_PORT are allowed."
+fi
+
+# ----------------------------------------------------------------------------
+# 4. cloud detection -> warn about provider-level firewall (script can't fix)
+# ----------------------------------------------------------------------------
+detect_cloud() {
+  local md="http://169.254.169.254"
+  # AWS IMDSv2
+  local tok
+  tok=$(curl -fsS -m 1 -X PUT "$md/latest/api/token" -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' 2>/dev/null || true)
+  if [ -n "$tok" ] && curl -fsS -m 1 -H "X-aws-ec2-metadata-token: $tok" "$md/latest/meta-data/instance-id" >/dev/null 2>&1; then echo aws; return; fi
+  if curl -fsS -m 1 -H 'Metadata-Flavor: Google' "$md/computeMetadata/v1/instance/id" >/dev/null 2>&1; then echo gcp; return; fi
+  if curl -fsS -m 1 -H 'Metadata: true' "$md/metadata/instance?api-version=2021-02-01" >/dev/null 2>&1; then echo azure; return; fi
+  echo none
+}
+CLOUD="$(detect_cloud)"
+case "$CLOUD" in
+  aws)   warn "AWS detected. GRE will not work until you (in AWS, NOT on this host): 1) allow inbound IP protocol 47 in the Security Group; 2) DISABLE the ENI source/dest check.";;
+  gcp)   warn "GCP detected. Add a firewall rule allowing IP protocol 47 (gre) to this instance.";;
+  azure) warn "Azure detected. Add an NSG rule allowing IP protocol 47 to this VM.";;
+esac
+
+# ----------------------------------------------------------------------------
+# 5. input: the access secret (the only thing we ask for)
+# ----------------------------------------------------------------------------
+# Environment: default testnet, override via DZ_ENV; never prompted.
+case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV' (testnet|devnet|mainnet-beta)";; esac
+
+# The secret is either a base64 keypair token (always prefixed with 'DZ_') or a
+# path to an existing keypair file. Provide via DZ_SECRET (no prompt) or once at
+# the prompt.
+SECRET="$DZ_SECRET"
+if [ -z "$SECRET" ]; then
+  SECRET="$(ask 'Access secret (DZ_-prefixed token, or path to a keypair file)' '')"
+fi
+[ -n "$SECRET" ] || die "No secret provided. Set DZ_SECRET or supply one when prompted."
+
+case "$SECRET" in
+  DZ_*)
+    # 'DZ_' + base64url(raw 64 keypair bytes). Restore the base64 alphabet and
+    # padding, decode to raw bytes, and build the Solana keypair JSON array in
+    # memory. It is injected into the container after start and is NEVER written
+    # to the host disk.
+    b64="$(printf '%s' "${SECRET#DZ_}" | tr '_-' '/+')"
+    case $(( ${#b64} % 4 )) in
+      2) b64="${b64}==" ;;
+      3) b64="${b64}=" ;;
+      1) die "Invalid DZ_ token (bad base64url length)." ;;
+    esac
+    # raw bytes -> single-line "[b1,b2,...]" (collapse od's multi-line output)
+    KEY_JSON="[$(printf '%s' "$b64" | base64 -d 2>/dev/null | od -An -v -t u1 | tr -s ' \n' ' ' | sed 's/^ //; s/ $//; s/ /,/g')]"
+    n=$(printf '%s' "$KEY_JSON" | tr ',' '\n' | grep -c '[0-9]')
+    [ "$n" -eq 64 ] || die "DZ_ token did not decode to a 64-byte keypair (got $n)."
+    KEY_SRC=token
+    info "Decoded token to a $n-byte keypair (held in memory; not written to host disk)."
+    ;;
+  *)
+    # otherwise it's a path to an existing keypair file (bind-mounted read-only)
+    case "$SECRET" in "~"*) SECRET_PATH="${REAL_HOME}${SECRET#\~}";; *) SECRET_PATH="$SECRET";; esac
+    [ -f "$SECRET_PATH" ] || die "Secret is not a DZ_-prefixed token, and no keypair file exists at: $SECRET"
+    KEYFILE="$(realpath -m "$SECRET_PATH")"
+    KEY_SRC=file
+    info "Using keypair file: $KEYFILE"
+    ;;
+esac
+
+# SELinux relabel for the bind mount
+MNT_OPT=ro
+if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" = Enforcing ]; then MNT_OPT=ro,Z; fi
+
+# ----------------------------------------------------------------------------
+# 6. run the container (detached, long-lived daemon)
+# ----------------------------------------------------------------------------
+info "Pulling $DZ_IMAGE ..."
+$SUDO docker pull -q "$DZ_IMAGE" >/dev/null
+
+info "Starting doublezero client (env=$DZ_ENV)..."
+$SUDO docker rm -f "$DZ_NAME" >/dev/null 2>&1 || true
+# Bind-mount the keypair only when the secret was a file; a token-derived key is
+# injected into the container after it starts (so it never touches the host disk).
+mount_args=()
+[ "$KEY_SRC" = file ] && mount_args=(-v "$KEYFILE":"$KEYPAIR_DEST":"$MNT_OPT")
+$SUDO docker run -d --name "$DZ_NAME" \
+  --restart unless-stopped \
+  --network host \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  -e DZ_ENV="$DZ_ENV" \
+  "${mount_args[@]}" \
+  "$DZ_IMAGE" >/dev/null
+
+# wait for the daemon socket
+info "Waiting for the daemon..."
+for _ in $(seq 1 30); do
+  $SUDO docker logs "$DZ_NAME" 2>&1 | grep -q "doublezerod ready" && break
+  $SUDO docker ps -q --filter "name=^${DZ_NAME}$" | grep -q . || die "Container exited early. Logs: sudo docker logs $DZ_NAME"
+  sleep 1
+done
+
+# Deliver a token-derived key by piping it straight into the container's
+# filesystem, so the plaintext keypair lives only in the container (and is gone
+# when the container is removed). A file secret is already bind-mounted above.
+if [ "$KEY_SRC" = token ]; then
+  printf '%s' "$KEY_JSON" | $SUDO docker exec -i "$DZ_NAME" \
+    sh -c 'umask 077; mkdir -p /root/.config/doublezero && cat > /root/.config/doublezero/id.json'
+  info "Installed keypair into the container (not stored on the host)."
+fi
+
+# ----------------------------------------------------------------------------
+# 7. connect (always `doublezero connect multicast`)
+# ----------------------------------------------------------------------------
+info "Connecting: doublezero connect multicast"
+# Allocate a pseudo-TTY when our stdout is a terminal so the CLI streams its
+# normal output to the screen (without -t, docker exec gives it no TTY and the
+# command's output is suppressed).
+EXEC_TTY=""; [ -t 1 ] && EXEC_TTY="-t"
+# NOTE: connect requires the host's public IP to have an access pass / allowlisted
+# user onchain for $DZ_ENV. If this errors with an access-pass message, that
+# provisioning step still needs to happen.
+$SUDO docker exec $EXEC_TTY "$DZ_NAME" doublezero connect multicast || warn "connect failed (often: no access pass for this IP, or provider firewall/NAT). See notes above."
+
+# ----------------------------------------------------------------------------
+# 8. status + management hints
+# ----------------------------------------------------------------------------
+echo
+$SUDO docker exec "$DZ_NAME" doublezero status || true
+echo
+info "Done. Manage with:"
+echo "  sudo docker exec -it $DZ_NAME doublezero status      # tunnel status"
+echo "  sudo docker exec -it $DZ_NAME doublezero latency     # device latencies"
+echo "  sudo docker logs -f $DZ_NAME                         # daemon logs"
+echo "  sudo docker rm -f $DZ_NAME                           # stop & remove"

--- a/client/install.sh
+++ b/client/install.sh
@@ -8,7 +8,7 @@
 #
 # It checks for Docker (offering to install it), preps the host for GRE, loads the
 # access secret, runs the thin doublezero client container
-# (ghcr.io/malbeclabs-latam/doublezero-edge-connect), and runs `doublezero connect multicast`.
+# (ghcr.io/malbeclabs/doublezero:mainnet-beta), and runs `doublezero connect multicast`.
 #
 # Attendantless: the only input is the access secret. Provide it via DZ_SECRET to
 # run with no prompts at all; otherwise you're prompted once. Everything else has
@@ -17,8 +17,8 @@
 # Env vars:
 #   DZ_SECRET=<DZ_token|path> base64 keypair token (always prefixed with 'DZ_')
 #                             OR a path to a keypair file. If set, runs non-interactively.
-#   DZ_ENV=testnet|devnet|mainnet-beta   default: testnet
-#   DZ_IMAGE=ghcr.io/malbeclabs-latam/doublezero-edge-connect:latest
+#   DZ_ENV=testnet|devnet|mainnet-beta   default: mainnet-beta
+#   DZ_IMAGE=ghcr.io/malbeclabs/doublezero:mainnet-beta
 #   DZ_NAME=doublezero                   container name
 #   DZ_ASSUME_YES=1                      skip confirmation prompts (e.g. Docker install)
 #
@@ -35,9 +35,9 @@ set -euo pipefail
 # ----------------------------------------------------------------------------
 # config / defaults
 # ----------------------------------------------------------------------------
-DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs-latam/doublezero-edge-connect:latest}"
+DZ_IMAGE="${DZ_IMAGE:-ghcr.io/malbeclabs/doublezero:mainnet-beta}"
 DZ_NAME="${DZ_NAME:-doublezero}"
-DZ_ENV="${DZ_ENV:-testnet}"
+DZ_ENV="${DZ_ENV:-mainnet-beta}"
 DZ_SECRET="${DZ_SECRET:-}"
 DZ_ASSUME_YES="${DZ_ASSUME_YES:-0}"
 KEYPAIR_DEST="/root/.config/doublezero/id.json"   # client's default keypair path (container runs as root)

--- a/client/install.sh
+++ b/client/install.sh
@@ -156,7 +156,7 @@ esac
 # ----------------------------------------------------------------------------
 # 5. input: the access secret (the only thing we ask for)
 # ----------------------------------------------------------------------------
-# Environment: default testnet, override via DZ_ENV; never prompted.
+# Environment: default mainnet-beta, override via DZ_ENV; never prompted.
 case "$DZ_ENV" in testnet|devnet|mainnet-beta) : ;; *) die "Invalid DZ_ENV '$DZ_ENV' (testnet|devnet|mainnet-beta)";; esac
 
 # The secret is either a base64 keypair token (always prefixed with 'DZ_') or a


### PR DESCRIPTION
## Summary of Changes
- Parametrize `client/Dockerfile` by Cloudsmith repo and baked default env so one file builds three thin-client image variants: **testnet**, **mainnet-beta**, and **devnet**.
- Publish the public `ghcr.io/malbeclabs/doublezero` image with env tags — `:testnet`, `:mainnet-beta`, `:latest` (= mainnet-beta), and pinned `:<env>-<version>` — and the **private** `ghcr.io/malbeclabs/doublezero-devnet` image for nightly devnet builds.
- Wire the build triggers to each release train: testnet on every `client/v*` tag, mainnet-beta on manual dispatch (at promotion time), devnet off the nightly `release.devnet.client.daily`.
- Split the installer into three env-specific scripts (`install.sh` → mainnet-beta, `install-testnet.sh`, `install-devnet.sh`) served at `get.doublezero.xyz/install`, `/install-testnet`, `/install-devnet`. The devnet installer authenticates to ghcr (private image) via `DZ_GHCR_TOKEN`.
- Add a weekly retention workflow that prunes untagged layers and keeps the last 10 pinned versions per env family, with a `dry_run` switch and protected moving tags.

## Diff Breakdown
| Category      | Files | Lines (+/-)  | Net   |
|---------------|-------|--------------|-------|
| Config/build  |     5 | +291 / -26   |  +265 |
| Scaffolding   |     4 | +552 / -8    |  +544 |
| **Total**     |     9 | +843 / -34   |  +809 |

Entirely infrastructure: parametrized Docker build + CI publish/retention workflows (config) and three installer scripts plus an entrypoint comment (scaffolding). No application/business logic. **Note:** this exceeds doublezero's ~500-line guideline, almost entirely because `install-testnet.sh` (+265) and `install-devnet.sh` (+278) are intentional near-duplicates of `install.sh` per the chosen "separate scripts" design; the substantive logic is small.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/release.docker.client.yml` — testnet publish on `client/v*` (deb version pinned from the testnet repo), new mainnet-beta dispatch job (`:mainnet-beta`/version/`:latest`), PR build-only across all three variants
- `client/install-devnet.sh` — devnet installer; private-image ghcr login gated on `DZ_GHCR_TOKEN`, defaults `DZ_ENV=devnet`
- `client/install-testnet.sh` — testnet installer; pulls `:testnet`, defaults `DZ_ENV=testnet`
- `.github/workflows/release.docker.client.devnet.yml` — private devnet image publish off the nightly, with `~`/`:` → `-` tag sanitization
- `.github/workflows/release.docker.client.cleanup.yml` — weekly ghcr retention; per-family keep-10, untagged prune, `dry_run` input
- `client/Dockerfile` — `DZ_CLOUDSMITH_REPO` / `DZ_DEP_REPO` / `DZ_DEFAULT_ENV` / `DZ_VERSION` build args; bakes `ENV DZ_ENV`; devnet pulls `doublezero-solana` from a dep repo
- `.github/workflows/release.install-script.yml` — uploads all three installers to the CDN; upload and invalidation split into separate steps
- `client/install.sh` — repointed from `malbeclabs-latam/doublezero-edge-connect` to the public `doublezero:mainnet-beta` image

</details>

## Testing Verification
- Built all three image variants locally (amd64) and confirmed each bakes the correct env and installs the expected version: mainnet-beta → `doublezero 0.25.1-1` (public repo latest), testnet → `0.27.1-1` (testnet repo latest), devnet → pinned nightly `0.27.2~git…` with `doublezero-solana 0.5.7-1` resolved from the testnet dep repo.
- Verified the devnet image resolves `doublezero-solana` from the dep repo and installs the pinned nightly build (an unpinned, single-repo devnet build fails on the missing dependency, which is why devnet needs the dep-repo + version pin).
- `shellcheck` and `bash -n` clean on all three installers; verified the devnet installer's missing-token guard fires before any docker work.

## Follow-ups (manual, not in this PR)
- Grant the repo's Actions **Write** access on both ghcr packages — CI publish currently fails with `permission_denied: write_package`.
- Set the new `doublezero-devnet` package visibility to **private** after its first publish.
