### PR TITLE
serviceability: validate device mgmt_vrf field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain programs
+  - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
+- Controller
+  - Skip rendering device config when a string field would not survive as a single config token (contains control or whitespace characters).
 - Device agents
   - Reduce agent CPU usage by continuing to fetch the full config every 5 seconds but only applying when it has changed or after 60s timeout
 

--- a/controlplane/controller/internal/controller/render.go
+++ b/controlplane/controller/internal/controller/render.go
@@ -5,7 +5,9 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"strings"
 	"text/template"
+	"unicode"
 )
 
 //go:embed templates/*
@@ -19,7 +21,61 @@ var templateFuncs = template.FuncMap{
 	"fail": func(msg string) (string, error) { return "", errors.New(msg) },
 }
 
+type renderedField struct {
+	name  string
+	value string
+}
+
+// isInvalidConfigChar reports whether r cannot appear in a config token. Control
+// characters break line structure; whitespace splits a value into extra tokens.
+func isInvalidConfigChar(r rune) bool {
+	return unicode.IsControl(r) || unicode.IsSpace(r)
+}
+
+// validateTemplateData rejects template inputs whose value would not survive
+// rendering into a single config token intact.
+func validateTemplateData(data templateData) error {
+	d := data.Device
+	if d == nil {
+		return nil // template execution reports the nil device on its own
+	}
+	fields := []renderedField{
+		{"device mgmt_vrf", d.MgmtVrf},
+		{"device exchange code", d.ExchangeCode},
+		{"device isis net", d.IsisNet},
+		{"device vpnv4 loopback interface name", d.Vpn4vLoopbackIntfName},
+		{"device ipv4 loopback interface name", d.Ipv4LoopbackIntfName},
+	}
+	for _, iface := range d.Interfaces {
+		fields = append(fields, renderedField{"interface name", iface.Name})
+		for _, topology := range iface.LinkTopologies {
+			fields = append(fields, renderedField{"interface link topology", topology})
+		}
+		for _, segment := range iface.FlexAlgoNodeSegments {
+			fields = append(fields, renderedField{"flex-algo topology name", segment.TopologyName})
+		}
+	}
+	for _, peer := range data.Ipv4BgpPeers {
+		fields = append(fields, renderedField{"ipv4 bgp peer name", peer.PeerName})
+	}
+	for _, peer := range data.Vpnv4BgpPeers {
+		fields = append(fields, renderedField{"vpnv4 bgp peer name", peer.PeerName})
+	}
+	for _, topology := range data.AllTopologies {
+		fields = append(fields, renderedField{"topology name", topology.Name})
+	}
+	for _, field := range fields {
+		if strings.ContainsFunc(field.value, isInvalidConfigChar) {
+			return fmt.Errorf("%s %q contains control or whitespace characters", field.name, field.value)
+		}
+	}
+	return nil
+}
+
 func renderConfig(data templateData) (string, error) {
+	if err := validateTemplateData(data); err != nil {
+		return "", fmt.Errorf("refusing to render config: %w", err)
+	}
 	t, err := template.New("tunnel.tmpl").Funcs(templateFuncs).ParseFS(f, "templates/tunnel.tmpl")
 	if err != nil {
 		return "", fmt.Errorf("error loading tunnel template: %v", err)

--- a/controlplane/controller/internal/controller/render_test.go
+++ b/controlplane/controller/internal/controller/render_test.go
@@ -55,6 +55,128 @@ func TestRenderGNMIManagementProvider(t *testing.T) {
 	}
 }
 
+func TestRenderConfigRejectsControlCharsInDeviceFields(t *testing.T) {
+	newData := func(mutate func(*templateData)) templateData {
+		data := templateData{
+			Strings:                  StringsHelper{},
+			MulticastGroupBlock:      "239.0.0.0/24",
+			TelemetryTWAMPListenPort: 862,
+			LocalASN:                 65342,
+			UnicastVrfs:              []uint16{1},
+			Device: &Device{
+				PublicIP:              net.IP{7, 7, 7, 7},
+				Vpn4vLoopbackIP:       net.IP{14, 14, 14, 14},
+				Vpn4vLoopbackIntfName: "Loopback255",
+				Ipv4LoopbackIntfName:  "Loopback256",
+				IsisNet:               "49.0000.0e0e.0e0e.0000.00",
+				ExchangeCode:          "tst",
+				BgpCommunity:          10050,
+				Interfaces:            []Interface{},
+				MgmtVrf:               "mgmt",
+			},
+		}
+		mutate(&data)
+		return data
+	}
+
+	if _, err := renderConfig(newData(func(*templateData) {})); err != nil {
+		t.Fatalf("renderConfig() with valid device fields: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		wantField string // substring the error must name
+		mutate    func(*templateData)
+	}{
+		{
+			name:      "newline in mgmt_vrf",
+			wantField: "mgmt_vrf",
+			mutate:    func(d *templateData) { d.Device.MgmtVrf = "mgmt\nbad" },
+		},
+		{
+			name:      "carriage return in mgmt_vrf",
+			wantField: "mgmt_vrf",
+			mutate:    func(d *templateData) { d.Device.MgmtVrf = "mgmt\rbad" },
+		},
+		{
+			name:      "space in mgmt_vrf",
+			wantField: "mgmt_vrf",
+			mutate:    func(d *templateData) { d.Device.MgmtVrf = "default bad" },
+		},
+		{
+			name:      "newline in exchange code",
+			wantField: "exchange code",
+			mutate:    func(d *templateData) { d.Device.ExchangeCode = "tst\nbad" },
+		},
+		{
+			name:      "space in isis net",
+			wantField: "isis net",
+			mutate:    func(d *templateData) { d.Device.IsisNet = "49.0000 bad" },
+		},
+		{
+			name:      "newline in vpnv4 loopback interface name",
+			wantField: "vpnv4 loopback interface name",
+			mutate:    func(d *templateData) { d.Device.Vpn4vLoopbackIntfName = "Loopback255\nbad" },
+		},
+		{
+			name:      "newline in ipv4 loopback interface name",
+			wantField: "ipv4 loopback interface name",
+			mutate:    func(d *templateData) { d.Device.Ipv4LoopbackIntfName = "Loopback256\nbad" },
+		},
+		{
+			name:      "newline in interface name",
+			wantField: "interface name",
+			mutate:    func(d *templateData) { d.Device.Interfaces = []Interface{{Name: "Ethernet1\nbad"}} },
+		},
+		{
+			name:      "newline in interface link topology",
+			wantField: "interface link topology",
+			mutate: func(d *templateData) {
+				d.Device.Interfaces = []Interface{{Name: "Ethernet1", LinkTopologies: []string{"topo\nbad"}}}
+			},
+		},
+		{
+			name:      "newline in flex-algo topology name",
+			wantField: "flex-algo topology name",
+			mutate: func(d *templateData) {
+				d.Device.Interfaces = []Interface{{Name: "Ethernet1", FlexAlgoNodeSegments: []FlexAlgoNodeSegmentModel{{TopologyName: "topo\nbad"}}}}
+			},
+		},
+		{
+			name:      "newline in ipv4 bgp peer name",
+			wantField: "ipv4 bgp peer name",
+			mutate: func(d *templateData) {
+				d.Ipv4BgpPeers = []BgpPeer{{PeerIP: net.IP{1, 2, 3, 4}, PeerName: "peer\nbad"}}
+			},
+		},
+		{
+			name:      "newline in vpnv4 bgp peer name",
+			wantField: "vpnv4 bgp peer name",
+			mutate: func(d *templateData) {
+				d.Vpnv4BgpPeers = []BgpPeer{{PeerIP: net.IP{1, 2, 3, 4}, PeerName: "peer\nbad"}}
+			},
+		},
+		{
+			name:      "newline in topology name",
+			wantField: "topology name",
+			mutate: func(d *templateData) {
+				d.AllTopologies = []TopologyModel{{Name: "topo\nbad"}}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderConfig(newData(tt.mutate))
+			if err == nil {
+				t.Fatalf("renderConfig() accepted field with control characters\nconfig:\n%s", got)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Fatalf("error %q does not name field %q", err, tt.wantField)
+			}
+		})
+	}
+}
+
 func TestRenderConfig(t *testing.T) {
 	tests := []struct {
 		Name        string

--- a/smartcontract/programs/doublezero-serviceability/src/state/device.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/device.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
-use doublezero_program_common::types::NetworkV4List;
+use doublezero_program_common::{types::NetworkV4List, validate_account_code};
 use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
 use std::{fmt, net::Ipv4Addr, str::FromStr};
 
@@ -687,6 +687,16 @@ impl Validate for Device {
             msg!("Code too long: {} bytes", self.code.len());
             return Err(DoubleZeroError::CodeTooLong);
         }
+        // mgmt_vrf must use the account-code charset and length bound.
+        // Empty selects the default VRF.
+        if validate_account_code(&self.mgmt_vrf).is_err() {
+            msg!("Invalid mgmt_vrf: {}", self.mgmt_vrf);
+            return Err(DoubleZeroError::InvalidAccountCode);
+        }
+        if self.mgmt_vrf.len() > 32 {
+            msg!("MgmtVrf too long: {} bytes", self.mgmt_vrf.len());
+            return Err(DoubleZeroError::CodeTooLong);
+        }
         // Location ID must be valid
         if self.location_pk == Pubkey::default() {
             msg!("Invalid location ID: {}", self.location_pk);
@@ -878,6 +888,69 @@ mod tests {
         };
         let err = val.validate();
         assert_eq!(err.unwrap_err(), DoubleZeroError::CodeTooLong);
+    }
+
+    #[test]
+    fn test_state_device_validate_mgmt_vrf() {
+        let valid = Device {
+            account_type: AccountType::Device,
+            owner: Pubkey::new_unique(),
+            index: 123,
+            bump_seed: 1,
+            reference_count: 0,
+            contributor_pk: Pubkey::new_unique(),
+            code: "test-321".to_string(),
+            device_type: DeviceType::Hybrid,
+            location_pk: Pubkey::new_unique(),
+            exchange_pk: Pubkey::new_unique(),
+            dz_prefixes: "110.1.0.0/23".parse().unwrap(),
+            public_ip: [1, 2, 3, 4].into(),
+            status: DeviceStatus::Activated,
+            metrics_publisher_pk: Pubkey::new_unique(),
+            mgmt_vrf: "default".to_string(),
+            deprecated_interfaces: vec![],
+            interfaces: vec![],
+            users_count: 1,
+            max_users: 2,
+            device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Pending,
+            unicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: 0,
+            max_multicast_publishers: 0,
+        };
+        assert!(valid.validate().is_ok());
+
+        // Empty means the default VRF.
+        let empty = Device {
+            mgmt_vrf: String::new(),
+            ..valid.clone()
+        };
+        assert!(empty.validate().is_ok());
+
+        for mgmt_vrf in ["mgmt\nbad", "mgmt vrf"] {
+            let val = Device {
+                mgmt_vrf: mgmt_vrf.to_string(),
+                ..valid.clone()
+            };
+            assert_eq!(
+                val.validate().unwrap_err(),
+                DoubleZeroError::InvalidAccountCode,
+                "mgmt_vrf {mgmt_vrf:?}"
+            );
+        }
+
+        let too_long = Device {
+            mgmt_vrf: "a".repeat(33),
+            ..valid
+        };
+        assert_eq!(
+            too_long.validate().unwrap_err(),
+            DoubleZeroError::CodeTooLong
+        );
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-serviceability/tests/device_mgmt_vrf_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_mgmt_vrf_test.rs
@@ -1,0 +1,172 @@
+//! Integration tests for mgmt_vrf validation in CreateDevice / UpdateDevice.
+
+use doublezero_serviceability::{
+    instructions::*,
+    pda::*,
+    processors::device::{create::DeviceCreateArgs, update::DeviceUpdateArgs},
+    resource::ResourceType,
+    state::device::*,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::{AccountMeta, InstructionError},
+    pubkey::Pubkey,
+    transaction::TransactionError,
+};
+
+mod test_helpers;
+use test_helpers::*;
+
+const INVALID_ACCOUNT_CODE: u32 = 19;
+const CODE_TOO_LONG: u32 = 34;
+
+fn assert_custom_error(result: Result<(), BanksClientError>, expected: u32, context: &str) {
+    match result {
+        Err(BanksClientError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(code),
+        ))) if code == expected => {}
+        _ => panic!("{context}: expected Custom({expected}), got {result:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_device_mgmt_vrf_validation() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let (location_pubkey, exchange_pubkey, contributor_pubkey) = setup_device_prerequisites(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (device_pubkey, _) = get_device_pda(&program_id, globalstate_account.account_index + 1);
+    let (tunnel_ids_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::TunnelIds(device_pubkey, 0));
+    let (dz_prefix_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::DzPrefixBlock(device_pubkey, 0));
+
+    let create_args = |mgmt_vrf: &str| {
+        DoubleZeroInstruction::CreateDevice(DeviceCreateArgs {
+            code: "dz1".to_string(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [8, 8, 8, 8].into(),
+            dz_prefixes: "110.1.0.0/23".parse().unwrap(),
+            metrics_publisher_pk: Pubkey::default(),
+            mgmt_vrf: mgmt_vrf.to_string(),
+            desired_status: Some(DeviceDesiredStatus::Activated),
+            resource_count: 2,
+        })
+    };
+    let create_accounts = vec![
+        AccountMeta::new(device_pubkey, false),
+        AccountMeta::new(contributor_pubkey, false),
+        AccountMeta::new(location_pubkey, false),
+        AccountMeta::new(exchange_pubkey, false),
+        AccountMeta::new(globalstate_pubkey, false),
+        AccountMeta::new(globalconfig_pubkey, false),
+        AccountMeta::new(tunnel_ids_pda, false),
+        AccountMeta::new(dz_prefix_pda, false),
+    ];
+
+    // CreateDevice rejects mgmt_vrf values outside the account-code charset.
+    for mgmt_vrf in ["mgmt\nbad", "mgmt\r\nbad", "mgmt vrf", "mgmt;vrf"] {
+        let result = execute_transaction_expect_failure(
+            &mut banks_client,
+            recent_blockhash,
+            program_id,
+            create_args(mgmt_vrf),
+            create_accounts.clone(),
+            &payer,
+        )
+        .await;
+        assert_custom_error(
+            result,
+            INVALID_ACCOUNT_CODE,
+            &format!("CreateDevice with mgmt_vrf {mgmt_vrf:?}"),
+        );
+    }
+
+    // CreateDevice rejects an mgmt_vrf longer than the 32-byte cap.
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        create_args(&"a".repeat(33)),
+        create_accounts.clone(),
+        &payer,
+    )
+    .await;
+    assert_custom_error(result, CODE_TOO_LONG, "CreateDevice with 33-byte mgmt_vrf");
+
+    // An empty mgmt_vrf (the default VRF) is accepted.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        create_args(""),
+        create_accounts,
+        &payer,
+    )
+    .await;
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    assert_eq!(device.mgmt_vrf, "");
+
+    // UpdateDevice must apply the same validation.
+    let update_args = |mgmt_vrf: &str| {
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            mgmt_vrf: Some(mgmt_vrf.to_string()),
+            ..DeviceUpdateArgs::default()
+        })
+    };
+    let update_accounts = vec![
+        AccountMeta::new(device_pubkey, false),
+        AccountMeta::new(contributor_pubkey, false),
+        AccountMeta::new(globalstate_pubkey, false),
+    ];
+
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        update_args("mgmt\nbad"),
+        update_accounts.clone(),
+        &payer,
+    )
+    .await;
+    assert_custom_error(
+        result,
+        INVALID_ACCOUNT_CODE,
+        "UpdateDevice with newline in mgmt_vrf",
+    );
+
+    // The failed update must not have modified the stored value, and a valid
+    // update still goes through.
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    assert_eq!(device.mgmt_vrf, "");
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        update_args("MGMT-2"),
+        update_accounts,
+        &payer,
+    )
+    .await;
+    let device = get_device(&mut banks_client, device_pubkey)
+        .await
+        .expect("Device not found");
+    assert_eq!(device.mgmt_vrf, "MGMT-2");
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/device_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_onchain_allocation_test.rs
@@ -4,102 +4,14 @@
 //! ResourceExtension accounts (TunnelIds + DzPrefixBlocks) in a single instruction.
 
 use doublezero_serviceability::{
-    instructions::*,
-    pda::*,
-    processors::{
-        contributor::create::ContributorCreateArgs, device::create::DeviceCreateArgs,
-        exchange::create::ExchangeCreateArgs, location::create::LocationCreateArgs,
-    },
-    resource::ResourceType,
+    instructions::*, pda::*, processors::device::create::DeviceCreateArgs, resource::ResourceType,
     state::device::*,
 };
 use solana_program_test::*;
-use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signer::Signer};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
 
 mod test_helpers;
 use test_helpers::*;
-
-/// Helper: create location, exchange, and contributor prerequisites.
-/// Returns (location_pubkey, exchange_pubkey, contributor_pubkey).
-async fn setup_device_prerequisites(
-    banks_client: &mut BanksClient,
-    recent_blockhash: solana_program::hash::Hash,
-    program_id: Pubkey,
-    globalstate_pubkey: Pubkey,
-    globalconfig_pubkey: Pubkey,
-    payer: &solana_sdk::signature::Keypair,
-) -> (Pubkey, Pubkey, Pubkey) {
-    // Create Location
-    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
-    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
-
-    execute_transaction(
-        banks_client,
-        recent_blockhash,
-        program_id,
-        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
-            code: "la".to_string(),
-            name: "Los Angeles".to_string(),
-            country: "us".to_string(),
-            lat: 1.234,
-            lng: 4.567,
-            loc_id: 0,
-        }),
-        vec![
-            AccountMeta::new(location_pubkey, false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ],
-        payer,
-    )
-    .await;
-
-    // Create Exchange
-    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
-    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
-
-    execute_transaction(
-        banks_client,
-        recent_blockhash,
-        program_id,
-        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
-            code: "la".to_string(),
-            name: "Los Angeles".to_string(),
-            lat: 1.234,
-            lng: 4.567,
-            reserved: 0,
-        }),
-        vec![
-            AccountMeta::new(exchange_pubkey, false),
-            AccountMeta::new(globalconfig_pubkey, false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ],
-        payer,
-    )
-    .await;
-
-    // Create Contributor
-    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
-    let (contributor_pubkey, _) =
-        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
-
-    execute_transaction(
-        banks_client,
-        recent_blockhash,
-        program_id,
-        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
-            code: "cont".to_string(),
-        }),
-        vec![
-            AccountMeta::new(contributor_pubkey, false),
-            AccountMeta::new(payer.pubkey(), false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ],
-        payer,
-    )
-    .await;
-
-    (location_pubkey, exchange_pubkey, contributor_pubkey)
-}
 
 /// Test atomic create+activate with onchain allocation (1 TunnelIds + 1 DzPrefixBlock)
 #[tokio::test]

--- a/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
@@ -3,10 +3,14 @@ use doublezero_serviceability::{
     entrypoint::process_instruction,
     instructions::*,
     pda::{
-        get_globalconfig_pda, get_globalstate_pda, get_program_config_pda,
-        get_resource_extension_pda, get_topology_pda,
+        get_contributor_pda, get_exchange_pda, get_globalconfig_pda, get_globalstate_pda,
+        get_location_pda, get_program_config_pda, get_resource_extension_pda, get_topology_pda,
     },
-    processors::{globalconfig::set::SetGlobalConfigArgs, topology::create::TopologyCreateArgs},
+    processors::{
+        contributor::create::ContributorCreateArgs, exchange::create::ExchangeCreateArgs,
+        globalconfig::set::SetGlobalConfigArgs, location::create::LocationCreateArgs,
+        topology::create::TopologyCreateArgs,
+    },
     resource::ResourceType,
     state::{
         accountdata::AccountData, accounttype::AccountType, device::Device,
@@ -636,6 +640,89 @@ pub async fn setup_program_with_globalconfig() -> (BanksClient, Keypair, Pubkey,
         globalstate_pubkey,
         globalconfig_pubkey,
     )
+}
+
+/// Create location, exchange, and contributor prerequisites for device tests.
+/// Returns (location_pubkey, exchange_pubkey, contributor_pubkey).
+#[allow(dead_code)]
+pub async fn setup_device_prerequisites(
+    banks_client: &mut BanksClient,
+    recent_blockhash: solana_program::hash::Hash,
+    program_id: Pubkey,
+    globalstate_pubkey: Pubkey,
+    globalconfig_pubkey: Pubkey,
+    payer: &Keypair,
+) -> (Pubkey, Pubkey, Pubkey) {
+    // Create Location
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (location_pubkey, _) = get_location_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLocation(LocationCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            country: "us".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            loc_id: 0,
+        }),
+        vec![
+            AccountMeta::new(location_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create Exchange
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (exchange_pubkey, _) = get_exchange_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateExchange(ExchangeCreateArgs {
+            code: "la".to_string(),
+            name: "Los Angeles".to_string(),
+            lat: 1.234,
+            lng: 4.567,
+            reserved: 0,
+        }),
+        vec![
+            AccountMeta::new(exchange_pubkey, false),
+            AccountMeta::new(globalconfig_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    // Create Contributor
+    let globalstate_account = get_globalstate(banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) =
+        get_contributor_pda(&program_id, globalstate_account.account_index + 1);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "cont".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    (location_pubkey, exchange_pubkey, contributor_pubkey)
 }
 
 /// Create the "unicast-default" topology.


### PR DESCRIPTION
## Summary
- Validate the device `mgmt_vrf` field in `Device::validate`: restrict it to the account-code charset (`[A-Za-z0-9:_-]`) and cap it at 32 bytes, matching how the device `code` is already bounded. Empty is still accepted (the default VRF).
- The controller skips rendering device config when a string field destined for the device config contains characters that wouldn't survive as a single config token (control characters or whitespace), failing closed instead of emitting a malformed config.
- Move `setup_device_prerequisites` from `device_onchain_allocation_test.rs` into `test_helpers.rs` so the new test reuses it.

## Testing Verification
- Audited `mgmt_vrf` across all existing devices on mainnet-beta, testnet, and devnet — every value (`""`, `default`, `MGMT`, `mgmt`, `management`) passes the new rule, so the `Device::validate` check applies cleanly to deployed accounts.
- New onchain integration test: CreateDevice/UpdateDevice reject out-of-charset (`Custom(19)`) and over-length (`Custom(34)`) values, a failed update leaves the stored value unchanged, and empty/valid values round-trip.
- New controller render test covers all 13 rendered string fields and asserts the error names the offending field.
