### PR TITLE
serviceability: transfer credits when adding a user to a multicast allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - Onchain programs
   - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
+  - Transfer connect/disconnect credits to the user's account when adding a user to a multicast group's publisher or subscriber allowlist, so the user can connect immediately. The airdrop is atomic with the allowlist update and mirrors `set_access_pass` (scaled for `allow_multiple_ip` passes). (#3851)
+- SDK
+  - Pass the `user_payer` account on the multicast allowlist add instructions so the onchain credit transfer can fund it.
 - Controller
   - Skip rendering device config when a string field would not survive as a single config token (contains control or whitespace characters).
 - Device agents

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -1,3 +1,48 @@
 pub mod check_status;
 pub mod close;
 pub mod set;
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed_unchecked,
+    rent::Rent, sysvar::Sysvar,
+};
+
+// Value to rent exempt three `User` accounts + configurable amount for connect/disconnect txns.
+// `User` account size assumes a single publisher and subscriber pubkey registered (266 bytes each).
+pub const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 266 * 3; // 266 bytes per User account x 3 accounts = 798 bytes
+
+/// Tops up `user_payer` so it holds enough SOL to cover rent for its `User` accounts plus the
+/// configured per-user airdrop, allowing the user to connect immediately. `multiplier` scales the
+/// target for passes that admit several users (e.g. `allow_multiple_ip` seat keypairs); pass `1`
+/// for single-user passes. The transfer is funded by `payer_account` and is a no-op when
+/// `user_payer` already meets the target. Performed via CPI so a failed transfer reverts the whole
+/// instruction (keeping the operation atomic with the surrounding account writes).
+pub fn airdrop_user_credits<'a>(
+    payer_account: &AccountInfo<'a>,
+    user_payer: &AccountInfo<'a>,
+    system_program: &AccountInfo<'a>,
+    user_airdrop_lamports: u64,
+    multiplier: u64,
+) -> ProgramResult {
+    let base_target = Rent::get()?
+        .minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES)
+        .saturating_add(user_airdrop_lamports);
+    let deposit = base_target
+        .saturating_mul(multiplier)
+        .saturating_sub(user_payer.lamports());
+
+    if deposit == 0 {
+        return Ok(());
+    }
+
+    msg!("Airdropping {} lamports to user account", deposit);
+    invoke_signed_unchecked(
+        &solana_system_interface::instruction::transfer(payer_account.key, user_payer.key, deposit),
+        &[
+            payer_account.clone(),
+            user_payer.clone(),
+            system_program.clone(),
+        ],
+        &[],
+    )
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::DoubleZeroError,
     pda::*,
+    processors::accesspass::airdrop_user_credits,
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
@@ -18,17 +19,11 @@ use solana_program::{
     clock::Clock,
     entrypoint::ProgramResult,
     msg,
-    program::invoke_signed_unchecked,
     pubkey::Pubkey,
-    rent::Rent,
     sysvar::Sysvar,
 };
 
 use std::net::Ipv4Addr;
-
-// Value to rent exempt two `User` accounts + configurable amount for connect/disconnect txns
-// `User` account size assumes a single publisher and subscriber pubkey registered
-const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 266 * 3; // 266 bytes per User account x 3 accounts = 798 bytes
 
 #[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone)]
 pub struct SetAccessPassArgs {
@@ -349,28 +344,17 @@ pub fn process_set_access_pass(
     // multiple IPs (e.g. seat keypairs that provision many nodes), scale the target by the sum of
     // the per-category caps so the keypair holds enough SOL to pay for every create_user it admits.
     // Passes without the flag keep today's fixed (1x) airdrop.
-    let base_target = Rent::get()
-        .unwrap()
-        .minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES)
-        .saturating_add(globalstate.user_airdrop_lamports);
     let multiplier = if value.allow_multiple_ip {
         (value.max_unicast_users as u64).saturating_add(value.max_multicast_users as u64)
     } else {
         1
     };
-    let deposit = base_target
-        .saturating_mul(multiplier)
-        .saturating_sub(user_payer.lamports());
-
-    msg!("Airdropping {} lamports to user account", deposit);
-    invoke_signed_unchecked(
-        &solana_system_interface::instruction::transfer(payer_account.key, user_payer.key, deposit),
-        &[
-            payer_account.clone(),
-            user_payer.clone(),
-            system_program.clone(),
-        ],
-        &[],
+    airdrop_user_credits(
+        payer_account,
+        user_payer,
+        system_program,
+        globalstate.user_airdrop_lamports,
+        multiplier,
     )?;
 
     Ok(())
@@ -378,8 +362,10 @@ pub fn process_set_access_pass(
 
 #[cfg(test)]
 mod tests {
-    use super::AIRDROP_USER_RENT_LAMPORTS_BYTES;
-    use crate::state::{accounttype::AccountType, user::User};
+    use crate::{
+        processors::accesspass::AIRDROP_USER_RENT_LAMPORTS_BYTES,
+        state::{accounttype::AccountType, user::User},
+    };
     use doublezero_program_common::types::NetworkV4;
     use solana_program::pubkey::Pubkey;
     use std::net::Ipv4Addr;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::DoubleZeroError,
     pda::get_accesspass_pda,
-    processors::validation::validate_program_account,
+    processors::{accesspass::airdrop_user_credits, validation::validate_program_account},
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
@@ -50,6 +50,7 @@ pub fn process_add_multicastgroup_pub_allowlist(
     let mgroup_account = next_account_info(accounts_iter)?;
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
+    let user_payer_account = next_account_info(accounts_iter)?;
     let payer_account = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
@@ -83,6 +84,12 @@ pub fn process_add_multicastgroup_pub_allowlist(
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());
     }
+
+    // Identify the access pass funding account and how many user seats it admits, so we can top up
+    // its credits below. Both must be resolved regardless of whether the pass is created here or
+    // already exists.
+    let funded_user_payer;
+    let multiplier;
 
     if accesspass_account.data_is_empty() {
         let (expected_pda_account, bump_seed) =
@@ -125,6 +132,10 @@ pub fn process_add_multicastgroup_pub_allowlist(
                 &[bump_seed],
             ],
         )?;
+
+        // Freshly created passes admit a single user.
+        funded_user_payer = value.user_payer;
+        multiplier = 1;
     } else {
         assert_eq!(
             accesspass_account.owner, program_id,
@@ -161,8 +172,33 @@ pub fn process_add_multicastgroup_pub_allowlist(
             accesspass.mgroup_pub_allowlist.push(*mgroup_account.key);
         }
 
+        // Mirror set_access_pass: scale the airdrop for passes that admit multiple users.
+        funded_user_payer = accesspass.user_payer;
+        multiplier = if accesspass.allow_multiple_ip() {
+            (accesspass.max_unicast_users as u64)
+                .saturating_add(accesspass.max_multicast_users as u64)
+        } else {
+            1
+        };
+
         try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
     }
+
+    // The supplied user_payer account must be the access pass's funding account.
+    assert_eq!(
+        user_payer_account.key, &funded_user_payer,
+        "Invalid user_payer account"
+    );
+
+    // Transfer credits so the user can connect immediately after being allowlisted. Performed in
+    // the same instruction as the allowlist update, so a failed transfer reverts the whole change.
+    airdrop_user_credits(
+        payer_account,
+        user_payer_account,
+        system_program,
+        globalstate.user_airdrop_lamports,
+        multiplier,
+    )?;
 
     #[cfg(test)]
     msg!("Updated: {:?}", mgroup);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs
@@ -50,7 +50,16 @@ pub fn process_add_multicastgroup_pub_allowlist(
     let mgroup_account = next_account_info(accounts_iter)?;
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
-    let user_payer_account = next_account_info(accounts_iter)?;
+
+    // Optional user_payer account for transferring connect credits (backwards compatible). Clients
+    // that fund the user pass it before payer/system_program; older clients omit it and skip the
+    // airdrop, preserving the previous behavior.
+    let user_payer_account = if accounts.len() >= 6 {
+        Some(next_account_info(accounts_iter)?)
+    } else {
+        None
+    };
+
     let payer_account = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
@@ -184,21 +193,23 @@ pub fn process_add_multicastgroup_pub_allowlist(
         try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
     }
 
-    // The supplied user_payer account must be the access pass's funding account.
-    assert_eq!(
-        user_payer_account.key, &funded_user_payer,
-        "Invalid user_payer account"
-    );
-
     // Transfer credits so the user can connect immediately after being allowlisted. Performed in
     // the same instruction as the allowlist update, so a failed transfer reverts the whole change.
-    airdrop_user_credits(
-        payer_account,
-        user_payer_account,
-        system_program,
-        globalstate.user_airdrop_lamports,
-        multiplier,
-    )?;
+    if let Some(user_payer_account) = user_payer_account {
+        // The supplied user_payer account must be the access pass's funding account.
+        assert_eq!(
+            user_payer_account.key, &funded_user_payer,
+            "Invalid user_payer account"
+        );
+
+        airdrop_user_credits(
+            payer_account,
+            user_payer_account,
+            system_program,
+            globalstate.user_airdrop_lamports,
+            multiplier,
+        )?;
+    }
 
     #[cfg(test)]
     msg!("Updated: {:?}", mgroup);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::DoubleZeroError,
     pda::get_accesspass_pda,
-    processors::validation::validate_program_account,
+    processors::{accesspass::airdrop_user_credits, validation::validate_program_account},
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
@@ -51,6 +51,7 @@ pub fn process_add_multicastgroup_sub_allowlist(
     let mgroup_account = next_account_info(accounts_iter)?;
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
+    let user_payer_account = next_account_info(accounts_iter)?;
     let payer_account = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
@@ -85,6 +86,12 @@ pub fn process_add_multicastgroup_sub_allowlist(
     if !is_authorized {
         return Err(DoubleZeroError::NotAllowed.into());
     }
+
+    // Identify the access pass funding account and how many user seats it admits, so we can top up
+    // its credits below. Both must be resolved regardless of whether the pass is created here or
+    // already exists.
+    let funded_user_payer;
+    let multiplier;
 
     if accesspass_account.data_is_empty() {
         let (expected_pda_account, bump_seed) =
@@ -127,6 +134,10 @@ pub fn process_add_multicastgroup_sub_allowlist(
                 &[bump_seed],
             ],
         )?;
+
+        // Freshly created passes admit a single user.
+        funded_user_payer = value.user_payer;
+        multiplier = 1;
     } else {
         assert_eq!(
             accesspass_account.owner, program_id,
@@ -173,8 +184,33 @@ pub fn process_add_multicastgroup_sub_allowlist(
             accesspass.mgroup_sub_allowlist.push(*mgroup_account.key);
         }
 
+        // Mirror set_access_pass: scale the airdrop for passes that admit multiple users.
+        funded_user_payer = accesspass.user_payer;
+        multiplier = if accesspass.allow_multiple_ip() {
+            (accesspass.max_unicast_users as u64)
+                .saturating_add(accesspass.max_multicast_users as u64)
+        } else {
+            1
+        };
+
         try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
     }
+
+    // The supplied user_payer account must be the access pass's funding account.
+    assert_eq!(
+        user_payer_account.key, &funded_user_payer,
+        "Invalid user_payer account"
+    );
+
+    // Transfer credits so the user can connect immediately after being allowlisted. Performed in
+    // the same instruction as the allowlist update, so a failed transfer reverts the whole change.
+    airdrop_user_credits(
+        payer_account,
+        user_payer_account,
+        system_program,
+        globalstate.user_airdrop_lamports,
+        multiplier,
+    )?;
 
     #[cfg(test)]
     msg!("Updated: {:?}", mgroup);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs
@@ -51,7 +51,16 @@ pub fn process_add_multicastgroup_sub_allowlist(
     let mgroup_account = next_account_info(accounts_iter)?;
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
-    let user_payer_account = next_account_info(accounts_iter)?;
+
+    // Optional user_payer account for transferring connect credits (backwards compatible). Clients
+    // that fund the user pass it before payer/system_program; older clients omit it and skip the
+    // airdrop, preserving the previous behavior.
+    let user_payer_account = if accounts.len() >= 6 {
+        Some(next_account_info(accounts_iter)?)
+    } else {
+        None
+    };
+
     let payer_account = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
@@ -196,21 +205,23 @@ pub fn process_add_multicastgroup_sub_allowlist(
         try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
     }
 
-    // The supplied user_payer account must be the access pass's funding account.
-    assert_eq!(
-        user_payer_account.key, &funded_user_payer,
-        "Invalid user_payer account"
-    );
-
     // Transfer credits so the user can connect immediately after being allowlisted. Performed in
     // the same instruction as the allowlist update, so a failed transfer reverts the whole change.
-    airdrop_user_credits(
-        payer_account,
-        user_payer_account,
-        system_program,
-        globalstate.user_airdrop_lamports,
-        multiplier,
-    )?;
+    if let Some(user_payer_account) = user_payer_account {
+        // The supplied user_payer account must be the access pass's funding account.
+        assert_eq!(
+            user_payer_account.key, &funded_user_payer,
+            "Invalid user_payer account"
+        );
+
+        airdrop_user_credits(
+            payer_account,
+            user_payer_account,
+            system_program,
+            globalstate.user_airdrop_lamports,
+            multiplier,
+        )?;
+    }
 
     #[cfg(test)]
     msg!("Updated: {:?}", mgroup);

--- a/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/create_subscribe_user_test.rs
@@ -293,6 +293,7 @@ async fn setup_create_subscribe_fixture(client_ip: [u8; 4]) -> CreateSubscribeFi
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -310,6 +311,7 @@ async fn setup_create_subscribe_fixture(client_ip: [u8; 4]) -> CreateSubscribeFi
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -595,6 +597,7 @@ async fn test_create_subscribe_user_ignores_tenant_allowlist() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -612,6 +615,7 @@ async fn test_create_subscribe_user_ignores_tenant_allowlist() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -1092,6 +1096,7 @@ async fn test_create_subscribe_user_foundation_owner_override() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(custom_owner, false),
         ],
         &payer,
     )
@@ -1395,6 +1400,7 @@ async fn test_create_subscribe_user_sentinel_owner_override() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(custom_owner, false),
         ],
         &payer,
     )
@@ -1680,6 +1686,7 @@ async fn test_create_subscribe_user_non_foundation_owner_override_rejected() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(non_foundation_payer.pubkey(), false),
         ],
         &payer,
     )

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -98,6 +98,7 @@ async fn test_multicast_publisher_allowlist() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -138,6 +139,100 @@ async fn test_multicast_publisher_allowlist() {
         .get_accesspass()
         .unwrap();
     assert_eq!(accesspass.mgroup_pub_allowlist.len(), 0);
+}
+
+/// Issue #3851: adding a user to a publisher allowlist must transfer the credits the user needs to
+/// connect, as part of the same instruction. A brand-new (unfunded) user_payer is funded with the
+/// connect/disconnect rent-exempt credits when the access pass is created here.
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_transfers_credits() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 9].into();
+    let user_payer = solana_sdk::pubkey::Pubkey::new_unique(); // fresh, unfunded account
+
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+
+    init_globalstate_and_config(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let gs = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .unwrap()
+        .get_global_state()
+        .unwrap();
+    let (multicastgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "pub-credits".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The user_payer account does not exist yet (zero balance).
+    assert!(banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .is_none());
+
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_pub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // The user_payer was funded with the connect/disconnect credits (multiplier is 1 for a
+    // freshly created single-user pass), matching set_access_pass behavior.
+    let balance = banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .expect("user_payer should be funded after allowlist add")
+        .lamports;
+    let expected = solana_sdk::rent::Rent::default().minimum_balance(
+        doublezero_serviceability::processors::accesspass::AIRDROP_USER_RENT_LAMPORTS_BYTES,
+    ) + gs.user_airdrop_lamports;
+    assert_eq!(
+        balance, expected,
+        "publisher allowlist add should transfer connect credits to the user_payer"
+    );
 }
 
 #[tokio::test]
@@ -246,6 +341,7 @@ async fn test_multicast_publisher_allowlist_sentinel_authority() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &sentinel,
     )
@@ -319,6 +415,7 @@ async fn test_multicast_publisher_allowlist_sentinel_authority() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &unauthorized,
     )
@@ -411,6 +508,7 @@ async fn test_multicast_publisher_allowlist_allow_multiple_ip() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -546,6 +644,7 @@ async fn test_multicast_publisher_allowlist_allow_multiple_ip_real_ip_in_args() 
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -702,6 +801,7 @@ async fn test_multicast_publisher_allowlist_wrong_pda_rejected() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_b, false), // wrong PDA
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_publisher_test.rs
@@ -235,6 +235,85 @@ async fn test_multicast_publisher_allowlist_transfers_credits() {
     );
 }
 
+/// Backwards compatibility: older clients call the instruction without the optional user_payer
+/// account (the legacy 3-account layout). The allowlist entry is still added, but no credits are
+/// transferred, preserving the pre-#3851 behavior.
+#[tokio::test]
+async fn test_multicast_publisher_allowlist_without_user_payer_account_skips_airdrop() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 9].into();
+    let user_payer = solana_sdk::pubkey::Pubkey::new_unique(); // fresh, unfunded account
+
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+
+    init_globalstate_and_config(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let gs = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .unwrap()
+        .get_global_state()
+        .unwrap();
+    let (multicastgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "pub-noairdrop".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    // Legacy layout: no user_payer account between globalstate and payer/system_program.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupPubAllowlist(AddMulticastGroupPubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The allowlist entry is added even on the legacy path.
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_pub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // ...but no credits were transferred: the user_payer account was never funded.
+    assert!(banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .is_none());
+}
+
 #[tokio::test]
 async fn test_multicast_publisher_allowlist_sentinel_authority() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -97,6 +97,7 @@ async fn test_multicast_subscriber_allowlist() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -136,6 +137,100 @@ async fn test_multicast_subscriber_allowlist() {
         .get_accesspass()
         .unwrap();
     assert_eq!(accesspass.mgroup_sub_allowlist.len(), 0);
+}
+
+/// Issue #3851: adding a user to a subscriber allowlist must transfer the credits the user needs
+/// to connect, as part of the same instruction. A brand-new (unfunded) user_payer is funded with
+/// the connect/disconnect rent-exempt credits when the access pass is created here.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_transfers_credits() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 9].into();
+    let user_payer = Pubkey::new_unique(); // fresh, unfunded account
+
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+
+    init_globalstate_and_config(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let gs = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .unwrap()
+        .get_global_state()
+        .unwrap();
+    let (multicastgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "sub-credits".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The user_payer account does not exist yet (zero balance).
+    assert!(banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .is_none());
+
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // The user_payer was funded with the connect/disconnect credits (multiplier is 1 for a
+    // freshly created single-user pass), matching set_access_pass behavior.
+    let balance = banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .expect("user_payer should be funded after allowlist add")
+        .lamports;
+    let expected = solana_sdk::rent::Rent::default().minimum_balance(
+        doublezero_serviceability::processors::accesspass::AIRDROP_USER_RENT_LAMPORTS_BYTES,
+    ) + gs.user_airdrop_lamports;
+    assert_eq!(
+        balance, expected,
+        "subscriber allowlist add should transfer connect credits to the user_payer"
+    );
 }
 
 #[tokio::test]
@@ -244,6 +339,7 @@ async fn test_multicast_subscriber_allowlist_sentinel_authority() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &sentinel,
     )
@@ -317,6 +413,7 @@ async fn test_multicast_subscriber_allowlist_sentinel_authority() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &unauthorized,
     )
@@ -432,6 +529,7 @@ async fn test_multicast_subscriber_allowlist_feed_authority() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &feed,
     )
@@ -557,6 +655,7 @@ async fn test_multicast_subscriber_allowlist_feed_authority_different_user_payer
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(original_user_payer, false),
         ],
         &feed,
     )
@@ -613,6 +712,7 @@ async fn test_multicast_subscriber_allowlist_feed_authority_different_user_payer
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(Pubkey::new_unique(), false),
         ],
         &sentinel,
     )
@@ -705,6 +805,7 @@ async fn test_multicast_subscriber_allowlist_allow_multiple_ip() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -840,6 +941,7 @@ async fn test_multicast_subscriber_allowlist_allow_multiple_ip_real_ip_in_args()
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -996,6 +1098,7 @@ async fn test_multicast_subscriber_allowlist_wrong_pda_rejected() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_b, false), // wrong PDA
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )
@@ -1112,6 +1215,7 @@ async fn test_multicast_subscriber_allowlist_allow_multiple_ip_feed_authority_di
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(original_user_payer, false),
         ],
         &feed,
     )
@@ -1264,6 +1368,7 @@ async fn test_multicast_subscriber_allowlist_feed_authority_remove() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
         ],
         &payer,
     )

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_allowlist_subcriber_test.rs
@@ -233,6 +233,85 @@ async fn test_multicast_subscriber_allowlist_transfers_credits() {
     );
 }
 
+/// Backwards compatibility: older clients call the instruction without the optional user_payer
+/// account (the legacy 3-account layout). The allowlist entry is still added, but no credits are
+/// transferred, preserving the pre-#3851 behavior.
+#[tokio::test]
+async fn test_multicast_subscriber_allowlist_without_user_payer_account_skips_airdrop() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let client_ip = [100, 0, 0, 9].into();
+    let user_payer = Pubkey::new_unique(); // fresh, unfunded account
+
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    let (multicastgroup_block_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::MulticastGroupBlock);
+
+    init_globalstate_and_config(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let gs = get_account_data(&mut banks_client, globalstate_pubkey)
+        .await
+        .unwrap()
+        .get_global_state()
+        .unwrap();
+    let (multicastgroup_pubkey, _) = get_multicastgroup_pda(&program_id, gs.account_index + 1);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateMulticastGroup(MulticastGroupCreateArgs {
+            code: "sub-noairdrop".to_string(),
+            max_bandwidth: 1_000_000_000,
+            owner: payer.pubkey(),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(multicastgroup_block_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    // Legacy layout: no user_payer account between globalstate and payer/system_program.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::AddMulticastGroupSubAllowlist(AddMulticastGroupSubAllowlistArgs {
+            client_ip,
+            user_payer,
+        }),
+        vec![
+            AccountMeta::new(multicastgroup_pubkey, false),
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The allowlist entry is added even on the legacy path.
+    let accesspass = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .unwrap()
+        .get_accesspass()
+        .unwrap();
+    assert!(accesspass
+        .mgroup_sub_allowlist
+        .contains(&multicastgroup_pubkey));
+
+    // ...but no credits were transferred: the user_payer account was never funded.
+    assert!(banks_client
+        .get_account(user_payer)
+        .await
+        .unwrap()
+        .is_none());
+}
+
 #[tokio::test]
 async fn test_multicast_subscriber_allowlist_sentinel_authority() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;

--- a/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_subscribe_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/multicastgroup_subscribe_test.rs
@@ -284,6 +284,7 @@ async fn setup_fixture() -> TestFixture {
                 AccountMeta::new(mgroup_pk, false),
                 AccountMeta::new(accesspass_pubkey, false),
                 AccountMeta::new(globalstate_pubkey, false),
+                AccountMeta::new(payer.pubkey(), false),
             ],
             &payer,
         )
@@ -306,6 +307,7 @@ async fn setup_fixture() -> TestFixture {
                 AccountMeta::new(mgroup_pk, false),
                 AccountMeta::new(accesspass_pubkey, false),
                 AccountMeta::new(globalstate_pubkey, false),
+                AccountMeta::new(payer.pubkey(), false),
             ],
             &payer,
         )

--- a/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/user_onchain_allocation_test.rs
@@ -1362,6 +1362,7 @@ async fn test_delete_user_atomic_decrements_multicast_subscribers_count() {
             AccountMeta::new(multicastgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -1579,6 +1580,7 @@ async fn test_multicast_publisher_block_deallocation_and_reuse() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -1758,6 +1760,7 @@ async fn test_multicast_publisher_block_deallocation_and_reuse() {
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass2_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )
@@ -1878,6 +1881,7 @@ async fn test_delete_user_atomic_decrements_subscribers_count_for_non_publisher(
             AccountMeta::new(mgroup_pubkey, false),
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
         ],
         &payer,
     )

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/publisher/add.rs
@@ -38,6 +38,7 @@ impl AddMulticastGroupPubAllowlistCommand {
                 AccountMeta::new(mgroup_pubkey, false),
                 AccountMeta::new(accesspass_pk, false),
                 AccountMeta::new(globalstate_pubkey, false),
+                AccountMeta::new(self.user_payer, false),
             ],
         )
     }

--- a/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
+++ b/smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/subscriber/add.rs
@@ -40,6 +40,7 @@ impl AddMulticastGroupSubAllowlistCommand {
                 AccountMeta::new(pda_pubkey, false),
                 AccountMeta::new(accesspass_pk, false),
                 AccountMeta::new(globalstate_pubkey, false),
+                AccountMeta::new(self.user_payer, false),
             ],
         )
     }


### PR DESCRIPTION
Resolves: #3851

## Summary of Changes
- Adding a user to a multicast group's publisher or subscriber allowlist now airdrops the connect/disconnect credits to the user's account as part of the same instruction, so the user can connect immediately after being allowlisted.
- The credit transfer is atomic with the allowlist update: it runs as a CPI within the instruction, so if the transfer fails the user is not added.
- Extracted the airdrop logic from `set_access_pass` into a shared `airdrop_user_credits` helper, reused by both allowlist add processors (and keeping `set_access_pass` behavior unchanged).
- The allowlist add processors now take the `user_payer` as an account, validate it matches the access pass funding account, and scale the airdrop for `allow_multiple_ip` passes (mirroring `set_access_pass`).
- Documented the change in the CHANGELOG under Onchain programs and SDK.

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     4 | +130 / -27   | +103 |
| Scaffolding  |     2 | +2 / -0      | +2   |
| Tests        |     5 | +218 / -0    | +218 |
| Docs         |     1 | +3 / -0      | +3   |
| **Total**    |    12 | +353 / -27   | +326 |

Small production change (the SDK edits are one-line account additions); most of the diff is test coverage and adapting existing allowlist call sites to pass the new account.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs` — new shared `airdrop_user_credits` helper + `AIRDROP_USER_RENT_LAMPORTS_BYTES` constant
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/publisher/add.rs` — read `user_payer` account, validate against the pass, airdrop credits (scaled for `allow_multiple_ip`)
- `smartcontract/programs/doublezero-serviceability/src/processors/multicastgroup/allowlist/subscriber/add.rs` — same as publisher
- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs` — refactored to use the shared helper (no behavior change)
- `smartcontract/sdk/rs/src/commands/multicastgroup/allowlist/{publisher,subscriber}/add.rs` — pass the `user_payer` account in the instruction

</details>

## Testing Verification
- Added `test_multicast_{publisher,subscriber}_allowlist_transfers_credits`: a brand-new, unfunded `user_payer` ends up funded with exactly the rent-exempt minimum that `set_access_pass` airdrops after being added to the allowlist.
- Verified the feed-authority "different user_payer" cases still succeed, with the airdrop funding the access pass's actual `user_payer` (not the arg), and that non-feed callers with a mismatched `user_payer` still fail.
- All serviceability allowlist, accesspass, subscribe, and onchain-allocation integration tests pass, plus the Rust SDK and CLI verb tests.
