### PR TITLE
cli: move migrate flex-algo and device count migrations into doublezero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - Client
   - Add a `--no-wait` flag to `doublezero disconnect` that skips waiting for the daemon to tear down the tunnel(s), exiting once the onchain user deletion is confirmed. (#3911)
+- CLI
+  - Add hidden `migrate flex-algo` (RFC-18 link-topology and Vpnv4 loopback FlexAlgoNodeSegment backfill); the prior `migrate` command is now `migrate user-pda`. Moved from `doublezero-admin`.
+  - Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber, publisher, and unicast-user counts. Moved from `doublezero-admin`.
 - Onchain programs
   - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
   - Transfer connect/disconnect credits to the user's account when adding a user to a multicast group's publisher or subscriber allowlist, so the user can connect immediately. The airdrop is atomic with the allowlist update and mirrors `set_access_pass` (scaled for `allow_multiple_ip` passes). (#3851)

--- a/smartcontract/cli/src/cli/command.rs
+++ b/smartcontract/cli/src/cli/command.rs
@@ -26,6 +26,7 @@ use crate::{
         },
         link::{CreateLinkCommands, LinkCliCommand, LinkCommands, TopologyCommands},
         location::{LocationCliCommand, LocationCommands},
+        migrate::{MigrateCliCommand, MigrateCommands},
         permission::{PermissionCliCommand, PermissionCommands},
         resource::{ResourceCliCommand, ResourceCommands},
         tenant::{AdministratorCommands, TenantCliCommand, TenantCommands},
@@ -36,7 +37,6 @@ use crate::{
     init::InitCliCommand,
     keygen::KeyGenCliCommand,
     logcommand::LogCliCommand,
-    migrate::MigrateCliCommand,
     subscribe::SubscribeCliCommand,
     version::VersionCliCommand,
 };
@@ -112,7 +112,10 @@ impl ServiceabilityCommand {
     {
         match self {
             Self::Init(args) => args.execute(ctx, client, out).await,
-            Self::Migrate(args) => args.execute(ctx, client, out).await,
+            Self::Migrate(args) => match args.command {
+                MigrateCommands::UserPda(cmd) => cmd.execute(ctx, client, out).await,
+                MigrateCommands::FlexAlgo(cmd) => cmd.execute(ctx, client, out).await,
+            },
             Self::Address(args) => args.execute(ctx, client, out).await,
             Self::Balance(args) => args.execute(ctx, client, out).await,
             Self::Export(args) => args.execute(ctx, client, out).await,
@@ -207,6 +210,10 @@ impl ServiceabilityCommand {
                     InterfaceCommands::Delete(args) => args.execute(ctx, client, out).await,
                 },
                 DeviceCommands::SetHealth(args) => args.execute(ctx, client, out).await,
+                DeviceCommands::MigrateMulticastCounts(args) => {
+                    args.execute(ctx, client, out).await
+                }
+                DeviceCommands::MigrateUnicastCounts(args) => args.execute(ctx, client, out).await,
             },
             Self::Link(cmd) => match cmd.command {
                 LinkCommands::Create(args) => match args.command {
@@ -396,10 +403,50 @@ mod tests {
         assert!(matches!(parsed.command, ServiceabilityCommand::Init(_)));
     }
 
+    // Bare `migrate` now requires a subcommand; assert the two leaves route.
     #[test]
-    fn parses_hidden_migrate() {
-        let parsed = TestCli::try_parse_from(["test", "migrate"]).unwrap();
-        assert!(matches!(parsed.command, ServiceabilityCommand::Migrate(_)));
+    fn parses_hidden_migrate_user_pda() {
+        let parsed = TestCli::try_parse_from(["test", "migrate", "user-pda"]).unwrap();
+        assert!(matches!(
+            parsed.command,
+            ServiceabilityCommand::Migrate(MigrateCliCommand {
+                command: MigrateCommands::UserPda(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_hidden_migrate_flex_algo() {
+        let parsed =
+            TestCli::try_parse_from(["test", "migrate", "flex-algo", "--dry-run"]).unwrap();
+        assert!(matches!(
+            parsed.command,
+            ServiceabilityCommand::Migrate(MigrateCliCommand {
+                command: MigrateCommands::FlexAlgo(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_hidden_device_migrate_counts() {
+        let multicast =
+            TestCli::try_parse_from(["test", "device", "migrate-multicast-counts"]).unwrap();
+        assert!(matches!(
+            multicast.command,
+            ServiceabilityCommand::Device(DeviceCliCommand {
+                command: DeviceCommands::MigrateMulticastCounts(_),
+            })
+        ));
+
+        let unicast =
+            TestCli::try_parse_from(["test", "device", "migrate-unicast-counts", "--dry-run"])
+                .unwrap();
+        assert!(matches!(
+            unicast.command,
+            ServiceabilityCommand::Device(DeviceCliCommand {
+                command: DeviceCommands::MigrateUnicastCounts(_),
+            })
+        ));
     }
 
     #[test]

--- a/smartcontract/cli/src/cli/device.rs
+++ b/smartcontract/cli/src/cli/device.rs
@@ -8,6 +8,8 @@ use crate::device::{
         update::UpdateDeviceInterfaceCliCommand,
     },
     list::ListDeviceCliCommand,
+    migrate_multicast_counts::MigrateMulticastCountsCliCommand,
+    migrate_unicast_counts::MigrateUnicastCountsCliCommand,
     sethealth::SetDeviceHealthCliCommand,
     update::UpdateDeviceCliCommand,
 };
@@ -68,4 +70,10 @@ pub enum DeviceCommands {
     // Hidden because this is an internal/testing command and not part of the public CLI surface.
     #[clap(hide = true)]
     SetHealth(SetDeviceHealthCliCommand),
+    /// Correct stale multicast subscriber/publisher counts on all devices
+    #[clap(hide = true)]
+    MigrateMulticastCounts(MigrateMulticastCountsCliCommand),
+    /// Correct stale unicast user counts on all devices
+    #[clap(hide = true)]
+    MigrateUnicastCounts(MigrateUnicastCountsCliCommand),
 }

--- a/smartcontract/cli/src/cli/migrate.rs
+++ b/smartcontract/cli/src/cli/migrate.rs
@@ -1,0 +1,17 @@
+use clap::{Args, Subcommand};
+
+use crate::migrate::{flex_algo::FlexAlgoMigrateCliCommand, user_pda::MigrateUserPdaCliCommand};
+
+#[derive(Args, Debug)]
+pub struct MigrateCliCommand {
+    #[command(subcommand)]
+    pub command: MigrateCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum MigrateCommands {
+    /// Migrate user accounts to the new PDA scheme
+    UserPda(MigrateUserPdaCliCommand),
+    /// Backfill link topologies and Vpnv4 loopback FlexAlgoNodeSegments (RFC-18)
+    FlexAlgo(FlexAlgoMigrateCliCommand),
+}

--- a/smartcontract/cli/src/cli/mod.rs
+++ b/smartcontract/cli/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub mod exchange;
 pub mod globalconfig;
 pub mod link;
 pub mod location;
+pub mod migrate;
 pub mod multicastgroup;
 pub mod permission;
 pub mod resource;

--- a/smartcontract/cli/src/device/migrate_multicast_counts.rs
+++ b/smartcontract/cli/src/device/migrate_multicast_counts.rs
@@ -1,0 +1,358 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_cli_core::CliContext;
+use doublezero_sdk::{
+    commands::{
+        device::{list::ListDeviceCommand, update::UpdateDeviceCommand},
+        user::list::ListUserCommand,
+    },
+    UserStatus, UserType,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashMap, io::Write};
+
+#[derive(Args, Debug)]
+pub struct MigrateMulticastCountsCliCommand {
+    /// Print what would be corrected without submitting transactions
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+}
+
+impl MigrateMulticastCountsCliCommand {
+    pub async fn execute<C: CliCommand, W: Write>(
+        self,
+        _ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        // Tally live multicast publishers and subscribers per device.
+        let users = client.list_user(ListUserCommand)?;
+        let mut per_device: HashMap<Pubkey, (u16, u16)> = HashMap::new(); // (publishers, subscribers)
+        for user in users.values() {
+            let is_live = user.status != UserStatus::Banned;
+            if user.user_type == UserType::Multicast && is_live {
+                let (pub_count, sub_count) = per_device.entry(user.device_pk).or_default();
+                if user.is_publisher() {
+                    *pub_count = pub_count.saturating_add(1);
+                } else {
+                    *sub_count = sub_count.saturating_add(1);
+                }
+            }
+        }
+
+        // Find devices with stale counts.
+        let devices = client.list_device(ListDeviceCommand)?;
+        let mut corrections_needed: Vec<(Pubkey, String, u16, u16, u16, u16)> = vec![];
+        for (device_pubkey, device) in &devices {
+            let (actual_pub, actual_sub) = per_device.get(device_pubkey).copied().unwrap_or((0, 0));
+            if device.multicast_publishers_count != actual_pub
+                || device.multicast_subscribers_count != actual_sub
+            {
+                corrections_needed.push((
+                    *device_pubkey,
+                    device.code.clone(),
+                    device.multicast_subscribers_count,
+                    actual_sub,
+                    device.multicast_publishers_count,
+                    actual_pub,
+                ));
+            }
+        }
+
+        if corrections_needed.is_empty() {
+            writeln!(out, "0 device(s) require correction")?;
+            return Ok(());
+        }
+
+        // Print what needs correcting (always, even in dry-run).
+        for (pubkey, code, old_sub, new_sub, old_pub, new_pub) in &corrections_needed {
+            writeln!(
+                out,
+                "device {code} ({pubkey}): subscribers {old_sub} -> {new_sub}, publishers {old_pub} -> {new_pub}"
+            )?;
+        }
+
+        if self.dry_run {
+            writeln!(out, "[dry-run] no transactions sent.")?;
+            return Ok(());
+        }
+
+        // Submit corrections.
+        let mut corrected = 0u32;
+        for (pubkey, code, _, actual_sub, _, actual_pub) in &corrections_needed {
+            let result = client.update_device(UpdateDeviceCommand {
+                pubkey: *pubkey,
+                code: None,
+                device_type: None,
+                public_ip: None,
+                dz_prefixes: None,
+                metrics_publisher: None,
+                contributor_pk: None,
+                location_pk: None,
+                mgmt_vrf: None,
+                max_users: None,
+                users_count: None,
+                status: None,
+                desired_status: None,
+                reference_count: None,
+                max_unicast_users: None,
+                unicast_users_count: None,
+                max_multicast_subscribers: None,
+                max_multicast_publishers: None,
+                multicast_subscribers_count: Some(*actual_sub),
+                multicast_publishers_count: Some(*actual_pub),
+            });
+            match result {
+                Ok(sig) => {
+                    corrected += 1;
+                    writeln!(out, "corrected {code} ({pubkey}): {sig}")?;
+                }
+                Err(e) => {
+                    writeln!(out, "WARNING: failed to correct {code} ({pubkey}): {e}")?;
+                }
+            }
+        }
+        writeln!(out, "{corrected} device(s) corrected")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::utils::{create_test_client, create_test_context};
+    use doublezero_sdk::{Device, DeviceStatus, DeviceType, User, UserCYOA, UserStatus, UserType};
+    use doublezero_serviceability::state::device::{DeviceDesiredStatus, DeviceHealth};
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::collections::HashMap;
+
+    fn make_device(sub_count: u16, pub_count: u16) -> Device {
+        Device {
+            account_type: doublezero_sdk::AccountType::Device,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            reference_count: 0,
+            bump_seed: 0,
+            contributor_pk: Pubkey::new_unique(),
+            location_pk: Pubkey::new_unique(),
+            exchange_pk: Pubkey::new_unique(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [192, 168, 1, 1].into(),
+            status: DeviceStatus::Activated,
+            metrics_publisher_pk: Pubkey::default(),
+            code: "testdevice".to_string(),
+            dz_prefixes: "10.0.0.1/32".parse().unwrap(),
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: sub_count,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: pub_count,
+            max_multicast_publishers: 0,
+            ..Default::default()
+        }
+    }
+
+    fn make_multicast_user(device_pk: Pubkey, is_publisher: bool) -> User {
+        User {
+            account_type: doublezero_sdk::AccountType::User,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            bump_seed: 0,
+            user_type: UserType::Multicast,
+            tenant_pk: Pubkey::new_unique(),
+            device_pk,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: [192, 168, 1, 1].into(),
+            dz_ip: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_id: 0,
+            tunnel_net: Default::default(),
+            status: UserStatus::Activated,
+            publishers: if is_publisher {
+                vec![Pubkey::new_unique()]
+            } else {
+                vec![]
+            },
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+            bgp_rtt_ns: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_migrate_no_op_when_counts_correct() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_device(3, 2);
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        for _ in 0..3 {
+            users.insert(
+                Pubkey::new_unique(),
+                make_multicast_user(device_pubkey, false),
+            );
+        }
+        for _ in 0..2 {
+            users.insert(
+                Pubkey::new_unique(),
+                make_multicast_user(device_pubkey, true),
+            );
+        }
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client.expect_update_device().times(0);
+
+        let mut out = Vec::new();
+        let res = MigrateMulticastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("0 device(s)"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_corrects_stale_counts() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        // Stale: sub=5, pub=0. Actual: sub=3, pub=2.
+        let device = make_device(5, 0);
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        for _ in 0..3 {
+            users.insert(
+                Pubkey::new_unique(),
+                make_multicast_user(device_pubkey, false),
+            );
+        }
+        for _ in 0..2 {
+            users.insert(
+                Pubkey::new_unique(),
+                make_multicast_user(device_pubkey, true),
+            );
+        }
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut out = Vec::new();
+        let res = MigrateMulticastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("1 device(s) corrected"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_failure_on_one_device_does_not_prevent_others() {
+        let mut client = create_test_client();
+        let device_pk_a = Pubkey::new_unique();
+        let device_pk_b = Pubkey::new_unique();
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        users.insert(
+            Pubkey::new_unique(),
+            make_multicast_user(device_pk_a, false),
+        );
+        users.insert(Pubkey::new_unique(), make_multicast_user(device_pk_a, true));
+        users.insert(
+            Pubkey::new_unique(),
+            make_multicast_user(device_pk_b, false),
+        );
+        users.insert(Pubkey::new_unique(), make_multicast_user(device_pk_b, true));
+
+        let devices: HashMap<Pubkey, Device> = HashMap::from([
+            (device_pk_a, make_device(5, 0)),
+            (device_pk_b, make_device(5, 0)),
+        ]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        // First call fails, second succeeds
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Err(eyre::eyre!("simulated failure")));
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut out = Vec::new();
+        let res = MigrateMulticastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("1 device(s) corrected"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_dry_run() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_device(5, 0); // stale
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        users.insert(
+            Pubkey::new_unique(),
+            make_multicast_user(device_pubkey, false),
+        );
+        users.insert(
+            Pubkey::new_unique(),
+            make_multicast_user(device_pubkey, true),
+        );
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client.expect_update_device().times(0); // must NOT be called
+
+        let mut out = Vec::new();
+        let res = MigrateMulticastCountsCliCommand { dry_run: true }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        // Should show what would be corrected
+        assert!(output.contains("subscribers"));
+        assert!(output.contains("publishers"));
+        // Should NOT submit
+        assert!(output.contains("[dry-run]"));
+    }
+}

--- a/smartcontract/cli/src/device/migrate_multicast_counts.rs
+++ b/smartcontract/cli/src/device/migrate_multicast_counts.rs
@@ -8,6 +8,7 @@ use doublezero_sdk::{
     },
     UserStatus, UserType,
 };
+use doublezero_serviceability::state::user::TunnelFlags;
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashMap, io::Write};
 
@@ -32,7 +33,12 @@ impl MigrateMulticastCountsCliCommand {
             let is_live = user.status != UserStatus::Banned;
             if user.user_type == UserType::Multicast && is_live {
                 let (pub_count, sub_count) = per_device.entry(user.device_pk).or_default();
-                if user.is_publisher() {
+                // Device publisher/subscriber counters track the durable
+                // CreatedAsPublisher flag, not the (mutable) publishers list:
+                // the onchain counters are incremented at creation and
+                // decremented at delete on this flag, and a user's publishers
+                // list can empty out (or fill) without moving the counter.
+                if TunnelFlags::is_set(user.tunnel_flags, TunnelFlags::CreatedAsPublisher) {
                     *pub_count = pub_count.saturating_add(1);
                 } else {
                     *sub_count = sub_count.saturating_add(1);
@@ -182,7 +188,11 @@ mod tests {
             subscribers: vec![],
             validator_pubkey: Pubkey::default(),
             tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
-            tunnel_flags: 0,
+            tunnel_flags: if is_publisher {
+                TunnelFlags::CreatedAsPublisher as u8
+            } else {
+                0
+            },
             bgp_status: Default::default(),
             last_bgp_up_at: 0,
             last_bgp_reported_at: 0,
@@ -354,5 +364,56 @@ mod tests {
         assert!(output.contains("publishers"));
         // Should NOT submit
         assert!(output.contains("[dry-run]"));
+    }
+
+    // Regression: the tally must classify multicast users by the durable
+    // `CreatedAsPublisher` flag (the axis the device counters are maintained
+    // on), not the live `publishers` list. Using `publishers.is_empty()`
+    // mis-counts two reachable states:
+    //   - created as publisher, later dropped all groups: empty list, flag set
+    //   - created as subscriber, later published: non-empty list, no flag
+    // Each user sits on its own device so a swap can't coincidentally net out.
+    #[tokio::test]
+    async fn test_migrate_counts_multicast_publishers_by_created_flag() {
+        let mut client = create_test_client();
+
+        // device1 stored pub=1, sub=0: one user created as publisher whose
+        // publishers list is now empty (disconnected its groups).
+        let device1_pk = Pubkey::new_unique();
+        let mut disconnected_pub = make_multicast_user(device1_pk, false);
+        disconnected_pub.tunnel_flags = TunnelFlags::CreatedAsPublisher as u8;
+
+        // device2 stored pub=0, sub=1: one user created as subscriber that is
+        // now publishing (non-empty publishers list, flag unset).
+        let device2_pk = Pubkey::new_unique();
+        let mut publishing_sub = make_multicast_user(device2_pk, true);
+        publishing_sub.tunnel_flags = 0;
+
+        let users: HashMap<Pubkey, User> = HashMap::from([
+            (Pubkey::new_unique(), disconnected_pub),
+            (Pubkey::new_unique(), publishing_sub),
+        ]);
+        let devices: HashMap<Pubkey, Device> = HashMap::from([
+            (device1_pk, make_device(0, 1)),
+            (device2_pk, make_device(1, 0)),
+        ]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        // Counts already match under the flag-based tally; the buggy
+        // publishers-list tally would flip both devices and call update twice.
+        client.expect_update_device().times(0);
+
+        let mut out = Vec::new();
+        let res = MigrateMulticastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("0 device(s)"));
     }
 }

--- a/smartcontract/cli/src/device/migrate_unicast_counts.rs
+++ b/smartcontract/cli/src/device/migrate_unicast_counts.rs
@@ -1,0 +1,331 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_cli_core::CliContext;
+use doublezero_sdk::{
+    commands::{
+        device::{list::ListDeviceCommand, update::UpdateDeviceCommand},
+        user::list::ListUserCommand,
+    },
+    UserStatus, UserType,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashMap, io::Write};
+
+#[derive(Args, Debug)]
+pub struct MigrateUnicastCountsCliCommand {
+    /// Print what would be corrected without submitting transactions
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+}
+
+impl MigrateUnicastCountsCliCommand {
+    pub async fn execute<C: CliCommand, W: Write>(
+        self,
+        _ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        // Tally live unicast users per device.
+        let users = client.list_user(ListUserCommand)?;
+        let mut per_device: HashMap<Pubkey, u16> = HashMap::new();
+        for user in users.values() {
+            let is_live = user.status != UserStatus::Banned;
+            if user.user_type != UserType::Multicast && is_live {
+                let count = per_device.entry(user.device_pk).or_default();
+                *count = count.saturating_add(1);
+            }
+        }
+
+        // Find devices with stale counts.
+        let devices = client.list_device(ListDeviceCommand)?;
+        let mut corrections_needed: Vec<(Pubkey, String, u16, u16)> = vec![];
+        for (device_pubkey, device) in &devices {
+            let actual = per_device.get(device_pubkey).copied().unwrap_or(0);
+            if device.unicast_users_count != actual {
+                corrections_needed.push((
+                    *device_pubkey,
+                    device.code.clone(),
+                    device.unicast_users_count,
+                    actual,
+                ));
+            }
+        }
+
+        if corrections_needed.is_empty() {
+            writeln!(out, "0 device(s) require correction")?;
+            return Ok(());
+        }
+
+        // Print what needs correcting (always, even in dry-run).
+        for (pubkey, code, old, new) in &corrections_needed {
+            writeln!(
+                out,
+                "device {code} ({pubkey}): unicast_users_count {old} -> {new}"
+            )?;
+        }
+
+        if self.dry_run {
+            writeln!(out, "[dry-run] no transactions sent.")?;
+            return Ok(());
+        }
+
+        // Submit corrections.
+        let mut corrected = 0u32;
+        for (pubkey, code, _, actual) in &corrections_needed {
+            let result = client.update_device(UpdateDeviceCommand {
+                pubkey: *pubkey,
+                code: None,
+                device_type: None,
+                public_ip: None,
+                dz_prefixes: None,
+                metrics_publisher: None,
+                contributor_pk: None,
+                location_pk: None,
+                mgmt_vrf: None,
+                max_users: None,
+                users_count: None,
+                status: None,
+                desired_status: None,
+                reference_count: None,
+                max_unicast_users: None,
+                unicast_users_count: Some(*actual),
+                max_multicast_subscribers: None,
+                max_multicast_publishers: None,
+                multicast_subscribers_count: None,
+                multicast_publishers_count: None,
+            });
+            match result {
+                Ok(sig) => {
+                    corrected += 1;
+                    writeln!(out, "corrected {code} ({pubkey}): {sig}")?;
+                }
+                Err(e) => {
+                    writeln!(out, "WARNING: failed to correct {code} ({pubkey}): {e}")?;
+                }
+            }
+        }
+        writeln!(out, "{corrected} device(s) corrected")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::utils::{create_test_client, create_test_context};
+    use doublezero_sdk::{Device, DeviceStatus, DeviceType, User, UserCYOA, UserStatus, UserType};
+    use doublezero_serviceability::state::device::{DeviceDesiredStatus, DeviceHealth};
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use std::collections::HashMap;
+
+    fn make_device(sub_count: u16, pub_count: u16) -> Device {
+        Device {
+            account_type: doublezero_sdk::AccountType::Device,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            reference_count: 0,
+            bump_seed: 0,
+            contributor_pk: Pubkey::new_unique(),
+            location_pk: Pubkey::new_unique(),
+            exchange_pk: Pubkey::new_unique(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [192, 168, 1, 1].into(),
+            status: DeviceStatus::Activated,
+            metrics_publisher_pk: Pubkey::default(),
+            code: "testdevice".to_string(),
+            dz_prefixes: "10.0.0.1/32".parse().unwrap(),
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: DeviceHealth::ReadyForUsers,
+            desired_status: DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: sub_count,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: pub_count,
+            max_multicast_publishers: 0,
+            ..Default::default()
+        }
+    }
+
+    fn make_device_unicast(unicast_count: u16) -> Device {
+        Device {
+            unicast_users_count: unicast_count,
+            multicast_subscribers_count: 0,
+            multicast_publishers_count: 0,
+            ..make_device(0, 0)
+        }
+    }
+
+    fn make_unicast_user(device_pk: Pubkey) -> User {
+        User {
+            user_type: UserType::IBRL,
+            publishers: vec![],
+            subscribers: vec![],
+            ..make_multicast_user(device_pk, false)
+        }
+    }
+
+    fn make_multicast_user(device_pk: Pubkey, is_publisher: bool) -> User {
+        User {
+            account_type: doublezero_sdk::AccountType::User,
+            owner: Pubkey::new_unique(),
+            index: 0,
+            bump_seed: 0,
+            user_type: UserType::Multicast,
+            tenant_pk: Pubkey::new_unique(),
+            device_pk,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip: [192, 168, 1, 1].into(),
+            dz_ip: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_id: 0,
+            tunnel_net: Default::default(),
+            status: UserStatus::Activated,
+            publishers: if is_publisher {
+                vec![Pubkey::new_unique()]
+            } else {
+                vec![]
+            },
+            subscribers: vec![],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+            bgp_rtt_ns: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_migrate_unicast_no_op_when_counts_correct() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_device_unicast(3);
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        for _ in 0..3 {
+            users.insert(Pubkey::new_unique(), make_unicast_user(device_pubkey));
+        }
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client.expect_update_device().times(0);
+
+        let mut out = Vec::new();
+        let res = MigrateUnicastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        assert!(String::from_utf8(out).unwrap().contains("0 device(s)"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_unicast_corrects_stale_counts() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_device_unicast(5); // stale: stored=5, actual=3
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        for _ in 0..3 {
+            users.insert(Pubkey::new_unique(), make_unicast_user(device_pubkey));
+        }
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut out = Vec::new();
+        let res = MigrateUnicastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        assert!(String::from_utf8(out)
+            .unwrap()
+            .contains("1 device(s) corrected"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_unicast_failure_on_one_device_does_not_prevent_others() {
+        let mut client = create_test_client();
+        let device_pk_a = Pubkey::new_unique();
+        let device_pk_b = Pubkey::new_unique();
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        users.insert(Pubkey::new_unique(), make_unicast_user(device_pk_a));
+        users.insert(Pubkey::new_unique(), make_unicast_user(device_pk_b));
+
+        let devices: HashMap<Pubkey, Device> = HashMap::from([
+            (device_pk_a, make_device_unicast(5)),
+            (device_pk_b, make_device_unicast(5)),
+        ]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Err(eyre::eyre!("simulated failure")));
+        client
+            .expect_update_device()
+            .times(1)
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let mut out = Vec::new();
+        let res = MigrateUnicastCountsCliCommand { dry_run: false }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        assert!(String::from_utf8(out)
+            .unwrap()
+            .contains("1 device(s) corrected"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_unicast_dry_run() {
+        let mut client = create_test_client();
+        let device_pubkey = Pubkey::new_unique();
+        let device = make_device_unicast(5); // stale
+
+        let mut users: HashMap<Pubkey, User> = HashMap::new();
+        users.insert(Pubkey::new_unique(), make_unicast_user(device_pubkey));
+        let devices: HashMap<Pubkey, Device> = HashMap::from([(device_pubkey, device)]);
+
+        client
+            .expect_list_user()
+            .returning(move |_| Ok(users.clone()));
+        client
+            .expect_list_device()
+            .returning(move |_| Ok(devices.clone()));
+        client.expect_update_device().times(0);
+
+        let mut out = Vec::new();
+        let res = MigrateUnicastCountsCliCommand { dry_run: true }
+            .execute(&create_test_context(), &client, &mut out)
+            .await;
+        assert!(res.is_ok());
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("unicast_users_count"));
+        assert!(output.contains("[dry-run]"));
+    }
+}

--- a/smartcontract/cli/src/device/mod.rs
+++ b/smartcontract/cli/src/device/mod.rs
@@ -3,5 +3,7 @@ pub mod delete;
 pub mod get;
 pub mod interface;
 pub mod list;
+pub mod migrate_multicast_counts;
+pub mod migrate_unicast_counts;
 pub mod sethealth;
 pub mod update;

--- a/smartcontract/cli/src/migrate/flex_algo.rs
+++ b/smartcontract/cli/src/migrate/flex_algo.rs
@@ -1,0 +1,176 @@
+use crate::doublezerocommand::CliCommand;
+use clap::Args;
+use doublezero_cli_core::CliContext;
+use doublezero_sdk::commands::{
+    device::list::ListDeviceCommand,
+    link::{list::ListLinkCommand, update::UpdateLinkCommand},
+    topology::{
+        assign_node_segments::AssignTopologyNodeSegmentsCommand, list::ListTopologyCommand,
+    },
+};
+use doublezero_serviceability::{pda::get_topology_pda, state::interface::LoopbackType};
+use solana_sdk::pubkey::Pubkey;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct FlexAlgoMigrateCliCommand {
+    /// Print what would be changed without submitting transactions
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+}
+
+impl FlexAlgoMigrateCliCommand {
+    pub async fn execute<C: CliCommand, W: Write>(
+        self,
+        _ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        let program_id = client.get_program_id();
+
+        // Verify UNICAST-DEFAULT topology PDA exists on chain.
+        let (unicast_default_pda, _) = get_topology_pda(&program_id, "UNICAST-DEFAULT");
+        client
+            .get_account(unicast_default_pda)
+            .map_err(|_| eyre::eyre!("UNICAST-DEFAULT topology PDA {unicast_default_pda} not found on chain — cannot proceed"))?;
+
+        // ── Part 1: link topology backfill ───────────────────────────────────────
+
+        let links = client.list_link(ListLinkCommand)?;
+        let mut links_tagged = 0u32;
+        let mut links_needing_tag = 0u32;
+        let mut links_skipped = 0u32;
+
+        let mut link_entries: Vec<(Pubkey, _)> = links.into_iter().collect();
+        link_entries.sort_by_key(|(pk, _)| pk.to_string());
+
+        for (pubkey, link) in &link_entries {
+            if link.link_topologies.is_empty() {
+                links_needing_tag += 1;
+                writeln!(
+                    out,
+                    "  [link] {pubkey} ({}) — would tag UNICAST-DEFAULT",
+                    link.code
+                )?;
+                if !self.dry_run {
+                    let result = client.update_link(UpdateLinkCommand {
+                        pubkey: *pubkey,
+                        code: None,
+                        contributor_pk: None,
+                        tunnel_type: None,
+                        bandwidth: None,
+                        mtu: None,
+                        delay_ns: None,
+                        jitter_ns: None,
+                        delay_override_ns: None,
+                        status: None,
+                        desired_status: None,
+                        tunnel_id: None,
+                        tunnel_net: None,
+                        link_topologies: Some(vec![unicast_default_pda]),
+                        unicast_drained: None,
+                    });
+                    match result {
+                        Ok(sig) => {
+                            links_tagged += 1;
+                            writeln!(out, "    tagged: {sig}")?;
+                        }
+                        Err(e) => {
+                            writeln!(out, "    WARNING: failed to tag {pubkey}: {e}")?;
+                        }
+                    }
+                }
+            } else {
+                links_skipped += 1;
+            }
+        }
+
+        // ── Part 2: Vpnv4 loopback FlexAlgoNodeSegment backfill ─────────────────
+
+        let topologies = client.list_topology(ListTopologyCommand)?;
+        let mut topology_entries: Vec<(Pubkey, _)> = topologies.into_iter().collect();
+        topology_entries.sort_by_key(|(pk, _)| pk.to_string());
+
+        let devices = client.list_device(ListDeviceCommand)?;
+        let mut device_entries: Vec<(Pubkey, _)> = devices.into_iter().collect();
+        device_entries.sort_by_key(|(pk, _)| pk.to_string());
+
+        let mut topologies_backfilled = 0u32;
+        let mut topologies_skipped = 0u32;
+
+        for (topology_pubkey, topology) in &topology_entries {
+            let mut devices_needing_backfill: Vec<Pubkey> = Vec::new();
+
+            for (device_pubkey, device) in &device_entries {
+                let needs_backfill = device.interfaces.iter().any(|iface| {
+                    iface.loopback_type == LoopbackType::Vpnv4
+                        && !iface
+                            .flex_algo_node_segments
+                            .iter()
+                            .any(|s| s.topology == *topology_pubkey)
+                });
+                if needs_backfill {
+                    devices_needing_backfill.push(*device_pubkey);
+                }
+            }
+
+            if devices_needing_backfill.is_empty() {
+                topologies_skipped += 1;
+                continue;
+            }
+
+            topologies_backfilled += 1;
+            writeln!(
+                out,
+                "  [topology] {} ({}) — {} device(s) need backfill",
+                topology.name,
+                topology_pubkey,
+                devices_needing_backfill.len()
+            )?;
+
+            if !self.dry_run {
+                let result =
+                    client.assign_topology_node_segments(AssignTopologyNodeSegmentsCommand {
+                        name: topology.name.clone(),
+                        device_pubkeys: devices_needing_backfill,
+                    });
+                match result {
+                    Ok(sigs) => {
+                        writeln!(out, "    backfilled in {} transaction(s)", sigs.len())?;
+                    }
+                    Err(e) => {
+                        writeln!(
+                            out,
+                            "    WARNING: failed to backfill topology {}: {e}",
+                            topology.name
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // ── Summary ──────────────────────────────────────────────────────────────
+
+        let dry_run_suffix = if self.dry_run {
+            " [DRY RUN — no changes made]"
+        } else {
+            ""
+        };
+        let tagged_summary = if self.dry_run {
+            format!("{links_needing_tag} link(s) would be tagged")
+        } else {
+            format!("{links_tagged} link(s) tagged")
+        };
+        let loopback_summary = if self.dry_run {
+            format!("{topologies_backfilled} topology(s) would be backfilled")
+        } else {
+            format!("{topologies_backfilled} topology(s) backfilled")
+        };
+        writeln!(
+            out,
+            "\nMigration complete: {tagged_summary}, {links_skipped} link(s) skipped; {loopback_summary}, {topologies_skipped} topology(s) already complete{dry_run_suffix}"
+        )?;
+
+        Ok(())
+    }
+}

--- a/smartcontract/cli/src/migrate/mod.rs
+++ b/smartcontract/cli/src/migrate/mod.rs
@@ -1,0 +1,2 @@
+pub mod flex_algo;
+pub mod user_pda;

--- a/smartcontract/cli/src/migrate/user_pda.rs
+++ b/smartcontract/cli/src/migrate/user_pda.rs
@@ -6,9 +6,9 @@ use serde_json::to_writer_pretty;
 use std::io::Write;
 
 #[derive(Args, Debug)]
-pub struct MigrateCliCommand {}
+pub struct MigrateUserPdaCliCommand {}
 
-impl MigrateCliCommand {
+impl MigrateUserPdaCliCommand {
     pub async fn execute<C: CliCommand, W: Write>(
         self,
         _ctx: &CliContext,

--- a/smartcontract/cli/src/tests.rs
+++ b/smartcontract/cli/src/tests.rs
@@ -1,7 +1,18 @@
 pub mod utils {
+    use doublezero_cli_core::{CliContext, CliContextBuilder};
+    use doublezero_config::Environment;
     use solana_sdk::pubkey::Pubkey;
 
     use crate::doublezerocommand::MockCliCommand;
+
+    /// Minimal context for verb tests. Commands that ignore `ctx` only need a
+    /// well-formed value; `Local` sources all URLs/program-IDs from config.
+    pub fn create_test_context() -> CliContext {
+        CliContextBuilder::new()
+            .with_env(Environment::Local)
+            .build()
+            .expect("test context")
+    }
 
     pub fn create_test_client() -> MockCliCommand {
         let mut client = MockCliCommand::new();


### PR DESCRIPTION
First of three PRs consolidating the admin-only commands of `doublezero-admin` into the regular `doublezero` CLI as hidden commands (the admin crate itself is retired in PR 3). This PR moves the serviceability-domain migration commands into the `doublezero-serviceability-cli` module crate, following RFC-20.

## Summary

- Restructure the hidden `migrate` command into a subcommand group: the existing user-PDA migration becomes `migrate user-pda`, and `migrate flex-algo` (RFC-18 link-topology and Vpnv4 loopback FlexAlgoNodeSegment backfill) joins it.
- Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber/publisher/unicast-user counts.
- Command bodies are moved unchanged from `doublezero-admin`, adapted to the RFC-20 `async execute(self, ctx, client, out)` signature. All four verbs are hidden.
- The 8 device-count unit tests move with the commands.

The commands still exist in `doublezero-admin` for now; they are deleted when that crate is retired in PR 3. This change is almost entirely moved code.

## Testing Verification

- `cargo test -p doublezero-serviceability-cli migrate` → 11 pass: the 8 moved device-count tests plus 3 new clap parse tests (which also confirm bare `migrate` now requires a subcommand).
- Verified hidden: top-level `--help` and `device --help` omit the new verbs; `migrate --help` lists `user-pda` and `flex-algo`.

Relates to RFC-18 (`rfcs/rfc18-link-classification-flex-algo.md`).

Part of a 3-PR series: **PR 1 (this)** migrate commands → PR 2 sentinel commands → PR 3 retire `doublezero-admin` (must merge after PR 1 and PR 2).
