### PR TITLE
cli: move sentinel commands into doublezero as hidden commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - CLI
   - Add hidden `migrate flex-algo` (RFC-18 link-topology and Vpnv4 loopback FlexAlgoNodeSegment backfill); the prior `migrate` command is now `migrate user-pda`. Moved from `doublezero-admin`.
   - Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber, publisher, and unicast-user counts. Moved from `doublezero-admin`.
+  - Add hidden `sentinel find-validator-multicast-publishers` and `sentinel create-validator-multicast-publishers` commands. Moved from `doublezero-admin`.
 - Onchain programs
   - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
   - Transfer connect/disconnect credits to the user's account when adding a user to a multicast group's publisher or subscriber allowlist, so the user can connect immediately. The airdrop is atomic with the allowlist update and mirrors `set_access_pass` (scaled for `allow_multiple_ip` passes). (#3851)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,7 @@ dependencies = [
  "doublezero-config",
  "doublezero-geolocation-cli",
  "doublezero-program-common",
+ "doublezero-sentinel",
  "doublezero-serviceability",
  "doublezero-serviceability-cli",
  "doublezero_sdk",

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -47,6 +47,7 @@ doublezero-cli-core.workspace = true
 doublezero-config.workspace = true
 doublezero-serviceability.workspace = true
 doublezero-program-common.workspace = true
+doublezero-sentinel.workspace = true
 tracing.workspace = true
 
 [features]

--- a/client/doublezero/src/cli/command.rs
+++ b/client/doublezero/src/cli/command.rs
@@ -4,7 +4,7 @@ use doublezero_geolocation_cli::GeolocationArgs;
 use doublezero_serviceability_cli::cli::ServiceabilityCommand;
 
 use crate::{
-    cli::multicast::MulticastCliCommand,
+    cli::{multicast::MulticastCliCommand, sentinel::SentinelCliCommand},
     command::{
         connect::ProvisioningCliCommand, disable::DisableCliCommand,
         disconnect::DecommissioningCliCommand, enable::EnableCliCommand,
@@ -37,6 +37,10 @@ pub enum Command {
     Latency(LatencyCliCommand),
     /// View your installed routes
     Routes(RoutesCliCommand),
+
+    /// Sentinel admin commands
+    #[command(hide = true)]
+    Sentinel(SentinelCliCommand),
 
     /// Manage geolocation probes and users
     Geolocation(GeolocationArgs),

--- a/client/doublezero/src/cli/mod.rs
+++ b/client/doublezero/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod command;
 pub mod multicast;
+pub mod sentinel;

--- a/client/doublezero/src/cli/sentinel.rs
+++ b/client/doublezero/src/cli/sentinel.rs
@@ -1,0 +1,914 @@
+use std::{collections::HashMap, io::Write, net::Ipv4Addr};
+
+use clap::{Args, Subcommand};
+use doublezero_sdk::{DZClient, UserType};
+use doublezero_sentinel::{
+    dz_ledger_reader::{self, DzDeviceInfo, DzLedgerReader, DzUser, RpcDzLedgerReader},
+    dz_ledger_writer::build_create_multicast_publisher_instructions,
+    multicast_create::{find_candidates, CandidateFilters},
+    multicast_find::{apply_filters, FindFilters},
+    nearest_device::{device_proximity_score, find_nearest_device_for_multicast},
+    output::{print_table, OutputOptions},
+    tunnel_endpoint::select_tunnel_endpoint,
+    validator_metadata_reader::{
+        HttpValidatorMetadataReader, ValidatorMetadataReader, DEFAULT_VALIDATOR_METADATA_URL,
+    },
+};
+use doublezero_serviceability::pda::get_tenant_pda;
+use serde::Serialize;
+use solana_client::{
+    nonblocking::rpc_client::RpcClient as NonblockingRpcClient, rpc_client::RpcClient,
+};
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    instruction::Instruction,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use tabled::Tabled;
+
+#[derive(Args, Debug)]
+pub struct SentinelCliCommand {
+    #[command(subcommand)]
+    pub command: SentinelCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SentinelCommands {
+    /// Find IBRL validators and their multicast publisher status.
+    FindValidatorMulticastPublishers(FindValidatorMulticastPublishersCommand),
+    /// Create multicast publisher users for IBRL validators that don't have one yet.
+    CreateValidatorMulticastPublishers(CreateValidatorMulticastPublishersCommand),
+}
+
+// ---------------------------------------------------------------------------
+// Find command
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Tabled)]
+struct ValidatorPublisherRow {
+    #[tabled(rename = "OWNER")]
+    owner: String,
+    #[tabled(rename = "CLIENT IP")]
+    client_ip: String,
+    #[tabled(rename = "DEVICE")]
+    device: String,
+    #[tabled(rename = "NEAREST DEVICE")]
+    nearest_device: String,
+    #[tabled(rename = "VOTE ACCOUNT")]
+    vote_account: String,
+    #[tabled(rename = "STAKE (SOL)")]
+    stake_sol: String,
+    #[tabled(rename = "CLIENT")]
+    client: String,
+    #[tabled(rename = "VERSION")]
+    version: String,
+    #[tabled(rename = "PUB")]
+    is_publisher: String,
+}
+
+#[derive(Serialize, Tabled)]
+struct SummaryRow {
+    #[tabled(rename = "CLIENT")]
+    client: String,
+    #[tabled(rename = "VALIDATORS")]
+    validators: usize,
+    #[tabled(rename = "ON DZ")]
+    on_dz: usize,
+    #[tabled(rename = "NOT ON DZ")]
+    not_on_dz: usize,
+    #[tabled(rename = "PUB")]
+    publishers: usize,
+    #[tabled(rename = "NOT PUB")]
+    not_publishers: usize,
+}
+
+/// Find IBRL validators and their multicast publisher status.
+#[derive(Debug, Args)]
+pub struct FindValidatorMulticastPublishersCommand {
+    /// Filter by multicast group (pubkey or code, e.g. "edge-solana-shreds").
+    #[arg(long, value_name = "KEY_OR_CODE")]
+    multicast_group: Option<String>,
+
+    /// Only show validators that are already a publisher.
+    #[arg(long, conflicts_with = "not_publisher")]
+    is_publisher: bool,
+
+    /// Only show validators that are NOT a publisher.
+    #[arg(long, conflicts_with = "is_publisher")]
+    not_publisher: bool,
+
+    /// Minimum activated stake in SOL to include.
+    #[arg(long, value_name = "SOL")]
+    min_stake: Option<f64>,
+
+    /// Maximum activated stake in SOL to include.
+    #[arg(long, value_name = "SOL")]
+    max_stake: Option<f64>,
+
+    /// Filter by validator client name (e.g. "JitoLabs", "AgaveBam", "Frankendancer"). Repeatable.
+    #[arg(long, value_name = "NAME")]
+    client: Vec<String>,
+
+    /// Include validators not yet connected to DZ.
+    #[arg(long)]
+    include_not_on_dz: bool,
+
+    /// Show a summary breakdown by client type instead of per-validator rows.
+    #[arg(long)]
+    summary: bool,
+
+    /// Use geographic distance (Haversine) instead of onchain link latency for nearest-device.
+    #[arg(long)]
+    nearest_via_geo: bool,
+
+    /// Validator metadata service URL.
+    #[arg(long, value_name = "URL", default_value = DEFAULT_VALIDATOR_METADATA_URL)]
+    validator_metadata_url: String,
+
+    #[command(flatten)]
+    output: OutputOptions,
+}
+
+impl FindValidatorMulticastPublishersCommand {
+    pub async fn execute(self, dzclient: &DZClient) -> eyre::Result<()> {
+        let program_id = *dzclient.get_program_id();
+        let rpc_client = dzclient.rpc_client();
+
+        let device_infos: HashMap<Pubkey, DzDeviceInfo> =
+            dz_ledger_reader::fetch_device_infos(rpc_client, &program_id).unwrap_or_default();
+
+        let latency_map = if self.nearest_via_geo {
+            None
+        } else {
+            let telemetry_id = dzclient
+                .get_environment()
+                .config()
+                .ok()
+                .map(|c| c.telemetry_program_id);
+            telemetry_id.and_then(|tid| {
+                dz_ledger_reader::fetch_device_latency_map(rpc_client, &tid)
+                    .map_err(|e| eprintln!("Warning: could not fetch latency data: {e}"))
+                    .ok()
+            })
+        };
+
+        let validator_metadata = HttpValidatorMetadataReader {
+            api_url: self.validator_metadata_url.clone(),
+        };
+        let dz_ledger = RpcDzLedgerReader::new(
+            NonblockingRpcClient::new_with_commitment(
+                dzclient.get_rpc().clone(),
+                CommitmentConfig::confirmed(),
+            ),
+            program_id,
+        );
+
+        // Resolve multicast group filter (pubkey or code).
+        let multicast_group_pk = match &self.multicast_group {
+            Some(key_or_code) => Some(
+                dz_ledger_reader::resolve_multicast_group(key_or_code, &dz_ledger)
+                    .await
+                    .map_err(|e| eyre::eyre!(e))?,
+            ),
+            None => None,
+        };
+
+        // Derive the solana tenant PDA to scope user queries.
+        let (solana_tenant_pk, _) = get_tenant_pda(&program_id, "solana");
+        let default_tenant_pk = Pubkey::default();
+
+        eprintln!("Fetching DZ Ledger users and validator metadata...");
+        let (all_users_unfiltered, validators) = tokio::try_join!(
+            async {
+                dz_ledger
+                    .fetch_all_dz_users()
+                    .await
+                    .map_err(|e| eyre::eyre!(e))
+            },
+            async {
+                validator_metadata
+                    .fetch_validators()
+                    .await
+                    .map_err(|e| eyre::eyre!(e))
+            },
+        )?;
+
+        // Scope to solana tenant (or default/unset tenant).
+        let all_users: Vec<_> = all_users_unfiltered
+            .into_iter()
+            .filter(|u| u.tenant_pk == solana_tenant_pk || u.tenant_pk == default_tenant_pk)
+            .collect();
+
+        let ibrl_users: Vec<_> = all_users
+            .iter()
+            .filter(|u| {
+                u.user_type == UserType::IBRL || u.user_type == UserType::IBRLWithAllocatedIP
+            })
+            .collect();
+        let ibrl_ips: std::collections::HashSet<Ipv4Addr> =
+            ibrl_users.iter().map(|u| u.client_ip).collect();
+
+        // Build per-IP set of multicast groups the IP publishes to.
+        let mut publisher_groups_by_ip: HashMap<Ipv4Addr, std::collections::HashSet<Pubkey>> =
+            HashMap::new();
+        for u in all_users
+            .iter()
+            .filter(|u| u.user_type == UserType::Multicast)
+        {
+            for pk in &u.publishers {
+                publisher_groups_by_ip
+                    .entry(u.client_ip)
+                    .or_default()
+                    .insert(*pk);
+            }
+        }
+
+        // User type breakdown.
+        let ibrl_count = all_users
+            .iter()
+            .filter(|u| u.user_type == UserType::IBRL)
+            .count();
+        let ibrl_ip_count = all_users
+            .iter()
+            .filter(|u| u.user_type == UserType::IBRLWithAllocatedIP)
+            .count();
+        let multicast_count = all_users
+            .iter()
+            .filter(|u| u.user_type == UserType::Multicast)
+            .count();
+        let edge_count = all_users
+            .iter()
+            .filter(|u| u.user_type == UserType::EdgeFiltering)
+            .count();
+        let other_count =
+            all_users.len() - ibrl_count - ibrl_ip_count - multicast_count - edge_count;
+
+        // "On DZ" = validator's gossip IP matches an IBRL user's client IP.
+        let dz_validator_count = validators.keys().filter(|ip| ibrl_ips.contains(ip)).count();
+        let not_dz_count = validators.len() - dz_validator_count;
+        eprintln!(
+            "User accounts: {} total ({} IBRL, {} IBRL+IP, {} Multicast, {} EdgeFiltering{})",
+            all_users.len(),
+            ibrl_count,
+            ibrl_ip_count,
+            multicast_count,
+            edge_count,
+            if other_count > 0 {
+                format!(", {} other", other_count)
+            } else {
+                String::new()
+            },
+        );
+        eprintln!(
+            "IBRL users: {} | Validators: {} ({} on DZ, {} not on DZ)",
+            ibrl_users.len(),
+            validators.len(),
+            dz_validator_count,
+            not_dz_count,
+        );
+
+        let filters = FindFilters {
+            min_stake: self.min_stake,
+            max_stake: self.max_stake,
+            clients: self.client.clone(),
+            is_publisher: self.is_publisher,
+            not_publisher: self.not_publisher,
+        };
+
+        // Cross-reference IBRL users with validators by IP.
+        let mut rows: Vec<ValidatorPublisherRow> = Vec::new();
+
+        for user in &ibrl_users {
+            if let Some(val) = validators.get(&user.client_ip) {
+                let is_pub = publisher_groups_by_ip
+                    .get(&user.client_ip)
+                    .is_some_and(|groups| match &multicast_group_pk {
+                        Some(group) => groups.contains(group),
+                        None => !groups.is_empty(),
+                    });
+
+                if !apply_filters(&filters, val, is_pub) {
+                    continue;
+                }
+
+                let device_label = device_infos
+                    .get(&user.device_pk)
+                    .map(|d| d.code.clone())
+                    .unwrap_or_else(|| user.device_pk.to_string());
+
+                let nearest_device_label = match find_nearest_device_for_multicast(
+                    &user.device_pk,
+                    &device_infos,
+                    latency_map.as_ref(),
+                ) {
+                    None => String::new(),
+                    Some(d) if d.pk == user.device_pk => d.code.clone(),
+                    Some(d) => {
+                        let score = device_infos
+                            .get(&user.device_pk)
+                            .map(|from| device_proximity_score(from, d, latency_map.as_ref()))
+                            .unwrap_or(f64::INFINITY);
+                        fmt_nearest_label(&d.code, score, self.nearest_via_geo)
+                    }
+                };
+
+                rows.push(ValidatorPublisherRow {
+                    owner: user.owner.to_string(),
+                    client_ip: user.client_ip.to_string(),
+                    device: device_label,
+                    nearest_device: nearest_device_label,
+                    vote_account: val.vote_account.clone(),
+                    stake_sol: format!("{:.2}", val.activated_stake_sol),
+                    client: val.software_client.clone(),
+                    version: val.software_version.clone(),
+                    is_publisher: if is_pub { "yes" } else { "no" }.to_string(),
+                });
+            }
+        }
+
+        // Include validators not on DZ for summary or when explicitly requested.
+        if self.include_not_on_dz || self.summary {
+            for val in validators.values() {
+                if ibrl_ips.contains(&val.gossip_ip) {
+                    continue; // already included above
+                }
+
+                if !apply_filters(&filters, val, false) {
+                    continue;
+                }
+
+                rows.push(ValidatorPublisherRow {
+                    owner: String::new(),
+                    client_ip: val.gossip_ip.to_string(),
+                    device: String::new(),
+                    nearest_device: String::new(),
+                    vote_account: val.vote_account.clone(),
+                    stake_sol: format!("{:.2}", val.activated_stake_sol),
+                    client: val.software_client.clone(),
+                    version: val.software_version.clone(),
+                    is_publisher: "no".to_string(),
+                });
+            }
+        }
+
+        // Sort by stake descending.
+        rows.sort_by(|a, b| {
+            let sa: f64 = a.stake_sol.parse().unwrap_or(0.0);
+            let sb: f64 = b.stake_sol.parse().unwrap_or(0.0);
+            sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        if self.summary {
+            // (count, on_dz, publishers)
+            let mut by_client: HashMap<String, (usize, usize, usize)> = HashMap::new();
+            for row in &rows {
+                let entry = by_client.entry(row.client.clone()).or_insert((0, 0, 0));
+                entry.0 += 1;
+                if !row.owner.is_empty() {
+                    entry.1 += 1; // on DZ
+                }
+                if row.is_publisher == "yes" {
+                    entry.2 += 1;
+                }
+            }
+
+            let total = rows.len();
+            let total_on_dz = rows.iter().filter(|r| !r.owner.is_empty()).count();
+            let total_pubs = rows.iter().filter(|r| r.is_publisher == "yes").count();
+
+            let mut summary_rows: Vec<SummaryRow> = by_client
+                .into_iter()
+                .map(|(client, (count, on_dz, pubs))| SummaryRow {
+                    client,
+                    validators: count,
+                    on_dz,
+                    not_on_dz: count - on_dz,
+                    publishers: pubs,
+                    not_publishers: on_dz - pubs,
+                })
+                .collect();
+            summary_rows.sort_by(|a, b| b.validators.cmp(&a.validators));
+            summary_rows.push(SummaryRow {
+                client: "TOTAL".to_string(),
+                validators: total,
+                on_dz: total_on_dz,
+                not_on_dz: total - total_on_dz,
+                publishers: total_pubs,
+                not_publishers: total_on_dz - total_pubs,
+            });
+            print_table(summary_rows, &self.output, &[1, 2, 3, 4, 5]);
+        } else {
+            if rows.is_empty() {
+                if self.output.json {
+                    println!("[]");
+                } else {
+                    eprintln!("No IBRL validators found matching filters.");
+                }
+                return Ok(());
+            }
+
+            if !self.output.json {
+                eprintln!("\nFound {} IBRL validator(s)\n", rows.len());
+            }
+
+            // right-align: STAKE (SOL) is column index 5
+            print_table(rows, &self.output, &[5]);
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Create command
+// ---------------------------------------------------------------------------
+
+/// Create multicast publisher users for IBRL validators that don't have one yet.
+#[derive(Debug, Args)]
+pub struct CreateValidatorMulticastPublishersCommand {
+    /// Multicast group (pubkey or code, e.g. "edge-solana-shreds"). Required.
+    #[arg(long, value_name = "KEY_OR_CODE")]
+    multicast_group: String,
+
+    /// Maximum number of users to create in this run.
+    #[arg(long, value_name = "N")]
+    limit: Option<usize>,
+
+    /// Minimum activated stake in SOL to include.
+    #[arg(long, value_name = "SOL")]
+    min_stake: Option<f64>,
+
+    /// Maximum activated stake in SOL to include.
+    #[arg(long, value_name = "SOL")]
+    max_stake: Option<f64>,
+
+    /// Filter by validator client name (e.g. "JitoLabs", "AgaveBam", "Frankendancer"). Repeatable.
+    #[arg(long, value_name = "NAME")]
+    client: Vec<String>,
+
+    /// Filter by client IP address. Repeatable.
+    #[arg(long, value_name = "IP")]
+    ip: Vec<Ipv4Addr>,
+
+    /// Validator metadata service URL.
+    #[arg(long, value_name = "URL", default_value = DEFAULT_VALIDATOR_METADATA_URL)]
+    validator_metadata_url: String,
+
+    /// Use geographic distance (Haversine) instead of onchain link latency for nearest-device.
+    #[arg(long)]
+    nearest_via_geo: bool,
+
+    /// Simulate transactions without sending.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+impl CreateValidatorMulticastPublishersCommand {
+    pub async fn execute(self, dzclient: &DZClient) -> eyre::Result<()> {
+        let program_id = *dzclient.get_program_id();
+        let rpc_client = dzclient.rpc_client();
+        let payer = dzclient
+            .payer_keypair()
+            .ok_or_else(|| eyre::eyre!("No keypair configured. Use --keypair to specify one."))?;
+        let payer_pk = payer.pubkey();
+
+        let mut device_infos: HashMap<Pubkey, DzDeviceInfo> =
+            dz_ledger_reader::fetch_device_infos(rpc_client, &program_id).unwrap_or_default();
+
+        let latency_map = if self.nearest_via_geo {
+            None
+        } else {
+            let telemetry_id = dzclient
+                .get_environment()
+                .config()
+                .ok()
+                .map(|c| c.telemetry_program_id);
+            telemetry_id.and_then(|tid| {
+                dz_ledger_reader::fetch_device_latency_map(rpc_client, &tid)
+                    .map_err(|e| eprintln!("Warning: could not fetch latency data: {e}"))
+                    .ok()
+            })
+        };
+
+        let validator_metadata = HttpValidatorMetadataReader {
+            api_url: self.validator_metadata_url.clone(),
+        };
+        let dz_ledger = RpcDzLedgerReader::new(
+            NonblockingRpcClient::new_with_commitment(
+                dzclient.get_rpc().clone(),
+                CommitmentConfig::confirmed(),
+            ),
+            program_id,
+        );
+
+        // Resolve multicast group.
+        let multicast_group_pk =
+            dz_ledger_reader::resolve_multicast_group(&self.multicast_group, &dz_ledger)
+                .await
+                .map_err(|e| eyre::eyre!(e))?;
+        eprintln!(
+            "Multicast group: {} ({})",
+            multicast_group_pk, self.multicast_group
+        );
+
+        // Derive the solana tenant PDA to scope user queries.
+        let (solana_tenant_pk, _) = get_tenant_pda(&program_id, "solana");
+        let default_tenant_pk = Pubkey::default();
+
+        // Fetch users and validator data.
+        eprintln!("Fetching DZ Ledger users and validator metadata...");
+        let (all_users_unfiltered, validators) = tokio::try_join!(
+            async {
+                dz_ledger
+                    .fetch_all_dz_users()
+                    .await
+                    .map_err(|e| eyre::eyre!(e))
+            },
+            async {
+                validator_metadata
+                    .fetch_validators()
+                    .await
+                    .map_err(|e| eyre::eyre!(e))
+            },
+        )?;
+
+        // Scope to solana tenant (or default/unset tenant).
+        let all_users: Vec<_> = all_users_unfiltered
+            .into_iter()
+            .filter(|u| u.tenant_pk == solana_tenant_pk || u.tenant_pk == default_tenant_pk)
+            .collect();
+
+        let filters = CandidateFilters {
+            min_stake: self.min_stake,
+            max_stake: self.max_stake,
+            clients: self.client,
+            ips: self.ip.clone(),
+            limit: self.limit,
+        };
+
+        let candidates = find_candidates(
+            &all_users,
+            &validators,
+            &multicast_group_pk,
+            &filters,
+            &device_infos,
+        );
+
+        if candidates.is_empty() {
+            // If specific IPs were requested, explain why each was skipped.
+            if !self.ip.is_empty() {
+                let ibrl_ips: std::collections::HashSet<Ipv4Addr> = all_users
+                    .iter()
+                    .filter(|u| {
+                        u.user_type == doublezero_sdk::UserType::IBRL
+                            || u.user_type == doublezero_sdk::UserType::IBRLWithAllocatedIP
+                    })
+                    .map(|u| u.client_ip)
+                    .collect();
+                let publisher_ips: std::collections::HashSet<Ipv4Addr> = all_users
+                    .iter()
+                    .filter(|u| {
+                        u.user_type == doublezero_sdk::UserType::Multicast
+                            && u.publishers.contains(&multicast_group_pk)
+                    })
+                    .map(|u| u.client_ip)
+                    .collect();
+                eprintln!("No candidates found. Per-IP diagnosis:");
+                for ip in &self.ip {
+                    let reason: String = if !ibrl_ips.contains(ip) {
+                        "no IBRL user found for this IP".to_string()
+                    } else if publisher_ips.contains(ip) {
+                        "already a publisher for this multicast group".to_string()
+                    } else if !validators.contains_key(ip) {
+                        "not found in validator metadata service".to_string()
+                    } else {
+                        let val = validators.get(ip).unwrap();
+                        let client_mismatch = !filters.clients.is_empty() && {
+                            let name = val.software_client.to_lowercase();
+                            !filters
+                                .clients
+                                .iter()
+                                .any(|c| name.contains(&c.to_lowercase()))
+                        };
+                        let stake_mismatch = filters
+                            .min_stake
+                            .is_some_and(|m| val.activated_stake_sol < m)
+                            || filters
+                                .max_stake
+                                .is_some_and(|m| val.activated_stake_sol > m);
+                        if client_mismatch {
+                            format!(
+                                "client '{}' does not match --client filter {:?}",
+                                val.software_client, filters.clients
+                            )
+                        } else if stake_mismatch {
+                            "filtered out by stake filter".to_string()
+                        } else {
+                            "filtered out (unknown reason)".to_string()
+                        }
+                    };
+                    eprintln!("  {ip}: {reason}");
+                }
+            } else {
+                eprintln!(
+                    "No candidates found — all matching validators already have a publisher."
+                );
+            }
+            return Ok(());
+        }
+
+        // Display plan (snapshot — target devices are re-evaluated at execution time).
+        eprintln!(
+            "\nWill create {} multicast publisher user(s) on group {}:",
+            candidates.len(),
+            self.multicast_group,
+        );
+        eprintln!(
+            "  user_type=Multicast  cyoa_type=GREOverDIA  publisher=true  subscriber=false\n"
+        );
+        #[derive(Tabled, Serialize)]
+        struct PlanRow {
+            #[tabled(rename = "OWNER")]
+            owner: String,
+            #[tabled(rename = "CLIENT IP")]
+            client_ip: String,
+            #[tabled(rename = "DEVICE")]
+            device: String,
+            #[tabled(rename = "NEAREST DEVICE")]
+            nearest_device: String,
+            #[tabled(rename = "DEVICE IP")]
+            device_ip: String,
+            #[tabled(rename = "TUNNEL ENDPOINT")]
+            tunnel_endpoint: String,
+            #[tabled(rename = "CLIENT")]
+            client: String,
+            #[tabled(rename = "STAKE (SOL)")]
+            stake_sol: String,
+        }
+
+        let plan_rows: Vec<PlanRow> = candidates
+            .iter()
+            .map(|c| {
+                let target_device = find_nearest_device_for_multicast(
+                    &c.device_pk,
+                    &device_infos,
+                    latency_map.as_ref(),
+                );
+                let nearest = match target_device {
+                    None => "none".to_string(),
+                    Some(d) if d.pk == c.device_pk => d.code.clone(),
+                    Some(d) => {
+                        let score = device_infos
+                            .get(&c.device_pk)
+                            .map(|from| device_proximity_score(from, d, latency_map.as_ref()))
+                            .unwrap_or(f64::INFINITY);
+                        fmt_nearest_label(&d.code, score, self.nearest_via_geo)
+                    }
+                };
+                let device_ip = target_device
+                    .map(|d| d.public_ip.to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                let tunnel_endpoint = target_device
+                    .map(|d| {
+                        let exclude = tunnel_exclude_ips(&all_users, c.client_ip, &device_infos);
+                        select_tunnel_endpoint(d.public_ip, &d.user_tunnel_endpoints, &exclude)
+                    })
+                    .unwrap_or(Ipv4Addr::UNSPECIFIED);
+                PlanRow {
+                    owner: c.owner.to_string(),
+                    client_ip: c.client_ip.to_string(),
+                    device: c.device_label.clone(),
+                    nearest_device: nearest,
+                    device_ip,
+                    tunnel_endpoint: if tunnel_endpoint == Ipv4Addr::UNSPECIFIED {
+                        "(legacy-assigned)".to_string()
+                    } else {
+                        tunnel_endpoint.to_string()
+                    },
+                    client: c.software_client.clone(),
+                    stake_sol: format!("{:.2}", c.stake_sol),
+                }
+            })
+            .collect();
+        print_table(plan_rows, &OutputOptions { json: false }, &[5]);
+        eprintln!();
+
+        if self.dry_run {
+            eprintln!("Dry run — no transactions sent.");
+            return Ok(());
+        }
+
+        // Confirmation prompt.
+        eprint!("Proceed? [y/N] ");
+        std::io::stderr().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            eyre::bail!("Aborted");
+        }
+
+        // Execute: for each candidate, re-evaluate the target device at execution time so
+        // that slots filled earlier in this run are reflected in subsequent picks.
+        let mut created = 0;
+        let mut skipped = 0;
+        for (i, candidate) in candidates.iter().enumerate() {
+            // Re-evaluate nearest available device now, accounting for slots filled this run.
+            let target = find_nearest_device_for_multicast(
+                &candidate.device_pk,
+                &device_infos,
+                latency_map.as_ref(),
+            );
+            let (target_device_pk, target_device_label) = match target {
+                Some(d) => (d.pk, d.code.clone()),
+                None => {
+                    eprintln!(
+                        "\n[{}/{}] Skipping {} (ip: {}) — no device with available capacity.",
+                        i + 1,
+                        candidates.len(),
+                        candidate.owner,
+                        candidate.client_ip,
+                    );
+                    skipped += 1;
+                    continue;
+                }
+            };
+
+            eprintln!(
+                "\n[{}/{}] Creating multicast publisher for {} (ip: {}, device: {}, target: {})...",
+                i + 1,
+                candidates.len(),
+                candidate.owner,
+                candidate.client_ip,
+                candidate.device_label,
+                target_device_label,
+            );
+
+            let dz_user = DzUser {
+                owner: candidate.owner,
+                client_ip: candidate.client_ip,
+                device_pk: target_device_pk,
+                tenant_pk: Pubkey::default(),
+                user_type: doublezero_sdk::UserType::IBRL,
+                publishers: vec![],
+                tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            };
+
+            let tunnel_endpoint = device_infos
+                .get(&target_device_pk)
+                .map(|d| {
+                    let exclude =
+                        tunnel_exclude_ips(&all_users, candidate.client_ip, &device_infos);
+                    select_tunnel_endpoint(d.public_ip, &d.user_tunnel_endpoints, &exclude)
+                })
+                .unwrap_or(Ipv4Addr::UNSPECIFIED);
+
+            if tunnel_endpoint == Ipv4Addr::UNSPECIFIED {
+                eprintln!(
+                    "  Error: no tunnel endpoint available on device {} for {} — all public_ip \
+                     and user_tunnel_endpoint IPs are already in use by this client_ip. Skipping.",
+                    target_device_label, candidate.client_ip,
+                );
+                skipped += 1;
+                continue;
+            }
+
+            let dz_prefix_count = device_infos
+                .get(&target_device_pk)
+                .map(|d| d.dz_prefix_count)
+                .unwrap_or(0);
+            let ixs = match build_create_multicast_publisher_instructions(
+                &program_id,
+                &payer_pk,
+                &candidate.owner,
+                &multicast_group_pk,
+                &dz_user,
+                tunnel_endpoint,
+                dz_prefix_count,
+            ) {
+                Ok(ixs) => ixs,
+                Err(e) => {
+                    eprintln!("  Error building instructions: {e} — skipping.");
+                    skipped += 1;
+                    continue;
+                }
+            };
+
+            let result = async {
+                send_instruction(rpc_client, payer, &[ixs.set_access_pass], "set_access_pass")
+                    .await?;
+                send_instruction(rpc_client, payer, &[ixs.add_allowlist], "add_pub_allowlist")
+                    .await?;
+                send_instruction(
+                    rpc_client,
+                    payer,
+                    &[ixs.create_user],
+                    "create_subscribe_user",
+                )
+                .await
+            }
+            .await;
+
+            match result {
+                Ok(()) => {
+                    eprintln!(
+                        "  Created multicast publisher for {} on {}",
+                        candidate.client_ip, target_device_label,
+                    );
+                    // Decrement local capacity so subsequent candidates see the updated state.
+                    if let Some(d) = device_infos.get_mut(&target_device_pk) {
+                        d.users_count += 1;
+                        d.multicast_publishers_count += 1;
+                    }
+                    created += 1;
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e} — skipping.");
+                    skipped += 1;
+                }
+            }
+        }
+
+        eprintln!(
+            "\nDone — created {created} multicast publisher(s){}.",
+            if skipped > 0 {
+                format!(", skipped {skipped}")
+            } else {
+                String::new()
+            }
+        );
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the set of tunnel endpoints already in use by users at `client_ip`.
+///
+/// For users with an explicit `tunnel_endpoint` onchain, use that value.
+/// For legacy users where `tunnel_endpoint == UNSPECIFIED`, the tunnel is
+/// implicitly routed through the device's `public_ip`, so resolve it from
+/// `device_infos` rather than dropping the entry.
+fn tunnel_exclude_ips(
+    users: &[DzUser],
+    client_ip: Ipv4Addr,
+    device_infos: &HashMap<Pubkey, DzDeviceInfo>,
+) -> Vec<Ipv4Addr> {
+    users
+        .iter()
+        .filter(|u| u.client_ip == client_ip)
+        .map(|u| {
+            if u.tunnel_endpoint != Ipv4Addr::UNSPECIFIED {
+                u.tunnel_endpoint
+            } else {
+                device_infos
+                    .get(&u.device_pk)
+                    .map(|d| d.public_ip)
+                    .unwrap_or(Ipv4Addr::UNSPECIFIED)
+            }
+        })
+        .filter(|ip| *ip != Ipv4Addr::UNSPECIFIED)
+        .collect()
+}
+
+/// Format a nearest-device label with its proximity score.
+/// Shows `"code (1234 µs)"` in latency mode or `"code (365 km)"` in geo mode.
+/// Falls back to plain `code` when the score is infinite (no latency data).
+fn fmt_nearest_label(code: &str, score: f64, geo_mode: bool) -> String {
+    if score.is_finite() {
+        if geo_mode {
+            format!("{code} ({:.0} km)", score)
+        } else {
+            format!("{code} ({:.0} µs)", score)
+        }
+    } else {
+        code.to_string()
+    }
+}
+
+async fn send_instruction(
+    rpc_client: &RpcClient,
+    payer: &Keypair,
+    ixs: &[Instruction],
+    label: &str,
+) -> eyre::Result<()> {
+    let blockhash = rpc_client
+        .get_latest_blockhash()
+        .map_err(|e| eyre::eyre!("failed to get blockhash for {label}: {e}"))?;
+
+    let mut tx = Transaction::new_with_payer(ixs, Some(&payer.pubkey()));
+    tx.sign(&[payer], blockhash);
+
+    let sig = rpc_client
+        .send_and_confirm_transaction(&tx)
+        .map_err(|e| eyre::eyre!("failed to send {label}: {e}"))?;
+
+    eprintln!("  {label}: {sig}");
+
+    Ok(())
+}

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -8,7 +8,7 @@ mod routes;
 use doublezero_config::Environment;
 mod requirements;
 mod servicecontroller;
-use crate::cli::{command::Command, multicast::MulticastCommands};
+use crate::cli::{command::Command, multicast::MulticastCommands, sentinel::SentinelCommands};
 use doublezero_cli_core::LogLevel;
 use doublezero_geolocation_cli::GeoCliCommandImpl;
 use doublezero_sdk::{
@@ -290,6 +290,17 @@ async fn main() -> eyre::Result<()> {
         Command::Latency(args) => args.execute(&client).await,
         Command::Routes(args) => args.execute(&client).await,
 
+        // Sentinel admin commands (binary-local): they take `DZClient` directly
+        // and write their own output, so no `ctx`/writer threading is needed.
+        Command::Sentinel(cmd) => match cmd.command {
+            SentinelCommands::FindValidatorMulticastPublishers(args) => {
+                args.execute(&dzclient).await
+            }
+            SentinelCommands::CreateValidatorMulticastPublishers(args) => {
+                args.execute(&dzclient).await
+            }
+        },
+
         // Geolocation module crate (doublezero-geolocation-cli per RFC-20)
         Command::Geolocation(args) => {
             let geo_client = GeoClient::from_context(&ctx, app.keypair.clone())?;
@@ -442,6 +453,24 @@ mod tests {
     fn url_alone_parses() {
         App::try_parse_from(["doublezero", "--url", "https://x.invalid/"])
             .expect("--url alone should parse");
+    }
+
+    #[test]
+    fn sentinel_subcommands_parse() {
+        App::try_parse_from([
+            "doublezero",
+            "sentinel",
+            "find-validator-multicast-publishers",
+        ])
+        .expect("find parses");
+        App::try_parse_from([
+            "doublezero",
+            "sentinel",
+            "create-validator-multicast-publishers",
+            "--multicast-group",
+            "mg-test",
+        ])
+        .expect("create parses");
     }
 
     use super::resolve_environment;


### PR DESCRIPTION
Second of three PRs consolidating `doublezero-admin`'s admin-only commands into the regular `doublezero` CLI as hidden commands (the admin crate is retired in PR 3). This PR moves the two `sentinel` validator-multicast-publisher commands into the `doublezero` binary.

## Summary

- Add hidden `doublezero sentinel find-validator-multicast-publishers` (read-only: lists IBRL validators and their multicast publisher status) and `sentinel create-validator-multicast-publishers` (provisions publisher users for validators missing one).
- `sentinel.rs` is moved verbatim from `doublezero-admin`; the commands keep their existing `execute(self, &DZClient)` signature and dispatch as binary-local commands using the `DZClient` already built in `main.rs` (like the geolocation/daemon-control verbs).
- Adds the `doublezero-sentinel` dependency to the `doublezero` binary. `solana-client`/`solana-sdk` are already present via the SDK, so the marginal additions are mainly reqwest/telemetry/metrics.

Minor behavior note: sentinel verbs now run the binary's standard non-fatal client-version warning (the old admin binary ran none); `--no-version-warning` suppresses it.

These commands still exist in `doublezero-admin` until that crate is retired in PR 3.

## Testing Verification

- `cargo test -p doublezero sentinel` passes: a clap parse test that exercises the required `--multicast-group` on the `create` verb and the all-optional `find` verb.
- Verified hidden: top-level `--help` omits `sentinel`; `sentinel --help` lists both subcommands.

Part of a 3-PR series: PR 1 migrate commands (#3903) → **PR 2 (this)** sentinel → PR 3 retire `doublezero-admin` (must merge after PR 1 and PR 2).
