### PR TITLE
e2e: wait for multicast-group convergence in doublezero status check

### DIFF
--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -438,6 +438,10 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 			fixturePath string
 			data        map[string]any
 			cmd         []string
+			// eventually polls until the output converges to the fixture instead of
+			// taking a single snapshot. Used for checks whose value is populated
+			// asynchronously by the client daemon.
+			eventually bool
 		}{
 			{
 				name:        "doublezero_multicast_group_list",
@@ -457,6 +461,11 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 					"MulticastGroups":           expectedMulticastGroups,
 				},
 				cmd: []string{"doublezero", "status"},
+				// doublezero status reflects multicast-group membership
+				// asynchronously: the second group subscription propagates into the
+				// client daemon's status view a short time after connect. Poll until
+				// the table converges rather than racing a single snapshot.
+				eventually: true,
 			},
 		}
 
@@ -464,11 +473,22 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 			if !t.Run(test.name, func(t *testing.T) {
 				t.Parallel()
 
-				got, err := client.Exec(t.Context(), test.cmd)
-				require.NoError(t, err, "error executing command on client")
-
 				want, err := fixtures.Render(test.fixturePath, test.data)
 				require.NoError(t, err, "error reading fixture")
+
+				if test.eventually {
+					require.Eventually(t, func() bool {
+						got, err := client.Exec(t.Context(), test.cmd)
+						if err != nil {
+							return false
+						}
+						return fixtures.DiffCLITable(got, []byte(want)) == ""
+					}, 60*time.Second, 1*time.Second, "%v output did not converge to expected", test.cmd)
+					return
+				}
+
+				got, err := client.Exec(t.Context(), test.cmd)
+				require.NoError(t, err, "error executing command on client")
 
 				diff := fixtures.DiffCLITable(got, []byte(want))
 				if diff != "" {

--- a/e2e/multicast_test.go
+++ b/e2e/multicast_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/malbeclabs/doublezero/e2e/internal/fixtures"
 	"github.com/malbeclabs/doublezero/e2e/internal/netutil"
 	"github.com/malbeclabs/doublezero/e2e/internal/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -477,23 +478,38 @@ func checkMulticastPostConnect(t *testing.T, log *slog.Logger, mode string, dn *
 				require.NoError(t, err, "error reading fixture")
 
 				if test.eventually {
-					require.Eventually(t, func() bool {
+					// Capture the last observation so a genuine timeout still
+					// surfaces the table/diff (or exec error) rather than failing
+					// opaquely.
+					var lastGot []byte
+					var lastErr error
+					var lastDiff string
+					ok := assert.Eventually(t, func() bool {
 						got, err := client.Exec(t.Context(), test.cmd)
 						if err != nil {
+							lastErr = err
 							return false
 						}
-						return fixtures.DiffCLITable(got, []byte(want)) == ""
-					}, 60*time.Second, 1*time.Second, "%v output did not converge to expected", test.cmd)
-					return
-				}
+						lastGot, lastErr = got, nil
+						lastDiff = fixtures.DiffCLITable(got, []byte(want))
+						return lastDiff == ""
+					}, 60*time.Second, 1*time.Second)
+					if !ok {
+						if lastErr != nil {
+							t.Fatalf("error executing command on client: %v", lastErr)
+						}
+						fmt.Println(string(lastGot))
+						t.Fatalf("output did not converge: -(want), +(got):%s", lastDiff)
+					}
+				} else {
+					got, err := client.Exec(t.Context(), test.cmd)
+					require.NoError(t, err, "error executing command on client")
 
-				got, err := client.Exec(t.Context(), test.cmd)
-				require.NoError(t, err, "error executing command on client")
-
-				diff := fixtures.DiffCLITable(got, []byte(want))
-				if diff != "" {
-					fmt.Println(string(got))
-					t.Fatalf("output mismatch: -(want), +(got):%s", diff)
+					diff := fixtures.DiffCLITable(got, []byte(want))
+					if diff != "" {
+						fmt.Println(string(got))
+						t.Fatalf("output mismatch: -(want), +(got):%s", diff)
+					}
 				}
 			}) {
 				t.Fail()


### PR DESCRIPTION
## Summary of Changes
* Wrap the post-connect `doublezero status` assertion in `checkMulticastPostConnect` in a polling loop so it waits for multicast-group membership to converge instead of taking a single, non-retried snapshot. This fixes a test-side race where the second group (`mg02`) subscription had not yet propagated into the client daemon's local status view, producing `S:mg01` instead of the expected `S:mg01,S:mg02` and failing the CLI-table diff.
* The fix is shared by both the publisher and subscriber paths. The sibling `doublezero_multicast_group_list` check is intentionally left as a single snapshot because it reads onchain state, which is already consistent.
* The polling timeout/interval (60s/1s) matches the existing convergence-sensitive checks in the same file (e.g. the multicast route check).
* On a genuine timeout, the last observed table and structured `-(want), +(got)` diff (or the last exec error) are still printed, so a real failure is not opaque.
* This is a pre-existing race that happened to surface on PR #3900; it is fixed here and not bundled into that PR.
* Fixes #3907

## Testing Verification
* `go vet -tags e2e ./e2e` passes; the package compiles and is `gofmt`-clean.
* The race is timing-dependent and only reproduces under load across repeated full `TestE2E_Multicast` runs (each spins up multiple cEOS containers), so it cannot be deterministically reproduced in a single run. The change converts the single-snapshot assertion that lost the race into the same `Eventually`-poll idiom already proven for the route/PIM convergence checks in this file, which read the same asynchronously-populated daemon state.
