### PR TITLE
serviceability: expose public fn to calculate access pass airdrop target

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -11,6 +11,23 @@ use solana_program::{
 // `User` account size assumes a single publisher and subscriber pubkey registered (266 bytes each).
 pub const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 266 * 3; // 266 bytes per User account x 3 accounts = 798 bytes
 
+/// Computes the target lamport balance a `user_payer` must hold to cover rent for its `User`
+/// accounts plus the configured per-user airdrop. `multiplier` scales the target for passes that
+/// admit several users (e.g. `allow_multiple_ip` seat keypairs); pass `1` for single-user passes.
+///
+/// Off-chain callers (e.g. the feed oracle) can obtain `Rent` over RPC — by fetching the rent
+/// sysvar account, or via `getMinimumBalanceForRentExemption` — since `Rent::get()` is a syscall
+/// only available inside a running program.
+pub fn airdrop_user_target_lamports(
+    rent: &Rent,
+    user_airdrop_lamports: u64,
+    multiplier: u64,
+) -> u64 {
+    rent.minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES)
+        .saturating_add(user_airdrop_lamports)
+        .saturating_mul(multiplier)
+}
+
 /// Tops up `user_payer` so it holds enough SOL to cover rent for its `User` accounts plus the
 /// configured per-user airdrop, allowing the user to connect immediately. `multiplier` scales the
 /// target for passes that admit several users (e.g. `allow_multiple_ip` seat keypairs); pass `1`
@@ -24,12 +41,8 @@ pub fn airdrop_user_credits<'a>(
     user_airdrop_lamports: u64,
     multiplier: u64,
 ) -> ProgramResult {
-    let base_target = Rent::get()?
-        .minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES)
-        .saturating_add(user_airdrop_lamports);
-    let deposit = base_target
-        .saturating_mul(multiplier)
-        .saturating_sub(user_payer.lamports());
+    let target = airdrop_user_target_lamports(&Rent::get()?, user_airdrop_lamports, multiplier);
+    let deposit = target.saturating_sub(user_payer.lamports());
 
     if deposit == 0 {
         return Ok(());
@@ -45,4 +58,25 @@ pub fn airdrop_user_credits<'a>(
         ],
         &[],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_airdrop_user_target_lamports() {
+        let rent = Rent::default();
+        let base = rent.minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES);
+        let airdrop = 40_000;
+
+        assert_eq!(
+            airdrop_user_target_lamports(&rent, airdrop, 1),
+            base + airdrop
+        );
+        assert_eq!(
+            airdrop_user_target_lamports(&rent, airdrop, 5),
+            (base + airdrop) * 5
+        );
+    }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -11,6 +11,10 @@ use solana_program::{
 // `User` account size assumes a single publisher and subscriber pubkey registered (266 bytes each).
 pub const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 266 * 3; // 266 bytes per User account x 3 accounts = 798 bytes
 
+/// Default per-user airdrop seeded into `GlobalState.user_airdrop_lamports` at initialization.
+/// Admins can override it via the `SetAirdrop` instruction.
+pub const DEFAULT_USER_AIRDROP_LAMPORTS: u64 = 40_000;
+
 /// Computes the target lamport balance a `user_payer` must hold to cover rent for its `User`
 /// accounts plus the configured per-user airdrop. `multiplier` scales the target for passes that
 /// admit several users (e.g. `allow_multiple_ip` seat keypairs); pass `1` for single-user passes.

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -1,5 +1,6 @@
 use crate::{
     pda::*,
+    processors::accesspass::DEFAULT_USER_AIRDROP_LAMPORTS,
     programversion::ProgramVersion,
     seeds::{SEED_GLOBALSTATE, SEED_PREFIX, SEED_PROGRAM_CONFIG},
     serializer::{try_acc_create, try_acc_write},
@@ -102,7 +103,7 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         activator_authority_pk: *payer_account.key,
         sentinel_authority_pk: *payer_account.key,
         contributor_airdrop_lamports: 1_000_000_000,
-        user_airdrop_lamports: 40_000,
+        user_airdrop_lamports: DEFAULT_USER_AIRDROP_LAMPORTS,
         health_oracle_pk: *payer_account.key,
         qa_allowlist: vec![*payer_account.key],
         feature_flags: 0,


### PR DESCRIPTION
## Summary

- Extract a public, pure `airdrop_user_target_lamports(rent, user_airdrop_lamports, multiplier)` from `airdrop_user_credits` in the serviceability program, so the feed oracle can compute the expected access pass airdrop target without duplicating the program's math.
- The function takes `&Rent` rather than calling `Rent::get()` internally, so it works both on-chain (caller passes `Rent::get()?`) and off-chain where `Rent` is fetched over RPC (`getMinimumBalanceForRentExemption` or the rent sysvar account).
- `airdrop_user_credits` now delegates the target calculation to the new function, then subtracts the current balance and transfers the difference. Its signature and behavior are unchanged, so the three existing call sites are untouched.

## Testing Verification

- Added a unit test asserting the target equals `minimum_balance(AIRDROP_USER_RENT_LAMPORTS_BYTES) + user_airdrop_lamports` for `multiplier = 1`, and that result scaled by `N` for `multiplier = N`.
- Existing accesspass and multicast allowlist tests still pass (`cargo test -p doublezero-serviceability`), confirming the refactor preserves the airdrop transfer behavior.