### PR TITLE
e2e: pin metrics-publisher on device recreate in QA provisioning

### DIFF
--- a/e2e/internal/qa/provisioning.go
+++ b/e2e/internal/qa/provisioning.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/malbeclabs/doublezero/config"
 	"github.com/malbeclabs/doublezero/e2e/internal/poll"
@@ -31,21 +32,22 @@ type ProvisioningTest struct {
 }
 
 type DeviceInfo struct {
-	Pubkey          string
-	Code            string
-	ContributorCode string
-	LocationCode    string
-	ExchangeCode    string
-	PublicIP        string
-	DzPrefixes      []string
-	MgmtVrf         string
-	MaxUsers        int
-	UsersCount      int
-	Status          string
-	Health          string
-	DeviceType      string
-	DesiredStatus   string
-	Interfaces      []InterfaceInfo
+	Pubkey           string
+	Code             string
+	ContributorCode  string
+	LocationCode     string
+	ExchangeCode     string
+	PublicIP         string
+	DzPrefixes       []string
+	MgmtVrf          string
+	MaxUsers         int
+	UsersCount       int
+	Status           string
+	Health           string
+	DeviceType       string
+	DesiredStatus    string
+	MetricsPublisher string
+	Interfaces       []InterfaceInfo
 }
 
 type InterfaceInfo struct {
@@ -54,16 +56,17 @@ type InterfaceInfo struct {
 }
 
 type DeviceSpec struct {
-	Code            string
-	ContributorCode string
-	LocationCode    string
-	ExchangeCode    string
-	PublicIP        string
-	DzPrefixes      []string
-	MgmtVrf         string
-	MaxUsers        int
-	DeviceType      string
-	Interfaces      []InterfaceInfo
+	Code             string
+	ContributorCode  string
+	LocationCode     string
+	ExchangeCode     string
+	PublicIP         string
+	DzPrefixes       []string
+	MgmtVrf          string
+	MaxUsers         int
+	DeviceType       string
+	MetricsPublisher string
+	Interfaces       []InterfaceInfo
 }
 
 type LinkInfo struct {
@@ -153,21 +156,22 @@ func (p *ProvisioningTest) GetDeviceByCode(ctx context.Context, code string) (*D
 			}
 
 			return &DeviceInfo{
-				Pubkey:          base58.Encode(device.PubKey[:]),
-				Code:            device.Code,
-				ContributorCode: contributors[device.ContributorPubKey],
-				LocationCode:    locations[device.LocationPubKey],
-				ExchangeCode:    exchanges[device.ExchangePubKey],
-				PublicIP:        net.IP(device.PublicIp[:]).String(),
-				DzPrefixes:      prefixes,
-				MgmtVrf:         device.MgmtVrf,
-				MaxUsers:        int(device.MaxUsers),
-				UsersCount:      int(device.UsersCount),
-				Status:          device.Status.String(),
-				Health:          device.DeviceHealth.String(),
-				DeviceType:      device.DeviceType.String(),
-				DesiredStatus:   device.DeviceDesiredStatus.String(),
-				Interfaces:      ifaces,
+				Pubkey:           base58.Encode(device.PubKey[:]),
+				Code:             device.Code,
+				ContributorCode:  contributors[device.ContributorPubKey],
+				LocationCode:     locations[device.LocationPubKey],
+				ExchangeCode:     exchanges[device.ExchangePubKey],
+				PublicIP:         net.IP(device.PublicIp[:]).String(),
+				DzPrefixes:       prefixes,
+				MgmtVrf:          device.MgmtVrf,
+				MaxUsers:         int(device.MaxUsers),
+				UsersCount:       int(device.UsersCount),
+				Status:           device.Status.String(),
+				Health:           device.DeviceHealth.String(),
+				DeviceType:       device.DeviceType.String(),
+				DesiredStatus:    device.DeviceDesiredStatus.String(),
+				MetricsPublisher: base58.Encode(device.MetricsPublisherPubKey[:]),
+				Interfaces:       ifaces,
 			}, nil
 		}
 	}
@@ -177,17 +181,70 @@ func (p *ProvisioningTest) GetDeviceByCode(ctx context.Context, code string) (*D
 
 func (p *ProvisioningTest) GetDeviceSpec(ctx context.Context, device *DeviceInfo) (*DeviceSpec, error) {
 	return &DeviceSpec{
-		Code:            device.Code,
-		ContributorCode: device.ContributorCode,
-		LocationCode:    device.LocationCode,
-		ExchangeCode:    device.ExchangeCode,
-		PublicIP:        device.PublicIP,
-		DzPrefixes:      device.DzPrefixes,
-		MgmtVrf:         device.MgmtVrf,
-		MaxUsers:        device.MaxUsers,
-		DeviceType:      device.DeviceType,
-		Interfaces:      device.Interfaces,
+		Code:             device.Code,
+		ContributorCode:  device.ContributorCode,
+		LocationCode:     device.LocationCode,
+		ExchangeCode:     device.ExchangeCode,
+		PublicIP:         device.PublicIP,
+		DzPrefixes:       device.DzPrefixes,
+		MgmtVrf:          device.MgmtVrf,
+		MaxUsers:         device.MaxUsers,
+		DeviceType:       device.DeviceType,
+		MetricsPublisher: device.MetricsPublisher,
+		Interfaces:       device.Interfaces,
 	}, nil
+}
+
+// ResolveMetricsPublisherPubkey derives the device's metrics-publisher public key
+// from the ansible-vault-encrypted keypair shipped to the device by the infra repo
+// (the same key the telemetry agent signs samples with). This is the authoritative
+// source of truth for the publisher: the on-chain record can drift (it had been set
+// to the transaction payer), but the keypair the agent actually uses cannot.
+func (p *ProvisioningTest) ResolveMetricsPublisherPubkey(ctx context.Context, deviceCode string) (string, error) {
+	keypairPath := filepath.Join(p.infraPath, "ansible/inventory", p.env, "host_files", deviceCode, "metrics-publisher-keypair.json")
+
+	vaultPass := os.Getenv("ANSIBLE_VAULT_PASSWORD")
+	if vaultPass == "" {
+		return "", fmt.Errorf("ANSIBLE_VAULT_PASSWORD is not set; cannot decrypt %s", keypairPath)
+	}
+
+	vaultFile, err := os.CreateTemp("", "vault-pass")
+	if err != nil {
+		return "", fmt.Errorf("failed to create vault pass file: %w", err)
+	}
+	defer os.Remove(vaultFile.Name())
+	if _, err := vaultFile.WriteString(vaultPass); err != nil {
+		vaultFile.Close()
+		return "", fmt.Errorf("failed to write vault pass: %w", err)
+	}
+	vaultFile.Close()
+
+	cmd := exec.CommandContext(ctx, "ansible-vault", "view",
+		"--vault-password-file", vaultFile.Name(), keypairPath)
+	decrypted, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("ansible-vault view failed for %s: %w", keypairPath, err)
+	}
+
+	// Stage the decrypted keypair in a temp file (os.CreateTemp creates it 0600) for
+	// solana-go to read, then remove it. The secret never leaves the runner — only the
+	// derived public key is sent on-chain.
+	keypairFile, err := os.CreateTemp("", "metrics-publisher-keypair-*.json")
+	if err != nil {
+		return "", fmt.Errorf("failed to create keypair temp file: %w", err)
+	}
+	defer os.Remove(keypairFile.Name())
+	if _, err := keypairFile.Write(decrypted); err != nil {
+		keypairFile.Close()
+		return "", fmt.Errorf("failed to write decrypted keypair: %w", err)
+	}
+	keypairFile.Close()
+
+	privKey, err := solana.PrivateKeyFromSolanaKeygenFile(keypairFile.Name())
+	if err != nil {
+		return "", fmt.Errorf("failed to parse metrics-publisher keypair: %w", err)
+	}
+	return privKey.PublicKey().String(), nil
 }
 
 func (p *ProvisioningTest) GetLinksForDevice(ctx context.Context, deviceCode string) ([]*LinkInfo, error) {
@@ -324,6 +381,13 @@ func (p *ProvisioningTest) CreateDevice(ctx context.Context, cfg *DeviceSpec) (s
 
 	if cfg.DeviceType != "" {
 		args = append(args, "--device-type", strings.ToLower(cfg.DeviceType))
+	}
+
+	// Pin the metrics publisher to the device's telemetry-agent keypair. Without
+	// this flag the CLI defaults the publisher to the transaction payer, which
+	// leaves the telemetry agent unable to write samples to the ledger.
+	if cfg.MetricsPublisher != "" {
+		args = append(args, "--metrics-publisher", cfg.MetricsPublisher)
 	}
 
 	output, err := p.runCLI(ctx, args...)

--- a/e2e/qa_provisioning_test.go
+++ b/e2e/qa_provisioning_test.go
@@ -64,6 +64,15 @@ func TestQA_DeviceProvisioning(t *testing.T) {
 	deviceConfig, err := prov.GetDeviceSpec(ctx, device)
 	require.NoError(t, err, "failed to capture device config")
 
+	// Resolve the device's metrics-publisher pubkey from the infra inventory keypair
+	// (the key the telemetry agent signs samples with) and pin it on recreate. The CLI
+	// otherwise defaults the publisher to the transaction payer, which silently strips
+	// the agent's permission to write samples to the ledger on every daily recreate.
+	metricsPublisher, err := prov.ResolveMetricsPublisherPubkey(ctx, deviceCode)
+	require.NoError(t, err, "failed to resolve metrics-publisher pubkey for device %s", deviceCode)
+	deviceConfig.MetricsPublisher = metricsPublisher
+	t.Logf("Resolved metrics-publisher pubkey: %s", metricsPublisher)
+
 	links, err := prov.GetLinksForDevice(ctx, deviceCode)
 	require.NoError(t, err, "failed to get links for device")
 	t.Logf("Found %d links connected to device", len(links))
@@ -149,6 +158,8 @@ func TestQA_DeviceProvisioning(t *testing.T) {
 	device, err = prov.GetDeviceByCode(ctx, deviceCode)
 	require.NoError(t, err, "failed to get recreated device")
 	require.Equal(t, newPubkey, device.Pubkey, "device pubkey should match new pubkey")
+	require.Equal(t, metricsPublisher, device.MetricsPublisher,
+		"recreated device metrics_publisher must match the telemetry-agent keypair, not the payer")
 
 	t.Log("==> Provisioning complete!")
 	t.Logf("Old pubkey: %s", oldPubkey)

--- a/smartcontract/cli/src/device/create.rs
+++ b/smartcontract/cli/src/device/create.rs
@@ -44,7 +44,7 @@ pub struct CreateDeviceCliCommand {
     /// List of DZ prefixes in comma-separated CIDR format (e.g. 10.1.0.0/16,10.2.0.0/16)
     #[arg(long)]
     pub dz_prefixes: NetworkV4List,
-    /// Metrics publisher public key (optional, defaults to zeroed pubkey)
+    /// Metrics publisher public key (optional, defaults to the transaction payer)
     #[arg(long, value_parser = validate_pubkey)]
     pub metrics_publisher: Option<String>,
     /// Management VRF name (optional)


### PR DESCRIPTION
## Summary of Changes
* The devnet QA provisioning test (`TestQA_DeviceProvisioning`) recreates the `chi-dn-dzd4` device record from scratch every day. It called `doublezero device create` **without** `--metrics-publisher`, and the CLI defaults an absent publisher to the transaction payer (`client.get_payer()`, the `DZ…Yan` admin/funder pubkey). The recreated on-chain `metrics_publisher_pk` therefore no longer matched the device's telemetry-agent keypair (`/mnt/flash/metrics-publisher-keypair.json`), so the agent lost permission to write samples to the ledger.
* This change resolves the device's real metrics-publisher pubkey from the ansible-vault-encrypted keypair shipped by infra (`ansible/inventory/devnet/host_files/chi-dn-dzd4/metrics-publisher-keypair.json`) — the authoritative source of truth, since the on-chain value had drifted — and passes it to `device create --metrics-publisher`. It then asserts the recreated record carries the correct value, so a regression is caught immediately instead of surfacing as a telemetry-permission failure the next day.
* `ResolveMetricsPublisherPubkey` decrypts the keypair with `ansible-vault view` (using `ANSIBLE_VAULT_PASSWORD`, already provided to the test step), derives the pubkey via `solana-go`, and never lets the secret leave the runner (temp file at `0600`, removed via `defer`; only the public key is sent on-chain).
* Also corrects the stale `--metrics-publisher` doc comment in the CLI — it defaults to the transaction payer, not a zeroed pubkey (this stale comment was the source of the original confusion).
* Addresses malbeclabs/infra#1702. Once merged to `main`, the next scheduled `qa.provisioning.devnet` run recreates the record with the correct publisher and keeps it correct on every subsequent run.

## Testing Verification
* Go and the Solana toolchain are not available in this environment, so I could not run `go build -tags=qa` / `go vet` or `cargo` here. The change was verified by inspection:
  * The new code reuses patterns already proven in this repo: `solana.PrivateKeyFromSolanaKeygenFile` (used in `e2e/internal/devnet/funder.go`) and the vault-password temp-file handling (mirrors `RunAnsibleAgentRestart` in the same file).
  * `github.com/gagliardetto/solana-go` is already a direct dependency (`go.mod`), and `MetricsPublisherPubKey` is an existing field on the serviceability device struct.
  * Struct and composite-literal field alignment was hand-formatted to match gofmt output (gofmt was unavailable).
  * The Rust change is a one-line doc-comment correction with no behavioral effect.
* End-to-end verification happens in the scheduled `qa.provisioning.devnet` run: the new in-test assertion confirms the recreated device's `MetricsPublisherPubKey` equals the resolved keypair pubkey, and the device continues reporting telemetry after each daily recreate.
* Architecture and security reviews were run; no Critical/High findings. The top finding (redundant decrypt-to-temp-file handling) was streamlined.

Fixes malbeclabs/infra#1702