### PR TITLE
cli: allow removing multicast roles in user subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - `doublezero user subscribe` can now remove multicast roles: `--publisher`/`--subscriber` accept an explicit value (`--publisher false` / `--subscriber false`) to drop a role, an omitted flag preserves the user's current role for the group, and the command errors when neither flag is given. Bare `--publisher`/`--subscriber` still mean `true`. (#3914)
 - Client
   - Add a `--no-wait` flag to `doublezero disconnect` that skips waiting for the daemon to tear down the tunnel(s), exiting once the onchain user deletion is confirmed. (#3911)
 - CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- CLI
-  - `doublezero user subscribe` can now remove multicast roles: `--publisher`/`--subscriber` accept an explicit value (`--publisher false` / `--subscriber false`) to drop a role, an omitted flag preserves the user's current role for the group, and the command errors when neither flag is given. Bare `--publisher`/`--subscriber` still mean `true`. (#3914)
 - Client
   - Add a `--no-wait` flag to `doublezero disconnect` that skips waiting for the daemon to tear down the tunnel(s), exiting once the onchain user deletion is confirmed. (#3911)
 - CLI
+  - `doublezero user subscribe` can now remove multicast roles: `--publisher`/`--subscriber` accept an explicit value (`--publisher false` / `--subscriber false`) to drop a role, an omitted flag preserves the user's current role for the group, and the command errors when neither flag is given. Bare `--publisher`/`--subscriber` still mean `true`. (#3914)
   - Add hidden `migrate flex-algo` (RFC-18 link-topology and Vpnv4 loopback FlexAlgoNodeSegment backfill); the prior `migrate` command is now `migrate user-pda`. Moved from `doublezero-admin`.
   - Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber, publisher, and unicast-user counts. Moved from `doublezero-admin`.
   - Add hidden `sentinel find-validator-multicast-publishers` and `sentinel create-validator-multicast-publishers` commands. Moved from `doublezero-admin`.

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -704,7 +704,7 @@ impl ProvisioningCliCommand {
 
                 // Subscribe to remaining groups
                 for group_pk in all_group_pks.iter().skip(1) {
-                    spinner.println(format!("    Subscribing to group: {group_pk}"));
+                    spinner.set_message(format!("Subscribing to group: {group_pk}"));
                     client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                         user_pk,
                         group_pk: *group_pk,
@@ -726,9 +726,8 @@ impl ProvisioningCliCommand {
                 // Subscribe to any pub groups not already subscribed
                 for group_pk in pub_group_pks {
                     if !user.publishers.contains(group_pk) {
-                        spinner.println(format!(
-                            "    Adding publisher subscription to existing Multicast user: {}",
-                            user_pk
+                        spinner.set_message(format!(
+                            "Adding publisher subscription to existing Multicast user: {user_pk}"
                         ));
 
                         let res =
@@ -756,9 +755,8 @@ impl ProvisioningCliCommand {
                 // Subscribe to any sub groups not already subscribed
                 for group_pk in sub_group_pks {
                     if !user.subscribers.contains(group_pk) {
-                        spinner.println(format!(
-                            "    Adding subscriber subscription to existing Multicast user: {}",
-                            user_pk
+                        spinner.set_message(format!(
+                            "Adding subscriber subscription to existing Multicast user: {user_pk}"
                         ));
 
                         let res =
@@ -842,7 +840,7 @@ impl ProvisioningCliCommand {
 
                 // Subscribe to remaining groups
                 for group_pk in all_group_pks.iter().skip(1) {
-                    spinner.println(format!("    Subscribing to group: {group_pk}"));
+                    spinner.set_message(format!("Subscribing to group: {group_pk}"));
                     client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                         user_pk,
                         group_pk: *group_pk,

--- a/smartcontract/cli/src/requirements.rs
+++ b/smartcontract/cli/src/requirements.rs
@@ -86,12 +86,16 @@ pub fn check_accesspass(
     client_ip: Ipv4Addr,
     enforce_epoch: bool,
 ) -> eyre::Result<bool> {
-    let (_, accesspass) = client
-        .get_accesspass(GetAccessPassCommand {
-            client_ip,
-            user_payer: client.get_payer(),
-        })?
-        .ok_or_else(|| eyre::eyre!("Access Pass not found"))?;
+    // A missing AccessPass returns Ok(false) (not an error) so the caller can
+    // render its own diagnostic (e.g. the client IP and UserPayer) before
+    // bailing, rather than surfacing a generic "not found" message.
+    let Some((_, accesspass)) = client.get_accesspass(GetAccessPassCommand {
+        client_ip,
+        user_payer: client.get_payer(),
+    })?
+    else {
+        return Ok(false);
+    };
 
     if !enforce_epoch {
         return Ok(true);

--- a/smartcontract/cli/src/user/subscribe.rs
+++ b/smartcontract/cli/src/user/subscribe.rs
@@ -43,7 +43,11 @@ impl SubscribeUserCliCommand {
         // Check requirements
         client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
 
-        // Require at least one role flag so we never issue a silent no-op.
+        // Require at least one role flag so we never issue a silent no-op. Note
+        // this only rejects the both-omitted case: re-asserting a role the user
+        // already holds (e.g. `--publisher true` on a current publisher) still
+        // issues a transaction the processor treats as a no-op, which costs a
+        // signature/credits.
         if self.publisher.is_none() && self.subscriber.is_none() {
             eyre::bail!(
                 "Specify at least one of --publisher[=true|false] or --subscriber[=true|false]"
@@ -72,8 +76,15 @@ impl SubscribeUserCliCommand {
         }
 
         // Update roles for each group. An omitted flag preserves the user's
-        // current role for that group; the processor toggles add/remove based on
-        // the resolved boolean values.
+        // current role for that group; the processor sets absolute state
+        // (idempotent add when true, idempotent remove when false), not a
+        // relative toggle.
+        //
+        // Preserving an already-held role re-asserts it as `true`, which the
+        // processor re-checks against the current onchain allowlist before the
+        // idempotent add/remove. If that allowlist drifted since the user
+        // subscribed, an unrelated role removal can be rejected with NotAllowed.
+        // This is an inherited processor property, not a regression here.
         for group_pk in &group_pks {
             let publisher = self
                 .publisher
@@ -442,6 +453,110 @@ mod tests {
             .execute(&ctx, &client, &mut output),
         );
         assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            format!("Updated roles for {mgroup_pubkey}: {signature}\n")
+        );
+    }
+
+    #[test]
+    fn test_cli_user_unsubscribe_subscriber_preserves_publisher() {
+        let mut client = create_test_client();
+
+        let (user_pubkey, _bump_seed) = get_user_old_pda(&client.get_program_id(), 1);
+        let signature = Signature::new_unique();
+        let client_ip = [192, 168, 1, 100].into();
+
+        let mgroup_pubkey = Pubkey::from_str_const("11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo");
+
+        // User is currently both a publisher and subscriber of the group.
+        let user = User {
+            account_type: AccountType::User,
+            index: 1,
+            bump_seed: 255,
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            device_pk: Pubkey::new_unique(),
+            owner: client.get_payer(),
+            tenant_pk: Pubkey::default(),
+            client_ip,
+            dz_ip: client_ip,
+            tunnel_id: 12345,
+            tunnel_net: "192.168.1.0/24".parse().unwrap(),
+            status: doublezero_sdk::UserStatus::Activated,
+            publishers: vec![mgroup_pubkey],
+            subscribers: vec![mgroup_pubkey],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+            bgp_rtt_ns: 0,
+        };
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 255,
+            tenant_pk: Pubkey::new_unique(),
+            multicast_ip: [239, 1, 1, 1].into(),
+            max_bandwidth: 1000,
+            status: MulticastGroupStatus::Activated,
+            code: "test".to_string(),
+            owner: mgroup_pubkey,
+            publisher_count: 1,
+            subscriber_count: 1,
+        };
+
+        client
+            .expect_get_user()
+            .with(predicate::eq(GetUserCommand {
+                pubkey: user_pubkey,
+            }))
+            .returning(move |_| Ok((user_pubkey, user.clone())));
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+            }))
+            .returning(move |_| Ok((mgroup_pubkey, mgroup.clone())));
+        // Removing only the subscriber role must preserve the existing publisher role.
+        client
+            .expect_update_multicastgroup_roles()
+            .with(predicate::eq(UpdateMulticastGroupRolesCommand {
+                user_pk: user_pubkey,
+                group_pk: mgroup_pubkey,
+                client_ip,
+                publisher: true,
+                subscriber: false,
+            }))
+            .times(1)
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            SubscribeUserCliCommand {
+                user: user_pubkey.to_string(),
+                groups: vec![mgroup_pubkey.to_string()],
+                publisher: None,
+                subscriber: Some(false),
+                wait: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output_str,
+            format!("Updated roles for {mgroup_pubkey}: {signature}\n")
+        );
     }
 
     #[test]
@@ -468,6 +583,78 @@ mod tests {
             }
             .execute(&ctx, &client, &mut output),
         );
-        assert!(res.is_err());
+        let err = res.unwrap_err().to_string();
+        assert!(
+            err.contains("Specify at least one of --publisher"),
+            "expected role-flag guidance, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_cli_user_subscribe_parses_role_flags() {
+        use clap::Parser;
+
+        #[derive(Parser, Debug)]
+        struct TestCli {
+            #[command(subcommand)]
+            command: TestCommand,
+        }
+
+        #[derive(clap::Subcommand, Debug)]
+        enum TestCommand {
+            Subscribe(SubscribeUserCliCommand),
+        }
+
+        let user_pk = Pubkey::new_unique().to_string();
+        let g1 = Pubkey::new_unique().to_string();
+        let g2 = Pubkey::new_unique().to_string();
+
+        let parse = |args: Vec<&str>| -> SubscribeUserCliCommand {
+            let TestCli {
+                command: TestCommand::Subscribe(cmd),
+            } = TestCli::try_parse_from(args).expect("parse should succeed");
+            cmd
+        };
+
+        // Bare `--publisher` means true.
+        let cmd = parse(vec![
+            "test",
+            "subscribe",
+            "--user",
+            &user_pk,
+            "--group",
+            &g1,
+            "--publisher",
+        ]);
+        assert_eq!(cmd.publisher, Some(true));
+        assert_eq!(cmd.subscriber, None);
+
+        // Explicit `--publisher false` means false.
+        let cmd = parse(vec![
+            "test",
+            "subscribe",
+            "--user",
+            &user_pk,
+            "--group",
+            &g1,
+            "--publisher",
+            "false",
+        ]);
+        assert_eq!(cmd.publisher, Some(false));
+
+        // Variadic `--group g1 g2` followed by a bare `--publisher` parses
+        // unambiguously: both groups land in `groups`, not as publisher's value.
+        let cmd = parse(vec![
+            "test",
+            "subscribe",
+            "--user",
+            &user_pk,
+            "--group",
+            &g1,
+            &g2,
+            "--publisher",
+        ]);
+        assert_eq!(cmd.groups, vec![g1, g2]);
+        assert_eq!(cmd.publisher, Some(true));
     }
 }

--- a/smartcontract/cli/src/user/subscribe.rs
+++ b/smartcontract/cli/src/user/subscribe.rs
@@ -17,15 +17,17 @@ pub struct SubscribeUserCliCommand {
     /// User Pubkey to subscribe
     #[arg(long, value_parser = validate_pubkey)]
     pub user: String,
-    /// Multicast group Pubkey or code to subscribe to (can be specified multiple times)
+    /// Multicast group Pubkey or code to update (can be specified multiple times)
     #[arg(long = "group", value_parser = validate_pubkey_or_code, num_args = 1..)]
     pub groups: Vec<String>,
-    /// Subscribe as a publisher
-    #[arg(long)]
-    pub publisher: bool,
-    /// Subscribe as a subscriber
-    #[arg(long)]
-    pub subscriber: bool,
+    /// Add (`--publisher` or `--publisher true`) or remove (`--publisher false`) the
+    /// publisher role. When omitted, the current publisher role is left unchanged.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub publisher: Option<bool>,
+    /// Add (`--subscriber` or `--subscriber true`) or remove (`--subscriber false`) the
+    /// subscriber role. When omitted, the current subscriber role is left unchanged.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub subscriber: Option<bool>,
     /// Wait for the subscription to complete.
     #[arg(short, long, default_value_t = false)]
     pub wait: bool,
@@ -40,6 +42,13 @@ impl SubscribeUserCliCommand {
     ) -> eyre::Result<()> {
         // Check requirements
         client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+        // Require at least one role flag so we never issue a silent no-op.
+        if self.publisher.is_none() && self.subscriber.is_none() {
+            eyre::bail!(
+                "Specify at least one of --publisher[=true|false] or --subscriber[=true|false]"
+            );
+        }
 
         let (user_pk, user) = client.get_user(GetUserCommand {
             pubkey: parse_pubkey(&self.user).ok_or_else(|| eyre::eyre!("Invalid user pubkey"))?,
@@ -62,17 +71,25 @@ impl SubscribeUserCliCommand {
             group_pks.push(group_pk);
         }
 
-        // Subscribe to each group
+        // Update roles for each group. An omitted flag preserves the user's
+        // current role for that group; the processor toggles add/remove based on
+        // the resolved boolean values.
         for group_pk in &group_pks {
+            let publisher = self
+                .publisher
+                .unwrap_or_else(|| user.publishers.contains(group_pk));
+            let subscriber = self
+                .subscriber
+                .unwrap_or_else(|| user.subscribers.contains(group_pk));
             let signature =
                 client.update_multicastgroup_roles(UpdateMulticastGroupRolesCommand {
                     user_pk,
                     group_pk: *group_pk,
                     client_ip: user.client_ip,
-                    publisher: self.publisher,
-                    subscriber: self.subscriber,
+                    publisher,
+                    subscriber,
                 })?;
-            writeln!(out, "Subscribed to {group_pk}: {signature}")?;
+            writeln!(out, "Updated roles for {group_pk}: {signature}")?;
         }
 
         if self.wait {
@@ -201,8 +218,8 @@ mod tests {
             SubscribeUserCliCommand {
                 user: user_pubkey.to_string(),
                 groups: vec![mgroup_pubkey.to_string()],
-                publisher: false,
-                subscriber: true,
+                publisher: Some(false),
+                subscriber: Some(true),
                 wait: false,
             }
             .execute(&ctx, &client, &mut output),
@@ -212,7 +229,7 @@ mod tests {
         let sig_str = signature.to_string();
         assert_eq!(
             output_str,
-            format!("Subscribed to {mgroup_pubkey}: {sig_str}\n")
+            format!("Updated roles for {mgroup_pubkey}: {sig_str}\n")
         );
     }
 
@@ -318,8 +335,8 @@ mod tests {
             SubscribeUserCliCommand {
                 user: user_pubkey.to_string(),
                 groups: vec![mgroup_pubkey1.to_string(), mgroup_pubkey2.to_string()],
-                publisher: false,
-                subscriber: true,
+                publisher: Some(false),
+                subscriber: Some(true),
                 wait: false,
             }
             .execute(&ctx, &client, &mut output),
@@ -329,7 +346,128 @@ mod tests {
         let sig_str = signature.to_string();
         assert_eq!(
             output_str,
-            format!("Subscribed to {mgroup_pubkey1}: {sig_str}\nSubscribed to {mgroup_pubkey2}: {sig_str}\n")
+            format!("Updated roles for {mgroup_pubkey1}: {sig_str}\nUpdated roles for {mgroup_pubkey2}: {sig_str}\n")
         );
+    }
+
+    #[test]
+    fn test_cli_user_unsubscribe_publisher_preserves_subscriber() {
+        let mut client = create_test_client();
+
+        let (user_pubkey, _bump_seed) = get_user_old_pda(&client.get_program_id(), 1);
+        let signature = Signature::new_unique();
+        let client_ip = [192, 168, 1, 100].into();
+
+        let mgroup_pubkey = Pubkey::from_str_const("11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo");
+
+        // User is currently both a publisher and subscriber of the group.
+        let user = User {
+            account_type: AccountType::User,
+            index: 1,
+            bump_seed: 255,
+            user_type: UserType::Multicast,
+            cyoa_type: UserCYOA::GREOverDIA,
+            device_pk: Pubkey::new_unique(),
+            owner: client.get_payer(),
+            tenant_pk: Pubkey::default(),
+            client_ip,
+            dz_ip: client_ip,
+            tunnel_id: 12345,
+            tunnel_net: "192.168.1.0/24".parse().unwrap(),
+            status: doublezero_sdk::UserStatus::Activated,
+            publishers: vec![mgroup_pubkey],
+            subscribers: vec![mgroup_pubkey],
+            validator_pubkey: Pubkey::default(),
+            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
+            tunnel_flags: 0,
+            bgp_status: Default::default(),
+            last_bgp_up_at: 0,
+            last_bgp_reported_at: 0,
+            bgp_rtt_ns: 0,
+        };
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 255,
+            tenant_pk: Pubkey::new_unique(),
+            multicast_ip: [239, 1, 1, 1].into(),
+            max_bandwidth: 1000,
+            status: MulticastGroupStatus::Activated,
+            code: "test".to_string(),
+            owner: mgroup_pubkey,
+            publisher_count: 1,
+            subscriber_count: 1,
+        };
+
+        client
+            .expect_get_user()
+            .with(predicate::eq(GetUserCommand {
+                pubkey: user_pubkey,
+            }))
+            .returning(move |_| Ok((user_pubkey, user.clone())));
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+            }))
+            .returning(move |_| Ok((mgroup_pubkey, mgroup.clone())));
+        // Removing only the publisher role must preserve the existing subscriber role.
+        client
+            .expect_update_multicastgroup_roles()
+            .with(predicate::eq(UpdateMulticastGroupRolesCommand {
+                user_pk: user_pubkey,
+                group_pk: mgroup_pubkey,
+                client_ip,
+                publisher: false,
+                subscriber: true,
+            }))
+            .times(1)
+            .returning(move |_| Ok(signature));
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            SubscribeUserCliCommand {
+                user: user_pubkey.to_string(),
+                groups: vec![mgroup_pubkey.to_string()],
+                publisher: Some(false),
+                subscriber: None,
+                wait: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_cli_user_subscribe_requires_role_flag() {
+        let mut client = create_test_client();
+
+        let (user_pubkey, _bump_seed) = get_user_old_pda(&client.get_program_id(), 1);
+        let mgroup_pubkey = Pubkey::from_str_const("11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo");
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            SubscribeUserCliCommand {
+                user: user_pubkey.to_string(),
+                groups: vec![mgroup_pubkey.to_string()],
+                publisher: None,
+                subscriber: None,
+                wait: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
## Summary of Changes

- `doublezero user subscribe` now updates multicast roles rather than only adding them. `--publisher`/`--subscriber` accept an explicit value: `--publisher false` drops the role, `--publisher` (or `--publisher true`) adds it, and an omitted flag preserves the user's current role for each group.
- The command now errors when neither `--publisher` nor `--subscriber` is given, so it never issues a silent no-op.
- Output wording changed from `Subscribed to <group>` to `Updated roles for <group>` to reflect add/remove semantics.
- `check_accesspass` returns `Ok(false)` when the access pass is missing instead of bailing with a generic "not found" error, letting the caller render its own diagnostic (client IP and UserPayer).
- `doublezero connect` uses spinner messages instead of printing separate lines while subscribing to groups.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +46 / -23   | +23  |
| Tests        |     1 | +125 / -8   | +117 |
| Scaffolding  |     1 | +6 / -8     |  -2  |
| Docs         |     1 | +2 / -0     |  +2  |
| **Total**    |     4 | +173 / -31  | +142 |

Small core-logic change to subscribe semantics, the bulk of additions are new unit tests covering role removal and the required-flag guard.

<details>
<summary>Key files (click to expand)</summary>

- [`smartcontract/cli/src/user/subscribe.rs`](https://github.com/malbeclabs/doublezero/pull/3914/files#diff-f8997355cd0816a877dee1f853d9ce6c2e83ab2ef2855e182d23c62c3a74b389) — `--publisher`/`--subscriber` become `Option<bool>` with `num_args = 0..=1`; resolve each role per-group (omitted = preserve current), require at least one flag, plus tests for role-removal and the required-flag guard
- [`smartcontract/cli/src/requirements.rs`](https://github.com/malbeclabs/doublezero/pull/3914/files#diff-adf9694947d4dda73eb79d7bf1e3991116b8dccfc00a1b0c6425bd2f28ef5b6e) — `check_accesspass` returns `Ok(false)` on a missing access pass instead of erroring
- [`client/doublezero/src/command/connect.rs`](https://github.com/malbeclabs/doublezero/pull/3914/files#diff-0e50f0119aa96b168465129d4b6f763c1125ae34defc1d682d9858bf9aac8184) — use `spinner.set_message` instead of `spinner.println` during group subscription

</details>

## Testing Verification
- Added unit tests: removing only the publisher role preserves the existing subscriber role (`test_cli_user_unsubscribe_publisher_preserves_subscriber`), and the command errors when neither role flag is supplied (`test_cli_user_subscribe_requires_role_flag`).
- Updated existing subscribe tests for the new `Option<bool>` flags and `Updated roles for ...` output.