### PR TITLE
ci: trigger devnet client image off the scheduled nightly umbrella

### DIFF
--- a/.github/workflows/release.docker.client.devnet.yml
+++ b/.github/workflows/release.docker.client.devnet.yml
@@ -1,11 +1,14 @@
 name: release.docker.client.devnet
 
 # Builds and publishes the PRIVATE devnet client image
-# (ghcr.io/<owner>/doublezero-devnet) after the nightly devnet client deb is
-# published. Triggered manually or chained off the nightly devnet client release.
+# (ghcr.io/<owner>/doublezero-devnet) after the nightly devnet release. Chained
+# off release.devnet.all.daily, the scheduled umbrella that publishes the devnet
+# client deb (via the reusable release.daily.yml). It must watch that top-level
+# workflow, not release.devnet.client.daily: workflow_run never fires for
+# reusable/called workflows, and release.devnet.client.daily is manual-only.
 on:
   workflow_run:
-    workflows: ["release.devnet.client.daily"]
+    workflows: ["release.devnet.all.daily"]
     types: [completed]
   workflow_dispatch:
 
@@ -19,7 +22,12 @@ env:
 
 jobs:
   publish:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # Build on the nightly's completion regardless of its overall conclusion: the
+    # client deb is published by an early matrix leg, so an unrelated later
+    # failure (e.g. qa) must not skip the image. The version is resolved from the
+    # devnet Cloudsmith repo, so a no-op/early run just rebuilds the latest. Skip
+    # only cancelled runs.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'cancelled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix the devnet client image so it actually rebuilds on the nightly. It was watching `release.devnet.client.daily` (manual-only, dormant since March); re-point it to **`release.devnet.all.daily`**, the scheduled umbrella (weekdays 14:00 UTC) that publishes the devnet client deb.
- This is required because the nightly publishes the client via the **reusable** `release.daily.yml`, and `workflow_run` never fires for reusable/called workflows — only the top-level umbrella emits the event.
- Relax the job gate to build on the nightly's completion regardless of overall conclusion (skipping only cancelled runs), so an unrelated later failure (e.g. qa) doesn't skip the image — the client deb is published by an early matrix leg, and the version is resolved from the devnet Cloudsmith repo anyway.

## Background
Follow-up to #3880. The devnet image had never auto-built: its trigger pointed at a workflow that isn't the one running nightly. testnet (off `releaser.client`) and mainnet-beta (manual dispatch) are wired correctly and unaffected.

## Testing Verification
- `release.docker.client.devnet.yml` parses as valid YAML.
- Confirmed `release.devnet.all.daily` is the scheduled (cron `0 14 * * 1-5`) top-level workflow and publishes `component: client` via the reusable `release.daily.yml`; `release.devnet.client.daily` is `workflow_dispatch`-only and last ran 2026-03-13.
- The manual `workflow_dispatch` path on this workflow already produced a working devnet image earlier, so only the trigger wiring changed.
