### PR TITLE
ci(e2e): skip privileged auto-run on dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,6 +126,17 @@ jobs:
             echo "::notice::Skipping e2e: docs/version-bump-only PR."
             exit 0
           fi
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping privileged e2e on a Dependabot PR (read-only token, no secrets). A maintainer can comment /run-e2e to start a trusted run."
+            {
+              echo "### Privileged e2e skipped"
+              echo
+              echo "Dependabot PRs run with a read-only token and no secrets, so privileged e2e cannot run on the \`pull_request\` event."
+              echo "A maintainer can comment \`/run-e2e\` to dispatch trusted e2e for this PR head SHA."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             echo "run-e2e=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping privileged e2e on an external fork PR. A maintainer can comment /run-e2e to start a trusted run."


### PR DESCRIPTION
## Summary

Dependabot PRs run with a read-only token and no secrets (GitHub's supply-chain safeguard), so the privileged `pull_request` e2e run fails and leaves a **sticky failing `e2e (shard N)` required check** that `/run-e2e` cannot override (the dispatched run satisfies `shard-e2e`, not `e2e`). This has blocked **every** dependabot PR from merging since `e2e` became a required check (~Dec 2025) — dependency updates have since had to be recreated by hand.

This extends the existing gate to treat dependabot like an external fork: skip the privileged auto-run, and let a maintainer comment `/run-e2e` to dispatch a trusted run after reviewing the diff — the same flow that already works for fork PRs (e.g. #3654).

The new condition mirrors the external-fork branch directly below it; no behavior change for human or fork PRs.

## Testing Verification

- Once merged, a dependabot PR's auto e2e will skip with the "Privileged e2e skipped" notice instead of failing, so `/run-e2e` becomes the sole provider of the required `e2e (shard N)` contexts — making dependabot PRs mergeable via the trusted-dispatch path for the first time since the requirement landed.
- Keying on `github.event.pull_request.user.login == 'dependabot[bot]'` (the PR author) rather than `github.actor`, so a maintainer re-running the workflow doesn't flip the gate.
