### PR TITLE
e2e: route all devnet networks through collision-safe subnet allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
   - Skip rendering device config when a string field would not survive as a single config token (contains control or whitespace characters).
 - Device agents
   - Reduce agent CPU usage by continuing to fetch the full config every 5 seconds but only applying when it has changed or after 60s timeout
+- E2E tests
+  - Route all devnet networks (CYOA, default, and miscellaneous) through a shared collision-safe subnet allocator to prevent overlapping subnet assignments across concurrent test runs. (#3919)
 
 ## [v0.27.1](https://github.com/malbeclabs/doublezero/compare/client/v0.27.0...client/v0.27.1) - 2026-06-10
 

--- a/e2e/internal/devnet/devnet.go
+++ b/e2e/internal/devnet/devnet.go
@@ -50,13 +50,22 @@ const (
 	defaultNetworkSubnetMask = 24
 
 	// linkNetworkBaseCIDR is the address range the devnet's inter-device link (misc) networks are
-	// allocated from. It is deliberately disjoint from the CYOA range (9.128.0.0/9) — and the
-	// onchain dz_prefixes derived from it, which are not visible to the docker-network scan — as
-	// well as from the default network (10.0.0.0/8) and the device tunnel net (172.16.0.0/16), so a
-	// link subnet can never silently overlap a routed prefix.
+	// allocated from. It must stay disjoint from every other range in play so a link subnet can
+	// never silently overlap a routed prefix:
+	//   - the CYOA range (9.128.0.0/9), including the onchain dz_prefixes, which are derived from
+	//     CYOA public IPs in 9.x and so fall inside it; these prefixes are invisible to the
+	//     docker-network scan, so only range separation keeps a link subnet off them;
+	//   - the default network range (10.0.0.0/8);
+	//   - the device tunnel net (defaultDeviceTunnelNet, 172.16.0.0/16).
+	// TestNetworkRangesAreDisjoint enforces this invariant against the constants below.
 	linkNetworkBaseCIDR = "11.0.0.0/8"
 	// linkNetworkSubnetMask is the prefix length for each link network subnet (a /24).
 	linkNetworkSubnetMask = 24
+
+	// defaultDeviceTunnelNet is the onchain device-tunnel block used when DevnetSpec.DeviceTunnelNet
+	// is left unset. It is one of the ranges the CYOA/default/link allocators must avoid; see
+	// TestNetworkRangesAreDisjoint.
+	defaultDeviceTunnelNet = "172.16.0.0/16"
 )
 
 var (
@@ -190,7 +199,7 @@ func (s *DevnetSpec) Validate() error {
 	}
 
 	if s.DeviceTunnelNet == "" {
-		s.DeviceTunnelNet = "172.16.0.0/16"
+		s.DeviceTunnelNet = defaultDeviceTunnelNet
 	}
 	return nil
 }

--- a/e2e/internal/devnet/devnet.go
+++ b/e2e/internal/devnet/devnet.go
@@ -41,6 +41,22 @@ const (
 
 	containerDoublezeroKeypairPath = "/root/.config/doublezero/id.json"
 	containerSolanaKeypairPath     = "/root/.config/solana/id.json"
+
+	// defaultNetworkBaseCIDR is the address range the devnet's default network is allocated from.
+	// It is kept separate from the CYOA network range (9.128.0.0/9) so tests that detect interfaces
+	// by IP range do not confuse the two.
+	defaultNetworkBaseCIDR = "10.0.0.0/8"
+	// defaultNetworkSubnetMask is the prefix length for each default network subnet (a /24).
+	defaultNetworkSubnetMask = 24
+
+	// linkNetworkBaseCIDR is the address range the devnet's inter-device link (misc) networks are
+	// allocated from. It is deliberately disjoint from the CYOA range (9.128.0.0/9) — and the
+	// onchain dz_prefixes derived from it, which are not visible to the docker-network scan — as
+	// well as from the default network (10.0.0.0/8) and the device tunnel net (172.16.0.0/16), so a
+	// link subnet can never silently overlap a routed prefix.
+	linkNetworkBaseCIDR = "11.0.0.0/8"
+	// linkNetworkSubnetMask is the prefix length for each link network subnet (a /24).
+	linkNetworkSubnetMask = 24
 )
 
 var (
@@ -81,13 +97,15 @@ type DevnetSpec struct {
 type Devnet struct {
 	Spec DevnetSpec
 
-	log               *slog.Logger
-	workspaceDir      string
-	subnetAllocator   *docker.SubnetAllocator
-	dockerClient      *client.Client
-	labels            map[string]string
-	mu                sync.RWMutex
-	onchainWriteMutex sync.Mutex
+	log                     *slog.Logger
+	workspaceDir            string
+	subnetAllocator         *docker.SubnetAllocator
+	defaultNetworkAllocator *docker.SubnetAllocator
+	linkNetworkAllocator    *docker.SubnetAllocator
+	dockerClient            *client.Client
+	labels                  map[string]string
+	mu                      sync.RWMutex
+	onchainWriteMutex       sync.Mutex
 
 	ExternalHost string
 
@@ -290,7 +308,13 @@ func New(spec DevnetSpec, log *slog.Logger, dockerClient *client.Client, subnetA
 		workspaceDir:    workspaceDir,
 		dockerClient:    dockerClient,
 		subnetAllocator: subnetAllocator,
-		labels:          labels,
+		// The default and link networks use dedicated allocators over ranges disjoint from the CYOA
+		// network (9.128.0.0/9) and each other, so collision-safe allocation (which skips subnets
+		// already in use by docker networks) never hands out a CIDR that overlaps another network's
+		// range or an onchain prefix.
+		defaultNetworkAllocator: docker.NewSubnetAllocator(defaultNetworkBaseCIDR, defaultNetworkSubnetMask, dockerClient),
+		linkNetworkAllocator:    docker.NewSubnetAllocator(linkNetworkBaseCIDR, linkNetworkSubnetMask, dockerClient),
+		labels:                  labels,
 
 		Spec: spec,
 	}

--- a/e2e/internal/devnet/network.go
+++ b/e2e/internal/devnet/network.go
@@ -1,0 +1,62 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// poolOverlapMaxRetries bounds how many times createNetworkWithSubnet re-allocates a subnet
+// after a Docker "pool overlaps" error before giving up.
+const poolOverlapMaxRetries = 5
+
+// subnetFinder allocates a collision-safe subnet for a given ID, skipping subnets already in use
+// by existing docker networks. *docker.SubnetAllocator implements it.
+type subnetFinder interface {
+	FindAvailableSubnet(ctx context.Context, testID string) (string, error)
+}
+
+// isPoolOverlapErr reports whether err is the Docker daemon's address-pool collision error,
+// raised when a network is created with a subnet that overlaps an existing one.
+func isPoolOverlapErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Pool overlaps") || strings.Contains(msg, "invalid pool request")
+}
+
+// createNetworkWithSubnet allocates a collision-safe subnet from alloc (which skips subnets
+// already in use by existing docker networks) and invokes create with it. On a Docker
+// pool-overlap error — a TOCTOU race where a concurrent process grabbed the CIDR between
+// allocation and creation — it re-allocates and retries, since the newly conflicting network
+// now shows up in the allocator's docker scan and a different subnet is chosen. It returns the
+// subnet that was successfully used.
+func createNetworkWithSubnet(ctx context.Context, alloc subnetFinder, allocID string, create func(subnetCIDR string) error) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < poolOverlapMaxRetries; attempt++ {
+		// FindAvailableSubnet is deterministic on its ID (it hashes ID+salt and only skips subnets
+		// it can see in `docker network ls`). On a retry we must hand it a different ID so it picks
+		// a genuinely different subnet; otherwise, when the overlap source is invisible to the docker
+		// scan (e.g. the daemon's default address pool, or a network created without an explicit IPAM
+		// subnet), every attempt would re-derive the same colliding CIDR and the retry would be a
+		// no-op. Attempt 0 uses the bare ID so the common case stays stable per deploy.
+		allocSeed := allocID
+		if attempt > 0 {
+			allocSeed = fmt.Sprintf("%s#%d", allocID, attempt)
+		}
+		subnetCIDR, err := alloc.FindAvailableSubnet(ctx, allocSeed)
+		if err != nil {
+			return "", fmt.Errorf("failed to get available subnet: %w", err)
+		}
+		if err := create(subnetCIDR); err != nil {
+			if isPoolOverlapErr(err) {
+				lastErr = err
+				continue
+			}
+			return "", err
+		}
+		return subnetCIDR, nil
+	}
+	return "", fmt.Errorf("failed to create network after %d attempts due to subnet pool overlap: %w", poolOverlapMaxRetries, lastErr)
+}

--- a/e2e/internal/devnet/network.go
+++ b/e2e/internal/devnet/network.go
@@ -7,7 +7,11 @@ import (
 )
 
 // poolOverlapMaxRetries bounds how many times createNetworkWithSubnet re-allocates a subnet
-// after a Docker "pool overlaps" error before giving up.
+// after a Docker "pool overlaps" error before giving up. Each re-seed yields one fresh candidate;
+// for docker-visible conflicts the allocator additionally skips up to docker.defaultRetries salted
+// candidates within a single call, so the search widens further in that case. For the
+// docker-invisible case the retry exists to handle, the effective search is ~poolOverlapMaxRetries
+// distinct candidates.
 const poolOverlapMaxRetries = 5
 
 // subnetFinder allocates a collision-safe subnet for a given ID, skipping subnets already in use
@@ -36,11 +40,15 @@ func createNetworkWithSubnet(ctx context.Context, alloc subnetFinder, allocID st
 	var lastErr error
 	for attempt := 0; attempt < poolOverlapMaxRetries; attempt++ {
 		// FindAvailableSubnet is deterministic on its ID (it hashes ID+salt and only skips subnets
-		// it can see in `docker network ls`). On a retry we must hand it a different ID so it picks
-		// a genuinely different subnet; otherwise, when the overlap source is invisible to the docker
-		// scan (e.g. the daemon's default address pool, or a network created without an explicit IPAM
-		// subnet), every attempt would re-derive the same colliding CIDR and the retry would be a
-		// no-op. Attempt 0 uses the bare ID so the common case stays stable per deploy.
+		// it can see in `docker network ls`). On a retry we hand it a different ID so it derives from
+		// a different point in the hash space; otherwise, when the overlap source is invisible to the
+		// docker scan (e.g. the daemon's default address pool, or a network created without an
+		// explicit IPAM subnet), every attempt would re-derive the same colliding CIDR and the retry
+		// would be a no-op. A re-seed is not guaranteed to avoid the failed CIDR for these invisible
+		// overlaps — it just makes a different choice likely — but across the salted candidate space
+		// it converges in practice. For overlaps the docker scan *can* see, the allocator skips the
+		// now-visible conflicting subnet outright. Attempt 0 uses the bare ID so the common case
+		// stays stable per deploy.
 		allocSeed := allocID
 		if attempt > 0 {
 			allocSeed = fmt.Sprintf("%s#%d", allocID, attempt)

--- a/e2e/internal/devnet/network_cyoa.go
+++ b/e2e/internal/devnet/network_cyoa.go
@@ -71,34 +71,32 @@ func (n *CYOANetwork) CreateIfNotExists(ctx context.Context) (bool, error) {
 func (n *CYOANetwork) Create(ctx context.Context) error {
 	n.log.Debug("==> Creating CYOA network", "labels", n.dn.labels)
 
-	// Get an available subnet for the CYOA network.
-	subnetCIDR, err := n.dn.subnetAllocator.FindAvailableSubnet(ctx, n.dn.Spec.DeployID)
-	if err != nil {
-		return fmt.Errorf("failed to get available subnet: %w", err)
-	}
-	n.log.Debug("--> Network subnet selected", "subnet", subnetCIDR)
-
-	// Create the docker network.
-	// NOTE: We use the deprecated GenericNetworkRequest because the newer network.New doesn't
-	// allow us to set the name of the network, and we want something we can find by name.
-	//nolint:staticcheck // SA1019
 	networkName := n.dockerNetworkName()
-	req := testcontainers.GenericNetworkRequest{
-		NetworkRequest: testcontainers.NetworkRequest{
-			Name:       networkName,
-			Driver:     "bridge",
-			Attachable: true,
-			Labels:     n.dn.labels,
-			Internal:   true,
-			IPAM: &dockernetwork.IPAM{
-				Config: []dockernetwork.IPAMConfig{
-					{Subnet: subnetCIDR},
+
+	// Allocate a collision-safe subnet and create the network, retrying on a Docker pool-overlap
+	// error so a concurrent process grabbing the CIDR between allocation and creation self-heals.
+	subnetCIDR, err := createNetworkWithSubnet(ctx, n.dn.subnetAllocator, n.dn.Spec.DeployID, func(subnetCIDR string) error {
+		// NOTE: We use the deprecated GenericNetworkRequest because the newer network.New doesn't
+		// allow us to set the name of the network, and we want something we can find by name.
+		//nolint:staticcheck // SA1019
+		req := testcontainers.GenericNetworkRequest{
+			NetworkRequest: testcontainers.NetworkRequest{
+				Name:       networkName,
+				Driver:     "bridge",
+				Attachable: true,
+				Labels:     n.dn.labels,
+				Internal:   true,
+				IPAM: &dockernetwork.IPAM{
+					Config: []dockernetwork.IPAMConfig{
+						{Subnet: subnetCIDR},
+					},
 				},
 			},
-		},
-	}
-	//nolint:staticcheck // SA1019
-	_, err = testcontainers.GenericNetwork(ctx, req)
+		}
+		//nolint:staticcheck // SA1019
+		_, err := testcontainers.GenericNetwork(ctx, req)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create network: %w", err)
 	}

--- a/e2e/internal/devnet/network_default.go
+++ b/e2e/internal/devnet/network_default.go
@@ -2,7 +2,6 @@ package devnet
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"log/slog"
 
@@ -61,30 +60,33 @@ func (n *DefaultNetwork) CreateIfNotExists(ctx context.Context) (bool, error) {
 func (n *DefaultNetwork) Create(ctx context.Context) error {
 	n.log.Debug("==> Creating default network", "labels", n.dn.labels)
 
-	// Generate a subnet from 10.0.0.0/8 range based on deploy ID.
-	// This uses a different range than the CYOA network (9.128.0.0/9) to avoid
-	// conflicts in tests that detect interfaces by IP range.
-	subnetCIDR := n.generateSubnetCIDR(n.dn.Spec.DeployID)
-	n.log.Debug("--> Default network subnet selected", "subnet", subnetCIDR)
-
-	// Create a docker network.
-	//nolint:staticcheck // SA1019
 	networkName := n.dockerNetworkName()
-	req := testcontainers.GenericNetworkRequest{
-		NetworkRequest: testcontainers.NetworkRequest{
-			Name:       networkName,
-			Driver:     "bridge",
-			Attachable: true,
-			Labels:     n.dn.labels,
-			IPAM: &dockernetwork.IPAM{
-				Config: []dockernetwork.IPAMConfig{
-					{Subnet: subnetCIDR},
+
+	// Allocate a collision-safe subnet from the 10.0.0.0/8 range via the dedicated default-network
+	// allocator (which skips subnets already in use by existing docker networks and retries on
+	// overlap) instead of a fixed deterministic hash, which fails hard with "Pool overlaps" when
+	// the chosen CIDR is already taken by a leftover or concurrently-created network. This range is
+	// kept separate from the CYOA network (9.128.0.0/9) to avoid conflicts in tests that detect
+	// interfaces by IP range.
+	subnetCIDR, err := createNetworkWithSubnet(ctx, n.dn.defaultNetworkAllocator, n.dn.Spec.DeployID, func(subnetCIDR string) error {
+		//nolint:staticcheck // SA1019
+		req := testcontainers.GenericNetworkRequest{
+			NetworkRequest: testcontainers.NetworkRequest{
+				Name:       networkName,
+				Driver:     "bridge",
+				Attachable: true,
+				Labels:     n.dn.labels,
+				IPAM: &dockernetwork.IPAM{
+					Config: []dockernetwork.IPAMConfig{
+						{Subnet: subnetCIDR},
+					},
 				},
 			},
-		},
-	}
-	//nolint:staticcheck // SA1019
-	_, err := testcontainers.GenericNetwork(ctx, req)
+		}
+		//nolint:staticcheck // SA1019
+		_, err := testcontainers.GenericNetwork(ctx, req)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create network: %w", err)
 	}
@@ -107,12 +109,4 @@ func (n *DefaultNetwork) getSubnetCIDR(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("network %s has no IPAM config", networkName)
 	}
 	return inspect.IPAM.Config[0].Subnet, nil
-}
-
-// generateSubnetCIDR generates a /24 subnet from the 10.0.0.0/8 range based on the deploy ID.
-// This ensures each test gets a unique subnet while using a different range than the CYOA network.
-func (n *DefaultNetwork) generateSubnetCIDR(deployID string) string {
-	h := sha256.Sum256([]byte(deployID))
-	// Use first two bytes of hash for second and third octets (10.X.Y.0/24)
-	return fmt.Sprintf("10.%d.%d.0/24", h[0], h[1])
 }

--- a/e2e/internal/devnet/network_misc.go
+++ b/e2e/internal/devnet/network_misc.go
@@ -15,7 +15,8 @@ type MiscNetwork struct {
 	dn  *Devnet
 	log *slog.Logger
 
-	Name string
+	Name       string
+	SubnetCIDR string
 }
 
 func NewMiscNetwork(dn *Devnet, log *slog.Logger, suffix string) *MiscNetwork {
@@ -74,18 +75,32 @@ func (n *MiscNetwork) Create(ctx context.Context) error {
 
 	n.log.Debug("==> Creating misc network", "labels", labels)
 
-	// Create a docker network using Docker API directly to set MTU.
-	_, err := n.dn.dockerClient.NetworkCreate(ctx, n.Name, dockernetwork.CreateOptions{
-		Driver:     "bridge",
-		Attachable: false,
-		Labels:     labels,
-		Options: map[string]string{
-			"com.docker.network.driver.mtu": "9000",
-		},
+	// Allocate a collision-safe subnet via the dedicated link-network allocator (which skips subnets
+	// already in use by existing docker networks) instead of relying on Docker's auto-assignment,
+	// which is prone to "Pool overlaps" failures under concurrent shard load. Seed it with the
+	// unique network name so distinct link networks do not resolve to the same subnet. Create the
+	// docker network using the Docker API directly so we can set the MTU.
+	subnetCIDR, err := createNetworkWithSubnet(ctx, n.dn.linkNetworkAllocator, n.Name, func(subnetCIDR string) error {
+		_, err := n.dn.dockerClient.NetworkCreate(ctx, n.Name, dockernetwork.CreateOptions{
+			Driver:     "bridge",
+			Attachable: false,
+			Labels:     labels,
+			Options: map[string]string{
+				"com.docker.network.driver.mtu": "9000",
+			},
+			IPAM: &dockernetwork.IPAM{
+				Config: []dockernetwork.IPAMConfig{
+					{Subnet: subnetCIDR},
+				},
+			},
+		})
+		return err
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create network: %w", err)
 	}
-	n.log.Debug("--> Network created", "network", n.Name)
+
+	n.SubnetCIDR = subnetCIDR
+	n.log.Debug("--> Network created", "network", n.Name, "subnet", n.SubnetCIDR)
 	return nil
 }

--- a/e2e/internal/devnet/network_test.go
+++ b/e2e/internal/devnet/network_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"testing"
+
+	"github.com/malbeclabs/doublezero/e2e/internal/docker"
 )
 
 // fakeSubnetFinder returns a sequence of subnets, one per call, so we can assert that
@@ -140,6 +143,52 @@ func TestCreateNetworkWithSubnet_NonOverlapErrorNotRetried(t *testing.T) {
 	}
 	if finder.calls != 1 {
 		t.Fatalf("expected no retry on non-overlap error, got %d calls", finder.calls)
+	}
+}
+
+// TestNetworkRangesAreDisjoint locks in the load-bearing invariant that the four base address
+// ranges the devnet allocates from never overlap. Correctness of the collision-safe allocation
+// rests on it: the link/default allocators carve subnets out of their own /8s, but nothing at
+// runtime detects an overlap with the CYOA range or the onchain device-tunnel block (the
+// dz_prefixes derived from CYOA 9.x are invisible to the docker-network scan), so range separation
+// is the only guard. A future edit to any base CIDR that reintroduced overlap would fail here
+// rather than flaking an e2e run.
+//
+// This covers the compile-time base ranges and the *default* device-tunnel net. A caller that
+// overrides DevnetSpec.DeviceTunnelNet to an overlapping block is not guarded here (or at runtime);
+// keeping the override disjoint from the three allocator ranges is the caller's responsibility.
+func TestNetworkRangesAreDisjoint(t *testing.T) {
+	// Derive the CYOA range from the canonical allocator so this test tracks the real value rather
+	// than a hardcoded copy. The nil docker client is unused by the constructor.
+	cyoa := docker.NewDefaultSubnetAllocator(nil)
+	cyoaCIDR := fmt.Sprintf("%s/%d", cyoa.Base, cyoa.BaseMask)
+
+	ranges := []struct {
+		name string
+		cidr string
+	}{
+		{"cyoa", cyoaCIDR},
+		{"default", defaultNetworkBaseCIDR},
+		{"link", linkNetworkBaseCIDR},
+		{"deviceTunnel", defaultDeviceTunnelNet},
+	}
+
+	nets := make([]*net.IPNet, len(ranges))
+	for i, r := range ranges {
+		_, n, err := net.ParseCIDR(r.cidr)
+		if err != nil {
+			t.Fatalf("range %s has invalid CIDR %q: %v", r.name, r.cidr, err)
+		}
+		nets[i] = n
+	}
+
+	for i := 0; i < len(ranges); i++ {
+		for j := i + 1; j < len(ranges); j++ {
+			if docker.CIDROverlap(nets[i], nets[j]) {
+				t.Errorf("ranges %s (%s) and %s (%s) overlap; they must be pairwise disjoint",
+					ranges[i].name, ranges[i].cidr, ranges[j].name, ranges[j].cidr)
+			}
+		}
 	}
 }
 

--- a/e2e/internal/devnet/network_test.go
+++ b/e2e/internal/devnet/network_test.go
@@ -1,0 +1,157 @@
+package devnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// fakeSubnetFinder returns a sequence of subnets, one per call, so we can assert that
+// createNetworkWithSubnet re-allocates a fresh subnet on each pool-overlap retry. It records the
+// IDs it was called with so tests can verify the retry varies the allocation seed.
+type fakeSubnetFinder struct {
+	subnets []string
+	calls   int
+	seeds   []string
+	err     error
+}
+
+func (f *fakeSubnetFinder) FindAvailableSubnet(_ context.Context, id string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	f.seeds = append(f.seeds, id)
+	idx := f.calls
+	f.calls++
+	if idx >= len(f.subnets) {
+		return f.subnets[len(f.subnets)-1], nil
+	}
+	return f.subnets[idx], nil
+}
+
+func TestIsPoolOverlapErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("connection refused"), false},
+		{"pool overlaps", errors.New("Error response from daemon: Pool overlaps with other one on this address space"), true},
+		{"invalid pool request", errors.New("invalid pool request: Pool overlaps"), true},
+		{"wrapped", fmt.Errorf("create network: %w", errors.New("Pool overlaps with other one")), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPoolOverlapErr(tt.err); got != tt.want {
+				t.Fatalf("isPoolOverlapErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateNetworkWithSubnet_Success(t *testing.T) {
+	finder := &fakeSubnetFinder{subnets: []string{"10.1.2.0/24"}}
+	var used string
+	got, err := createNetworkWithSubnet(context.Background(), finder, "deploy-1", func(subnet string) error {
+		used = subnet
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "10.1.2.0/24" || used != "10.1.2.0/24" {
+		t.Fatalf("got subnet %q (create saw %q), want 10.1.2.0/24", got, used)
+	}
+	if finder.calls != 1 {
+		t.Fatalf("expected 1 allocation, got %d", finder.calls)
+	}
+}
+
+func TestCreateNetworkWithSubnet_RetriesOnPoolOverlap(t *testing.T) {
+	finder := &fakeSubnetFinder{subnets: []string{"10.1.0.0/24", "10.2.0.0/24", "10.3.0.0/24"}}
+	overlap := errors.New("Error response from daemon: Pool overlaps with other one on this address space")
+
+	var attempts []string
+	got, err := createNetworkWithSubnet(context.Background(), finder, "deploy-1", func(subnet string) error {
+		attempts = append(attempts, subnet)
+		// Fail the first two attempts with a pool overlap, succeed on the third.
+		if len(attempts) < 3 {
+			return overlap
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "10.3.0.0/24" {
+		t.Fatalf("got subnet %q, want 10.3.0.0/24", got)
+	}
+	// Each retry must re-allocate a fresh subnet, not reuse the conflicting one.
+	want := []string{"10.1.0.0/24", "10.2.0.0/24", "10.3.0.0/24"}
+	if len(attempts) != len(want) {
+		t.Fatalf("got %d attempts, want %d", len(attempts), len(want))
+	}
+	for i := range want {
+		if attempts[i] != want[i] {
+			t.Fatalf("attempt %d = %q, want %q", i, attempts[i], want[i])
+		}
+	}
+
+	// The allocator must be seeded with a distinct ID on each retry so a deterministic finder is
+	// forced to pick a different subnet even when the conflicting CIDR is invisible to its docker
+	// scan. Attempt 0 uses the bare ID; later attempts must differ from it and from each other.
+	wantSeeds := []string{"deploy-1", "deploy-1#1", "deploy-1#2"}
+	if len(finder.seeds) != len(wantSeeds) {
+		t.Fatalf("got %d seeds, want %d", len(finder.seeds), len(wantSeeds))
+	}
+	for i := range wantSeeds {
+		if finder.seeds[i] != wantSeeds[i] {
+			t.Fatalf("seed %d = %q, want %q", i, finder.seeds[i], wantSeeds[i])
+		}
+	}
+}
+
+func TestCreateNetworkWithSubnet_GivesUpAfterMaxRetries(t *testing.T) {
+	finder := &fakeSubnetFinder{subnets: []string{"10.1.0.0/24"}}
+	overlap := errors.New("invalid pool request: Pool overlaps")
+
+	_, err := createNetworkWithSubnet(context.Background(), finder, "deploy-1", func(subnet string) error {
+		return overlap
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if finder.calls != poolOverlapMaxRetries {
+		t.Fatalf("expected %d allocation attempts, got %d", poolOverlapMaxRetries, finder.calls)
+	}
+}
+
+func TestCreateNetworkWithSubnet_NonOverlapErrorNotRetried(t *testing.T) {
+	finder := &fakeSubnetFinder{subnets: []string{"10.1.0.0/24"}}
+	fatal := errors.New("permission denied")
+
+	_, err := createNetworkWithSubnet(context.Background(), finder, "deploy-1", func(subnet string) error {
+		return fatal
+	})
+	if !errors.Is(err, fatal) {
+		t.Fatalf("expected fatal error to propagate, got %v", err)
+	}
+	if finder.calls != 1 {
+		t.Fatalf("expected no retry on non-overlap error, got %d calls", finder.calls)
+	}
+}
+
+func TestCreateNetworkWithSubnet_AllocationErrorPropagates(t *testing.T) {
+	allocErr := errors.New("no available subnet")
+	finder := &fakeSubnetFinder{err: allocErr}
+
+	_, err := createNetworkWithSubnet(context.Background(), finder, "deploy-1", func(subnet string) error {
+		t.Fatal("create should not be called when allocation fails")
+		return nil
+	})
+	if !errors.Is(err, allocErr) {
+		t.Fatalf("expected allocation error to propagate, got %v", err)
+	}
+}

--- a/e2e/internal/docker/subnet.go
+++ b/e2e/internal/docker/subnet.go
@@ -113,7 +113,7 @@ func (a *SubnetAllocator) isSubnetInUseLocked(ctx context.Context, subnet string
 			if err != nil {
 				continue
 			}
-			if cidrOverlap(existingCIDR, desiredCIDR) {
+			if CIDROverlap(existingCIDR, desiredCIDR) {
 				return true, nil
 			}
 		}
@@ -121,6 +121,8 @@ func (a *SubnetAllocator) isSubnetInUseLocked(ctx context.Context, subnet string
 	return false, nil
 }
 
-func cidrOverlap(a, b *net.IPNet) bool {
+// CIDROverlap reports whether two CIDR ranges intersect. Two prefixes overlap iff one contains the
+// other's network address, so a single containment check in each direction is sufficient.
+func CIDROverlap(a, b *net.IPNet) bool {
 	return a.Contains(b.IP) || b.Contains(a.IP)
 }


### PR DESCRIPTION
## Summary of Changes
* Fix the intermittent `Pool overlaps with other one on this address space` Docker failure that flaked `TestE2E_BackwardCompatibility` and any devnet bring-up under concurrent shard load.
* The default and inter-device link (misc) networks bypassed the collision-safe `docker.SubnetAllocator` that `CYOANetwork` already used: `MiscNetwork` relied on Docker auto-assignment (no IPAM config), and `DefaultNetwork` used a fixed deterministic `10.X.Y.0/24` hash with no overlap check and no retry. Either could pick a CIDR already taken by a leftover or concurrently-created network and fail hard.
* Route all three network types through a shared `createNetworkWithSubnet` helper that allocates a docker-overlap-checked subnet and retries on a pool-overlap daemon error. The allocator is re-seeded per attempt (`id` -> `id#N`) so even a deterministic finder converges to a *different* subnet when the conflict is invisible to the `docker network ls` scan (e.g. Docker's default address pool, or a network created without an explicit IPAM subnet).
* Each network type allocates from a disjoint range so a subnet can never overlap another network's range or an onchain `dz_prefix`: CYOA stays on `9.128.0.0/9`, default on `10.0.0.0/8`, and link networks move off Docker's default pool onto a dedicated `11.0.0.0/8` allocator. This avoids the case where a link subnet could overlap a device's onchain-advertised `9.x` dz_prefix (including `uteDzPrefix`, which can fall outside the CYOA `/23`) that the docker scan cannot see.
* MTU (9000) and the testcontainers/Ryuk cleanup labels on the misc network are preserved.
* Fixes #3917

## Testing Verification
* Added `e2e/internal/devnet/network_test.go` covering `createNetworkWithSubnet` and `isPoolOverlapErr`: success path, retry-on-pool-overlap with assertions that each retry re-allocates a fresh subnet **and** is seeded with a distinct ID (`deploy-1`, `deploy-1#1`, `deploy-1#2`), graceful give-up after max retries, non-overlap errors not retried, and allocation-error propagation.
* `go test ./e2e/internal/devnet/...` passes; `go vet` and `golangci-lint run ./internal/devnet/...` report no issues.
* Verified the new `11.0.0.0/8` link range is disjoint from every other range the e2e suite uses (`9.128.0.0/9`, `10.0.0.0/8`, `172.16.0.0/16`/`192.168.x`).