### PR TITLE
e2e: apply disconnectTimeout at start of DisconnectUser

### DIFF
--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -206,6 +206,9 @@ func (c *Client) DoublezeroOrPublicIP() net.IP {
 }
 
 func (c *Client) DisconnectUser(ctx context.Context, waitForStatus bool, waitForDeletion bool) error {
+	ctx, cancel := context.WithTimeout(ctx, disconnectTimeout)
+	defer cancel()
+
 	resp, err := c.grpcClient.GetStatus(ctx, &emptypb.Empty{})
 	if err != nil {
 		return fmt.Errorf("failed to get user status on host %s: %w", c.Host, err)
@@ -222,8 +225,6 @@ func (c *Client) DisconnectUser(ctx context.Context, waitForStatus bool, waitFor
 	// We do this to handle the case where the client thinks it's disconnected but the user exists
 	// onchain, which can happen if the previous connect attempt timed out in the CLI but eventually
 	// succeeded onchain.
-	ctx, cancel := context.WithTimeout(ctx, disconnectTimeout)
-	defer cancel()
 	_, err = c.grpcClient.Disconnect(ctx, &emptypb.Empty{})
 	if err != nil {
 		return fmt.Errorf("failed to disconnect on host %s: %w", c.Host, err)


### PR DESCRIPTION
## Summary

- `DisconnectUser` called `GetStatus` before applying `disconnectTimeout`, so when a QA host's gRPC server hung (not rejecting, just not responding), the call blocked indefinitely
- Moves `context.WithTimeout(ctx, disconnectTimeout)` to the top of the function so the initial `GetStatus` is bounded by the same 150 s cap as the rest of the function
- Root cause of the 2026-06-20 mainnet-beta QA run hanging for 13+ minutes in cleanup before the 20 m test-suite timeout killed everything (`nyc-mn-qa01` unresponsive, `TestQA_MulticastPublisherMultipleGroups` cleanup stuck on `GetStatus → waitOnHeader`)