### PR TITLE
e2e: wait for OpenForRequests phase before seat payment

### DIFF
--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -80,6 +80,37 @@ func (c *Client) FeedSeatPrice(ctx context.Context) ([]*pb.DevicePrice, error) {
 	return resp.GetPrices(), nil
 }
 
+// WaitForOpenForRequests polls the on-chain execution controller until the
+// shred-subscription program enters OpenForRequests phase, which is the only
+// phase that accepts FundPaymentEscrowUsdc transactions. The UpdatingPrices
+// window is short but can collide with a scheduled CI run; callers should
+// invoke this before FeedSeatPay to avoid a spurious failure.
+func (c *Client) WaitForOpenForRequests(ctx context.Context) error {
+	programID, err := solana.PublicKeyFromBase58(c.ShredSubscriptionProgramID)
+	if err != nil {
+		return fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
+	}
+	shredsClient := shreds.New(shreds.NewRPCClient(c.SolanaRPCURL), programID)
+
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = 2 * time.Second
+	exp.MaxInterval = 10 * time.Second
+	exp.MaxElapsedTime = 2 * time.Minute
+
+	return backoff.Retry(func() error {
+		ec, err := shredsClient.FetchExecutionController(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to fetch execution controller: %w", err)
+		}
+		phase := ec.GetPhase()
+		if phase != shreds.ExecutionPhaseOpenForRequests {
+			c.log.Info("Waiting for OpenForRequests phase", "host", c.Host, "phase", phase.String())
+			return fmt.Errorf("program in %q phase, not yet open for requests", phase)
+		}
+		return nil
+	}, backoff.WithContext(exp, ctx))
+}
+
 // FeedSeatPay calls the FeedSeatPay RPC to pay for a seat on a device.
 // The client's public IP is auto-filled. Instant allocation is the default.
 func (c *Client) FeedSeatPay(ctx context.Context, devicePubkey string, amount string) error {

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -136,6 +136,13 @@ func TestQA_MulticastSettlement(t *testing.T) {
 		return
 	}
 
+	if !t.Run("wait_for_open_phase", func(t *testing.T) {
+		err := client.WaitForOpenForRequests(ctx)
+		require.NoError(t, err, "shred-subscription program did not enter OpenForRequests phase within timeout")
+	}) {
+		return
+	}
+
 	if !t.Run("record_balance_before_pay", func(t *testing.T) {
 		var err error
 		balanceBeforePay, err = client.GetUSDCBalance(ctx)


### PR DESCRIPTION
## Summary

- The `TestQA_MulticastSettlement/pay_for_seat` subtest was failing when the CI cron ran during the shred-subscription program's `UpdatingPrices` window. `FundPaymentEscrowUsdc` requires `OpenForRequests` phase; hitting `UpdatingPrices` returns "Invalid execution phase: updating prices" with no retry.
- Adds `WaitForOpenForRequests` to the QA client — polls `FetchExecutionController` (already in the shreds Go SDK) with exponential backoff (2 s → 10 s, 2 min max) until the phase is `OpenForRequests`.
- Adds a `wait_for_open_phase` subtest ordered **before** `record_balance_before_pay` so the balance snapshot is taken immediately before payment, not before a potential 2-minute wait.