### PR TITLE
e2e/qa: make mainnet-beta QA client resilient to flaky/stale Solana RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
   - Reduce agent CPU usage by continuing to fetch the full config every 5 seconds but only applying when it has changed or after 60s timeout
 - E2E tests
   - Route all devnet networks (CYOA, default, and miscellaneous) through a shared collision-safe subnet allocator to prevent overlapping subnet assignments across concurrent test runs. (#3919)
+  - Harden the mainnet-beta QA client against flaky/stale Solana RPC: multi-endpoint failover (with a public-RPC default fallback when `SOLANA_RPC_FALLBACK_URLS` is unset), active slot-lag detection, poll-until-consistent post-write reads, and configurable timeout/retry budgets. Eliminates manual `SOLANA_RPC_URL` repointing during RPC outages. (#3930)
 
 ## [v0.27.1](https://github.com/malbeclabs/doublezero/compare/client/v0.27.0...client/v0.27.1) - 2026-06-10
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -222,3 +222,51 @@ write/device_delete_2                    PASS        PASS        PASS        PAS
 ```
 
 </details>
+
+## QA Client Solana RPC Resilience
+
+The mainnet-beta QA workflows drive settlement reads/writes (USDC balance,
+shred-subscription seat state) against a Solana RPC endpoint. That endpoint can
+flake two ways, each of which used to force a manual repoint of the
+`SOLANA_RPC_URL` CI secret:
+
+1. **Non-responsive / timeout** — the RPC stops answering.
+2. **Stale reads** — the RPC accepts the call and returns old-but-valid account
+   state because the node is lagging the cluster. This is not an error, so
+   error-based retries don't catch it.
+
+The QA client (`e2e/internal/qa/`) handles both automatically:
+
+- **Multi-endpoint failover.** Reads go through a sticky-index failover pool. On
+  a retryable failure (timeout, network error, HTTP 429/5xx) it advances to the
+  next endpoint and retries; once failed over it stays on the new endpoint for
+  the rest of the run. Failover is transparent to both direct RPC reads and the
+  shreds SDK reads.
+- **Active slot-lag detection.** Before a staleness-sensitive read (and at client
+  construction) the pool probes each endpoint's slot height (`getSlot`) and fails
+  over to the freshest one when the current endpoint trails the max observed slot
+  by more than the configured threshold.
+- **Poll-until-consistent reads.** Post-write reads (settlement USDC balance, the
+  client seat) poll until the expected state is observed rather than trusting a
+  single read after a write.
+
+Settlement **writes** (`FeedSeatPay`/`FeedSeatWithdraw`) target the pool's
+current (health-selected) endpoint but deliberately do **not** auto-retry across
+endpoints, since a payment that timed out on submission may have landed onchain
+and a blind retry risks double-submission.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SOLANA_RPC_URL` | `api.mainnet-beta.solana.com` (mainnet) | Primary Solana RPC endpoint. |
+| `SOLANA_RPC_FALLBACK_URLS` | unset → public `api.mainnet-beta.solana.com` appended on mainnet | Comma-separated ordered fallback endpoints. When unset, the public mainnet RPC is used as the default fallback. On testnet/devnet (DZ ledger RPC) no public default is added. |
+| `QA_SOLANA_RPC_TIMEOUT` | `30s` | Per-call timeout before an endpoint is treated as failed. |
+| `QA_SOLANA_RPC_INITIAL_BACKOFF` | `1s` | Initial backoff for the USDC balance retry loop. |
+| `QA_SOLANA_RPC_MAX_ELAPSED` | `30s` | Max elapsed time for the balance retry loop. |
+| `QA_SOLANA_RPC_MAX_RETRIES` | `5` | Max retries for the balance retry loop. |
+| `QA_SOLANA_RPC_MAX_SLOT_LAG` | `150` | Slot-height lag (≈60s) above which a node is considered stale and is failed over. |
+
+A single resolved endpoint (testnet/devnet, or a primary that equals the public
+default after de-duplication) collapses the pool back to the prior
+single-endpoint behavior.

--- a/e2e/internal/qa/client.go
+++ b/e2e/internal/qa/client.go
@@ -105,6 +105,11 @@ type Client struct {
 	serviceability *serviceability.Client
 	devices        map[string]*Device
 
+	// solanaRPC is the multi-endpoint failover pool used for all Solana RPC
+	// reads (USDC balance, shred-subscription program state). It transparently
+	// fails over a dead/timing-out endpoint and can fail over a lagging node.
+	solanaRPC *solanaRPCPool
+
 	Host         string
 	AllocateAddr bool
 
@@ -158,6 +163,21 @@ func NewClient(ctx context.Context, log *slog.Logger, hostname string, port int,
 		solanaRPCURL = networkConfig.LedgerPublicRPCURL
 	}
 
+	// Build the failover RPC pool. On mainnet the public Solana RPC is appended
+	// as a default fallback when SOLANA_RPC_FALLBACK_URLS is unset, so a private
+	// primary automatically gets a safety net. On testnet/devnet (DZ ledger RPC)
+	// there is no public default — the pool collapses to a single endpoint and
+	// behaves exactly as before unless fallbacks are explicitly configured.
+	publicDefault := ""
+	if networkConfig.Moniker == config.EnvMainnetBeta || networkConfig.Moniker == config.EnvMainnet {
+		publicDefault = config.MainnetSolanaRPC
+	}
+	solanaRPC := newSolanaRPCPool(log, solanaRPCURL, publicDefault, rpcBudgetFromEnv())
+	if solanaRPC.EndpointCount() > 1 {
+		// Pick the freshest endpoint to start on, skipping any that are lagging.
+		solanaRPC.SelectHealthiestEndpoint(ctx)
+	}
+
 	return &Client{
 		log:            log,
 		grpcClient:     grpcClient,
@@ -165,6 +185,7 @@ func NewClient(ctx context.Context, log *slog.Logger, hostname string, port int,
 		publicIP:       publicIP,
 		serviceability: serviceabilityClient,
 		devices:        devices,
+		solanaRPC:      solanaRPC,
 
 		Host:                       hostname,
 		AllocateAddr:               allocateAddr,

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -98,7 +98,7 @@ func (c *Client) ClosestDevice(ctx context.Context) (*Device, error) {
 func (c *Client) FeedSeatPrice(ctx context.Context) ([]*pb.DevicePrice, error) {
 	c.log.Debug("Querying seat prices", "host", c.Host)
 	var prices []*pb.DevicePrice
-	err := c.withWriteFailover(func(rpcURL string) error {
+	err := c.withReadFailover(func(rpcURL string) error {
 		resp, err := c.grpcClient.FeedSeatPrice(ctx, &pb.FeedSeatPriceRequest{
 			SolanaRpcUrl:               rpcURL,
 			DzLedgerUrl:                c.DZLedgerURL,
@@ -119,13 +119,14 @@ func (c *Client) FeedSeatPrice(ctx context.Context) ([]*pb.DevicePrice, error) {
 	return prices, nil
 }
 
-// withWriteFailover runs an agent-driven settlement command against the pool's
-// current Solana RPC endpoint, failing over to the next endpoint and retrying
-// on error. It is only safe for idempotent operations (reads/queries) — see
-// the note on FeedSeatPay/FeedSeatWithdraw, which deliberately do not retry to
-// avoid double-submitting a settlement transaction. With a single endpoint (or
-// no pool) it runs fn exactly once.
-func (c *Client) withWriteFailover(fn func(rpcURL string) error) error {
+// withReadFailover runs an agent-driven settlement query against the pool's
+// current Solana RPC endpoint, failing over to the next endpoint on a retryable
+// error. It is ONLY safe for idempotent operations (reads/queries): the
+// settlement WRITES (FeedSeatPay/FeedSeatWithdraw) deliberately bypass this and
+// do not retry across endpoints, since a write that timed out on submission may
+// have landed onchain and a blind retry risks double-submission. With a single
+// endpoint (or no pool) it runs fn exactly once.
+func (c *Client) withReadFailover(fn func(rpcURL string) error) error {
 	attempts := 1
 	if c.solanaRPC != nil {
 		attempts = c.solanaRPC.EndpointCount()
@@ -136,10 +137,14 @@ func (c *Client) withWriteFailover(fn func(rpcURL string) error) error {
 		if lastErr == nil {
 			return nil
 		}
-		if c.solanaRPC != nil {
+		// Only fail over on retryable (connectivity/timeout) failures; a genuine
+		// business error should surface rather than burn the remaining endpoints.
+		if c.solanaRPC != nil && isRetryableRPCErr(lastErr) {
 			c.log.Warn("Settlement query failed, failing over to next endpoint",
-				"host", c.Host, "endpoint", c.currentSolanaRPCURL(), "error", lastErr)
+				"host", c.Host, "endpoint", redactURL(c.currentSolanaRPCURL()), "error", c.solanaRPC.scrubErr(lastErr))
 			c.solanaRPC.Failover()
+		} else {
+			return lastErr
 		}
 	}
 	return lastErr
@@ -260,7 +265,10 @@ func (c *Client) GetEffectiveSeatPrice(ctx context.Context, devicePubkey string,
 	var seat *shreds.ClientSeat
 	if err := poll.Until(ctx, func() (bool, error) {
 		s, fetchErr := shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
-		if errors.Is(fetchErr, shreds.ErrAccountNotFound) {
+		// A missing account surfaces as rpc.ErrNotFound through the live RPC
+		// path (gagliardetto GetAccountInfo) and as shreds.ErrAccountNotFound
+		// through the shreds nil-result path; treat both as "not yet visible".
+		if errors.Is(fetchErr, shreds.ErrAccountNotFound) || errors.Is(fetchErr, rpc.ErrNotFound) {
 			c.log.Debug("Client seat not yet visible, polling", "host", c.Host)
 			return false, nil
 		}

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -3,6 +3,7 @@ package qa
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -11,10 +12,38 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/malbeclabs/doublezero/e2e/internal/poll"
 	pb "github.com/malbeclabs/doublezero/e2e/proto/qa/gen/pb-go"
 	shreds "github.com/malbeclabs/doublezero/sdk/shreds/go"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+// seatReadTimeout/seatReadInterval bound the poll-until-visible window for
+// reading post-write seat state from a possibly-lagging RPC node.
+const (
+	seatReadTimeout  = 30 * time.Second
+	seatReadInterval = 2 * time.Second
+)
+
+// currentSolanaRPCURL returns the pool's current endpoint URL, falling back to
+// the static SolanaRPCURL field for callers constructed without a pool (e.g.
+// hand-built test clients).
+func (c *Client) currentSolanaRPCURL() string {
+	if c.solanaRPC != nil {
+		return c.solanaRPC.CurrentURL()
+	}
+	return c.SolanaRPCURL
+}
+
+// shredsClient builds a shred-subscription client backed by the failover RPC
+// pool when present, so reads transparently fail over a dead or lagging
+// endpoint. Falls back to a single-endpoint client for hand-built test clients.
+func (c *Client) shredsClient(programID solana.PublicKey) *shreds.Client {
+	if c.solanaRPC != nil {
+		return shreds.New(c.solanaRPC.RPC(), programID)
+	}
+	return shreds.New(shreds.NewRPCClient(c.SolanaRPCURL), programID)
+}
 
 // FeedEnable calls the FeedEnable RPC to start the doublezerod reconciler.
 func (c *Client) FeedEnable(ctx context.Context) error {
@@ -64,20 +93,56 @@ func (c *Client) ClosestDevice(ctx context.Context) (*Device, error) {
 }
 
 // FeedSeatPrice calls the FeedSeatPrice RPC to query device seat prices.
+// This is an idempotent read, so on RPC failure it fails over to the next
+// endpoint and retries.
 func (c *Client) FeedSeatPrice(ctx context.Context) ([]*pb.DevicePrice, error) {
 	c.log.Debug("Querying seat prices", "host", c.Host)
-	resp, err := c.grpcClient.FeedSeatPrice(ctx, &pb.FeedSeatPriceRequest{
-		SolanaRpcUrl:               c.SolanaRPCURL,
-		DzLedgerUrl:                c.DZLedgerURL,
-		UsdcMint:                   c.USDCMint,
-		Keypair:                    c.Keypair,
-		ShredSubscriptionProgramId: c.ShredSubscriptionProgramID,
+	var prices []*pb.DevicePrice
+	err := c.withWriteFailover(func(rpcURL string) error {
+		resp, err := c.grpcClient.FeedSeatPrice(ctx, &pb.FeedSeatPriceRequest{
+			SolanaRpcUrl:               rpcURL,
+			DzLedgerUrl:                c.DZLedgerURL,
+			UsdcMint:                   c.USDCMint,
+			Keypair:                    c.Keypair,
+			ShredSubscriptionProgramId: c.ShredSubscriptionProgramID,
+		})
+		if err != nil {
+			return err
+		}
+		prices = resp.GetPrices()
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get seat prices on host %s: %w", c.Host, err)
 	}
-	c.log.Debug("Seat prices retrieved", "host", c.Host, "count", len(resp.GetPrices()))
-	return resp.GetPrices(), nil
+	c.log.Debug("Seat prices retrieved", "host", c.Host, "count", len(prices))
+	return prices, nil
+}
+
+// withWriteFailover runs an agent-driven settlement command against the pool's
+// current Solana RPC endpoint, failing over to the next endpoint and retrying
+// on error. It is only safe for idempotent operations (reads/queries) — see
+// the note on FeedSeatPay/FeedSeatWithdraw, which deliberately do not retry to
+// avoid double-submitting a settlement transaction. With a single endpoint (or
+// no pool) it runs fn exactly once.
+func (c *Client) withWriteFailover(fn func(rpcURL string) error) error {
+	attempts := 1
+	if c.solanaRPC != nil {
+		attempts = c.solanaRPC.EndpointCount()
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		lastErr = fn(c.currentSolanaRPCURL())
+		if lastErr == nil {
+			return nil
+		}
+		if c.solanaRPC != nil {
+			c.log.Warn("Settlement query failed, failing over to next endpoint",
+				"host", c.Host, "endpoint", c.currentSolanaRPCURL(), "error", lastErr)
+			c.solanaRPC.Failover()
+		}
+	}
+	return lastErr
 }
 
 // WaitForOpenForRequests polls the on-chain execution controller until the
@@ -90,7 +155,7 @@ func (c *Client) WaitForOpenForRequests(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
 	}
-	shredsClient := shreds.New(shreds.NewRPCClient(c.SolanaRPCURL), programID)
+	shredsClient := c.shredsClient(programID)
 
 	exp := backoff.NewExponentialBackOff()
 	exp.InitialInterval = 2 * time.Second
@@ -113,13 +178,21 @@ func (c *Client) WaitForOpenForRequests(ctx context.Context) error {
 
 // FeedSeatPay calls the FeedSeatPay RPC to pay for a seat on a device.
 // The client's public IP is auto-filled. Instant allocation is the default.
+//
+// The settlement transaction is submitted against the pool's current (already
+// health-selected) Solana RPC endpoint. It deliberately does NOT auto-retry
+// across endpoints on failure: a payment that timed out on submission may have
+// landed onchain, so a blind retry against another endpoint risks
+// double-submission. The construction-time slot-lag selection plus read-path
+// failover keep CurrentURL() pointed at a healthy endpoint by the time this is
+// called.
 func (c *Client) FeedSeatPay(ctx context.Context, devicePubkey string, amount string) error {
 	c.log.Debug("Paying for seat", "host", c.Host, "device", devicePubkey, "amount", amount)
 	resp, err := c.grpcClient.FeedSeatPay(ctx, &pb.FeedSeatPayRequest{
 		DevicePubkey:               devicePubkey,
 		ClientIp:                   c.publicIP.To4().String(),
 		Amount:                     amount,
-		SolanaRpcUrl:               c.SolanaRPCURL,
+		SolanaRpcUrl:               c.currentSolanaRPCURL(),
 		ShredSubscriptionProgramId: c.ShredSubscriptionProgramID,
 		DzLedgerUrl:                c.DZLedgerURL,
 		UsdcMint:                   c.USDCMint,
@@ -137,13 +210,15 @@ func (c *Client) FeedSeatPay(ctx context.Context, devicePubkey string, amount st
 }
 
 // FeedSeatWithdraw calls the FeedSeatWithdraw RPC to withdraw a seat from a device.
-// Instant withdrawal is the default.
+// Instant withdrawal is the default. Like FeedSeatPay, this targets the pool's
+// current endpoint and does not auto-retry across endpoints to avoid
+// double-submitting a settlement transaction.
 func (c *Client) FeedSeatWithdraw(ctx context.Context, devicePubkey string) error {
 	c.log.Debug("Withdrawing seat", "host", c.Host, "device", devicePubkey)
 	resp, err := c.grpcClient.FeedSeatWithdraw(ctx, &pb.FeedSeatWithdrawRequest{
 		DevicePubkey:               devicePubkey,
 		ClientIp:                   c.publicIP.To4().String(),
-		SolanaRpcUrl:               c.SolanaRPCURL,
+		SolanaRpcUrl:               c.currentSolanaRPCURL(),
 		ShredSubscriptionProgramId: c.ShredSubscriptionProgramID,
 		DzLedgerUrl:                c.DZLedgerURL,
 		UsdcMint:                   c.USDCMint,
@@ -175,9 +250,26 @@ func (c *Client) GetEffectiveSeatPrice(ctx context.Context, devicePubkey string,
 	}
 
 	clientIPBits := binary.BigEndian.Uint32(c.publicIP.To4())
-	shredsClient := shreds.New(shreds.NewRPCClient(c.SolanaRPCURL), programID)
-	seat, err := shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
-	if err != nil {
+	shredsClient := c.shredsClient(programID)
+
+	// This reads state written by the preceding FeedSeatPay. A lagging RPC node
+	// can briefly serve a view in which the seat account does not yet exist, so
+	// poll until it is visible rather than failing on a single stale read.
+	// (The failover pool fails over on RPC errors, but an account-not-found is a
+	// valid empty read, not an error, so it needs poll-until.)
+	var seat *shreds.ClientSeat
+	if err := poll.Until(ctx, func() (bool, error) {
+		s, fetchErr := shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
+		if errors.Is(fetchErr, shreds.ErrAccountNotFound) {
+			c.log.Debug("Client seat not yet visible, polling", "host", c.Host)
+			return false, nil
+		}
+		if fetchErr != nil {
+			return false, fetchErr
+		}
+		seat = s
+		return true, nil
+	}, seatReadTimeout, seatReadInterval); err != nil {
 		return 0, fmt.Errorf("failed to fetch client seat on host %s: %w", c.Host, err)
 	}
 
@@ -202,7 +294,7 @@ func (c *Client) IsSeatProratingEnabled(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
 	}
 
-	shredsClient := shreds.New(shreds.NewRPCClient(c.SolanaRPCURL), programID)
+	shredsClient := c.shredsClient(programID)
 	cfg, err := shredsClient.FetchProgramConfig(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch program config on host %s: %w", c.Host, err)
@@ -247,13 +339,25 @@ func (c *Client) GetUSDCBalance(ctx context.Context) (uint64, error) {
 		return 0, fmt.Errorf("failed to derive ATA for owner %s and mint %s: %w", ownerPubkey, usdcMint, err)
 	}
 
-	solanaClient := rpc.New(c.SolanaRPCURL)
+	// Use the failover pool when present so a dead/lagging endpoint is replaced
+	// transparently; fall back to a single-endpoint client for hand-built test
+	// clients. Before reading, actively fail over off a lagging node so a
+	// stale-but-valid read can't produce a spurious assertion failure.
+	var solanaClient *rpc.Client
+	budget := rpcBudgetFromEnv()
+	if c.solanaRPC != nil {
+		c.solanaRPC.SelectHealthiestEndpoint(ctx)
+		solanaClient = c.solanaRPC.RPC()
+		budget = c.solanaRPC.budget
+	} else {
+		solanaClient = rpc.New(c.SolanaRPCURL)
+	}
 
 	var result *rpc.GetTokenAccountBalanceResult
 	exp := backoff.NewExponentialBackOff()
-	exp.InitialInterval = 1 * time.Second
-	exp.MaxElapsedTime = 30 * time.Second
-	retryPolicy := backoff.WithMaxRetries(exp, 5)
+	exp.InitialInterval = budget.initialBackoff
+	exp.MaxElapsedTime = budget.maxElapsed
+	retryPolicy := backoff.WithMaxRetries(exp, budget.maxRetries)
 	retryPolicy = backoff.WithContext(retryPolicy, ctx)
 
 	if err := backoff.Retry(func() error {

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -35,6 +35,20 @@ func (c *Client) currentSolanaRPCURL() string {
 	return c.SolanaRPCURL
 }
 
+// scrubRPCErr redacts any endpoint credential embedded in an RPC error string
+// (solana-go embeds the full request URL, which may carry an API key, in its
+// connectivity/HTTP error messages). Returns the plain error string when there
+// is no pool to source endpoint URLs from.
+func (c *Client) scrubRPCErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	if c.solanaRPC != nil {
+		return c.solanaRPC.scrubErr(err)
+	}
+	return err.Error()
+}
+
 // shredsClient builds a shred-subscription client backed by the failover RPC
 // pool when present, so reads transparently fail over a dead or lagging
 // endpoint. Falls back to a single-endpoint client for hand-built test clients.
@@ -372,12 +386,14 @@ func (c *Client) GetUSDCBalance(ctx context.Context) (uint64, error) {
 		var rpcErr error
 		result, rpcErr = solanaClient.GetTokenAccountBalance(ctx, ata, rpc.CommitmentConfirmed)
 		if rpcErr != nil {
-			c.log.Debug("Retryable RPC error fetching USDC balance", "host", c.Host, "ata", ata, "error", rpcErr)
+			// Scrub: solana-go embeds the (possibly API-keyed) endpoint URL in
+			// its error strings, so never log/return the raw error.
+			c.log.Debug("Retryable RPC error fetching USDC balance", "host", c.Host, "ata", ata, "error", c.scrubRPCErr(rpcErr))
 			return rpcErr
 		}
 		return nil
 	}, retryPolicy); err != nil {
-		return 0, fmt.Errorf("failed to get token account balance for ATA %s on host %s: %w", ata, c.Host, err)
+		return 0, fmt.Errorf("failed to get token account balance for ATA %s on host %s: %s", ata, c.Host, c.scrubRPCErr(err))
 	}
 
 	balance, err := strconv.ParseUint(result.Value.Amount, 10, 64)

--- a/e2e/internal/qa/solanarpc.go
+++ b/e2e/internal/qa/solanarpc.go
@@ -1,0 +1,346 @@
+package qa
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+)
+
+const (
+	// Default per-call timeout for a single Solana RPC request before it is
+	// treated as a failover-triggering failure.
+	defaultRPCTimeout = 30 * time.Second
+	// Default backoff budget for the GetUSDCBalance retry loop.
+	defaultRPCInitialBackoff = 1 * time.Second
+	defaultRPCMaxElapsed     = 30 * time.Second
+	defaultRPCMaxRetries     = uint64(5)
+	// Default slot-lag threshold (in slots) above which an endpoint is
+	// considered stale and skipped in favor of a fresher one. ~150 slots is
+	// roughly 60s at 400ms/slot.
+	defaultRPCMaxSlotLag = uint64(150)
+)
+
+// rpcBudget holds the configurable timeout/retry budget for Solana RPC reads.
+// All values are read from the environment with defaults that preserve the
+// pre-existing hardcoded behavior, so nothing changes unless CI opts in.
+type rpcBudget struct {
+	// timeout bounds a single RPC call (per endpoint attempt).
+	timeout time.Duration
+	// initialBackoff and maxElapsed/maxRetries bound the balance retry loop.
+	initialBackoff time.Duration
+	maxElapsed     time.Duration
+	maxRetries     uint64
+	// maxSlotLag is the slot-height lag threshold for active staleness failover.
+	maxSlotLag uint64
+}
+
+func rpcBudgetFromEnv() rpcBudget {
+	return rpcBudget{
+		timeout:        envDuration("QA_SOLANA_RPC_TIMEOUT", defaultRPCTimeout),
+		initialBackoff: envDuration("QA_SOLANA_RPC_INITIAL_BACKOFF", defaultRPCInitialBackoff),
+		maxElapsed:     envDuration("QA_SOLANA_RPC_MAX_ELAPSED", defaultRPCMaxElapsed),
+		maxRetries:     envUint("QA_SOLANA_RPC_MAX_RETRIES", defaultRPCMaxRetries),
+		maxSlotLag:     envUint("QA_SOLANA_RPC_MAX_SLOT_LAG", defaultRPCMaxSlotLag),
+	}
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+func envUint(key string, def uint64) uint64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+// resolveSolanaRPCEndpoints builds the ordered, de-duplicated endpoint list for
+// the failover pool: the primary first, then any fallbacks from
+// SOLANA_RPC_FALLBACK_URLS (comma-separated). When the fallback var is unset,
+// publicDefault is appended as the safety-net endpoint (empty publicDefault adds
+// nothing, e.g. on testnet/devnet where the DZ ledger RPC has no public
+// mainnet fallback). Blanks are dropped and duplicates collapse so a config
+// with no distinct fallback behaves exactly as it does today.
+func resolveSolanaRPCEndpoints(primary, publicDefault string) []string {
+	var raw []string
+	raw = append(raw, primary)
+	if fb := os.Getenv("SOLANA_RPC_FALLBACK_URLS"); fb != "" {
+		raw = append(raw, strings.Split(fb, ",")...)
+	} else if publicDefault != "" {
+		raw = append(raw, publicDefault)
+	}
+
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, u := range raw {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	return out
+}
+
+// solanaRPCPool is a multi-endpoint Solana RPC client with sticky-index
+// failover. It implements rpc.JSONRPCClient so failover is transparent to both
+// direct rpc.Client reads and the shreds SDK reads (which both build on
+// rpc.Client). On a retryable failure (timeout, network error, HTTP 429/5xx)
+// the current endpoint is advanced and the next is tried; the last error is
+// returned only after every endpoint is exhausted. The sticky index means once
+// failed over, the pool stays on the new endpoint rather than bouncing back to
+// a known-bad node mid-run.
+type solanaRPCPool struct {
+	log    *slog.Logger
+	urls   []string
+	budget rpcBudget
+
+	// clients holds one underlying jsonrpc client per endpoint; endpointRPC
+	// wraps each for direct (single-endpoint) probing such as slot-lag checks.
+	clients     []jsonrpc.RPCClient
+	endpointRPC []*rpc.Client
+
+	mu      sync.Mutex
+	current int
+
+	// rpcClient is the lazily-built rpc.Client backed by this failover pool.
+	rpcOnce   sync.Once
+	rpcClient *rpc.Client
+}
+
+// newSolanaRPCPool builds a failover pool over the resolved endpoint list.
+// primary is the effective Solana RPC URL; publicDefault is appended as a
+// fallback when SOLANA_RPC_FALLBACK_URLS is unset (pass "" to disable, e.g. on
+// testnet/devnet). A single resolved endpoint collapses to today's behavior.
+func newSolanaRPCPool(log *slog.Logger, primary, publicDefault string, budget rpcBudget) *solanaRPCPool {
+	urls := resolveSolanaRPCEndpoints(primary, publicDefault)
+	clients := make([]jsonrpc.RPCClient, len(urls))
+	endpointRPC := make([]*rpc.Client, len(urls))
+	for i, u := range urls {
+		clients[i] = jsonrpc.NewClient(u)
+		endpointRPC[i] = rpc.NewWithCustomRPCClient(clients[i])
+	}
+	return &solanaRPCPool{
+		log:         log,
+		urls:        urls,
+		budget:      budget,
+		clients:     clients,
+		endpointRPC: endpointRPC,
+	}
+}
+
+// RPC returns the rpc.Client backed by this failover pool. It is safe to pass
+// to shreds.New (it satisfies the shreds RPCClient interface).
+func (p *solanaRPCPool) RPC() *rpc.Client {
+	p.rpcOnce.Do(func() {
+		p.rpcClient = rpc.NewWithCustomRPCClient(p)
+	})
+	return p.rpcClient
+}
+
+// CurrentURL returns the URL of the currently-selected endpoint.
+func (p *solanaRPCPool) CurrentURL() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.urls[p.current]
+}
+
+// Failover advances to the next endpoint unconditionally. Used by write paths
+// (FeedSeat*) that drive an external command with CurrentURL() and want to
+// retry against a different endpoint on failure.
+func (p *solanaRPCPool) Failover() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.urls) > 1 {
+		p.current = (p.current + 1) % len(p.urls)
+	}
+}
+
+// EndpointCount returns the number of resolved endpoints.
+func (p *solanaRPCPool) EndpointCount() int { return len(p.urls) }
+
+func (p *solanaRPCPool) currentIndex() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.current
+}
+
+// advance moves past `from` only if no other caller already advanced the index,
+// so concurrent callers that all hit a dead endpoint don't skip healthy ones.
+func (p *solanaRPCPool) advance(from int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.current == from && len(p.urls) > 1 {
+		p.current = (p.current + 1) % len(p.urls)
+	}
+}
+
+// withFailover runs fn against the current endpoint, failing over to the next
+// on a retryable error, until an endpoint succeeds or all are exhausted.
+func (p *solanaRPCPool) withFailover(ctx context.Context, fn func(c jsonrpc.RPCClient, callCtx context.Context) error) error {
+	var lastErr error
+	for attempt := 0; attempt < len(p.clients); attempt++ {
+		idx := p.currentIndex()
+		callCtx, cancel := context.WithTimeout(ctx, p.budget.timeout)
+		err := fn(p.clients[idx], callCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Don't burn through endpoints if the parent context is done.
+		if ctx.Err() != nil {
+			return err
+		}
+		if !isRetryableRPCErr(err) {
+			return err
+		}
+		p.log.Warn("Solana RPC endpoint failed, failing over",
+			"endpoint", p.urls[idx], "error", err)
+		p.advance(idx)
+	}
+	return lastErr
+}
+
+func (p *solanaRPCPool) CallForInto(ctx context.Context, out any, method string, params []any) error {
+	return p.withFailover(ctx, func(c jsonrpc.RPCClient, callCtx context.Context) error {
+		return c.CallForInto(callCtx, out, method, params)
+	})
+}
+
+func (p *solanaRPCPool) CallWithCallback(ctx context.Context, method string, params []any, callback func(*http.Request, *http.Response) error) error {
+	return p.withFailover(ctx, func(c jsonrpc.RPCClient, callCtx context.Context) error {
+		return c.CallWithCallback(callCtx, method, params, callback)
+	})
+}
+
+func (p *solanaRPCPool) CallBatch(ctx context.Context, requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error) {
+	var resp jsonrpc.RPCResponses
+	err := p.withFailover(ctx, func(c jsonrpc.RPCClient, callCtx context.Context) error {
+		var innerErr error
+		resp, innerErr = c.CallBatch(callCtx, requests)
+		return innerErr
+	})
+	return resp, err
+}
+
+// SelectHealthiestEndpoint probes every endpoint's slot height and fails over to
+// the freshest one if the current endpoint trails the max observed slot by more
+// than the configured lag threshold. This turns a "stale but valid" lagging node
+// (which never returns an error) into an explicit failover trigger. It is a
+// no-op with fewer than two endpoints. Probe failures degrade gracefully: a
+// node that can't be probed is treated as maximally lagged (slot 0) and simply
+// won't be selected, and if every probe fails the current endpoint is kept.
+func (p *solanaRPCPool) SelectHealthiestEndpoint(ctx context.Context) {
+	if len(p.clients) < 2 {
+		return
+	}
+
+	slots := make([]uint64, len(p.clients))
+	var maxSlot uint64
+	for i := range p.endpointRPC {
+		cctx, cancel := context.WithTimeout(ctx, p.budget.timeout)
+		slot, err := p.endpointRPC[i].GetSlot(cctx, rpc.CommitmentConfirmed)
+		cancel()
+		if err != nil {
+			p.log.Debug("Solana RPC slot probe failed", "endpoint", p.urls[i], "error", err)
+			continue
+		}
+		slots[i] = slot
+		if slot > maxSlot {
+			maxSlot = slot
+		}
+	}
+	if maxSlot == 0 {
+		// Every probe failed; keep the current endpoint and let error-based
+		// failover handle it.
+		return
+	}
+
+	// Pick the least-lagged (highest-slot) endpoint.
+	best := -1
+	var bestSlot uint64
+	for i, s := range slots {
+		if s > bestSlot {
+			bestSlot = s
+			best = i
+		}
+	}
+	if best < 0 {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	curSlot := slots[p.current]
+	if maxSlot-curSlot > p.budget.maxSlotLag {
+		p.log.Info("Solana RPC endpoint lagging, failing over to fresher endpoint",
+			"from", p.urls[p.current], "fromSlot", curSlot,
+			"to", p.urls[best], "toSlot", bestSlot,
+			"lag", maxSlot-curSlot, "threshold", p.budget.maxSlotLag)
+		p.current = best
+	}
+}
+
+// isRetryableRPCErr reports whether an RPC error should trigger failover to
+// another endpoint: timeouts, network errors, and HTTP 429/5xx. JSON-RPC
+// business errors (e.g. invalid params, account-specific errors) and context
+// cancellation are NOT retryable — they should surface or be handled by
+// poll-until-consistent callers.
+func isRetryableRPCErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var httpErr *jsonrpc.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Code == 429 || httpErr.Code >= 500
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{"connection reset", "connection refused", "eof", "timeout", "no such host", "broken pipe"} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e/internal/qa/solanarpc.go
+++ b/e2e/internal/qa/solanarpc.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -24,6 +25,10 @@ const (
 	defaultRPCInitialBackoff = 1 * time.Second
 	defaultRPCMaxElapsed     = 30 * time.Second
 	defaultRPCMaxRetries     = uint64(5)
+	// Dedicated (short) timeout for slot-lag probes; a healthy getSlot returns
+	// in well under a second, so probes shouldn't inherit the full per-call
+	// budget and stall a read behind a dead endpoint.
+	defaultRPCProbeTimeout = 5 * time.Second
 	// Default slot-lag threshold (in slots) above which an endpoint is
 	// considered stale and skipped in favor of a fresher one. ~150 slots is
 	// roughly 60s at 400ms/slot.
@@ -52,6 +57,39 @@ func rpcBudgetFromEnv() rpcBudget {
 		maxRetries:     envUint("QA_SOLANA_RPC_MAX_RETRIES", defaultRPCMaxRetries),
 		maxSlotLag:     envUint("QA_SOLANA_RPC_MAX_SLOT_LAG", defaultRPCMaxSlotLag),
 	}
+}
+
+// redactURL strips credentials from an RPC URL before logging. Private Solana
+// RPC providers (Helius, QuickNode, Triton, ...) commonly embed an API key in
+// the userinfo, path, or query string, so log only scheme://host and replace
+// any path/query with a placeholder. On parse failure it returns a coarse
+// placeholder rather than risk leaking the raw string into CI logs.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "<redacted-rpc-url>"
+	}
+	out := u.Scheme + "://" + u.Host
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.User != nil {
+		out += "/<redacted>"
+	}
+	return out
+}
+
+// scrubErr returns the error message with any of the pool's endpoint URLs
+// replaced by their redacted form, since solana-go errors often embed the full
+// request URL (which may carry an API key).
+func (p *solanaRPCPool) scrubErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	for _, u := range p.urls {
+		if strings.Contains(msg, u) {
+			msg = strings.ReplaceAll(msg, u, redactURL(u))
+		}
+	}
+	return msg
 }
 
 func envDuration(key string, def time.Duration) time.Duration {
@@ -224,7 +262,7 @@ func (p *solanaRPCPool) withFailover(ctx context.Context, fn func(c jsonrpc.RPCC
 			return err
 		}
 		p.log.Warn("Solana RPC endpoint failed, failing over",
-			"endpoint", p.urls[idx], "error", err)
+			"endpoint", redactURL(p.urls[idx]), "error", p.scrubErr(err))
 		p.advance(idx)
 	}
 	return lastErr
@@ -264,19 +302,36 @@ func (p *solanaRPCPool) SelectHealthiestEndpoint(ctx context.Context) {
 		return
 	}
 
+	// Probe all endpoints concurrently with a short, dedicated probe timeout
+	// (a healthy getSlot returns in well under a second). Probing serially with
+	// the full per-call budget could otherwise add timeout*N latency in front of
+	// every staleness-sensitive read.
+	probeTimeout := p.budget.timeout
+	if probeTimeout > defaultRPCProbeTimeout {
+		probeTimeout = defaultRPCProbeTimeout
+	}
 	slots := make([]uint64, len(p.clients))
-	var maxSlot uint64
+	var wg sync.WaitGroup
 	for i := range p.endpointRPC {
-		cctx, cancel := context.WithTimeout(ctx, p.budget.timeout)
-		slot, err := p.endpointRPC[i].GetSlot(cctx, rpc.CommitmentConfirmed)
-		cancel()
-		if err != nil {
-			p.log.Debug("Solana RPC slot probe failed", "endpoint", p.urls[i], "error", err)
-			continue
-		}
-		slots[i] = slot
-		if slot > maxSlot {
-			maxSlot = slot
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cctx, cancel := context.WithTimeout(ctx, probeTimeout)
+			defer cancel()
+			slot, err := p.endpointRPC[i].GetSlot(cctx, rpc.CommitmentConfirmed)
+			if err != nil {
+				p.log.Debug("Solana RPC slot probe failed", "endpoint", redactURL(p.urls[i]), "error", p.scrubErr(err))
+				return
+			}
+			slots[i] = slot
+		}(i)
+	}
+	wg.Wait()
+
+	var maxSlot uint64
+	for _, s := range slots {
+		if s > maxSlot {
+			maxSlot = s
 		}
 	}
 	if maxSlot == 0 {
@@ -303,8 +358,8 @@ func (p *solanaRPCPool) SelectHealthiestEndpoint(ctx context.Context) {
 	curSlot := slots[p.current]
 	if maxSlot-curSlot > p.budget.maxSlotLag {
 		p.log.Info("Solana RPC endpoint lagging, failing over to fresher endpoint",
-			"from", p.urls[p.current], "fromSlot", curSlot,
-			"to", p.urls[best], "toSlot", bestSlot,
+			"from", redactURL(p.urls[p.current]), "fromSlot", curSlot,
+			"to", redactURL(p.urls[best]), "toSlot", bestSlot,
 			"lag", maxSlot-curSlot, "threshold", p.budget.maxSlotLag)
 		p.current = best
 	}

--- a/e2e/internal/qa/solanarpc.go
+++ b/e2e/internal/qa/solanarpc.go
@@ -386,6 +386,22 @@ func isRetryableRPCErr(err error) bool {
 		return httpErr.Code == 429 || httpErr.Code >= 500
 	}
 
+	// JSON-RPC-level errors. CallForInto returns the response's *jsonrpc.RPCError
+	// directly, so an endpoint that explicitly reports it is behind the cluster
+	// surfaces here, not as an HTTP/network error. Fail over on those stale-node
+	// codes; all other JSON-RPC errors are business errors that should surface.
+	var rpcErr *jsonrpc.RPCError
+	if errors.As(err, &rpcErr) {
+		switch rpcErr.Code {
+		// -32005: node is behind by N slots. -32004: block not available for the
+		// requested slot (node still catching up). Both are the stale-endpoint
+		// condition this failover targets.
+		case -32005, -32004:
+			return true
+		}
+		return false
+	}
+
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		return true

--- a/e2e/internal/qa/solanarpc_test.go
+++ b/e2e/internal/qa/solanarpc_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -135,7 +136,7 @@ func TestSelectHealthiestEndpoint_AllProbesFailKeepsCurrent(t *testing.T) {
 }
 
 func TestFailover_AdvancesOnRetryableError(t *testing.T) {
-	timeoutErr := &jsonrpc.HTTPError{Code: 503}
+	timeoutErr := jsonrpc.NewHTTPError(503, errors.New("http error"))
 	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return timeoutErr }}
 	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return nil }}
 	pool := newTestPool(ep0, ep1)
@@ -154,7 +155,7 @@ func TestFailover_AdvancesOnRetryableError(t *testing.T) {
 }
 
 func TestFailover_ExhaustionReturnsLastError(t *testing.T) {
-	httpErr := &jsonrpc.HTTPError{Code: 500}
+	httpErr := jsonrpc.NewHTTPError(500, errors.New("http error"))
 	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
 	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return httpErr }}
 	pool := newTestPool(ep0, ep1)
@@ -187,7 +188,7 @@ func TestFailover_NonRetryableDoesNotAdvance(t *testing.T) {
 }
 
 func TestFailover_SingleEndpointPassthrough(t *testing.T) {
-	httpErr := &jsonrpc.HTTPError{Code: 503}
+	httpErr := jsonrpc.NewHTTPError(503, errors.New("http error"))
 	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
 	pool := newTestPool(ep0)
 
@@ -273,9 +274,9 @@ func TestIsRetryableRPCErr(t *testing.T) {
 		{"nil", nil, false},
 		{"context canceled", context.Canceled, false},
 		{"context deadline", context.DeadlineExceeded, true},
-		{"http 429", &jsonrpc.HTTPError{Code: 429}, true},
-		{"http 503", &jsonrpc.HTTPError{Code: 503}, true},
-		{"http 400", &jsonrpc.HTTPError{Code: 400}, false},
+		{"http 429", jsonrpc.NewHTTPError(429, errors.New("http error")), true},
+		{"http 503", jsonrpc.NewHTTPError(503, errors.New("http error")), true},
+		{"http 400", jsonrpc.NewHTTPError(400, errors.New("http error")), false},
 		{"connection reset", errors.New("read tcp: connection reset by peer"), true},
 		{"eof", errors.New("unexpected EOF"), true},
 		{"business error", errors.New("invalid params: bad pubkey"), false},
@@ -289,7 +290,7 @@ func TestIsRetryableRPCErr(t *testing.T) {
 	}
 }
 
-func TestWriteFailover_RetriesThenSucceeds(t *testing.T) {
+func TestReadFailover_RetriesThenSucceeds(t *testing.T) {
 	pool := newTestPool(
 		&fakeJSONRPCClient{name: "0"},
 		&fakeJSONRPCClient{name: "1"},
@@ -297,10 +298,10 @@ func TestWriteFailover_RetriesThenSucceeds(t *testing.T) {
 	c := &Client{log: testLogger(), solanaRPC: pool, SolanaRPCURL: "http://endpoint-0"}
 
 	var seenURLs []string
-	err := c.withWriteFailover(func(url string) error {
+	err := c.withReadFailover(func(url string) error {
 		seenURLs = append(seenURLs, url)
 		if url == "http://endpoint-0" {
-			return errors.New("rpc unreachable")
+			return errors.New("dial tcp: connection refused")
 		}
 		return nil
 	})
@@ -312,10 +313,30 @@ func TestWriteFailover_RetriesThenSucceeds(t *testing.T) {
 	}
 }
 
-func TestWriteFailover_NoPoolRunsOnce(t *testing.T) {
+func TestReadFailover_NonRetryableDoesNotFailOver(t *testing.T) {
+	pool := newTestPool(
+		&fakeJSONRPCClient{name: "0"},
+		&fakeJSONRPCClient{name: "1"},
+	)
+	c := &Client{log: testLogger(), solanaRPC: pool, SolanaRPCURL: "http://endpoint-0"}
+
+	calls := 0
+	err := c.withReadFailover(func(url string) error {
+		calls++
+		return errors.New("invalid program config: business rejection")
+	})
+	if err == nil {
+		t.Fatal("expected business error to surface")
+	}
+	if calls != 1 {
+		t.Fatalf("expected single attempt for non-retryable error, got %d", calls)
+	}
+}
+
+func TestReadFailover_NoPoolRunsOnce(t *testing.T) {
 	c := &Client{log: testLogger(), SolanaRPCURL: "http://only"}
 	calls := 0
-	err := c.withWriteFailover(func(url string) error {
+	err := c.withReadFailover(func(url string) error {
 		calls++
 		if url != "http://only" {
 			t.Fatalf("expected static URL, got %s", url)
@@ -327,5 +348,59 @@ func TestWriteFailover_NoPoolRunsOnce(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("expected single attempt without pool, got %d", calls)
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://mainnet.helius-rpc.com/?api-key=SECRET", "https://mainnet.helius-rpc.com/<redacted>"},
+		{"https://example.quiknode.pro/TOKEN123/", "https://example.quiknode.pro/<redacted>"},
+		{"https://api.mainnet-beta.solana.com", "https://api.mainnet-beta.solana.com"},
+		{"https://user:pass@rpc.example.com", "https://rpc.example.com/<redacted>"},
+		{"not a url", "<redacted-rpc-url>"},
+	}
+	for _, tt := range tests {
+		if got := redactURL(tt.in); got != tt.want {
+			t.Fatalf("redactURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestScrubErr_RemovesEndpointURLs(t *testing.T) {
+	pool := newTestPool(&fakeJSONRPCClient{name: "0"})
+	pool.urls = []string{"https://mainnet.helius-rpc.com/?api-key=SECRET"}
+	err := errors.New("rpc call failed on https://mainnet.helius-rpc.com/?api-key=SECRET: timeout")
+	got := pool.scrubErr(err)
+	if strings.Contains(got, "SECRET") {
+		t.Fatalf("scrubErr leaked credential: %q", got)
+	}
+}
+
+// TestFailover_ConcurrentAdvanceConverges exercises many goroutines failing over
+// through a shared pool where only the last endpoint succeeds, asserting the
+// sticky index converges to exactly the healthy endpoint and never overshoots.
+// Run with -race to catch index races.
+func TestFailover_ConcurrentAdvanceConverges(t *testing.T) {
+	httpErr := jsonrpc.NewHTTPError(503, errors.New("http error"))
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return httpErr }}
+	ep2 := &fakeJSONRPCClient{name: "2", callForInto: func(any, string, []any) error { return nil }}
+	pool := newTestPool(ep0, ep1, ep2)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = pool.CallForInto(context.Background(), nil, "getSlot", nil)
+		}()
+	}
+	wg.Wait()
+
+	if pool.CurrentURL() != "http://endpoint-2" {
+		t.Fatalf("expected convergence to healthy endpoint-2, got %s", pool.CurrentURL())
 	}
 }

--- a/e2e/internal/qa/solanarpc_test.go
+++ b/e2e/internal/qa/solanarpc_test.go
@@ -1,0 +1,331 @@
+package qa
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeJSONRPCClient is a programmable jsonrpc.RPCClient for testing failover.
+type fakeJSONRPCClient struct {
+	name string
+	// callForInto is invoked for CallForInto; if nil, returns errBoom.
+	callForInto func(out any, method string, params []any) error
+	mu          sync.Mutex
+	calls       int
+}
+
+func (f *fakeJSONRPCClient) CallForInto(ctx context.Context, out any, method string, params []any) error {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.callForInto != nil {
+		return f.callForInto(out, method, params)
+	}
+	return errors.New("boom")
+}
+
+func (f *fakeJSONRPCClient) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// Unused methods needed to satisfy jsonrpc.RPCClient.
+func (f *fakeJSONRPCClient) Call(ctx context.Context, method string, params ...any) (*jsonrpc.RPCResponse, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeJSONRPCClient) CallRaw(ctx context.Context, request *jsonrpc.RPCRequest) (*jsonrpc.RPCResponse, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeJSONRPCClient) CallFor(ctx context.Context, out any, method string, params ...any) error {
+	return f.CallForInto(ctx, out, method, params)
+}
+func (f *fakeJSONRPCClient) CallWithCallback(ctx context.Context, method string, params []any, callback func(*http.Request, *http.Response) error) error {
+	return errors.New("not implemented")
+}
+func (f *fakeJSONRPCClient) CallBatch(ctx context.Context, requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeJSONRPCClient) CallBatchRaw(ctx context.Context, requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeJSONRPCClient) Close() error { return nil }
+
+func newTestPool(clients ...*fakeJSONRPCClient) *solanaRPCPool {
+	urls := make([]string, len(clients))
+	jc := make([]jsonrpc.RPCClient, len(clients))
+	endpointRPC := make([]*rpc.Client, len(clients))
+	for i, c := range clients {
+		urls[i] = "http://endpoint-" + c.name
+		jc[i] = c
+		endpointRPC[i] = rpc.NewWithCustomRPCClient(c)
+	}
+	return &solanaRPCPool{
+		log:         testLogger(),
+		urls:        urls,
+		budget:      rpcBudget{timeout: time.Second, maxSlotLag: defaultRPCMaxSlotLag},
+		clients:     jc,
+		endpointRPC: endpointRPC,
+	}
+}
+
+// slotResponder returns a callForInto func that answers getSlot with the given
+// slot and fails everything else.
+func slotResponder(slot uint64, err error) func(any, string, []any) error {
+	return func(out any, method string, params []any) error {
+		if method != "getSlot" {
+			return errors.New("unexpected method " + method)
+		}
+		if err != nil {
+			return err
+		}
+		if p, ok := out.(*uint64); ok {
+			*p = slot
+		}
+		return nil
+	}
+}
+
+func TestSelectHealthiestEndpoint_FailsOverLaggingNode(t *testing.T) {
+	// endpoint-0 is far behind, endpoint-1 is current.
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: slotResponder(1000, nil)}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: slotResponder(1000+defaultRPCMaxSlotLag+1, nil)}
+	pool := newTestPool(ep0, ep1)
+
+	pool.SelectHealthiestEndpoint(context.Background())
+	if pool.CurrentURL() != "http://endpoint-1" {
+		t.Fatalf("expected failover to fresher endpoint-1, got %s", pool.CurrentURL())
+	}
+}
+
+func TestSelectHealthiestEndpoint_WithinThresholdStays(t *testing.T) {
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: slotResponder(1000, nil)}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: slotResponder(1000+defaultRPCMaxSlotLag-1, nil)}
+	pool := newTestPool(ep0, ep1)
+
+	pool.SelectHealthiestEndpoint(context.Background())
+	if pool.CurrentURL() != "http://endpoint-0" {
+		t.Fatalf("expected to stay on endpoint-0 within lag threshold, got %s", pool.CurrentURL())
+	}
+}
+
+func TestSelectHealthiestEndpoint_AllProbesFailKeepsCurrent(t *testing.T) {
+	probeErr := errors.New("probe failed")
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: slotResponder(0, probeErr)}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: slotResponder(0, probeErr)}
+	pool := newTestPool(ep0, ep1)
+
+	pool.SelectHealthiestEndpoint(context.Background())
+	if pool.CurrentURL() != "http://endpoint-0" {
+		t.Fatalf("expected to keep current endpoint when all probes fail, got %s", pool.CurrentURL())
+	}
+}
+
+func TestFailover_AdvancesOnRetryableError(t *testing.T) {
+	timeoutErr := &jsonrpc.HTTPError{Code: 503}
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return timeoutErr }}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return nil }}
+	pool := newTestPool(ep0, ep1)
+
+	if err := pool.CallForInto(context.Background(), nil, "getSlot", nil); err != nil {
+		t.Fatalf("expected success after failover, got %v", err)
+	}
+	if pool.CurrentURL() != "http://endpoint-1" {
+		t.Fatalf("expected sticky failover to endpoint-1, got %s", pool.CurrentURL())
+	}
+	// A subsequent call should stay on endpoint-1 (sticky), not retry endpoint-0.
+	_ = pool.CallForInto(context.Background(), nil, "getSlot", nil)
+	if ep0.callCount() != 1 {
+		t.Fatalf("expected endpoint-0 called once (sticky), got %d", ep0.callCount())
+	}
+}
+
+func TestFailover_ExhaustionReturnsLastError(t *testing.T) {
+	httpErr := &jsonrpc.HTTPError{Code: 500}
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return httpErr }}
+	pool := newTestPool(ep0, ep1)
+
+	err := pool.CallForInto(context.Background(), nil, "getSlot", nil)
+	if err == nil {
+		t.Fatal("expected error after all endpoints exhausted")
+	}
+	if ep0.callCount() != 1 || ep1.callCount() != 1 {
+		t.Fatalf("expected each endpoint tried once, got ep0=%d ep1=%d", ep0.callCount(), ep1.callCount())
+	}
+}
+
+func TestFailover_NonRetryableDoesNotAdvance(t *testing.T) {
+	businessErr := errors.New("invalid params")
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return businessErr }}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return nil }}
+	pool := newTestPool(ep0, ep1)
+
+	err := pool.CallForInto(context.Background(), nil, "getSlot", nil)
+	if err == nil {
+		t.Fatal("expected non-retryable error to surface")
+	}
+	if pool.CurrentURL() != "http://endpoint-0" {
+		t.Fatalf("expected to stay on endpoint-0 for non-retryable error, got %s", pool.CurrentURL())
+	}
+	if ep1.callCount() != 0 {
+		t.Fatalf("expected endpoint-1 untouched, got %d", ep1.callCount())
+	}
+}
+
+func TestFailover_SingleEndpointPassthrough(t *testing.T) {
+	httpErr := &jsonrpc.HTTPError{Code: 503}
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
+	pool := newTestPool(ep0)
+
+	err := pool.CallForInto(context.Background(), nil, "getSlot", nil)
+	if err == nil {
+		t.Fatal("expected error with single endpoint")
+	}
+	if ep0.callCount() != 1 {
+		t.Fatalf("expected single attempt, got %d", ep0.callCount())
+	}
+	if pool.CurrentURL() != "http://endpoint-0" {
+		t.Fatalf("single endpoint should not change, got %s", pool.CurrentURL())
+	}
+}
+
+func TestResolveSolanaRPCEndpoints(t *testing.T) {
+	tests := []struct {
+		name          string
+		primary       string
+		publicDefault string
+		fallbackEnv   string
+		want          []string
+	}{
+		{
+			name:          "public default appended when fallback unset",
+			primary:       "https://private",
+			publicDefault: "https://public",
+			want:          []string{"https://private", "https://public"},
+		},
+		{
+			name:          "no public default on testnet/devnet",
+			primary:       "https://dz-ledger",
+			publicDefault: "",
+			want:          []string{"https://dz-ledger"},
+		},
+		{
+			name:          "explicit fallbacks override default and dedupe",
+			primary:       "https://private",
+			publicDefault: "https://public",
+			fallbackEnv:   "https://a, https://b ,https://a",
+			want:          []string{"https://private", "https://a", "https://b"},
+		},
+		{
+			name:          "primary equal to public default collapses",
+			primary:       "https://public",
+			publicDefault: "https://public",
+			want:          []string{"https://public"},
+		},
+		{
+			name:          "blank fallback entries dropped",
+			primary:       "https://private",
+			publicDefault: "",
+			fallbackEnv:   ",  ,https://b,",
+			want:          []string{"https://private", "https://b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.fallbackEnv != "" {
+				t.Setenv("SOLANA_RPC_FALLBACK_URLS", tt.fallbackEnv)
+			} else {
+				t.Setenv("SOLANA_RPC_FALLBACK_URLS", "")
+			}
+			got := resolveSolanaRPCEndpoints(tt.primary, tt.publicDefault)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestIsRetryableRPCErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, true},
+		{"http 429", &jsonrpc.HTTPError{Code: 429}, true},
+		{"http 503", &jsonrpc.HTTPError{Code: 503}, true},
+		{"http 400", &jsonrpc.HTTPError{Code: 400}, false},
+		{"connection reset", errors.New("read tcp: connection reset by peer"), true},
+		{"eof", errors.New("unexpected EOF"), true},
+		{"business error", errors.New("invalid params: bad pubkey"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableRPCErr(tt.err); got != tt.want {
+				t.Fatalf("isRetryableRPCErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteFailover_RetriesThenSucceeds(t *testing.T) {
+	pool := newTestPool(
+		&fakeJSONRPCClient{name: "0"},
+		&fakeJSONRPCClient{name: "1"},
+	)
+	c := &Client{log: testLogger(), solanaRPC: pool, SolanaRPCURL: "http://endpoint-0"}
+
+	var seenURLs []string
+	err := c.withWriteFailover(func(url string) error {
+		seenURLs = append(seenURLs, url)
+		if url == "http://endpoint-0" {
+			return errors.New("rpc unreachable")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after failover, got %v", err)
+	}
+	if len(seenURLs) != 2 || seenURLs[0] != "http://endpoint-0" || seenURLs[1] != "http://endpoint-1" {
+		t.Fatalf("unexpected URL sequence: %v", seenURLs)
+	}
+}
+
+func TestWriteFailover_NoPoolRunsOnce(t *testing.T) {
+	c := &Client{log: testLogger(), SolanaRPCURL: "http://only"}
+	calls := 0
+	err := c.withWriteFailover(func(url string) error {
+		calls++
+		if url != "http://only" {
+			t.Fatalf("expected static URL, got %s", url)
+		}
+		return errors.New("fail")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("expected single attempt without pool, got %d", calls)
+	}
+}

--- a/e2e/internal/qa/solanarpc_test.go
+++ b/e2e/internal/qa/solanarpc_test.go
@@ -154,6 +154,22 @@ func TestFailover_AdvancesOnRetryableError(t *testing.T) {
 	}
 }
 
+func TestFailover_AdvancesOnStaleNodeRPCError(t *testing.T) {
+	// A node that explicitly reports it is behind (-32005) should trigger
+	// failover, not surface as a non-retryable business error.
+	behind := &jsonrpc.RPCError{Code: -32005, Message: "Node is behind by 153 slots"}
+	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return behind }}
+	ep1 := &fakeJSONRPCClient{name: "1", callForInto: func(any, string, []any) error { return nil }}
+	pool := newTestPool(ep0, ep1)
+
+	if err := pool.CallForInto(context.Background(), nil, "getSlot", nil); err != nil {
+		t.Fatalf("expected failover past stale node, got %v", err)
+	}
+	if pool.CurrentURL() != "http://endpoint-1" {
+		t.Fatalf("expected failover to endpoint-1, got %s", pool.CurrentURL())
+	}
+}
+
 func TestFailover_ExhaustionReturnsLastError(t *testing.T) {
 	httpErr := jsonrpc.NewHTTPError(500, errors.New("http error"))
 	ep0 := &fakeJSONRPCClient{name: "0", callForInto: func(any, string, []any) error { return httpErr }}
@@ -280,6 +296,9 @@ func TestIsRetryableRPCErr(t *testing.T) {
 		{"connection reset", errors.New("read tcp: connection reset by peer"), true},
 		{"eof", errors.New("unexpected EOF"), true},
 		{"business error", errors.New("invalid params: bad pubkey"), false},
+		{"rpc node behind -32005", &jsonrpc.RPCError{Code: -32005, Message: "Node is behind by 153 slots"}, true},
+		{"rpc block unavailable -32004", &jsonrpc.RPCError{Code: -32004, Message: "Block not available for slot"}, true},
+		{"rpc invalid params -32602", &jsonrpc.RPCError{Code: -32602, Message: "invalid params"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary of Changes
* Make the mainnet-beta QA client tolerate both Solana RPC failure modes automatically, eliminating the manual `SOLANA_RPC_URL` secret repointing during outages.
* **Multi-endpoint failover.** A sticky-index failover pool (`solanaRPCPool`) implements `rpc.JSONRPCClient`, so failover is transparent to both direct RPC reads and the shreds SDK reads. On a retryable failure (timeout, network error, HTTP 429/5xx) it advances to the next endpoint; it stays sticky once failed over. Endpoints are resolved from `SOLANA_RPC_URL` plus `SOLANA_RPC_FALLBACK_URLS`, with the public mainnet RPC appended as a default fallback when the var is unset (mainnet only; testnet/devnet keep the DZ-ledger single endpoint).
* **Active slot-lag detection.** Probes each endpoint's slot height (`getSlot`) concurrently and fails over to the freshest node when the current endpoint trails the max observed slot beyond a configurable threshold — turning a "stale but valid" lagging node into an explicit failover trigger.
* **Poll-until-consistent post-write reads.** The post-write client-seat read polls until the seat is visible (tolerating `rpc.ErrNotFound`/`ErrAccountNotFound`) rather than failing on a single stale read; the settlement test already polls the balance.
* **Configurable timeout/retry budgets** (`QA_SOLANA_RPC_*`) replacing the hardcoded 30s window; defaults preserve current behavior.
* Settlement **writes** (`FeedSeatPay`/`FeedSeatWithdraw`) target the pool's health-selected endpoint but deliberately do not retry across endpoints, to avoid double-submitting a settlement transaction.
* Fixes #3930

## Testing Verification
* New unit tests (`solanarpc_test.go`, no network): failover advances on retryable errors and is sticky; exhaustion returns the last error; non-retryable/business errors surface without failover; single-endpoint passthrough; endpoint resolution dedupe and public-default-when-unset; slot-lag failover / within-threshold / all-probes-fail; read-failover retry vs non-retryable; credential redaction and error scrubbing.
* Concurrent-failover test runs under `go test -race` and asserts the sticky index converges to exactly the healthy endpoint without overshoot.
* Verified against the live error path that a missing account surfaces as `rpc.ErrNotFound` (not the shreds sentinel), so the poll-until guard now matches both.
* `go test -race -tags qa ./e2e/internal/qa/...` green; `golangci-lint` clean; the `e2e` test binary compiles under `-tags qa`.
* Full mainnet-beta QA validation happens in the infra workflow after merge.

Note: the code diff is comment-dense (~385 lines of actual code; the remainder is documentation comments).
