### PR TITLE
make dependabot monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
     directories:
       - "**/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
+    labels:
+      - "skip-changelog"
+      - "dependencies"
+      - "go"
     groups:
       go-minor-patch:
         update-types:
@@ -27,8 +31,12 @@ updates:
     directories:
       - "**/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
+    labels:
+      - "skip-changelog"
+      - "dependencies"
+      - "rust"
     groups:
       rust-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary of Changes
* Make dependabot monthly instead of weekly
* Add Skip-changelog to dependabot commits, since they don't have changelog entries.
