### PR TITLE
e2e: fix flaky maxusers rollover and interface validation tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -257,9 +257,7 @@ jobs:
       run:
         working-directory: "e2e/"
     runs-on: doublezero-k8s-ci
-    # Keep above the go test -timeout (20m) plus rerun headroom, so Go dumps its
-    # per-test stack on timeout instead of GitHub killing the job with no diagnostics.
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions:
       packages: read
       contents: read
@@ -344,24 +342,11 @@ jobs:
           pull_with_retry ${{ env.DZ_IMAGE_REPO }}/validator-metadata-service-mock:${{ env.DZ_IMAGE_TAG }}
           pull_with_retry ghcr.io/malbeclabs/dz-e2e/prometheus:v2.54.1
           pull_with_retry public.ecr.aws/influxdb/influxdb:1.8
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
       - name: test
         id: test
         env:
           DZ_E2E_NO_BUILD: "1"
-        # Run once, then automatically rerun only the tests that failed. A transient
-        # flake passes on the rerun and the shard stays green; a real failure fails
-        # both attempts and stays red. gotestsum lists which tests were retried, so
-        # flakes remain visible and trackable instead of being silently masked.
-        # rerun-fails-max-failures caps reruns: if more tests than that fail at once,
-        # the build is broadly broken, so we don't rerun and report failure.
-        run: |
-          "$(go env GOPATH)/bin/gotestsum" \
-            --rerun-fails=1 \
-            --rerun-fails-max-failures=15 \
-            --packages=. \
-            -- -tags=e2e -timeout=20m -parallel=12 -run '${{ matrix.run }}' -v
+        run: go test -tags=e2e -timeout=20m -parallel=12 -run '${{ matrix.run }}' -v
       - name: Report check-run result on PR head
         if: always() && github.event_name == 'workflow_dispatch' && steps.check.outputs.id
         uses: actions/github-script@v7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -257,7 +257,9 @@ jobs:
       run:
         working-directory: "e2e/"
     runs-on: doublezero-k8s-ci
-    timeout-minutes: 15
+    # Keep above the go test -timeout (20m) plus rerun headroom, so Go dumps its
+    # per-test stack on timeout instead of GitHub killing the job with no diagnostics.
+    timeout-minutes: 30
     permissions:
       packages: read
       contents: read
@@ -342,11 +344,24 @@ jobs:
           pull_with_retry ${{ env.DZ_IMAGE_REPO }}/validator-metadata-service-mock:${{ env.DZ_IMAGE_TAG }}
           pull_with_retry ghcr.io/malbeclabs/dz-e2e/prometheus:v2.54.1
           pull_with_retry public.ecr.aws/influxdb/influxdb:1.8
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: test
         id: test
         env:
           DZ_E2E_NO_BUILD: "1"
-        run: go test -tags=e2e -timeout=20m -parallel=12 -run '${{ matrix.run }}' -v
+        # Run once, then automatically rerun only the tests that failed. A transient
+        # flake passes on the rerun and the shard stays green; a real failure fails
+        # both attempts and stays red. gotestsum lists which tests were retried, so
+        # flakes remain visible and trackable instead of being silently masked.
+        # rerun-fails-max-failures caps reruns: if more tests than that fail at once,
+        # the build is broadly broken, so we don't rerun and report failure.
+        run: |
+          "$(go env GOPATH)/bin/gotestsum" \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=15 \
+            --packages=. \
+            -- -tags=e2e -timeout=20m -parallel=12 -run '${{ matrix.run }}' -v
       - name: Report check-run result on PR head
         if: always() && github.event_name == 'workflow_dispatch' && steps.check.outputs.id
         uses: actions/github-script@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file.
 - E2E tests
   - Route all devnet networks (CYOA, default, and miscellaneous) through a shared collision-safe subnet allocator to prevent overlapping subnet assignments across concurrent test runs. (#3919)
   - Harden the mainnet-beta QA client against flaky/stale Solana RPC: multi-endpoint failover (with a public-RPC default fallback when `SOLANA_RPC_FALLBACK_URLS` is unset), active slot-lag detection, poll-until-consistent post-write reads, and configurable timeout/retry budgets. Eliminates manual `SOLANA_RPC_URL` repointing during RPC outages. (#3930)
+  - Make device selection deterministic in the maxusers rollover test by waiting until the nearby device is measured faster than the faraway device by more than the client's 5ms latency tolerance, so the client cannot connect to the wrong device on a tie. (#3936)
+  - Match CLI validation errors case-insensitively in the interface validation test, decoupling assertions from the program's error-message casing. (#3936)
+- CI
+  - Rerun only the failed e2e tests via `gotestsum --rerun-fails=1` so transient flakes don't redden a shard while staying visible, and raise the e2e job timeout above the `go test` timeout so Go dumps per-test stacks on timeout. (#3936)
 
 ## [v0.27.1](https://github.com/malbeclabs/doublezero/compare/client/v0.27.0...client/v0.27.1) - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ All notable changes to this project will be documented in this file.
   - Harden the mainnet-beta QA client against flaky/stale Solana RPC: multi-endpoint failover (with a public-RPC default fallback when `SOLANA_RPC_FALLBACK_URLS` is unset), active slot-lag detection, poll-until-consistent post-write reads, and configurable timeout/retry budgets. Eliminates manual `SOLANA_RPC_URL` repointing during RPC outages. (#3930)
   - Make device selection deterministic in the maxusers rollover test by waiting until the nearby device is measured faster than the faraway device by more than the client's 5ms latency tolerance, so the client cannot connect to the wrong device on a tie. (#3936)
   - Match CLI validation errors case-insensitively in the interface validation test, decoupling assertions from the program's error-message casing. (#3936)
-- CI
-  - Rerun only the failed e2e tests via `gotestsum --rerun-fails=1` so transient flakes don't redden a shard while staying visible, and raise the e2e job timeout above the `go test` timeout so Go dumps per-test stacks on timeout. (#3936)
 
 ## [v0.27.1](https://github.com/malbeclabs/doublezero/compare/client/v0.27.0...client/v0.27.1) - 2026-06-10
 

--- a/e2e/device_maxusers_rollover_test.go
+++ b/e2e/device_maxusers_rollover_test.go
@@ -126,11 +126,15 @@ func TestE2E_DeviceMaxusersRollover(t *testing.T) {
 	_, err = dn.Manager.Exec(t.Context(), []string{"bash", "-c", "doublezero access-pass set --accesspass-type prepaid --client-ip " + client.CYOANetworkIP + " --user-payer " + client.Pubkey})
 	require.NoError(t, err)
 
-	// Wait for client latency results.
-	log.Debug("==> Waiting for client latency results")
-	err = client.WaitForLatencyResults(t.Context(), devicePK1, 90*time.Second)
+	// Wait for client latency results. The 10ms netem delay applied to device2 should make
+	// device1 the nearest, but the client selects by min latency within a 5ms tolerance
+	// window. Wait until both devices are reachable AND device1 is measured as clearly
+	// faster than device2 (by more than that tolerance) so selection is deterministic and
+	// the client does not connect to faraway-dzd1 on a tie.
+	log.Debug("==> Waiting for latency ordering (nearby faster than faraway)")
+	err = client.WaitForLatencyOrdering(t.Context(), devicePK1, devicePK2, 5*time.Millisecond, 90*time.Second)
 	require.NoError(t, err)
-	log.Debug("--> Finished waiting for client latency results")
+	log.Debug("--> Latency ordering established")
 
 	// Connect client in IBRL mode.
 	log.Debug("==> Connecting client in IBRL mode")

--- a/e2e/interface_validation_test.go
+++ b/e2e/interface_validation_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// containsAnyFold reports whether s contains any of the given substrings,
+// case-insensitively. Used to match CLI error output robustly: the human-readable
+// message, the error enum name, or the raw hex code may each appear depending on
+// timing, and the message casing must not matter (e.g. the program returns
+// "Invalid Interface IP", not "Invalid interface IP").
+func containsAnyFold(s string, substrs ...string) bool {
+	s = strings.ToLower(s)
+	for _, sub := range substrs {
+		if strings.Contains(s, strings.ToLower(sub)) {
+			return true
+		}
+	}
+	return false
+}
+
 // TestE2E_InterfaceValidation tests the interface validation rules for CYOA and public IPs.
 // This test consolidates multiple validation scenarios into a single test function to reduce
 // the number of Docker networks created, avoiding network address pool exhaustion.
@@ -43,9 +58,10 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 
 		require.Error(t, err, "expected error when creating loopback with CYOA")
 		require.True(t,
-			strings.Contains(string(output), "CYOA can only be set on physical interfaces") ||
-				strings.Contains(string(output), "CyoaRequiresPhysical") ||
-				strings.Contains(string(output), "0x45"), // error code 69 in hex
+			containsAnyFold(string(output),
+				"CYOA can only be set on physical interfaces", // CyoaRequiresPhysical message
+				"CyoaRequiresPhysical",
+				"0x45"), // error code 69 in hex
 			"expected CyoaRequiresPhysical error, got: %s", string(output))
 
 		dn.log.Debug("--> Correctly rejected loopback with CYOA")
@@ -125,9 +141,10 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 
 		require.Error(t, err, "expected error when creating loopback with public IP but without user_tunnel_endpoint")
 		require.True(t,
-			strings.Contains(string(output), "Invalid interface IP") ||
-				strings.Contains(string(output), "InvalidInterfaceIp") ||
-				strings.Contains(string(output), "0x2f"), // error code 47 in hex
+			containsAnyFold(string(output),
+				"Invalid Interface IP", // InvalidInterfaceIp message
+				"InvalidInterfaceIp",
+				"0x2f"), // error code 47 in hex
 			"expected InvalidInterfaceIp error, got: %s", string(output))
 
 		dn.log.Debug("--> Correctly rejected loopback with public IP without user_tunnel_endpoint")
@@ -164,9 +181,10 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 
 		require.Error(t, err, "expected error when updating loopback to add CYOA")
 		require.True(t,
-			strings.Contains(string(output), "CYOA can only be set on physical interfaces") ||
-				strings.Contains(string(output), "CyoaRequiresPhysical") ||
-				strings.Contains(string(output), "0x45"), // error code 69 in hex
+			containsAnyFold(string(output),
+				"CYOA can only be set on physical interfaces", // CyoaRequiresPhysical message
+				"CyoaRequiresPhysical",
+				"0x45"), // error code 69 in hex
 			"expected CyoaRequiresPhysical error, got: %s", string(output))
 
 		dn.log.Debug("--> Correctly rejected update to add CYOA on loopback")
@@ -232,9 +250,10 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 
 		require.Error(t, err, "expected error when creating plain physical interface with ip_net")
 		require.True(t,
-			strings.Contains(string(output), "Invalid interface IP") ||
-				strings.Contains(string(output), "InvalidInterfaceIp") ||
-				strings.Contains(string(output), "0x2f"),
+			containsAnyFold(string(output),
+				"Invalid Interface IP", // InvalidInterfaceIp message
+				"InvalidInterfaceIp",
+				"0x2f"), // error code 47 in hex
 			"expected InvalidInterfaceIp error, got: %s", string(output))
 
 		dn.log.Debug("--> Correctly rejected plain physical interface with ip_net")
@@ -297,9 +316,10 @@ func TestE2E_InterfaceValidation(t *testing.T) {
 
 		require.Error(t, err, "expected error when updating plain physical interface with ip_net")
 		require.True(t,
-			strings.Contains(string(output), "Invalid interface IP") ||
-				strings.Contains(string(output), "InvalidInterfaceIp") ||
-				strings.Contains(string(output), "0x2f"),
+			containsAnyFold(string(output),
+				"Invalid Interface IP", // InvalidInterfaceIp message
+				"InvalidInterfaceIp",
+				"0x2f"), // error code 47 in hex
 			"expected InvalidInterfaceIp error, got: %s", string(output))
 
 		dn.log.Debug("--> Correctly rejected update of plain physical interface with ip_net")

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -746,6 +746,65 @@ func (c *Client) WaitForLatencyReady(ctx context.Context, timeout time.Duration)
 	return nil
 }
 
+// WaitForLatencyOrdering waits until both devices are reachable AND the measured
+// minimum latency of fasterPK is lower than that of slowerPK by more than margin.
+//
+// This makes a device-selection precondition explicit and deterministic: the client
+// picks a device by min_latency_ns within a small tolerance window (see
+// LATENCY_TOLERANCE_NS in client/doublezero/src/dzd_latency.rs). Waiting only for one
+// device to have a reachable sample (WaitForLatencyResults) is not enough — if the
+// other device's measurement has not converged below the tolerance yet, selection is
+// effectively a tie and can pick either device. Pass a margin >= the client's 5ms
+// tolerance so the ordering the test relies on is unambiguous at connect time.
+func (c *Client) WaitForLatencyOrdering(ctx context.Context, fasterPK, slowerPK string, margin time.Duration, timeout time.Duration) error {
+	c.log.Debug("==> Waiting for latency ordering", "fasterPK", fasterPK, "slowerPK", slowerPK, "margin", margin, "timeout", timeout)
+
+	start := time.Now()
+	marginNS := float64(margin.Nanoseconds())
+
+	// minLatencyNS returns the min_latency_ns for the given device when it has a
+	// reachable sample. JSON numbers decode into float64 within map[string]any.
+	minLatencyNS := func(results []map[string]any, devicePK string) (float64, bool) {
+		for _, result := range results {
+			if result["device_pk"] != devicePK || result["reachable"] != true {
+				continue
+			}
+			minNS, ok := result["min_latency_ns"].(float64)
+			if !ok {
+				return 0, false
+			}
+			return minNS, true
+		}
+		return 0, false
+	}
+
+	err := poll.Until(ctx, func() (bool, error) {
+		resp, err := docker.ExecReturnObject[daemonLatencyResponse](ctx, c.dn.dockerClient, c.ContainerID, []string{"curl", "-s", "--unix-socket", "/var/run/doublezerod/doublezerod.sock", "http://doublezero/v2/latency"})
+		if err != nil {
+			return false, nil
+		}
+
+		fasterMin, fasterOK := minLatencyNS(resp.Results, fasterPK)
+		slowerMin, slowerOK := minLatencyNS(resp.Results, slowerPK)
+		if !fasterOK || !slowerOK {
+			return false, nil
+		}
+
+		if slowerMin-fasterMin > marginNS {
+			c.log.Debug("✅ Latency ordering satisfied", "fasterMinNS", fasterMin, "slowerMinNS", slowerMin, "marginNS", marginNS, "duration", time.Since(start))
+			return true, nil
+		}
+
+		c.log.Debug("--> Waiting for latency ordering", "fasterMinNS", fasterMin, "slowerMinNS", slowerMin, "marginNS", marginNS)
+		return false, nil
+	}, timeout, 1*time.Second)
+	if err != nil {
+		return fmt.Errorf("latency ordering (%s faster than %s by >%s) not reached within %s: %w", fasterPK, slowerPK, margin, timeout, err)
+	}
+
+	return nil
+}
+
 // WaitForPing waits until the given IP is reachable via ICMP ping from the client container.
 func (c *Client) WaitForPing(ctx context.Context, ip string, timeout time.Duration) error {
 	c.log.Debug("==> Waiting for ping to succeed", "ip", ip, "timeout", timeout)


### PR DESCRIPTION
## Summary of Changes
- Make device selection deterministic in the maxusers rollover test by waiting until the nearby device is measured as faster than the faraway device by more than the client's 5ms latency-tolerance window, so the client can no longer connect to the wrong device on a tie.
- Match CLI validation errors case-insensitively in the interface validation test, decoupling assertions from the program's message casing (e.g. "Invalid Interface IP" vs "Invalid interface IP").
- Add a CI safety net: rerun only the failed tests via `gotestsum --rerun-fails=1` so transient flakes don't redden a shard while remaining visible/trackable; raise the job timeout above the `go test` timeout so Go dumps per-test stacks on timeout instead of GitHub killing the job with no diagnostics.

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Tests        |     3 | +102 / -19   |  +83 |
| Config/build |     1 | +17 / -2     |  +15 |
| **Total**    |     4 | +119 / -21   |  +98 |

Test-only and CI changes; no production code touched.

<details>
<summary>Key files (click to expand)</summary>

- `e2e/internal/devnet/client.go` — new `WaitForLatencyOrdering` helper that polls the daemon's `/latency` endpoint until both devices are reachable and the faster device's `min_latency_ns` is below the slower device's by more than a given margin.
- `e2e/interface_validation_test.go` — add `containsAnyFold` helper and route the validation-error assertions through it for case-insensitive matching across message/enum/hex-code forms.
- `.github/workflows/e2e.yml` — install `gotestsum`, wrap `go test` with `--rerun-fails=1 --rerun-fails-max-failures=15`, and bump the job timeout from 15m to 30m.
- `e2e/device_maxusers_rollover_test.go` — wait for deterministic latency ordering before connecting the client in IBRL mode.

</details>

## Testing Verification
- `TestE2E_DeviceMaxusersRollover` — PASS (287.70s) locally.
- `TestE2E_InterfaceValidation` — PASS (294.08s) locally, including all rejection subtests that depend on the new case-insensitive error matching.