### PR TITLE
cli: feature-gate sentinel server deps out of the doublezero binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,21 @@ jobs:
           sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - run: make rust-validator-test
+  # The doublezero CLI must not link aws-lc-sys (raises the glibc floor to 2.38, breaks
+  # installs on Ubuntu 22.04). It reaches the CLI only via
+  # sentinel's server-only deps, which are feature-gated off. cargo tree -i exits non-zero
+  # when the package is absent (the wanted state); exit 0 means it crept back in.
+  rust-cli-no-aws-lc:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Assert aws-lc-sys absent from doublezero CLI
+        run: |
+          if cargo tree -p doublezero -e normal -i aws-lc-sys >/dev/null 2>&1; then
+            echo "::error::aws-lc-sys is linked into the doublezero CLI"
+            cargo tree -p doublezero -e normal -i aws-lc-sys
+            exit 1
+          fi
+          echo "OK: aws-lc-sys not in the doublezero CLI dependency tree"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   - Add hidden `migrate flex-algo` (RFC-18 link-topology and Vpnv4 loopback FlexAlgoNodeSegment backfill); the prior `migrate` command is now `migrate user-pda`. Moved from `doublezero-admin`.
   - Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber, publisher, and unicast-user counts. Moved from `doublezero-admin`.
   - Add hidden `sentinel find-validator-multicast-publishers` and `sentinel create-validator-multicast-publishers` commands. Moved from `doublezero-admin`.
+  - Feature-gate `doublezero-sentinel`'s server-mode deps (Prometheus exporter) behind a default-on `server` feature and depend on it with `default-features = false`, so the `doublezero` binary no longer links `rustls`/`aws-lc-sys`. Restores the glibc floor (binaries built on Ubuntu 24.04 load on 22.04 again) and shrinks the binary.
 - Onchain programs
   - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
   - Transfer connect/disconnect credits to the user's account when adding a user to a multicast group's publisher or subscriber allowlist, so the user can connect immediately. The airdrop is atomic with the allowlist update and mirrors `set_access_pass` (scaled for `allow_multiple_ip` passes). (#3851)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,11 @@ tokio = { version = "1", default-features = false, features = [
 doublezero-cli-core = { path = "crates/doublezero-cli-core" }
 doublezero-config = { path = "config" }
 doublezero-geolocation-cli = { path = "crates/doublezero-geolocation-cli" }
-doublezero-sentinel = { path = "crates/sentinel" }
+# default-features = false MUST be set here, not on the consumer edge: an inheriting
+# member's `default-features = false` is ignored unless the workspace dep declares it.
+# This keeps sentinel's server-only deps (Prometheus exporter → rustls/aws-lc-sys) out of
+# the `doublezero` CLI.
+doublezero-sentinel = { path = "crates/sentinel", default-features = false }
 doublezero-serviceability-cli = { path = "smartcontract/cli" }
 doublezero-program-common = { path = "smartcontract/programs/common" }
 doublezero_sdk = { path = "smartcontract/sdk/rs" }

--- a/client/doublezero/Cargo.toml
+++ b/client/doublezero/Cargo.toml
@@ -47,6 +47,9 @@ doublezero-cli-core.workspace = true
 doublezero-config.workspace = true
 doublezero-serviceability.workspace = true
 doublezero-program-common.workspace = true
+# Inherits default-features = false from [workspace.dependencies] (the override is ignored
+# if set here), keeping sentinel's `server` deps (Prometheus exporter → rustls/aws-lc-sys)
+# out of the CLI.
 doublezero-sentinel.workspace = true
 tracing.workspace = true
 

--- a/crates/sentinel/Cargo.toml
+++ b/crates/sentinel/Cargo.toml
@@ -19,7 +19,11 @@ doublezero_sdk.workspace = true
 doublezero-serviceability.workspace = true
 doublezero-telemetry.workspace = true
 metrics.workspace = true
-metrics-exporter-prometheus.workspace = true
+# Server/daemon-only: pulls in hyper-rustls → rustls(aws-lc-rs) → aws-lc-sys (~2MB C, glibc 2.38+
+# floor). Gated behind the default-on `server` feature so the `doublezero` CLI, which depends on
+# this crate with default-features = false, doesn't link it. Any future daemon-only dep must go
+# here too, or the CLI bloat returns.
+metrics-exporter-prometheus = { workspace = true, optional = true }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -36,6 +40,11 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 
+[features]
+default = ["server"]
+# Daemon/server mode: Prometheus metrics exporter (HTTP). Off for the CLI.
+server = ["dep:metrics-exporter-prometheus"]
+
 [dev-dependencies]
 mockall.workspace = true
 
@@ -45,3 +54,4 @@ path = "src/lib.rs"
 [[bin]]
 name = "doublezero-sentinel"
 path = "src/main.rs"
+required-features = ["server"]


### PR DESCRIPTION
## Summary of Changes

* Feature-gate `doublezero-sentinel`'s daemon-only Prometheus exporter behind a default-on `server` Cargo feature and consume the crate from the `doublezero` CLI with default features off, so the CLI no longer links `metrics-exporter-prometheus` → `hyper-rustls` → `rustls(aws-lc-rs)` → `aws-lc-sys`.
* A recent commit made sentinel a direct CLI dep, which pulled ~2MB of aws-lc-sys C code in and raised the binary's glibc floor from 2.34 to 2.38 — breaking installs on Ubuntu 22.04. This restores the floor.
* The `default-features = false` is declared in `[workspace.dependencies]` (root `Cargo.toml`), not just the CLI edge: cargo silently ignores the override on an inheriting member otherwise.
* Adds a `rust` CI job asserting `aws-lc-sys` stays out of the CLI dependency tree, so the regression can't return unnoticed.

## Testing Verification

* Manually verified that a snapshot build (`goreleaser --snapshot --clean -f release/.goreleaser.devnet.client.yaml`) now runs on Ubuntu 22.04. 
* Manual run of devnet daily release on this branch: https://github.com/malbeclabs/doublezero/actions/runs/28046844720