### PR TITLE
cli: add --narrow output to device, link, and access-pass list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
   - Add hidden `device migrate-multicast-counts` and `device migrate-unicast-counts` to reconcile stale per-device subscriber, publisher, and unicast-user counts. Moved from `doublezero-admin`.
   - Add hidden `sentinel find-validator-multicast-publishers` and `sentinel create-validator-multicast-publishers` commands. Moved from `doublezero-admin`.
   - Feature-gate `doublezero-sentinel`'s server-mode deps (Prometheus exporter) behind a default-on `server` feature and depend on it with `default-features = false`, so the `doublezero` binary no longer links `rustls`/`aws-lc-sys`. Restores the glibc floor (binaries built on Ubuntu 24.04 load on 22.04 again) and shrinks the binary.
+  - Add a `--narrow` flag to `device list`, `link list`, and `access-pass list` that renders a width-reduced table for wide output — dropping low-value columns, abbreviating pubkeys to a copyable leading-prefix, and shortening headers — while leaving `--json` and the default table unchanged. (#3938)
 - Onchain programs
   - Validate the device `mgmt_vrf` field against the account-code charset (`[A-Za-z0-9:_-]`) and a 32-byte length cap, matching the device `code` field. Empty (the default VRF) is still accepted.
   - Transfer connect/disconnect credits to the user's account when adding a user to a multicast group's publisher or subscriber allowlist, so the user can connect immediately. The airdrop is atomic with the allowlist update and mirrors `set_access_pass` (scaled for `allow_multiple_ip` passes). (#3851)

--- a/smartcontract/cli/src/accesspass/list.rs
+++ b/smartcontract/cli/src/accesspass/list.rs
@@ -1,15 +1,18 @@
-use crate::doublezerocommand::CliCommand;
+use crate::{doublezerocommand::CliCommand, user::list::narrow_groups};
 use clap::Args;
 use doublezero_cli_core::CliContext;
 use doublezero_program_common::serializer;
-use doublezero_sdk::commands::{
-    accesspass::list::ListAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
-    tenant::list::ListTenantCommand,
+use doublezero_sdk::{
+    commands::{
+        accesspass::list::ListAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
+        tenant::list::ListTenantCommand,
+    },
+    MulticastGroup,
 };
 use doublezero_serviceability::state::accesspass::{AccessPassStatus, AccessPassType};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
-use std::{io::Write, net::Ipv4Addr};
+use std::{collections::HashMap, io::Write, net::Ipv4Addr};
 use tabled::{settings::Style, Table, Tabled};
 
 #[derive(Args, Debug, Default)]
@@ -54,6 +57,11 @@ pub struct ListAccessPassCliCommand {
     /// Output as compact JSON
     #[arg(long, default_value_t = false)]
     pub json_compact: bool,
+    /// Narrow table output: shortens pubkeys, abbreviates accesspass_type, shows
+    /// the first multicast group per role (`+N` for the rest), maps the default
+    /// tenant pubkey to `empty`, and shortens the epoch/connections headers.
+    #[arg(long, default_value_t = false)]
+    pub narrow: bool,
 }
 
 #[derive(Tabled, Serialize)]
@@ -75,6 +83,99 @@ pub struct AccessPassDisplay {
     pub status: AccessPassStatus,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
+    #[tabled(skip)]
+    #[serde(skip)]
+    pub accesspass_type_value: AccessPassType,
+    #[tabled(skip)]
+    #[serde(skip)]
+    pub mgroup_pub_allowlist: Vec<Pubkey>,
+    #[tabled(skip)]
+    #[serde(skip)]
+    pub mgroup_sub_allowlist: Vec<Pubkey>,
+}
+
+/// Narrow variant of [`AccessPassDisplay`] for terminals: shortens every
+/// pubkey, abbreviates the multicast and accesspass_type columns, maps the
+/// blank tenant pubkey to `empty`, and shortens the wider headers.
+#[derive(Tabled)]
+pub struct AccessPassDisplayNarrow {
+    #[tabled(display = "crate::util::display_pubkey_short")]
+    pub account: Pubkey,
+    pub accesspass_type: String,
+    pub client_ip: Ipv4Addr,
+    #[tabled(display = "crate::util::display_pubkey_short")]
+    pub user_payer: Pubkey,
+    pub tenant: String,
+    pub multicast: String,
+    #[tabled(rename = "lst_epch")]
+    pub last_access_epoch: String,
+    #[tabled(rename = "rem_epch")]
+    pub remaining_epoch: String,
+    pub flags: String,
+    #[tabled(rename = "conns")]
+    pub connections: u16,
+    pub unicast_users: String,
+    pub multicast_users: String,
+    pub status: AccessPassStatus,
+    #[tabled(display = "crate::util::display_pubkey_short")]
+    pub owner: Pubkey,
+}
+
+/// Abbreviate the accesspass type for narrow output, shortening every embedded
+/// key. The match is exhaustive on purpose: a new payload-carrying variant must
+/// be handled here rather than silently rendering full-width.
+fn accesspass_type_short(t: &AccessPassType) -> String {
+    match t {
+        AccessPassType::SolanaValidator(pk) => {
+            format!(
+                "solana_validator: {}",
+                crate::util::display_pubkey_short(pk)
+            )
+        }
+        AccessPassType::SolanaRPC(pk) => {
+            format!("solana_rpc: {}", crate::util::display_pubkey_short(pk))
+        }
+        AccessPassType::Others(type_name, key) => {
+            format!("others: {type_name} ({})", shorten_str(key))
+        }
+        AccessPassType::Prepaid | AccessPassType::EdgeSeat => t.to_string(),
+    }
+}
+
+/// Truncate an arbitrary string to a copyable leading-10-char prefix + `..`
+/// (matching the pubkey abbreviation length) for narrow output. char-based, so
+/// it never splits a multibyte boundary on a non-ASCII `Others` key.
+fn shorten_str(s: &str) -> String {
+    if s.chars().count() > 12 {
+        let prefix: String = s.chars().take(10).collect();
+        format!("{prefix}..")
+    } else {
+        s.to_string()
+    }
+}
+
+impl AccessPassDisplayNarrow {
+    fn from_display(d: &AccessPassDisplay, mgroups: &HashMap<Pubkey, MulticastGroup>) -> Self {
+        Self {
+            account: d.account,
+            accesspass_type: accesspass_type_short(&d.accesspass_type_value),
+            client_ip: d.client_ip,
+            user_payer: d.user_payer,
+            // A literal default (all-ones) tenant pubkey reads as blank; show
+            // "empty". Non-default tenants stringify differently and are
+            // unaffected; the substring can't occur inside a real code/pubkey.
+            tenant: d.tenant.replace(&Pubkey::default().to_string(), "empty"),
+            multicast: narrow_groups(&d.mgroup_pub_allowlist, &d.mgroup_sub_allowlist, mgroups),
+            last_access_epoch: d.last_access_epoch.clone(),
+            remaining_epoch: d.remaining_epoch.clone(),
+            flags: d.flags.clone(),
+            connections: d.connections,
+            unicast_users: d.unicast_users.clone(),
+            multicast_users: d.multicast_users.clone(),
+            status: d.status,
+            owner: d.owner,
+        }
+    }
 }
 
 impl ListAccessPassCliCommand {
@@ -256,6 +357,9 @@ impl ListAccessPassCliCommand {
                 ),
                 status: access_pass.status,
                 owner: access_pass.owner,
+                accesspass_type_value: access_pass.accesspass_type.clone(),
+                mgroup_pub_allowlist: access_pass.mgroup_pub_allowlist.clone(),
+                mgroup_sub_allowlist: access_pass.mgroup_sub_allowlist.clone(),
             })
             .collect();
 
@@ -265,6 +369,14 @@ impl ListAccessPassCliCommand {
             serde_json::to_string_pretty(&access_pass_displays)?
         } else if self.json_compact {
             serde_json::to_string(&access_pass_displays)?
+        } else if self.narrow {
+            let narrow: Vec<AccessPassDisplayNarrow> = access_pass_displays
+                .iter()
+                .map(|d| AccessPassDisplayNarrow::from_display(d, &mgroups))
+                .collect();
+            Table::new(narrow)
+                .with(Style::psql().remove_horizontals())
+                .to_string()
         } else {
             Table::new(access_pass_displays)
                 .with(Style::psql().remove_horizontals())
@@ -406,6 +518,7 @@ mod tests {
                 not_multicast_group_subscriber: None,
                 json: false,
                 json_compact: false,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -429,6 +542,7 @@ mod tests {
                 multicast_group_subscriber: None,
                 not_multicast_group_publisher: None,
                 not_multicast_group_subscriber: None,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -463,6 +577,86 @@ mod tests {
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, " account                                   | accesspass_type | client_ip | user_payer                                | tenant | multicast | last_access_epoch | remaining_epoch | flags | connections | unicast_users | multicast_users | status    | owner                                     \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB | prepaid         | 1.2.3.4   | 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB |        | P:test    | 123               | 113             |       | 0           | 0 / 1         | 0 / 1           | connected | 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB \n");
+        // Narrow output: shortened pubkeys, abbreviated type/multicast, short
+        // headers; fits within 240 cols.
+        let mut output = Vec::new();
+        let res = block_on(
+            ListAccessPassCliCommand {
+                narrow: true,
+                ..Default::default()
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        let header = output_str.lines().next().unwrap();
+        for expected in [
+            "account",
+            "accesspass_type",
+            "client_ip",
+            "user_payer",
+            "tenant",
+            "multicast",
+            "lst_epch",
+            "rem_epch",
+            "conns",
+            "status",
+            "owner",
+        ] {
+            assert!(header.contains(expected), "missing header {expected}");
+        }
+        for hidden in ["last_access_epoch", "remaining_epoch", "connections"] {
+            assert!(
+                !header.contains(hidden),
+                "narrow header should not contain {hidden}"
+            );
+        }
+        // SolanaValidator type keeps its label but shortens the embedded key.
+        assert!(output_str.contains("solana_validator: 1111111FVA.."));
+        assert!(!output_str.contains("solana_validator: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB"));
+        for line in output_str.lines() {
+            assert!(
+                line.len() <= 240,
+                "narrow line exceeds 240 cols: {}",
+                line.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_accesspass_type_short() {
+        let pk = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::SolanaValidator(pk)),
+            "solana_validator: 1111111FVA.."
+        );
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::SolanaRPC(pk)),
+            "solana_rpc: 1111111FVA.."
+        );
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::Prepaid),
+            "prepaid"
+        );
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::EdgeSeat),
+            "edge_seat"
+        );
+        // Others: type_name kept, embedded key truncated to a copyable prefix.
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::Others(
+                "custom".to_string(),
+                "1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB".to_string()
+            )),
+            "others: custom (1111111FVA..)"
+        );
+        assert_eq!(
+            super::accesspass_type_short(&AccessPassType::Others(
+                "x".to_string(),
+                "short".to_string()
+            )),
+            "others: x (short)"
+        );
     }
 
     fn setup_multicast_client() -> (

--- a/smartcontract/cli/src/accesspass/list.rs
+++ b/smartcontract/cli/src/accesspass/list.rs
@@ -58,8 +58,8 @@ pub struct ListAccessPassCliCommand {
     #[arg(long, default_value_t = false)]
     pub json_compact: bool,
     /// Narrow table output: shortens pubkeys, abbreviates accesspass_type, shows
-    /// the first multicast group per role (`+N` for the rest), maps the default
-    /// tenant pubkey to `empty`, and shortens the epoch/connections headers.
+    /// the first multicast group per role (`+N` for the rest), labels a
+    /// no-tenant pass `empty`, and shortens the epoch/connections headers.
     #[arg(long, default_value_t = false)]
     pub narrow: bool,
 }
@@ -95,8 +95,8 @@ pub struct AccessPassDisplay {
 }
 
 /// Narrow variant of [`AccessPassDisplay`] for terminals: shortens every
-/// pubkey, abbreviates the multicast and accesspass_type columns, maps the
-/// blank tenant pubkey to `empty`, and shortens the wider headers.
+/// pubkey, abbreviates the multicast and accesspass_type columns, labels a
+/// no-tenant pass `empty`, and shortens the wider headers.
 #[derive(Tabled)]
 pub struct AccessPassDisplayNarrow {
     #[tabled(display = "crate::util::display_pubkey_short")]
@@ -136,21 +136,12 @@ fn accesspass_type_short(t: &AccessPassType) -> String {
             format!("solana_rpc: {}", crate::util::display_pubkey_short(pk))
         }
         AccessPassType::Others(type_name, key) => {
-            format!("others: {type_name} ({})", shorten_str(key))
+            format!(
+                "others: {type_name} ({})",
+                crate::util::abbreviate_prefix(key)
+            )
         }
         AccessPassType::Prepaid | AccessPassType::EdgeSeat => t.to_string(),
-    }
-}
-
-/// Truncate an arbitrary string to a copyable leading-10-char prefix + `..`
-/// (matching the pubkey abbreviation length) for narrow output. char-based, so
-/// it never splits a multibyte boundary on a non-ASCII `Others` key.
-fn shorten_str(s: &str) -> String {
-    if s.chars().count() > 12 {
-        let prefix: String = s.chars().take(10).collect();
-        format!("{prefix}..")
-    } else {
-        s.to_string()
     }
 }
 
@@ -161,10 +152,15 @@ impl AccessPassDisplayNarrow {
             accesspass_type: accesspass_type_short(&d.accesspass_type_value),
             client_ip: d.client_ip,
             user_payer: d.user_payer,
-            // A literal default (all-ones) tenant pubkey reads as blank; show
-            // "empty". Non-default tenants stringify differently and are
-            // unaffected; the substring can't occur inside a real code/pubkey.
-            tenant: d.tenant.replace(&Pubkey::default().to_string(), "empty"),
+            // A pass with no tenant renders blank (empty allowlist) or shows the
+            // all-ones default pubkey when it is explicitly allowlisted; surface
+            // both as "empty". A real tenant code/pubkey stringifies differently
+            // and is unaffected.
+            tenant: if d.tenant.is_empty() {
+                "empty".to_string()
+            } else {
+                d.tenant.replace(&Pubkey::default().to_string(), "empty")
+            },
             multicast: narrow_groups(&d.mgroup_pub_allowlist, &d.mgroup_sub_allowlist, mgroups),
             last_access_epoch: d.last_access_epoch.clone(),
             remaining_epoch: d.remaining_epoch.clone(),
@@ -614,6 +610,11 @@ mod tests {
         // SolanaValidator type keeps its label but shortens the embedded key.
         assert!(output_str.contains("solana_validator: 1111111FVA.."));
         assert!(!output_str.contains("solana_validator: 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB"));
+        // No-tenant passes (empty allowlist) render as `empty`, not blank.
+        assert!(
+            output_str.contains("empty"),
+            "tenant should render as empty"
+        );
         for line in output_str.lines() {
             assert!(
                 line.len() <= 240,

--- a/smartcontract/cli/src/device/list.rs
+++ b/smartcontract/cli/src/device/list.rs
@@ -49,6 +49,9 @@ pub struct ListDeviceCliCommand {
     /// Output as compact JSON
     #[arg(long, default_value_t = false)]
     pub json_compact: bool,
+    /// Narrow table output: drops dz_prefixes, mgmt_vrf, and owner.
+    #[arg(long, default_value_t = false)]
+    pub narrow: bool,
 }
 
 #[derive(Tabled, Serialize)]
@@ -107,6 +110,47 @@ pub struct DeviceDisplay {
     pub reference_count: u32,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
+}
+
+/// Narrow variant of [`DeviceDisplay`] for terminals: drops dz_prefixes,
+/// mgmt_vrf, and owner (the contributor code already identifies the operator).
+#[derive(Tabled)]
+pub struct DeviceDisplayNarrow {
+    pub account: Pubkey,
+    pub code: String,
+    #[tabled(rename = "contributor")]
+    pub contributor_code: String,
+    #[tabled(rename = "location")]
+    pub location_code: String,
+    #[tabled(rename = "exchange")]
+    pub exchange_code: String,
+    pub device_type: DeviceType,
+    pub public_ip: Ipv4Addr,
+    #[tabled(display = "crate::util::display_string_vec")]
+    pub cyoa_ips: Vec<String>,
+    pub users: u16,
+    pub max_users: u16,
+    pub status: DeviceStatus,
+    pub health: DeviceHealth,
+}
+
+impl DeviceDisplayNarrow {
+    fn from_display(d: &DeviceDisplay) -> Self {
+        Self {
+            account: d.account,
+            code: d.code.clone(),
+            contributor_code: d.contributor_code.clone(),
+            location_code: d.location_code.clone(),
+            exchange_code: d.exchange_code.clone(),
+            device_type: d.device_type,
+            public_ip: d.public_ip,
+            cyoa_ips: d.cyoa_ips.clone(),
+            users: d.users,
+            max_users: d.max_users,
+            status: d.status,
+            health: d.health,
+        }
+    }
 }
 
 impl ListDeviceCliCommand {
@@ -265,6 +309,14 @@ impl ListDeviceCliCommand {
             serde_json::to_string_pretty(&device_displays)?
         } else if self.json_compact {
             serde_json::to_string(&device_displays)?
+        } else if self.narrow {
+            let narrow: Vec<DeviceDisplayNarrow> = device_displays
+                .iter()
+                .map(DeviceDisplayNarrow::from_display)
+                .collect();
+            Table::new(narrow)
+                .with(Style::psql().remove_horizontals())
+                .to_string()
         } else {
             Table::new(device_displays)
                 .with(Style::psql().remove_horizontals())
@@ -412,6 +464,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: false,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -432,12 +485,63 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
         assert!(res.is_ok());
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\",\"code\":\"device1_code\",\"bump_seed\":2,\"location_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"contributor_code\":\"contributor1_code\",\"location_code\":\"location1_code\",\"location_name\":\"location1_name\",\"exchange_pk\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPA\",\"exchange_code\":\"exchange1_code\",\"exchange_name\":\"exchange1_name\",\"device_type\":\"Hybrid\",\"public_ip\":\"1.2.3.4\",\"dz_prefixes\":\"1.2.3.4/32\",\"cyoa_ips\":[],\"users\":0,\"max_users\":255,\"unicast_users_count\":0,\"max_unicast_users\":0,\"multicast_subscribers_count\":0,\"max_multicast_subscribers\":0,\"multicast_publishers_count\":0,\"max_multicast_publishers\":0,\"status\":\"Activated\",\"health\":\"ReadyForUsers\",\"desired_status\":\"Activated\",\"mgmt_vrf\":\"default\",\"metrics_publisher_pk\":\"11111111111111111111111111111111\",\"reference_count\":0,\"owner\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB\"}]\n");
+        // Narrow output: drops dz_prefixes, mgmt_vrf, owner; fits within 240 cols.
+        let mut output = Vec::new();
+        let res = block_on(
+            ListDeviceCliCommand {
+                contributor: None,
+                exchange: None,
+                location: None,
+                device_type: None,
+                status: None,
+                health: None,
+                desired_status: None,
+                code: None,
+                json: false,
+                json_compact: false,
+                narrow: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        let header = output_str.lines().next().unwrap();
+        for expected in [
+            "account",
+            "code",
+            "contributor",
+            "location",
+            "exchange",
+            "device_type",
+            "public_ip",
+            "cyoa_ips",
+            "users",
+            "max_users",
+            "status",
+            "health",
+        ] {
+            assert!(header.contains(expected), "missing header {expected}");
+        }
+        for hidden in ["dz_prefixes", "mgmt_vrf", "owner"] {
+            assert!(
+                !header.contains(hidden),
+                "narrow header should not contain {hidden}"
+            );
+        }
+        for line in output_str.lines() {
+            assert!(
+                line.len() <= 240,
+                "narrow line exceeds 240 cols: {}",
+                line.len()
+            );
+        }
     }
 
     #[test]
@@ -596,6 +700,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -761,6 +866,7 @@ mod tests {
                 code: Some("ams".to_string()),
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -925,6 +1031,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1107,6 +1214,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1295,6 +1403,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1479,6 +1588,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1661,6 +1771,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1826,6 +1937,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1990,6 +2102,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2121,6 +2234,7 @@ mod tests {
                 code: None,
                 json: true,
                 json_compact: false,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2163,6 +2277,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2206,6 +2321,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2248,6 +2364,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2290,6 +2407,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2332,6 +2450,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2371,6 +2490,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2410,6 +2530,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2449,6 +2570,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -2668,6 +2790,7 @@ mod tests {
                 code: None,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );

--- a/smartcontract/cli/src/link/list.rs
+++ b/smartcontract/cli/src/link/list.rs
@@ -1,4 +1,7 @@
-use crate::{doublezerocommand::CliCommand, topology::resolve_topology_names};
+use crate::{
+    doublezerocommand::CliCommand,
+    topology::{resolve_topology_names, resolve_topology_names_short},
+};
 use clap::Args;
 use doublezero_cli_core::CliContext;
 use doublezero_program_common::{serializer, types::NetworkV4};
@@ -58,6 +61,10 @@ pub struct ListLinkCliCommand {
     /// Output as compact JSON.
     #[arg(long, default_value_t = false)]
     pub json_compact: bool,
+    /// Narrow table output: drops side names, mtu, tunnel_net, and owner;
+    /// abbreviates health and drained status; shortens column headers.
+    #[arg(long, default_value_t = false)]
+    pub narrow: bool,
 }
 
 #[derive(Tabled, Serialize)]
@@ -99,6 +106,78 @@ pub struct LinkDisplay {
     pub owner: Pubkey,
     pub link_topologies: String,
     pub unicast_drained: bool,
+    #[tabled(skip)]
+    #[serde(skip)]
+    pub link_topologies_narrow: String,
+}
+
+/// Narrow variant of [`LinkDisplay`] for terminals: drops the side device
+/// names, mtu, tunnel_net, and owner; abbreviates health and drained status;
+/// shortens the wider headers.
+#[derive(Tabled)]
+pub struct LinkDisplayNarrow {
+    #[tabled(display = "crate::util::display_pubkey_short")]
+    pub account: Pubkey,
+    pub code: String,
+    #[tabled(rename = "contributor")]
+    pub contributor_code: String,
+    pub side_a_iface_name: String,
+    pub side_z_iface_name: String,
+    pub link_type: LinkLinkType,
+    #[tabled(display = "crate::util::display_as_bandwidth", rename = "bandwidth")]
+    pub bandwidth: u64,
+    #[tabled(display = "crate::util::display_as_ms", rename = "delay_ms")]
+    pub delay_ns: u64,
+    #[tabled(display = "crate::util::display_as_ms", rename = "jtr_ms")]
+    pub jitter_ns: u64,
+    #[tabled(display = "crate::util::display_as_ms", rename = "dly_ovrd_ms")]
+    pub delay_override_ns: u64,
+    #[tabled(rename = "tnl_id")]
+    pub tunnel_id: u16,
+    pub status: String,
+    pub health: String,
+    #[tabled(rename = "topos")]
+    pub link_topologies: String,
+    pub unicast_drained: bool,
+}
+
+/// Abbreviate the drained statuses for narrow output; pass others through.
+fn abbreviate_link_status(status: &LinkStatus) -> String {
+    match status {
+        LinkStatus::SoftDrained => "sft_drain".to_string(),
+        LinkStatus::HardDrained => "hrd_drain".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Abbreviate the one long health value for narrow output; pass others through.
+fn abbreviate_link_health(health: &LinkHealth) -> String {
+    match health {
+        LinkHealth::ReadyForService => "ready".to_string(),
+        other => other.to_string(),
+    }
+}
+
+impl LinkDisplayNarrow {
+    fn from_display(d: &LinkDisplay) -> Self {
+        Self {
+            account: d.account,
+            code: d.code.clone(),
+            contributor_code: d.contributor_code.clone(),
+            side_a_iface_name: d.side_a_iface_name.clone(),
+            side_z_iface_name: d.side_z_iface_name.clone(),
+            link_type: d.link_type,
+            bandwidth: d.bandwidth,
+            delay_ns: d.delay_ns,
+            jitter_ns: d.jitter_ns,
+            delay_override_ns: d.delay_override_ns,
+            tunnel_id: d.tunnel_id,
+            status: abbreviate_link_status(&d.status),
+            health: abbreviate_link_health(&d.health),
+            link_topologies: d.link_topologies_narrow.clone(),
+            unicast_drained: d.unicast_drained,
+        }
+    }
 }
 
 impl ListLinkCliCommand {
@@ -251,6 +330,10 @@ impl ListLinkCliCommand {
                     unicast_drained: link.link_flags
                         & doublezero_serviceability::state::link::LINK_FLAG_UNICAST_DRAINED
                         != 0,
+                    link_topologies_narrow: resolve_topology_names_short(
+                        &link.link_topologies,
+                        &topology_map,
+                    ),
                 }
             })
             .collect();
@@ -266,6 +349,14 @@ impl ListLinkCliCommand {
             serde_json::to_string_pretty(&tunnel_displays)?
         } else if self.json_compact {
             serde_json::to_string(&tunnel_displays)?
+        } else if self.narrow {
+            let narrow: Vec<LinkDisplayNarrow> = tunnel_displays
+                .iter()
+                .map(LinkDisplayNarrow::from_display)
+                .collect();
+            Table::new(narrow)
+                .with(Style::psql().remove_horizontals())
+                .to_string()
         } else {
             Table::new(tunnel_displays)
                 .with(Style::psql().remove_horizontals())
@@ -447,6 +538,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: false,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -471,6 +563,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -478,6 +571,104 @@ mod tests {
 
         let output_str = String::from_utf8(output).unwrap();
         assert_eq!(output_str, "[{\"account\":\"1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR\",\"code\":\"tunnel_code\",\"contributor_code\":\"contributor1_code\",\"side_a_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_a_name\":\"device2_code\",\"side_a_iface_name\":\"eth0\",\"side_z_pk\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"side_z_name\":\"device2_code\",\"side_z_iface_name\":\"eth1\",\"link_type\":\"WAN\",\"bandwidth\":10000000000,\"mtu\":4500,\"delay_ns\":20000,\"jitter_ns\":1121,\"delay_override_ns\":0,\"tunnel_id\":1234,\"tunnel_net\":\"1.2.3.4/32\",\"desired_status\":\"Activated\",\"status\":\"Activated\",\"health\":\"ReadyForService\",\"owner\":\"11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9\",\"link_topologies\":\"default\",\"unicast_drained\":false}]\n");
+        // Narrow output: drops side names, mtu, tunnel_net, owner; abbreviates
+        // health/status; shortens headers; fits within 240 cols.
+        let mut output = Vec::new();
+        let res = block_on(
+            ListLinkCliCommand {
+                contributor: None,
+                side_a: None,
+                side_z: None,
+                link_type: None,
+                status: None,
+                health: None,
+                desired_status: None,
+                code: None,
+                topology: None,
+                wan: false,
+                dzx: false,
+                json: false,
+                json_compact: false,
+                narrow: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        let header = output_str.lines().next().unwrap();
+        for expected in [
+            "account",
+            "code",
+            "contributor",
+            "side_a_iface_name",
+            "side_z_iface_name",
+            "link_type",
+            "bandwidth",
+            "delay_ms",
+            "jtr_ms",
+            "dly_ovrd_ms",
+            "tnl_id",
+            "status",
+            "health",
+            "topos",
+            "unicast_drained",
+        ] {
+            assert!(header.contains(expected), "missing header {expected}");
+        }
+        for hidden in [
+            "side_a_name",
+            "side_z_name",
+            "mtu",
+            "tunnel_net",
+            "tunnel_id",
+            "jitter_ms",
+            "delay_override_ms",
+            "link_topologies",
+            "owner",
+        ] {
+            assert!(
+                !header.contains(hidden),
+                "narrow header should not contain {hidden}"
+            );
+        }
+        // ReadyForService is abbreviated to "ready".
+        assert!(!output_str.contains("ready-for-service"));
+        for line in output_str.lines() {
+            assert!(
+                line.len() <= 240,
+                "narrow line exceeds 240 cols: {}",
+                line.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_abbreviate_link_status_and_health() {
+        use doublezero_serviceability::state::link::{LinkHealth, LinkStatus};
+        assert_eq!(
+            super::abbreviate_link_status(&LinkStatus::SoftDrained),
+            "sft_drain"
+        );
+        assert_eq!(
+            super::abbreviate_link_status(&LinkStatus::HardDrained),
+            "hrd_drain"
+        );
+        assert_eq!(
+            super::abbreviate_link_status(&LinkStatus::Activated),
+            "activated"
+        );
+        assert_eq!(
+            super::abbreviate_link_health(&LinkHealth::ReadyForService),
+            "ready"
+        );
+        assert_eq!(
+            super::abbreviate_link_health(&LinkHealth::Impaired),
+            "impaired"
+        );
+        assert_eq!(
+            super::abbreviate_link_health(&LinkHealth::Pending),
+            "pending"
+        );
     }
 
     #[test]
@@ -685,6 +876,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: false,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -874,6 +1066,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1062,6 +1255,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -1216,6 +1410,7 @@ mod tests {
                 dzx: false,
                 json: false,
                 json_compact: true,
+                narrow: false,
             }
             .execute(&ctx, &client, &mut output),
         );

--- a/smartcontract/cli/src/link/list.rs
+++ b/smartcontract/cli/src/link/list.rs
@@ -12,12 +12,12 @@ use doublezero_sdk::{
         link::list::ListLinkCommand,
         topology::list::ListTopologyCommand,
     },
-    Link, LinkLinkType, LinkStatus,
+    Link, LinkLinkType, LinkStatus, TopologyInfo,
 };
 use doublezero_serviceability::state::link::{LinkDesiredStatus, LinkHealth};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
-use std::{io::Write, str::FromStr};
+use std::{collections::HashMap, io::Write, str::FromStr};
 use tabled::{settings::Style, Table, Tabled};
 
 #[derive(Args, Debug)]
@@ -106,9 +106,11 @@ pub struct LinkDisplay {
     pub owner: Pubkey,
     pub link_topologies: String,
     pub unicast_drained: bool,
+    /// Raw topology pubkeys, moved from the source link, so `--narrow` can build
+    /// an abbreviated `topos` cell lazily without precomputing it for every row.
     #[tabled(skip)]
     #[serde(skip)]
-    pub link_topologies_narrow: String,
+    pub link_topologies_raw: Vec<Pubkey>,
 }
 
 /// Narrow variant of [`LinkDisplay`] for terminals: drops the side device
@@ -159,7 +161,7 @@ fn abbreviate_link_health(health: &LinkHealth) -> String {
 }
 
 impl LinkDisplayNarrow {
-    fn from_display(d: &LinkDisplay) -> Self {
+    fn from_display(d: &LinkDisplay, topology_map: &HashMap<Pubkey, TopologyInfo>) -> Self {
         Self {
             account: d.account,
             code: d.code.clone(),
@@ -174,7 +176,7 @@ impl LinkDisplayNarrow {
             tunnel_id: d.tunnel_id,
             status: abbreviate_link_status(&d.status),
             health: abbreviate_link_health(&d.health),
-            link_topologies: d.link_topologies_narrow.clone(),
+            link_topologies: resolve_topology_names_short(&d.link_topologies_raw, topology_map),
             unicast_drained: d.unicast_drained,
         }
     }
@@ -330,10 +332,7 @@ impl ListLinkCliCommand {
                     unicast_drained: link.link_flags
                         & doublezero_serviceability::state::link::LINK_FLAG_UNICAST_DRAINED
                         != 0,
-                    link_topologies_narrow: resolve_topology_names_short(
-                        &link.link_topologies,
-                        &topology_map,
-                    ),
+                    link_topologies_raw: link.link_topologies,
                 }
             })
             .collect();
@@ -352,7 +351,7 @@ impl ListLinkCliCommand {
         } else if self.narrow {
             let narrow: Vec<LinkDisplayNarrow> = tunnel_displays
                 .iter()
-                .map(LinkDisplayNarrow::from_display)
+                .map(|d| LinkDisplayNarrow::from_display(d, &topology_map))
                 .collect();
             Table::new(narrow)
                 .with(Style::psql().remove_horizontals())

--- a/smartcontract/cli/src/topology/mod.rs
+++ b/smartcontract/cli/src/topology/mod.rs
@@ -12,6 +12,24 @@ pub fn resolve_topology_names(
     pubkeys: &[Pubkey],
     topology_map: &HashMap<Pubkey, TopologyInfo>,
 ) -> String {
+    resolve_topology_names_with(pubkeys, topology_map, |pk| pk.to_string())
+}
+
+/// Like [`resolve_topology_names`] but abbreviates the pubkey shown for an
+/// unknown topology (one not in `topology_map`), for narrow output. Known
+/// topology names are kept in full.
+pub fn resolve_topology_names_short(
+    pubkeys: &[Pubkey],
+    topology_map: &HashMap<Pubkey, TopologyInfo>,
+) -> String {
+    resolve_topology_names_with(pubkeys, topology_map, crate::util::display_pubkey_short)
+}
+
+fn resolve_topology_names_with(
+    pubkeys: &[Pubkey],
+    topology_map: &HashMap<Pubkey, TopologyInfo>,
+    fallback: impl Fn(&Pubkey) -> String,
+) -> String {
     if pubkeys.is_empty() {
         "default".to_string()
     } else {
@@ -21,9 +39,31 @@ pub fn resolve_topology_names(
                 topology_map
                     .get(pk)
                     .map(|t| t.name.clone())
-                    .unwrap_or_else(|| pk.to_string())
+                    .unwrap_or_else(|| fallback(pk))
             })
             .collect::<Vec<_>>()
             .join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_topology_names, resolve_topology_names_short};
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn short_resolver_abbreviates_unknown_topology() {
+        let map = HashMap::new();
+        let pk = Pubkey::new_unique();
+        // Unknown topology (not in the map) → shortened pubkey for narrow output.
+        assert_eq!(
+            resolve_topology_names_short(&[pk], &map),
+            crate::util::display_pubkey_short(&pk)
+        );
+        // The full resolver keeps the unabbreviated 44-char key.
+        assert_eq!(resolve_topology_names(&[pk], &map), pk.to_string());
+        // Empty → "default" for both.
+        assert_eq!(resolve_topology_names_short(&[], &map), "default");
     }
 }

--- a/smartcontract/cli/src/user/list.rs
+++ b/smartcontract/cli/src/user/list.rs
@@ -510,7 +510,7 @@ fn abbreviate_user_type(ut: &UserType) -> String {
 /// Build the narrow `groups` cell: up to one `P:` entry and one `S:` entry,
 /// each showing the first group's abbreviated name plus `+N` for remaining
 /// groups of that role. Empty roles are omitted.
-fn narrow_groups(
+pub(crate) fn narrow_groups(
     publishers: &[Pubkey],
     subscribers: &[Pubkey],
     mgroups: &HashMap<Pubkey, MulticastGroup>,
@@ -531,9 +531,10 @@ fn narrow_role_entry(
     mgroups: &HashMap<Pubkey, MulticastGroup>,
 ) -> Option<String> {
     let first = pks.first()?;
-    let name = mgroups
-        .get(first)
-        .map_or_else(|| first.to_string(), |g| abbreviate_name(&g.code));
+    let name = mgroups.get(first).map_or_else(
+        || crate::util::display_pubkey_short(first),
+        |g| abbreviate_name(&g.code),
+    );
     let extra = pks.len() - 1;
     Some(if extra > 0 {
         format!("{prefix}:{name}+{extra}")
@@ -610,6 +611,13 @@ mod tests {
         assert_eq!(
             narrow_groups(&[g1, g2], &[g3, g1], &mgroups),
             "P:edge..reds+1,S:jito..ream+1",
+        );
+        // A group absent from the map falls back to a shortened pubkey, not the
+        // full 44-char key.
+        let unknown = Pubkey::new_unique();
+        assert_eq!(
+            narrow_groups(&[unknown], &[], &mgroups),
+            format!("P:{}", crate::util::display_pubkey_short(&unknown)),
         );
     }
 

--- a/smartcontract/cli/src/util.rs
+++ b/smartcontract/cli/src/util.rs
@@ -22,21 +22,30 @@ pub fn display_as_bandwidth(bandwidth: &u64) -> String {
     bandwidth_to_string(bandwidth)
 }
 
-/// Number of leading base58 characters kept when abbreviating a pubkey for
-/// narrow table output. A contiguous prefix (not a first..last split) keeps the
-/// abbreviation copyable for prefix searches in explorers.
-const SHORT_PUBKEY_PREFIX_LEN: usize = 10;
+/// Number of leading characters kept when abbreviating a pubkey or key for
+/// narrow table output.
+const SHORT_PREFIX_LEN: usize = 10;
 
-/// Abbreviate a pubkey for narrow table output: the leading
-/// [`SHORT_PUBKEY_PREFIX_LEN`] base58 characters followed by `..`
-/// (e.g. `7Np3kR9xQ2..`). Base58 is ASCII, so byte slicing is safe.
-pub fn display_pubkey_short(pk: &Pubkey) -> String {
-    let s = pk.to_string();
-    if s.len() > SHORT_PUBKEY_PREFIX_LEN + 2 {
-        format!("{}..", &s[..SHORT_PUBKEY_PREFIX_LEN])
+/// Canonical narrow-output abbreviation: keep the leading [`SHORT_PREFIX_LEN`]
+/// characters + `..` (or the string unchanged when it is no longer than that).
+/// A contiguous prefix stays copyable for prefix searches in explorers, and the
+/// char-based slice never splits a multibyte boundary. New `--narrow` columns
+/// should abbreviate pubkeys and embedded keys through here (or
+/// [`display_pubkey_short`]); multicast group codes use `abbreviate_name`
+/// (a first/last split that preserves both ends of the code) instead.
+pub fn abbreviate_prefix(s: &str) -> String {
+    if s.chars().count() > SHORT_PREFIX_LEN + 2 {
+        let prefix: String = s.chars().take(SHORT_PREFIX_LEN).collect();
+        format!("{prefix}..")
     } else {
-        s
+        s.to_string()
     }
+}
+
+/// Abbreviate a pubkey for narrow table output via [`abbreviate_prefix`]
+/// (e.g. `7Np3kR9xQ2..`).
+pub fn display_pubkey_short(pk: &Pubkey) -> String {
+    abbreviate_prefix(&pk.to_string())
 }
 
 pub fn display_string_vec(v: &[String]) -> String {

--- a/smartcontract/cli/src/util.rs
+++ b/smartcontract/cli/src/util.rs
@@ -22,6 +22,23 @@ pub fn display_as_bandwidth(bandwidth: &u64) -> String {
     bandwidth_to_string(bandwidth)
 }
 
+/// Number of leading base58 characters kept when abbreviating a pubkey for
+/// narrow table output. A contiguous prefix (not a first..last split) keeps the
+/// abbreviation copyable for prefix searches in explorers.
+const SHORT_PUBKEY_PREFIX_LEN: usize = 10;
+
+/// Abbreviate a pubkey for narrow table output: the leading
+/// [`SHORT_PUBKEY_PREFIX_LEN`] base58 characters followed by `..`
+/// (e.g. `7Np3kR9xQ2..`). Base58 is ASCII, so byte slicing is safe.
+pub fn display_pubkey_short(pk: &Pubkey) -> String {
+    let s = pk.to_string();
+    if s.len() > SHORT_PUBKEY_PREFIX_LEN + 2 {
+        format!("{}..", &s[..SHORT_PUBKEY_PREFIX_LEN])
+    } else {
+        s
+    }
+}
+
 pub fn display_string_vec(v: &[String]) -> String {
     v.join(", ")
 }


### PR DESCRIPTION
## Summary of Changes
- Add a `--narrow` flag to `device list`, `link list`, and `access-pass list` that renders a width-reduced table for wide output — dropping low-value columns and abbreviating the rest — while leaving `--json` and the default table untouched.
- Abbreviate pubkeys to a contiguous leading-10-char prefix + `..` (copyable for prefix search in explorers); shorten the validator/RPC/`others` keys embedded in `accesspass_type`; reuse the user-list `P:/S:` multicast shortening; map the default tenant pubkey to `empty`.
- Best-effort width target: identifiers (codes, contributor, interface and topology names) stay readable; only pubkeys, embedded keys, and unknown-group/topology fallbacks are bounded.

## Diff Breakdown
| Category    | Files | Lines (+/-)   | Net    |
|-------------|-------|---------------|--------|
| Core logic  |     6 | ~+150 / -11   | ~+139  |
| Scaffolding |     3 | ~+157 / 0     | ~+157  |
| Tests       |     5 | ~+281 / 0     | ~+281  |
| **Total**   |     6 | +588 / -11    |  +577  |

Roughly half the diff is test assertions (per-list narrow checks + helper unit tests); the remainder splits between the formatting/conversion helpers (core) and the clap flags + narrow display structs + render branches (scaffolding). All six files are mixed logic+tests, so per-category file counts overlap.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/accesspass/list.rs` — `AccessPassDisplayNarrow`; shortens all pubkeys including the key inside `accesspass_type` (exhaustive over SolanaValidator/SolanaRPC/Others); multicast via the shared `narrow_groups`; default tenant → `empty`; `lst_epch`/`rem_epch`/`conns` headers.
- `smartcontract/cli/src/link/list.rs` — `LinkDisplayNarrow`; drops side device names, mtu, tunnel_net, owner; abbreviates health (`ready`) and drained status (`sft_drain`/`hrd_drain`); shortens account; narrow `topos` with a shortened unknown-topology fallback.
- `smartcontract/cli/src/device/list.rs` — `DeviceDisplayNarrow`; drops dz_prefixes, mgmt_vrf, owner (keeps the full account).
- `smartcontract/cli/src/topology/mod.rs` — `resolve_topology_names_short` shortens the pubkey shown for an unknown topology (narrow only; full list unchanged).
- `smartcontract/cli/src/util.rs` — `display_pubkey_short` now emits a contiguous leading-prefix abbreviation instead of a first..last split.
- `smartcontract/cli/src/user/list.rs` — `narrow_groups` made `pub(crate)` for reuse; unknown-group fallback shortened.

</details>

## Testing Verification
- Added per-list narrow tests asserting kept vs dropped/renamed headers and a ≤240-column bound on every rendered line, plus unit tests for the new abbreviation helpers (link status/health, `accesspass_type` including SolanaRPC/Others/EdgeSeat, `narrow_groups` unknown-group fallback, and `resolve_topology_names_short` unknown-topology fallback).
- Verified against mainnet-beta: max line width dropped from 344→225 (device), 404→237 (link), and 500→229 (access-pass).
