### PR TITLE
e2e: increase client route propagation timeout to reduce flakiness

### DIFF
--- a/e2e/multi_client_ibrl_allocated_ip_test.go
+++ b/e2e/multi_client_ibrl_allocated_ip_test.go
@@ -233,14 +233,14 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 			return false
 		}
 		return strings.Contains(string(output), client2DZIP)
-	}, 60*time.Second, 1*time.Second, "client1 should have route to client2")
+	}, 90*time.Second, 1*time.Second, "client1 should have route to client2")
 	require.Eventually(t, func() bool {
 		output, err := client2.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
 		if err != nil {
 			return false
 		}
 		return strings.Contains(string(output), client1DZIP)
-	}, 60*time.Second, 1*time.Second, "client2 should have route to client1")
+	}, 90*time.Second, 1*time.Second, "client2 should have route to client1")
 	log.Debug("--> Clients have routes to each other")
 
 	// Disconnect client1.


### PR DESCRIPTION
## Summary of Changes
- Increase the client-side route propagation timeouts in `TestE2E_MultiClientIBRLAllocatedIP` from 60s to 90s, aligning them with the device-level iBGP checks that precede them in the propagation chain
- Fixes intermittent CI failures ("client1 should have route to client2", condition never satisfied) caused by the client checks expiring before routes finished propagating under load

## Diff Breakdown
| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Tests    |     1 | +2 / -2     |  +0 |

Pure test-timing change; no production code affected.

<details>
<summary>Key files (click to expand)</summary>

- `e2e/multi_client_ibrl_allocated_ip_test.go` — bump both client route-check timeouts from 60s to 90s to match the device-side iBGP propagation window

</details>

## Testing Verification
- Routes reach a client only after its device learns them via iBGP (90s budget) and re-advertises them over the client BGP session; the client checks previously allowed only 60s, so a near-limit device propagation left insufficient time for the client install. Raising the client budget to 90s removes that race.
- Ran `TestE2E_MultiClientIBRLAllocatedIP` locally in a repeat loop to confirm it no longer flakes (first iteration passed in 666s; additional iterations in progress).
