### PR TITLE
devcontainer: install uv for the Python SDKs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,3 +68,10 @@ ENV DIND_LOCALHOST=host.docker.internal
 # Tell Testcontainers to connect to the Docker daemon via host.docker.internal,
 # so sidecar containers like Ryuk can reach the DinD container hosting the daemon.
 ENV TESTCONTAINERS_HOST_OVERRIDE=${DIND_LOCALHOST}
+
+# Install uv for the Python SDKs (sdk/*/python use uv + committed uv.lock files).
+# CI provisions uv via astral-sh/setup-uv@v6; this mirrors it in the devcontainer
+# so `make sdk-test` / `uv lock` work here too. Installed via the standalone script
+# (rather than COPY --from=ghcr.io/astral-sh/uv) to avoid a ghcr.io auth dependency
+# during the image build.
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh


### PR DESCRIPTION
## Summary

Installs `uv` in the dev container (`.devcontainer/Dockerfile`) via uv's standalone install script (to `/usr/local/bin`).

## What was broken

- The dev container shipped no `uv`, but all four Python SDKs — `sdk/{borsh-incremental,revdist,serviceability,telemetry}/python` — are uv projects with committed `uv.lock` files, and the Makefile drives them through uv (`make sdk-test`, `make sdk-compat-test`, and `make python-test-*` all run `uv run pytest`).
- So inside the container the project standardizes on, none of those targets ran and `uv lock` (to refresh a lockfile) wasn't available either. A contributor couldn't run, reproduce, or fix the Python SDK tests locally. CI passed only because it provisions uv via `astral-sh/setup-uv@v6`.
- This gap was concrete: the recent revdist solana-py 0.40 breakage (fixed in #3947) couldn't be reproduced or fixed from the dev container because `uv` wasn't there. With #3947 now on main (revdist migrated to the async client, `solana>=0.40`, `pytest-asyncio`), running those tests locally requires uv.

## Approach

Installed via uv's standalone script rather than `COPY --from=ghcr.io/astral-sh/uv`, to avoid a ghcr.io auth dependency during the image build and to match how the Dockerfile already installs Go, Solana, and gotest.

## Testing Verification

- Built `.devcontainer/Dockerfile`: `uv` and `uvx` (0.11.25) install to `/usr/local/bin` and run on arm64.
- Full `devcontainer up` succeeds and the resulting container has `uv` on PATH.
