### PR TITLE
scripts: add DZ token generation and decoding helpers

### DIFF
--- a/scripts/dz-token-to-file.sh
+++ b/scripts/dz-token-to-file.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <DZ_TOKEN> <output_file>"
+    exit 1
+fi
+
+TOKEN="$1"
+OUTPUT_FILE="$2"
+
+if [[ "$TOKEN" != DZ_* ]]; then
+    echo "Error: token must start with DZ_"
+    exit 1
+fi
+
+B64URL="${TOKEN#DZ_}"
+
+python3 - "$B64URL" "$OUTPUT_FILE" <<'PY'
+import base64
+import json
+import sys
+
+token = sys.argv[1]
+output_file = sys.argv[2]
+
+# Restore Base64 padding
+padding = "=" * ((4 - len(token) % 4) % 4)
+
+try:
+    raw = base64.urlsafe_b64decode(token + padding)
+except Exception as e:
+    print(f"Invalid token: {e}", file=sys.stderr)
+    sys.exit(1)
+
+if len(raw) != 64:
+    print(
+        f"Invalid Solana secret key length: {len(raw)} bytes (expected 64)",
+        file=sys.stderr
+    )
+    sys.exit(1)
+
+with open(output_file, "w") as f:
+    json.dump(list(raw), f)
+
+print(f"Wrote Solana keypair to {output_file}")
+PY
+
+chmod 600 "$OUTPUT_FILE"

--- a/scripts/gen-dz-token.sh
+++ b/scripts/gen-dz-token.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <solana-keypair-file>"
+    exit 1
+fi
+
+KEYPAIR_FILE="$1"
+
+if [[ ! -f "$KEYPAIR_FILE" ]]; then
+    echo "File not found: $KEYPAIR_FILE"
+    exit 1
+fi
+
+TOKEN=$(
+python3 - "$KEYPAIR_FILE" <<'PY'
+import json
+import base64
+import sys
+
+with open(sys.argv[1], "r") as f:
+    key = json.load(f)
+
+raw = bytes(key)
+
+token = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+print(f"DZ_{token}")
+PY
+)
+
+echo "$TOKEN"


### PR DESCRIPTION
## Summary

- Add `scripts/gen-dz-token.sh` to convert a Solana keypair file into a `DZ_`-prefixed, base64url-encoded token
- Add `scripts/dz-token-to-file.sh` to decode a `DZ_` token back into a Solana keypair JSON file

## Details

The two scripts are inverse operations for moving a Solana keypair between its on-disk JSON array form and a compact, shareable `DZ_` token string:

- `gen-dz-token.sh <keypair.json>` reads the 64-byte secret key, base64url-encodes it (no padding), and prints `DZ_<token>`.
- `dz-token-to-file.sh <DZ_TOKEN> <output_file>` validates the prefix, restores base64 padding, decodes, checks the 64-byte length, writes the keypair JSON, and sets `0600` permissions on the output.

## Testing Verification

- Round-tripped a keypair through `gen-dz-token.sh` and `dz-token-to-file.sh`, confirming the decoded file matches the original keypair.
- Verified the length and prefix validation paths reject malformed input.
