### PR TITLE
doublezerod: add route-liveness-backoff-max flag to fix multi-client IBRL e2e flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Client
+  - Add a `-route-liveness-backoff-max` daemon flag to cap the Down-state liveness probe interval. Defaults to 60s (production behavior unchanged); the e2e harness pins a small value to avoid a probe gap that flaked the multi-client IBRL tests. (#3949)
+
 ## [v0.28.0](https://github.com/malbeclabs/doublezero/compare/client/v0.27.1...client/v0.28.0) - 2026-06-26
 
 

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -50,7 +50,7 @@ var (
 	routeLivenessDetectMult  = flag.Uint("route-liveness-detect-mult", defaultRouteLivenessDetectMult, "route liveness detect mult")
 	routeLivenessMinTxFloor  = flag.Duration("route-liveness-min-tx-floor", defaultRouteLivenessMinTxFloor, "route liveness min tx floor")
 	routeLivenessMaxTxCeil   = flag.Duration("route-liveness-max-tx-ceil", defaultRouteLivenessMaxTxCeil, "route liveness max tx ceil")
-	routeLivenessBackoffMax  = flag.Duration("route-liveness-backoff-max", defaultRouteLivenessBackoffMax, "route liveness backoff max (cap on Down-state probe interval)")
+	routeLivenessBackoffMax  = flag.Duration("route-liveness-backoff-max", defaultRouteLivenessBackoffMax, "route liveness backoff max (cap on Down-state probe interval; must be >= route-liveness-min-tx-floor)")
 	routeLivenessPeerMetrics = flag.Bool("route-liveness-peer-metrics", false, "enables per peer metrics for route liveness (high cardinality)")
 	routeLivenessDebug       = flag.Bool("route-liveness-debug", false, "enables debug logging for route liveness")
 

--- a/client/doublezerod/cmd/doublezerod/main.go
+++ b/client/doublezerod/cmd/doublezerod/main.go
@@ -50,6 +50,7 @@ var (
 	routeLivenessDetectMult  = flag.Uint("route-liveness-detect-mult", defaultRouteLivenessDetectMult, "route liveness detect mult")
 	routeLivenessMinTxFloor  = flag.Duration("route-liveness-min-tx-floor", defaultRouteLivenessMinTxFloor, "route liveness min tx floor")
 	routeLivenessMaxTxCeil   = flag.Duration("route-liveness-max-tx-ceil", defaultRouteLivenessMaxTxCeil, "route liveness max tx ceil")
+	routeLivenessBackoffMax  = flag.Duration("route-liveness-backoff-max", defaultRouteLivenessBackoffMax, "route liveness backoff max (cap on Down-state probe interval)")
 	routeLivenessPeerMetrics = flag.Bool("route-liveness-peer-metrics", false, "enables per peer metrics for route liveness (high cardinality)")
 	routeLivenessDebug       = flag.Bool("route-liveness-debug", false, "enables debug logging for route liveness")
 
@@ -72,6 +73,9 @@ const (
 	defaultRouteLivenessDetectMult = 3
 	defaultRouteLivenessMinTxFloor = 50 * time.Millisecond
 	defaultRouteLivenessMaxTxCeil  = 3 * time.Second
+	// Matches liveness.defaultBackoffMax so production behavior is unchanged; the
+	// e2e harness overrides this to a small value to avoid the Down-state probe gap.
+	defaultRouteLivenessBackoffMax = 1 * time.Minute
 
 	defaultRouteLivenessBindIP = "0.0.0.0"
 )
@@ -176,6 +180,7 @@ func main() {
 			DetectMult: uint8(*routeLivenessDetectMult),
 			MinTxFloor: *routeLivenessMinTxFloor,
 			MaxTxCeil:  *routeLivenessMaxTxCeil,
+			BackoffMax: *routeLivenessBackoffMax,
 
 			EnablePeerMetrics: *routeLivenessPeerMetrics,
 

--- a/client/doublezerod/internal/liveness/manager_test.go
+++ b/client/doublezerod/internal/liveness/manager_test.go
@@ -82,6 +82,46 @@ func TestClient_Liveness_Manager_NewManager_BindsAndLocalAddr(t *testing.T) {
 	require.NotZero(t, la.Port)
 }
 
+// TestClient_Liveness_Manager_RegisterRoute_PropagatesBackoffMax pins the plumbing this
+// change adds: ManagerConfig.BackoffMax (set from the -route-liveness-backoff-max flag)
+// flows into each registered session's backoffMax, which caps the Down-state probe
+// interval. A zero BackoffMax falls back to the 60s default via Validate. This is the
+// seam the e2e harness overrides to a small value to close the Down-state probe gap.
+func TestClient_Liveness_Manager_RegisterRoute_PropagatesBackoffMax(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		backoffMax time.Duration
+		want       time.Duration
+	}{
+		{"explicit", 3 * time.Second, 3 * time.Second},
+		{"zero-uses-default", 0, defaultBackoffMax},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m, err := newTestManager(t, func(cfg *ManagerConfig) {
+				cfg.BackoffMax = tc.backoffMax
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = m.Close() })
+
+			r := newTestRoute(func(r *Route) {
+				r.Src = net.IPv4(127, 0, 0, 1)
+				r.Dst = &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(32, 32)}
+			})
+			require.NoError(t, m.RegisterRoute(r, "lo", m.LocalAddr().Port))
+
+			peer := Peer{Interface: "lo", LocalIP: r.Src.String(), PeerIP: r.Dst.IP.String()}
+			m.mu.Lock()
+			sess := m.sessions[peer]
+			m.mu.Unlock()
+			require.NotNil(t, sess)
+			require.Equal(t, tc.want, sess.backoffMax)
+		})
+	}
+}
+
 func TestClient_Liveness_Manager_RegisterRoute_Deduplicates(t *testing.T) {
 	t.Parallel()
 	m, err := newTestManager(t, nil)

--- a/client/doublezerod/internal/liveness/session_test.go
+++ b/client/doublezerod/internal/liveness/session_test.go
@@ -294,11 +294,12 @@ func TestClient_Liveness_Session_BackoffResetsWhenNotDown(t *testing.T) {
 	require.Equal(t, uint32(1), s.backoffFactor)
 }
 
-// TestClient_Liveness_Session_ComputeNextTx_DownIntervalCappedAtBackoffMax pins the
-// cap semantics that fix the #3949 e2e flake: while Down, the effective transmit
-// interval grows via exponential backoff but must never exceed backoffMax (plus the
-// ±10% jitter band). With a small backoffMax the Down probe schedule has no large gap,
-// so the active client's liveness handshake converges promptly once the data path is up.
+// TestClient_Liveness_Session_ComputeNextTx_DownIntervalCappedAtBackoffMax is a guardrail
+// for the cap semantics this fix relies on: while Down, the effective transmit interval
+// grows via exponential backoff but must never exceed backoffMax (plus the ±10% jitter
+// band). The cap logic already exists; pinning a small backoffMax (as the e2e harness now
+// does) keeps the Down probe schedule gap-free so the active client's liveness handshake
+// converges promptly once the data path is up.
 func TestClient_Liveness_Session_ComputeNextTx_DownIntervalCappedAtBackoffMax(t *testing.T) {
 	t.Parallel()
 	for _, backoffMax := range []time.Duration{3 * time.Second, 200 * time.Millisecond, 1 * time.Minute} {

--- a/client/doublezerod/internal/liveness/session_test.go
+++ b/client/doublezerod/internal/liveness/session_test.go
@@ -294,6 +294,41 @@ func TestClient_Liveness_Session_BackoffResetsWhenNotDown(t *testing.T) {
 	require.Equal(t, uint32(1), s.backoffFactor)
 }
 
+// TestClient_Liveness_Session_ComputeNextTx_DownIntervalCappedAtBackoffMax pins the
+// cap semantics that fix the #3949 e2e flake: while Down, the effective transmit
+// interval grows via exponential backoff but must never exceed backoffMax (plus the
+// ±10% jitter band). With a small backoffMax the Down probe schedule has no large gap,
+// so the active client's liveness handshake converges promptly once the data path is up.
+func TestClient_Liveness_Session_ComputeNextTx_DownIntervalCappedAtBackoffMax(t *testing.T) {
+	t.Parallel()
+	for _, backoffMax := range []time.Duration{3 * time.Second, 200 * time.Millisecond, 1 * time.Minute} {
+		backoffMax := backoffMax
+		t.Run(backoffMax.String(), func(t *testing.T) {
+			t.Parallel()
+			s := newSess()
+			s.state = StateDown
+			s.localTxMin = 1 * time.Second
+			s.minTxFloor = 50 * time.Millisecond
+			s.maxTxCeil = 3 * time.Second
+			s.backoffMax = backoffMax
+			s.backoffFactor = 1
+			r := rand.New(rand.NewSource(1))
+
+			// The jitter band is ±10% of the (capped) effective interval, so the
+			// observed interval can sit at most backoffMax/10 above backoffMax.
+			maxInterval := backoffMax + backoffMax/10
+			now := time.Unix(0, 0)
+			for i := 0; i < 20; i++ {
+				next := s.ComputeNextTx(now, r)
+				interval := next.Sub(now)
+				require.LessOrEqual(t, interval, maxInterval,
+					"iteration %d: Down interval %v must be capped at backoffMax %v (+jitter)", i, interval, backoffMax)
+				now = next
+			}
+		})
+	}
+}
+
 func TestClient_Liveness_Session_HandleRxIgnoredWhenAdminDown(t *testing.T) {
 	t.Parallel()
 	s := newSess()

--- a/e2e/internal/devnet/client.go
+++ b/e2e/internal/devnet/client.go
@@ -38,6 +38,11 @@ type ClientSpec struct {
 	RouteLivenessEnablePassive bool
 	RouteLivenessEnableActive  bool
 
+	// RouteLivenessBackoffMax caps the Down-state probe interval (exponential backoff).
+	// When zero, the daemon default applies. Pinned to a small value in tests to avoid
+	// a multi-second gap between probes that can outlast the test deadline.
+	RouteLivenessBackoffMax time.Duration
+
 	// RouteLivenessEnable is a flag to enable or disable route liveness. False puts the system in
 	// passive-mode, and true puts it in active-mode.
 	// RouteLivenessEnable bool
@@ -207,6 +212,9 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 	if c.Spec.RouteLivenessDebug {
 		extraArgs = append(extraArgs, "-route-liveness-debug")
+	}
+	if c.Spec.RouteLivenessBackoffMax > 0 {
+		extraArgs = append(extraArgs, fmt.Sprintf("-route-liveness-backoff-max=%s", c.Spec.RouteLivenessBackoffMax))
 	}
 	if c.Spec.LatencyProbeTunnelEndpoints {
 		extraArgs = append(extraArgs, "-latency-probe-tunnel-endpoints")

--- a/e2e/multi_client_ibrl_allocated_ip_test.go
+++ b/e2e/multi_client_ibrl_allocated_ip_test.go
@@ -3,6 +3,7 @@
 package e2e_test
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -304,12 +305,16 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 // #3949 flake slow to diagnose.
 func dumpClientRouteDiag(t *testing.T, log *slog.Logger, name string, client *devnet.Client, peerDZIP string) {
 	t.Helper()
+	// Use a fresh bounded context: the test deadline may already have cancelled
+	// t.Context(), and a wedged container must not let the dump hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	for _, cmd := range [][]string{
 		{"doublezero", "status"},
 		{"ip", "route", "show"},
 		{"ip", "r", "list", "dev", "doublezero0"},
 	} {
-		out, err := client.Exec(t.Context(), cmd)
+		out, err := client.Exec(ctx, cmd)
 		log.Error("route-diag",
 			"client", name,
 			"pubkey", client.Pubkey,

--- a/e2e/multi_client_ibrl_allocated_ip_test.go
+++ b/e2e/multi_client_ibrl_allocated_ip_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/malbeclabs/doublezero/e2e/internal/devnet"
 	"github.com/malbeclabs/doublezero/e2e/internal/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,6 +131,7 @@ func TestE2E_MultiClientIBRLAllocatedIP(t *testing.T) {
 	client1, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:       100,
 		RouteLivenessEnableActive: true,
+		RouteLivenessBackoffMax:   3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client1 added", "client1Pubkey", client1.Pubkey, "client1IP", client1.CYOANetworkIP)
@@ -139,6 +141,7 @@ func TestE2E_MultiClientIBRLAllocatedIP(t *testing.T) {
 	client2, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:        110,
 		RouteLivenessEnablePassive: true, // route liveness in passive mode for this client
+		RouteLivenessBackoffMax:    3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client2 added", "client2Pubkey", client2.Pubkey, "client2IP", client2.CYOANetworkIP)
@@ -226,21 +229,32 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 	log.Debug("--> Cross-exchange routes have propagated via iBGP")
 
 	// Check that the clients have routes to each other.
+	// client1 runs route-liveness in active mode, so its kernel route to client2 is
+	// withheld until the client↔client liveness handshake reaches Up. On failure, dump
+	// diagnostics for both clients so a flake is self-explaining (see #3949).
 	log.Debug("==> Checking that the clients have routes to each other")
-	require.Eventually(t, func() bool {
+	if !assert.Eventually(t, func() bool {
 		output, err := client1.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
 		if err != nil {
 			return false
 		}
 		return strings.Contains(string(output), client2DZIP)
-	}, 90*time.Second, 1*time.Second, "client1 should have route to client2")
-	require.Eventually(t, func() bool {
+	}, 90*time.Second, 1*time.Second, "client1 should have route to client2") {
+		dumpClientRouteDiag(t, log, "client1", client1, client2DZIP)
+		dumpClientRouteDiag(t, log, "client2", client2, client1DZIP)
+		t.Fatalf("client1 should have route to client2 (%s)", client2DZIP)
+	}
+	if !assert.Eventually(t, func() bool {
 		output, err := client2.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
 		if err != nil {
 			return false
 		}
 		return strings.Contains(string(output), client1DZIP)
-	}, 90*time.Second, 1*time.Second, "client2 should have route to client1")
+	}, 90*time.Second, 1*time.Second, "client2 should have route to client1") {
+		dumpClientRouteDiag(t, log, "client1", client1, client2DZIP)
+		dumpClientRouteDiag(t, log, "client2", client2, client1DZIP)
+		t.Fatalf("client2 should have route to client1 (%s)", client1DZIP)
+	}
 	log.Debug("--> Clients have routes to each other")
 
 	// Disconnect client1.
@@ -283,4 +297,26 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 	require.Nil(t, status[0].DoubleZeroIP, status)
 	require.Equal(t, devnet.ClientSessionStatusDisconnected, status[0].DoubleZeroStatus.SessionStatus)
 	log.Debug("--> Confirmed clients are disconnected and do not have a DZ IP allocated")
+}
+
+// dumpClientRouteDiag emits tunnel/route state for a client when a route-convergence
+// assertion times out. These checks otherwise emit nothing on failure, which made the
+// #3949 flake slow to diagnose.
+func dumpClientRouteDiag(t *testing.T, log *slog.Logger, name string, client *devnet.Client, peerDZIP string) {
+	t.Helper()
+	for _, cmd := range [][]string{
+		{"doublezero", "status"},
+		{"ip", "route", "show"},
+		{"ip", "r", "list", "dev", "doublezero0"},
+	} {
+		out, err := client.Exec(t.Context(), cmd)
+		log.Error("route-diag",
+			"client", name,
+			"pubkey", client.Pubkey,
+			"peerDZIP", peerDZIP,
+			"cmd", strings.Join(cmd, " "),
+			"output", string(out),
+			"error", err,
+		)
+	}
 }

--- a/e2e/multi_client_ibrl_allocated_ip_test.go
+++ b/e2e/multi_client_ibrl_allocated_ip_test.go
@@ -3,7 +3,6 @@
 package e2e_test
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/malbeclabs/doublezero/e2e/internal/devnet"
 	"github.com/malbeclabs/doublezero/e2e/internal/random"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -231,31 +229,10 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 
 	// Check that the clients have routes to each other.
 	// client1 runs route-liveness in active mode, so its kernel route to client2 is
-	// withheld until the client↔client liveness handshake reaches Up. On failure, dump
-	// diagnostics for both clients so a flake is self-explaining (see #3949).
+	// withheld until the client↔client liveness handshake reaches Up (see #3949).
 	log.Debug("==> Checking that the clients have routes to each other")
-	if !assert.Eventually(t, func() bool {
-		output, err := client1.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client2DZIP)
-	}, 90*time.Second, 1*time.Second, "client1 should have route to client2") {
-		dumpClientRouteDiag(t, log, "client1", client1, client2DZIP)
-		dumpClientRouteDiag(t, log, "client2", client2, client1DZIP)
-		t.Fatalf("client1 should have route to client2 (%s)", client2DZIP)
-	}
-	if !assert.Eventually(t, func() bool {
-		output, err := client2.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 90*time.Second, 1*time.Second, "client2 should have route to client1") {
-		dumpClientRouteDiag(t, log, "client1", client1, client2DZIP)
-		dumpClientRouteDiag(t, log, "client2", client2, client1DZIP)
-		t.Fatalf("client2 should have route to client1 (%s)", client1DZIP)
-	}
+	requireClientHasRoutes(t, log, "client1", client1, 90*time.Second, 1*time.Second, client2DZIP)
+	requireClientHasRoutes(t, log, "client2", client2, 90*time.Second, 1*time.Second, client1DZIP)
 	log.Debug("--> Clients have routes to each other")
 
 	// Disconnect client1.
@@ -298,30 +275,4 @@ func runMultiClientIBRLAllocatedIPWorkflowTest(t *testing.T, log *slog.Logger, d
 	require.Nil(t, status[0].DoubleZeroIP, status)
 	require.Equal(t, devnet.ClientSessionStatusDisconnected, status[0].DoubleZeroStatus.SessionStatus)
 	log.Debug("--> Confirmed clients are disconnected and do not have a DZ IP allocated")
-}
-
-// dumpClientRouteDiag emits tunnel/route state for a client when a route-convergence
-// assertion times out. These checks otherwise emit nothing on failure, which made the
-// #3949 flake slow to diagnose.
-func dumpClientRouteDiag(t *testing.T, log *slog.Logger, name string, client *devnet.Client, peerDZIP string) {
-	t.Helper()
-	// Use a fresh bounded context: the test deadline may already have cancelled
-	// t.Context(), and a wedged container must not let the dump hang.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	for _, cmd := range [][]string{
-		{"doublezero", "status"},
-		{"ip", "route", "show"},
-		{"ip", "r", "list", "dev", "doublezero0"},
-	} {
-		out, err := client.Exec(ctx, cmd)
-		log.Error("route-diag",
-			"client", name,
-			"pubkey", client.Pubkey,
-			"peerDZIP", peerDZIP,
-			"cmd", strings.Join(cmd, " "),
-			"output", string(out),
-			"error", err,
-		)
-	}
 }

--- a/e2e/multi_client_ibrl_helpers_test.go
+++ b/e2e/multi_client_ibrl_helpers_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/e2e/internal/devnet"
+	"github.com/stretchr/testify/assert"
+)
+
+// requireClientHasRoutes asserts that a client's doublezero0 kernel route table contains
+// every peer DZ IP within the timeout, dumping diagnostics and failing the test on timeout.
+//
+// Active route-liveness clients withhold the kernel route until the client↔client liveness
+// handshake reaches Up, so these checks are the ones that flaked in #3949. On failure we
+// emit the client's tunnel/route state so the flake is self-explaining.
+func requireClientHasRoutes(t *testing.T, log *slog.Logger, name string, client *devnet.Client, timeout, interval time.Duration, wantPeerDZIPs ...string) {
+	t.Helper()
+	ok := assert.Eventually(t, func() bool {
+		output, err := client.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
+		if err != nil {
+			return false
+		}
+		out := string(output)
+		for _, ip := range wantPeerDZIPs {
+			if !strings.Contains(out, ip) {
+				return false
+			}
+		}
+		return true
+	}, timeout, interval, "%s should have routes to %s", name, strings.Join(wantPeerDZIPs, ", "))
+	if ok {
+		return
+	}
+	dumpClientRouteDiag(t, log, name, client, strings.Join(wantPeerDZIPs, ", "))
+	t.Fatalf("%s should have routes to %s", name, strings.Join(wantPeerDZIPs, ", "))
+}
+
+// dumpClientRouteDiag emits tunnel/route state for a client when a route-convergence
+// assertion times out. These checks otherwise emit nothing on failure, which made the
+// #3949 flake slow to diagnose.
+func dumpClientRouteDiag(t *testing.T, log *slog.Logger, name string, client *devnet.Client, peerDZIPs string) {
+	t.Helper()
+	// Use a fresh bounded context so a wedged container can't make the diagnostic
+	// dump hang (the dump runs before t.Fatalf, while t.Context() is still live).
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for _, cmd := range [][]string{
+		{"doublezero", "status"},
+		{"ip", "route", "show"},
+		{"ip", "r", "list", "dev", "doublezero0"},
+	} {
+		out, err := client.Exec(ctx, cmd)
+		log.Error("route-diag",
+			"client", name,
+			"pubkey", client.Pubkey,
+			"peerDZIPs", peerDZIPs,
+			"cmd", strings.Join(cmd, " "),
+			"output", string(out),
+			"error", err,
+		)
+	}
+}

--- a/e2e/multi_client_ibrl_liveness_test.go
+++ b/e2e/multi_client_ibrl_liveness_test.go
@@ -327,27 +327,9 @@ func runMultiClientIBRLRouteLivenessTest(t *testing.T, log *slog.Logger, dn *dev
 
 	// Wait for clients to have routes to each other before starting liveness tests.
 	log.Debug("==> Waiting for client routes before liveness testing")
-	require.Eventually(t, func() bool {
-		output, err := client1.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client2DZIP) && strings.Contains(string(output), client3DZIP)
-	}, 60*time.Second, 1*time.Second, "client1 should have routes to client2 and client3")
-	require.Eventually(t, func() bool {
-		output, err := client2.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 60*time.Second, 5*time.Second, "client2 should have route to client1")
-	require.Eventually(t, func() bool {
-		output, err := client3.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 60*time.Second, 5*time.Second, "client3 should have route to client1")
+	requireClientHasRoutes(t, log, "client1", client1, 60*time.Second, 1*time.Second, client2DZIP, client3DZIP)
+	requireClientHasRoutes(t, log, "client2", client2, 60*time.Second, 5*time.Second, client1DZIP)
+	requireClientHasRoutes(t, log, "client3", client3, 60*time.Second, 5*time.Second, client1DZIP)
 	log.Debug("--> Client routes established")
 
 	// --- Route liveness block matrix ---

--- a/e2e/multi_client_ibrl_liveness_test.go
+++ b/e2e/multi_client_ibrl_liveness_test.go
@@ -131,6 +131,7 @@ func TestE2E_MultiClientIBRL_RouteLiveness(t *testing.T) {
 	client1, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:       100,
 		RouteLivenessEnableActive: true,
+		RouteLivenessBackoffMax:   3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client1 added", "client1Pubkey", client1.Pubkey, "client1IP", client1.CYOANetworkIP)
@@ -140,6 +141,7 @@ func TestE2E_MultiClientIBRL_RouteLiveness(t *testing.T) {
 	client2, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:        110,
 		RouteLivenessEnablePassive: true, // route liveness in passive mode for this client
+		RouteLivenessBackoffMax:    3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client2 added", "client2Pubkey", client2.Pubkey, "client2IP", client2.CYOANetworkIP)
@@ -149,6 +151,7 @@ func TestE2E_MultiClientIBRL_RouteLiveness(t *testing.T) {
 	client3, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:       120,
 		RouteLivenessEnableActive: true,
+		RouteLivenessBackoffMax:   3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client3 added", "client3Pubkey", client3.Pubkey, "client3IP", client3.CYOANetworkIP)

--- a/e2e/multi_client_ibrl_test.go
+++ b/e2e/multi_client_ibrl_test.go
@@ -137,6 +137,7 @@ func TestE2E_MultiClientIBRL(t *testing.T) {
 	client1, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:       100,
 		RouteLivenessEnableActive: true,
+		RouteLivenessBackoffMax:   3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client1 added", "client1Pubkey", client1.Pubkey, "client1IP", client1.CYOANetworkIP)
@@ -146,6 +147,7 @@ func TestE2E_MultiClientIBRL(t *testing.T) {
 	client2, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:        110,
 		RouteLivenessEnablePassive: true, // route liveness in passive mode for this client
+		RouteLivenessBackoffMax:    3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client2 added", "client2Pubkey", client2.Pubkey, "client2IP", client2.CYOANetworkIP)
@@ -155,6 +157,7 @@ func TestE2E_MultiClientIBRL(t *testing.T) {
 	client3, err := dn.AddClient(t.Context(), devnet.ClientSpec{
 		CYOANetworkIPHostID:       120,
 		RouteLivenessEnableActive: true, //
+		RouteLivenessBackoffMax:   3 * time.Second,
 	})
 	require.NoError(t, err)
 	log.Debug("--> Client3 added", "client3Pubkey", client3.Pubkey, "client3IP", client3.CYOANetworkIP)

--- a/e2e/multi_client_ibrl_test.go
+++ b/e2e/multi_client_ibrl_test.go
@@ -307,33 +307,15 @@ func runMultiClientIBRLWorkflowTest(t *testing.T, log *slog.Logger, dn *devnet.D
 
 	// Client1 (on DZD1) should have routes to client2 (on DZD2) and client3 (on DZD2).
 	log.Debug("--> Client1 (on DZD1) should have routes to client2 (on DZD2) and client3 (on DZD2)")
-	require.Eventually(t, func() bool {
-		output, err := client1.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client2DZIP) && strings.Contains(string(output), client3DZIP)
-	}, 60*time.Second, 1*time.Second, "client1 should have route to client2")
+	requireClientHasRoutes(t, log, "client1", client1, 60*time.Second, 1*time.Second, client2DZIP, client3DZIP)
 
 	// Client2 (on DZD2) should have routes to client1 (on DZD1) only.
 	log.Debug("--> Client2 (on DZD2) should have routes to client1 (on DZD1) only")
-	require.Eventually(t, func() bool {
-		output, err := client2.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 120*time.Second, 5*time.Second, "client2 should have route to client1")
+	requireClientHasRoutes(t, log, "client2", client2, 120*time.Second, 5*time.Second, client1DZIP)
 
 	// Client3 (on DZD2) should have routes to client1 (on DZD1) only.
 	log.Debug("--> Client3 (on DZD2) should have routes to client1 (on DZD1) only")
-	require.Eventually(t, func() bool {
-		output, err := client3.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 120*time.Second, 5*time.Second, "client3 should have route to client1")
+	requireClientHasRoutes(t, log, "client3", client3, 120*time.Second, 5*time.Second, client1DZIP)
 
 	// Client2 (on DZD2) should not have routes to client3 (on DZD2).
 	log.Debug("--> Client2 (on DZD2) should not have routes to client3 (on DZD2)")
@@ -359,13 +341,7 @@ func runMultiClientIBRLWorkflowTest(t *testing.T, log *slog.Logger, dn *devnet.D
 
 	// Client4 (on DZD2) should have route to client1 (on DZD1).
 	log.Debug("--> Client4 (on DZD2) should have route to client1 (on DZD1)")
-	require.Eventually(t, func() bool {
-		output, err := client4.Exec(t.Context(), []string{"ip", "r", "list", "dev", "doublezero0"})
-		if err != nil {
-			return false
-		}
-		return strings.Contains(string(output), client1DZIP)
-	}, 120*time.Second, 5*time.Second, "client4 should have routes to client1")
+	requireClientHasRoutes(t, log, "client4", client4, 120*time.Second, 5*time.Second, client1DZIP)
 
 	log.Debug("--> Clients have routes to each other")
 


### PR DESCRIPTION
## Summary of Changes
* Add a `-route-liveness-backoff-max` daemon flag capping the active-mode Down-state liveness probe interval; production default stays 60s (now explicit, behavior unchanged).
* Pin `RouteLivenessBackoffMax: 3s` on the multi-client IBRL e2e clients so the Down probe schedule is `0,1,3,3,3,…` (no >3s gap) and the active client's route installs once the data path is up — instead of stalling in the 60s `(63s,123s)` dead zone that outlasts the 90s deadline.
* Add e2e route-convergence failure diagnostics, extracted into a shared helper used by all three multi-client IBRL tests, so future flakes are self-explaining.
* Fixes #3949

Root cause: active route-liveness withholds the kernel route until a BFD-style handshake reaches `Up`; while `Down`, `ComputeNextTx` backs off exponentially capped at `BackoffMax` (defaulted to 60s by `ManagerConfig.Validate`). The resulting 60s gap between probes at `t=63s..123s` outlives the test deadline, so only the active direction ("client1 should have route to client2") flaked. #3944's 60→90s bump moved the deadline deeper into the gap, which is why it didn't help.

## Testing Verification
* New manager-level test (`RegisterRoute_PropagatesBackoffMax`) covers the plumbing this PR adds: `ManagerConfig.BackoffMax` flows into each session's `backoffMax`, and a zero value falls back to the 60s default via `Validate`.
* Added a `ComputeNextTx` guardrail test asserting the Down-state interval stays capped at `backoffMax` (+jitter) across 20 consecutive Down transmits. Note: the cap logic itself pre-exists on `main`, so this is a guardrail/characterization test rather than a regression of the cap behavior.
* `go vet -tags e2e ./e2e/...` clean; liveness package tests green.
