### PR TITLE
serviceability: EdgeSeat feed-seat data model and SetAccessPassFeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
+- Serviceability
+  - The `AccessPass` `EdgeSeat` variant now carries a `Vec<FeedSeat>` payload (`feed_key` + per-feed cap) instead of being a bare marker. This changes the `AccessPass` borsh layout for EdgeSeat passes. (#3954)
+
 ### Added
 
 - Serviceability
   - `Feed` account: a catalog entry for one metro's multicast group set, keyed by `(code, exchange)` (one `feed_key` is one feed in one metro), managed by a catalog admin (`FEED_AUTHORITY` Permission or `FOUNDATION`) via `CreateFeed`/`UpdateFeed`/`DeleteFeed`. (#3953)
+  - `SetAccessPassFeeds` provisions feed_keys (SKU seats) onto an EdgeSeat pass; the oracle calls it via its `ACCESS_PASS_ADMIN` Permission. (#3954)
 
 ### Changes
 

--- a/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
+++ b/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
@@ -1196,7 +1196,7 @@ fn generate_access_pass_edge_seat(dir: &Path) {
         account_type: AccountType::AccessPass,
         owner,
         bump_seed: 242,
-        accesspass_type: AccessPassType::EdgeSeat,
+        accesspass_type: AccessPassType::EdgeSeat(vec![]),
         client_ip: Ipv4Addr::UNSPECIFIED,
         user_payer,
         last_access_epoch: u64::MAX,

--- a/smartcontract/cli/src/accesspass/list.rs
+++ b/smartcontract/cli/src/accesspass/list.rs
@@ -141,7 +141,9 @@ fn accesspass_type_short(t: &AccessPassType) -> String {
                 crate::util::abbreviate_prefix(key)
             )
         }
-        AccessPassType::Prepaid | AccessPassType::EdgeSeat => t.to_string(),
+        // Compact form: the discriminant only (feed details are shown in the get/JSON views).
+        AccessPassType::EdgeSeat(_) => t.to_discriminant_string(),
+        AccessPassType::Prepaid => t.to_string(),
     }
 }
 
@@ -212,7 +214,7 @@ impl ListAccessPassCliCommand {
         // Filter access passes by EdgeSeat type
         if self.edge_seat {
             access_passes.retain(|(_, access_pass)| {
-                matches!(access_pass.accesspass_type, AccessPassType::EdgeSeat)
+                matches!(access_pass.accesspass_type, AccessPassType::EdgeSeat(_))
             });
         }
         // Filter access passes by client IP
@@ -640,7 +642,7 @@ mod tests {
             "prepaid"
         );
         assert_eq!(
-            super::accesspass_type_short(&AccessPassType::EdgeSeat),
+            super::accesspass_type_short(&AccessPassType::EdgeSeat(vec![])),
             "edge_seat"
         );
         // Others: type_name kept, embedded key truncated to a copyable prefix.

--- a/smartcontract/cli/src/accesspass/set.rs
+++ b/smartcontract/cli/src/accesspass/set.rs
@@ -100,7 +100,7 @@ impl SetAccessPassCliCommand {
                     "Others access pass type requires --others-name <STRING> and --others-key <STRING>"
                 ),
             },
-            CliAccessPassType::EdgeSeat => AccessPassType::EdgeSeat,
+            CliAccessPassType::EdgeSeat => AccessPassType::EdgeSeat(vec![]),
         };
 
         // Convert tenant code to PDA if provided
@@ -941,7 +941,7 @@ mod tests {
         client
             .expect_set_accesspass()
             .with(predicate::eq(SetAccessPassCommand {
-                accesspass_type: AccessPassType::EdgeSeat,
+                accesspass_type: AccessPassType::EdgeSeat(vec![]),
                 client_ip,
                 user_payer: payer,
                 last_access_epoch: 11,

--- a/smartcontract/cli/src/feed/get.rs
+++ b/smartcontract/cli/src/feed/get.rs
@@ -32,7 +32,6 @@ struct FeedDisplay {
     pub exchange: String,
     /// Number of multicast groups joinable in this metro.
     pub groups: usize,
-    pub reference_count: u32,
     pub owner: String,
 }
 
@@ -59,7 +58,6 @@ impl GetFeedCliCommand {
             name: feed.name,
             exchange: feed.exchange.to_string(),
             groups: feed.groups.len(),
-            reference_count: feed.reference_count,
             owner: feed.owner.to_string(),
         };
 

--- a/smartcontract/cli/src/feed/list.rs
+++ b/smartcontract/cli/src/feed/list.rs
@@ -27,7 +27,6 @@ pub struct FeedDisplay {
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub exchange: Pubkey,
     pub groups: usize,
-    pub reference_count: u32,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
@@ -49,7 +48,6 @@ impl ListFeedCliCommand {
                 name: feed.name,
                 exchange: feed.exchange,
                 groups: feed.groups.len(),
-                reference_count: feed.reference_count,
                 owner: feed.owner,
             })
             .collect::<Vec<FeedDisplay>>();

--- a/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
@@ -4,7 +4,7 @@ use crate::{
     processors::{
         accesspass::{
             check_status::process_check_status_access_pass, close::process_close_access_pass,
-            set::process_set_access_pass,
+            set::process_set_access_pass, set_feeds::process_set_access_pass_feeds,
         },
         allowlist::{
             foundation::{
@@ -419,6 +419,9 @@ pub fn process_instruction(
         }
         DoubleZeroInstruction::DeleteFeed(value) => {
             process_delete_feed(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::SetAccessPassFeeds(value) => {
+            process_set_access_pass_feeds(program_id, accounts, &value)?
         }
     };
     Ok(())

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -1387,17 +1387,11 @@ mod tests {
             DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
                 client_ip: Ipv4Addr::UNSPECIFIED,
                 user_payer: Pubkey::new_unique(),
-                feeds: vec![doublezero_serviceability_feed_seat()],
+                feeds: vec![crate::processors::accesspass::set_feeds::FeedSeatConfig {
+                    max_users: 4,
+                }],
             }),
             "SetAccessPassFeeds",
         );
-    }
-
-    fn doublezero_serviceability_feed_seat() -> crate::state::accesspass::FeedSeat {
-        crate::state::accesspass::FeedSeat {
-            feed_key: Pubkey::new_unique(),
-            max_users: 4,
-            current_users: 0,
-        }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -1,6 +1,7 @@
 use crate::processors::{
     accesspass::{
-        check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs, set::SetAccessPassArgs,
+        check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs,
+        set::SetAccessPassArgs, set_feeds::SetAccessPassFeedsArgs,
     },
     allowlist::{
         foundation::{add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs},
@@ -246,9 +247,10 @@ pub enum DoubleZeroInstruction {
 
     Deprecated111(), // variant 111, (was MigrateDeviceInterfaces)
 
-    CreateFeed(FeedCreateArgs), // variant 112
-    UpdateFeed(FeedUpdateArgs), // variant 113
-    DeleteFeed(FeedDeleteArgs), // variant 114
+    CreateFeed(FeedCreateArgs),                 // variant 112
+    UpdateFeed(FeedUpdateArgs),                 // variant 113
+    DeleteFeed(FeedDeleteArgs),                 // variant 114
+    SetAccessPassFeeds(SetAccessPassFeedsArgs), // variant 115
 }
 
 impl DoubleZeroInstruction {
@@ -394,6 +396,7 @@ impl DoubleZeroInstruction {
             112 => Ok(Self::CreateFeed(FeedCreateArgs::try_from(rest).unwrap())),
             113 => Ok(Self::UpdateFeed(FeedUpdateArgs::try_from(rest).unwrap())),
             114 => Ok(Self::DeleteFeed(FeedDeleteArgs::try_from(rest).unwrap())),
+            115 => Ok(Self::SetAccessPassFeeds(SetAccessPassFeedsArgs::try_from(rest).unwrap())),
 
             _ => Err(ProgramError::InvalidInstructionData),
         }
@@ -542,6 +545,7 @@ impl DoubleZeroInstruction {
             Self::CreateFeed(_) => "CreateFeed".to_string(), // variant 112
             Self::UpdateFeed(_) => "UpdateFeed".to_string(), // variant 113
             Self::DeleteFeed(_) => "DeleteFeed".to_string(), // variant 114
+            Self::SetAccessPassFeeds(_) => "SetAccessPassFeeds".to_string(), // variant 115
         }
     }
 
@@ -682,6 +686,7 @@ impl DoubleZeroInstruction {
             Self::CreateFeed(args) => format!("{args:?}"), // variant 112
             Self::UpdateFeed(args) => format!("{args:?}"), // variant 113
             Self::DeleteFeed(args) => format!("{args:?}"), // variant 114
+            Self::SetAccessPassFeeds(args) => format!("{args:?}"), // variant 115
         }
     }
 }
@@ -1378,5 +1383,21 @@ mod tests {
             DoubleZeroInstruction::DeleteFeed(FeedDeleteArgs {}),
             "DeleteFeed",
         );
+        test_instruction(
+            DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+                client_ip: Ipv4Addr::UNSPECIFIED,
+                user_payer: Pubkey::new_unique(),
+                feeds: vec![doublezero_serviceability_feed_seat()],
+            }),
+            "SetAccessPassFeeds",
+        );
+    }
+
+    fn doublezero_serviceability_feed_seat() -> crate::state::accesspass::FeedSeat {
+        crate::state::accesspass::FeedSeat {
+            feed_key: Pubkey::new_unique(),
+            max_users: 4,
+            current_users: 0,
+        }
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_status;
 pub mod close;
 pub mod set;
+pub mod set_feeds;
 
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed_unchecked,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -108,13 +108,24 @@ pub fn process_set_access_pass_feeds(
     // newly-referenced feeds. NOTE: feeds dropped from the pass are intentionally NOT decremented
     // here — their accounts are not passed, and an over-count only makes a feed harder to delete
     // (never unsafe), since reference_count solely guards DeleteFeed.
-    let mut new_seats = Vec::with_capacity(value.feeds.len());
+    let mut new_seats: Vec<FeedSeat> = Vec::with_capacity(value.feeds.len());
     for (seat, feed_account) in value.feeds.iter().zip(feed_accounts.iter()) {
         assert_eq!(
             *feed_account.key, seat.feed_key,
             "Feed account does not match seat feed_key"
         );
         assert_eq!(feed_account.owner, program_id, "Invalid Feed Account Owner");
+
+        // Reject a feed_key listed more than once: it would double-bump reference_count and
+        // write duplicate seats, neither of which is reclaimable.
+        if new_seats.iter().any(|s| s.feed_key == seat.feed_key) {
+            msg!(
+                "Duplicate feed_key in SetAccessPassFeeds: {}",
+                seat.feed_key
+            );
+            return Err(DoubleZeroError::InvalidArgument.into());
+        }
+
         let mut feed = Feed::try_from(*feed_account)?;
 
         let current_users = prior_seats
@@ -122,6 +133,18 @@ pub fn process_set_access_pass_feeds(
             .find(|s| s.feed_key == seat.feed_key)
             .map(|s| s.current_users)
             .unwrap_or(0);
+
+        // A re-provision must not set a cap below the live count carried over from the prior seat,
+        // or the seat would start over its cap (enforced once connect-time ticking lands).
+        if seat.max_users < current_users {
+            msg!(
+                "max_users {} below current_users {} for feed {}",
+                seat.max_users,
+                current_users,
+                seat.feed_key
+            );
+            return Err(DoubleZeroError::InvalidArgument.into());
+        }
 
         if !prior_seats.iter().any(|s| s.feed_key == seat.feed_key) {
             assert!(feed_account.is_writable, "Feed Account is not writable");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -1,0 +1,148 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    pda::get_accesspass_pda,
+    serializer::try_acc_write,
+    state::{
+        accesspass::{AccessPass, AccessPassType, FeedSeat},
+        feed::Feed,
+        globalstate::GlobalState,
+        permission::permission_flags,
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use core::fmt;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    pubkey::Pubkey,
+};
+use std::net::Ipv4Addr;
+
+/// Provision the feed_keys (SKU seats) onto an EdgeSeat access pass. The provisioning actor is the
+/// oracle, authorized via its `ACCESS_PASS_ADMIN` Permission — not the deprecated `feed_authority`
+/// slot. `current_users` is preserved for feeds already present on the pass; caps come from the
+/// caller (seeded from the coupon).
+#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone)]
+pub struct SetAccessPassFeedsArgs {
+    #[incremental(default = Ipv4Addr::UNSPECIFIED)]
+    pub client_ip: Ipv4Addr,
+    pub user_payer: Pubkey,
+    pub feeds: Vec<FeedSeat>,
+}
+
+impl fmt::Debug for SetAccessPassFeedsArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "client_ip: {}, user_payer: {}, feeds: {}",
+            self.client_ip,
+            self.user_payer,
+            self.feeds.len()
+        )
+    }
+}
+
+pub fn process_set_access_pass_feeds(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &SetAccessPassFeedsArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let accesspass_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    // One Feed account per requested seat, in the same order as `value.feeds`.
+    let mut feed_accounts = Vec::with_capacity(value.feeds.len());
+    for _ in 0..value.feeds.len() {
+        feed_accounts.push(next_account_info(accounts_iter)?);
+    }
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+    assert_eq!(
+        accesspass_account.owner, program_id,
+        "Invalid AccessPass Account Owner"
+    );
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert!(
+        accesspass_account.is_writable,
+        "AccessPass Account is not writable"
+    );
+
+    let (expected_pda, _) = get_accesspass_pda(program_id, &value.client_ip, &value.user_payer);
+    assert_eq!(
+        accesspass_account.key, &expected_pda,
+        "Invalid AccessPass PubKey"
+    );
+
+    // Provisioning actor authorized via ACCESS_PASS_ADMIN (Permission PDA or legacy fallback).
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::ACCESS_PASS_ADMIN,
+    )?;
+
+    let mut accesspass = AccessPass::try_from(accesspass_account)?;
+
+    // Only EdgeSeat passes carry feed seats. Require the pass to already be EdgeSeat (the oracle
+    // sets the type via SetAccessPass first) so this instruction can't silently convert a pass of
+    // another type (e.g. SolanaValidator) into an EdgeSeat.
+    if !matches!(accesspass.accesspass_type, AccessPassType::EdgeSeat(_)) {
+        msg!("SetAccessPassFeeds requires an EdgeSeat access pass");
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+    let prior_seats = accesspass.feed_seats().to_vec();
+
+    // Validate each referenced Feed, preserve live counts, and bump reference_count for
+    // newly-referenced feeds. NOTE: feeds dropped from the pass are intentionally NOT decremented
+    // here — their accounts are not passed, and an over-count only makes a feed harder to delete
+    // (never unsafe), since reference_count solely guards DeleteFeed.
+    let mut new_seats = Vec::with_capacity(value.feeds.len());
+    for (seat, feed_account) in value.feeds.iter().zip(feed_accounts.iter()) {
+        assert_eq!(
+            *feed_account.key, seat.feed_key,
+            "Feed account does not match seat feed_key"
+        );
+        assert_eq!(feed_account.owner, program_id, "Invalid Feed Account Owner");
+        let mut feed = Feed::try_from(*feed_account)?;
+
+        let current_users = prior_seats
+            .iter()
+            .find(|s| s.feed_key == seat.feed_key)
+            .map(|s| s.current_users)
+            .unwrap_or(0);
+
+        if !prior_seats.iter().any(|s| s.feed_key == seat.feed_key) {
+            assert!(feed_account.is_writable, "Feed Account is not writable");
+            feed.reference_count = feed
+                .reference_count
+                .checked_add(1)
+                .ok_or(DoubleZeroError::InvalidIndex)?;
+            try_acc_write(&feed, feed_account, payer_account, accounts)?;
+        }
+
+        new_seats.push(FeedSeat {
+            feed_key: seat.feed_key,
+            max_users: seat.max_users,
+            current_users,
+        });
+    }
+
+    accesspass.accesspass_type = AccessPassType::EdgeSeat(new_seats);
+    try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
+
+    msg!("Set {} feed(s) on access pass", value.feeds.len());
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -10,9 +10,8 @@ use crate::{
         permission::permission_flags,
     },
 };
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_incremental::BorshDeserializeIncremental;
-use core::fmt;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
@@ -21,28 +20,31 @@ use solana_program::{
 };
 use std::net::Ipv4Addr;
 
+/// Upper bound on the number of feed seats provisioned in a single call. Bounds the AccessPass
+/// account growth and the duplicate scan below; mirrors the catalog-side feed limits.
+pub const MAX_ACCESS_PASS_FEEDS: usize = 64;
+
+/// Per-feed provisioning input paired by position with the passed `Feed` accounts. The `feed_key`
+/// is read from the account (not duplicated here) and `current_users` is maintained server-side,
+/// so the only caller-supplied value is the cap.
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone)]
+pub struct FeedSeatConfig {
+    pub max_users: u16,
+}
+
 /// Provision the feed_keys (SKU seats) onto an EdgeSeat access pass. The provisioning actor is the
 /// oracle, authorized via its `ACCESS_PASS_ADMIN` Permission — not the deprecated `feed_authority`
 /// slot. `current_users` is preserved for feeds already present on the pass; caps come from the
 /// caller (seeded from the coupon).
-#[derive(BorshSerialize, BorshDeserializeIncremental, PartialEq, Clone)]
+///
+/// Each entry in `feeds` is paired by position with a `Feed` account (see
+/// `process_set_access_pass_feeds` for the account layout).
+#[derive(BorshSerialize, BorshDeserializeIncremental, Debug, PartialEq, Clone)]
 pub struct SetAccessPassFeedsArgs {
     #[incremental(default = Ipv4Addr::UNSPECIFIED)]
     pub client_ip: Ipv4Addr,
     pub user_payer: Pubkey,
-    pub feeds: Vec<FeedSeat>,
-}
-
-impl fmt::Debug for SetAccessPassFeedsArgs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "client_ip: {}, user_payer: {}, feeds: {}",
-            self.client_ip,
-            self.user_payer,
-            self.feeds.len()
-        )
-    }
+    pub feeds: Vec<FeedSeatConfig>,
 }
 
 pub fn process_set_access_pass_feeds(
@@ -50,18 +52,30 @@ pub fn process_set_access_pass_feeds(
     accounts: &[AccountInfo],
     value: &SetAccessPassFeedsArgs,
 ) -> ProgramResult {
+    if value.feeds.len() > MAX_ACCESS_PASS_FEEDS {
+        msg!(
+            "SetAccessPassFeeds accepts at most {} feeds, got {}",
+            MAX_ACCESS_PASS_FEEDS,
+            value.feeds.len()
+        );
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
     let accounts_iter = &mut accounts.iter();
 
+    // Account layout: [accesspass, globalstate, feed_0 .. feed_{N-1}, payer, system, (permission)].
+    // The trailing [payer, system, permission] convention matches the sibling accesspass handlers.
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
-    let payer_account = next_account_info(accounts_iter)?;
-    let _system_program = next_account_info(accounts_iter)?;
 
     // One Feed account per requested seat, in the same order as `value.feeds`.
     let mut feed_accounts = Vec::with_capacity(value.feeds.len());
     for _ in 0..value.feeds.len() {
         feed_accounts.push(next_account_info(accounts_iter)?);
     }
+
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
 
     assert!(payer_account.is_signer, "Payer must be a signer");
     assert_eq!(
@@ -109,20 +123,14 @@ pub fn process_set_access_pass_feeds(
     // here — their accounts are not passed, and an over-count only makes a feed harder to delete
     // (never unsafe), since reference_count solely guards DeleteFeed.
     let mut new_seats: Vec<FeedSeat> = Vec::with_capacity(value.feeds.len());
-    for (seat, feed_account) in value.feeds.iter().zip(feed_accounts.iter()) {
-        assert_eq!(
-            *feed_account.key, seat.feed_key,
-            "Feed account does not match seat feed_key"
-        );
+    for (config, feed_account) in value.feeds.iter().zip(feed_accounts.iter()) {
         assert_eq!(feed_account.owner, program_id, "Invalid Feed Account Owner");
+        let feed_key = *feed_account.key;
 
         // Reject a feed_key listed more than once: it would double-bump reference_count and
         // write duplicate seats, neither of which is reclaimable.
-        if new_seats.iter().any(|s| s.feed_key == seat.feed_key) {
-            msg!(
-                "Duplicate feed_key in SetAccessPassFeeds: {}",
-                seat.feed_key
-            );
+        if new_seats.iter().any(|s| s.feed_key == feed_key) {
+            msg!("Duplicate feed_key in SetAccessPassFeeds: {}", feed_key);
             return Err(DoubleZeroError::InvalidArgument.into());
         }
 
@@ -130,34 +138,34 @@ pub fn process_set_access_pass_feeds(
 
         let current_users = prior_seats
             .iter()
-            .find(|s| s.feed_key == seat.feed_key)
+            .find(|s| s.feed_key == feed_key)
             .map(|s| s.current_users)
             .unwrap_or(0);
 
         // A re-provision must not set a cap below the live count carried over from the prior seat,
         // or the seat would start over its cap (enforced once connect-time ticking lands).
-        if seat.max_users < current_users {
+        if config.max_users < current_users {
             msg!(
                 "max_users {} below current_users {} for feed {}",
-                seat.max_users,
+                config.max_users,
                 current_users,
-                seat.feed_key
+                feed_key
             );
             return Err(DoubleZeroError::InvalidArgument.into());
         }
 
-        if !prior_seats.iter().any(|s| s.feed_key == seat.feed_key) {
+        if !prior_seats.iter().any(|s| s.feed_key == feed_key) {
             assert!(feed_account.is_writable, "Feed Account is not writable");
             feed.reference_count = feed
                 .reference_count
                 .checked_add(1)
-                .ok_or(DoubleZeroError::InvalidIndex)?;
+                .ok_or(DoubleZeroError::ArithmeticOverflow)?;
             try_acc_write(&feed, feed_account, payer_account, accounts)?;
         }
 
         new_seats.push(FeedSeat {
-            feed_key: seat.feed_key,
-            max_users: seat.max_users,
+            feed_key,
+            max_users: config.max_users,
             current_users,
         });
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -118,23 +118,22 @@ pub fn process_set_access_pass_feeds(
     }
     let prior_seats = accesspass.feed_seats().to_vec();
 
-    // Validate each referenced Feed, preserve live counts, and bump reference_count for
-    // newly-referenced feeds. NOTE: feeds dropped from the pass are intentionally NOT decremented
-    // here — their accounts are not passed, and an over-count only makes a feed harder to delete
-    // (never unsafe), since reference_count solely guards DeleteFeed.
+    // Validate each referenced Feed and preserve live counts. Feeds are not reference-counted, so
+    // this only reads the Feed accounts (to bind feed_key and confirm the feed exists) and never
+    // writes them; dropping a feed from a pass needs nothing here.
     let mut new_seats: Vec<FeedSeat> = Vec::with_capacity(value.feeds.len());
     for (config, feed_account) in value.feeds.iter().zip(feed_accounts.iter()) {
         assert_eq!(feed_account.owner, program_id, "Invalid Feed Account Owner");
         let feed_key = *feed_account.key;
 
-        // Reject a feed_key listed more than once: it would double-bump reference_count and
-        // write duplicate seats, neither of which is reclaimable.
+        // Reject a feed_key listed more than once: it would write duplicate seats.
         if new_seats.iter().any(|s| s.feed_key == feed_key) {
             msg!("Duplicate feed_key in SetAccessPassFeeds: {}", feed_key);
             return Err(DoubleZeroError::InvalidArgument.into());
         }
 
-        let mut feed = Feed::try_from(*feed_account)?;
+        // Confirm the account really is a Feed (owner checked above, discriminator here).
+        Feed::try_from(*feed_account)?;
 
         let current_users = prior_seats
             .iter()
@@ -152,15 +151,6 @@ pub fn process_set_access_pass_feeds(
                 feed_key
             );
             return Err(DoubleZeroError::InvalidArgument.into());
-        }
-
-        if !prior_seats.iter().any(|s| s.feed_key == feed_key) {
-            assert!(feed_account.is_writable, "Feed Account is not writable");
-            feed.reference_count = feed
-                .reference_count
-                .checked_add(1)
-                .ok_or(DoubleZeroError::ArithmeticOverflow)?;
-            try_acc_write(&feed, feed_account, payer_account, accounts)?;
         }
 
         new_seats.push(FeedSeat {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/feed/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/feed/create.rs
@@ -90,7 +90,6 @@ pub fn process_create_feed(
         bump_seed,
         code: code.clone(),
         name: value.name.clone(),
-        reference_count: 0,
         exchange: value.exchange,
         groups: value.groups.clone(),
     };

--- a/smartcontract/programs/doublezero-serviceability/src/processors/feed/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/feed/delete.rs
@@ -1,6 +1,5 @@
 use crate::{
     authorize::authorize,
-    error::DoubleZeroError,
     serializer::try_acc_close,
     state::{feed::Feed, globalstate::GlobalState, permission::permission_flags},
 };
@@ -45,14 +44,11 @@ pub fn process_delete_feed(
         permission_flags::FEED_AUTHORITY | permission_flags::FOUNDATION,
     )?;
 
-    let feed = Feed::try_from(feed_account)?;
-    if feed.reference_count > 0 {
-        msg!(
-            "Cannot delete feed: reference_count of {} > 0",
-            feed.reference_count
-        );
-        return Err(DoubleZeroError::ReferenceCountNotZero.into());
-    }
+    // Validate the account really is a Feed before closing it (guards against closing an unrelated
+    // program-owned account). Feeds are not reference-counted: a still-referenced feed_key that is
+    // deleted simply fails closed at connect (the metro gate can't load the deleted Feed), so
+    // deletion is safe and the oracle owns keeping feeds and passes in sync.
+    Feed::try_from(feed_account)?;
 
     msg!("Deleted feed: {}", feed_account.key);
 

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -11,6 +11,25 @@ use solana_program::{
 };
 use std::{fmt, net::Ipv4Addr};
 
+/// One purchased SKU seat on an EdgeSeat access pass. `feed_key` is the pubkey of the
+/// serviceability `Feed` account (the catalog entry); `max_users` is the per-feed concurrent-user
+/// cap seeded from the coupon; `current_users` is the live count, ticked at connect and released
+/// at disconnect.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FeedSeat {
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "doublezero_program_common::serializer::serialize_pubkey_as_string",
+            deserialize_with = "doublezero_program_common::serializer::deserialize_pubkey_from_string"
+        )
+    )]
+    pub feed_key: Pubkey, // 32
+    pub max_users: u16,     // 2
+    pub current_users: u16, // 2
+}
+
 #[repr(u8)]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone, PartialEq)]
 #[borsh(use_discriminant = true)]
@@ -39,8 +58,13 @@ pub enum AccessPassType {
         Pubkey,
     ),
     Others(String, String), // (type_name, key)
-    // The seat is identified by the access pass `user_payer`, so the variant carries no payload.
-    EdgeSeat,
+    /// A metro-gated seat scoped to one or more feeds. Each `FeedSeat` is one SKU (feed_key +
+    /// per-feed cap). Provisioned by the oracle via `SetAccessPassFeeds`.
+    ///
+    /// Layout note (#1700): this variant previously carried no payload (#3865). EdgeSeat is new and
+    /// has no production passes, so changing the payload (same discriminant index 4) does not
+    /// orphan any deployed account; no migration is required.
+    EdgeSeat(Vec<FeedSeat>),
 }
 
 impl AccessPassType {
@@ -50,7 +74,7 @@ impl AccessPassType {
             AccessPassType::SolanaValidator(_) => "solana_validator".to_string(),
             AccessPassType::SolanaRPC(_) => "solana_rpc".to_string(),
             AccessPassType::Others(type_name, _) => type_name.clone(),
-            AccessPassType::EdgeSeat => "edge_seat".to_string(),
+            AccessPassType::EdgeSeat(_) => "edge_seat".to_string(),
         }
     }
 }
@@ -64,7 +88,7 @@ impl fmt::Display for AccessPassType {
             AccessPassType::Others(type_name, key) => {
                 write!(f, "others: {} ({})", type_name, key)
             }
-            AccessPassType::EdgeSeat => write!(f, "edge_seat"),
+            AccessPassType::EdgeSeat(seats) => write!(f, "edge_seat: {} feed(s)", seats.len()),
         }
     }
 }
@@ -194,7 +218,7 @@ impl fmt::Display for AccessPass {
             AccessPassType::Others(type_name, details) => {
                 write!(f, "Others: {} ({})", type_name, details)
             }
-            AccessPassType::EdgeSeat => write!(f, "EdgeSeat"),
+            AccessPassType::EdgeSeat(seats) => write!(f, "EdgeSeat: ({} feed(s))", seats.len()),
         }
     }
 }
@@ -274,7 +298,7 @@ impl AccessPass {
     /// types this is a no-op and always succeeds. Does NOT touch `connection_count` — that counter
     /// is maintained independently by the user create/delete processors.
     pub fn try_add_user(&mut self, user_type: UserType) -> Result<(), DoubleZeroError> {
-        if !matches!(self.accesspass_type, AccessPassType::EdgeSeat) {
+        if !matches!(self.accesspass_type, AccessPassType::EdgeSeat(_)) {
             return Ok(());
         }
         match user_type {
@@ -297,7 +321,7 @@ impl AccessPass {
     /// Release a seat held by a user. EdgeSeat-only: no-op for all other access-pass types. Does NOT
     /// touch `connection_count`.
     pub fn remove_user(&mut self, user_type: UserType) {
-        if !matches!(self.accesspass_type, AccessPassType::EdgeSeat) {
+        if !matches!(self.accesspass_type, AccessPassType::EdgeSeat(_)) {
             return;
         }
         match user_type {
@@ -307,6 +331,14 @@ impl AccessPass {
             _ => {
                 self.unicast_user_count = self.unicast_user_count.saturating_sub(1);
             }
+        }
+    }
+
+    /// The feed seats provisioned on this pass (empty for non-EdgeSeat passes).
+    pub fn feed_seats(&self) -> &[FeedSeat] {
+        match &self.accesspass_type {
+            AccessPassType::EdgeSeat(seats) => seats,
+            _ => &[],
         }
     }
 }
@@ -339,9 +371,13 @@ mod tests {
         let b = AccessPassType::SolanaValidator(Pubkey::default());
         assert_eq!(object_length(&b).unwrap(), 33);
 
-        // EdgeSeat carries no payload: a bare discriminant byte.
-        let c = AccessPassType::EdgeSeat;
-        assert_eq!(object_length(&c).unwrap(), 1);
+        // EdgeSeat: discriminant byte + borsh vec length prefix (4) for an empty seat vec.
+        let c = AccessPassType::EdgeSeat(vec![]);
+        assert_eq!(object_length(&c).unwrap(), 5);
+
+        // Each FeedSeat adds 36 bytes (32 pubkey + 2 + 2).
+        let d = AccessPassType::EdgeSeat(vec![FeedSeat::default()]);
+        assert_eq!(object_length(&d).unwrap(), 1 + 4 + 36);
     }
 
     #[test]
@@ -480,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_edge_seat_user_caps() {
-        let mut ap = test_accesspass(AccessPassType::EdgeSeat);
+        let mut ap = test_accesspass(AccessPassType::EdgeSeat(vec![]));
 
         // Unicast: cap is 2.
         ap.try_add_user(UserType::IBRL).unwrap();

--- a/smartcontract/programs/doublezero-serviceability/src/state/feed.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/feed.rs
@@ -28,7 +28,6 @@ pub struct Feed {
     pub bump_seed: u8,             // 1
     pub code: String,              // 4 + len (PDA seed, immutable)
     pub name: String,              // 4 + len
-    pub reference_count: u32,      // 4 - number of access passes referencing this feed
     pub exchange: Pubkey,          // 32 (PDA seed, immutable) - the metro this feed serves
     pub groups: Vec<Pubkey>,       // 4 + 32*len - multicast groups joinable in this metro
 }
@@ -49,13 +48,12 @@ impl fmt::Display for Feed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "account_type: {}, owner: {}, bump_seed: {}, code: {}, name: {}, reference_count: {}, exchange: {}, groups: {}",
+            "account_type: {}, owner: {}, bump_seed: {}, code: {}, name: {}, exchange: {}, groups: {}",
             self.account_type,
             self.owner,
             self.bump_seed,
             self.code,
             self.name,
-            self.reference_count,
             self.exchange,
             self.groups.len()
         )
@@ -72,7 +70,6 @@ impl TryFrom<&[u8]> for Feed {
             bump_seed: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             code: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             name: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
-            reference_count: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             exchange: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             groups: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
@@ -119,7 +116,6 @@ mod tests {
             bump_seed: 1,
             code: "shreds".to_string(),
             name: "Shreds".to_string(),
-            reference_count: 0,
             exchange,
             groups,
         }

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -1973,7 +1973,7 @@ async fn test_set_accesspass_refills_depleted_user_payer() {
         get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &user_payer.pubkey());
 
     let set_access_pass_args = SetAccessPassArgs {
-        accesspass_type: AccessPassType::EdgeSeat,
+        accesspass_type: AccessPassType::EdgeSeat(vec![]),
         client_ip: Ipv4Addr::UNSPECIFIED,
         last_access_epoch: u64::MAX,
         allow_multiple_ip: false,

--- a/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
@@ -699,7 +699,7 @@ async fn test_edge_seat_user_caps_enforced() {
         recent_blockhash,
         env.program_id,
         DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
-            accesspass_type: AccessPassType::EdgeSeat,
+            accesspass_type: AccessPassType::EdgeSeat(vec![]),
             client_ip: Ipv4Addr::UNSPECIFIED,
             last_access_epoch: 9999,
             allow_multiple_ip: false,

--- a/smartcontract/programs/doublezero-serviceability/tests/feed_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/feed_test.rs
@@ -1,18 +1,15 @@
 use doublezero_serviceability::{
-    entrypoint::process_instruction,
     error::DoubleZeroError,
     instructions::DoubleZeroInstruction,
     pda::{get_feed_pda, get_globalstate_pda, get_program_config_pda},
     processors::feed::{create::FeedCreateArgs, delete::FeedDeleteArgs, update::FeedUpdateArgs},
-    state::{accounttype::AccountType, feed::Feed, globalstate::GlobalState},
+    state::accounttype::AccountType,
 };
 use solana_program_test::*;
 use solana_sdk::{
-    account::Account,
     instruction::{AccountMeta, InstructionError},
     program_error::ProgramError,
     pubkey::Pubkey,
-    rent::Rent,
     signature::Signer,
     transaction::TransactionError,
 };
@@ -129,7 +126,6 @@ async fn test_feed_create_get_update_delete() {
     assert_eq!(feed.account_type, AccountType::Feed);
     assert_eq!(feed.code, "shreds".to_string());
     assert_eq!(feed.name, "Shreds".to_string());
-    assert_eq!(feed.reference_count, 0);
     assert_eq!(feed.owner, payer.pubkey());
     assert_eq!(feed.exchange, exchange);
     assert_eq!(feed.groups, groups);
@@ -392,83 +388,4 @@ async fn test_feed_create_unauthorized_caller_rejected() {
     .await;
 
     assert_custom_at_ix0(&result, custom_code(DoubleZeroError::NotAllowed));
-}
-
-fn serialized_account(program_id: Pubkey, data: Vec<u8>) -> Account {
-    Account {
-        lamports: Rent::default().minimum_balance(data.len()).max(1),
-        data,
-        owner: program_id,
-        executable: false,
-        rent_epoch: 0,
-    }
-}
-
-#[tokio::test]
-async fn test_feed_delete_with_reference_count_rejected() {
-    // No instruction in this PR bumps a feed's reference_count (SetAccessPassFeeds is a later PR),
-    // so the referenced Feed and its authorizing GlobalState are seeded directly before start.
-    let program_id = Pubkey::new_unique();
-    let authority = test_payer();
-
-    let mut program_test = ProgramTest::new(
-        "doublezero_serviceability",
-        program_id,
-        processor!(process_instruction),
-    );
-
-    let (globalstate_pubkey, globalstate_bump) = get_globalstate_pda(&program_id);
-    let globalstate = GlobalState {
-        bump_seed: globalstate_bump,
-        foundation_allowlist: vec![authority.pubkey()],
-        ..GlobalState::default()
-    };
-    program_test.add_account(
-        globalstate_pubkey,
-        serialized_account(program_id, borsh::to_vec(&globalstate).unwrap()),
-    );
-
-    let exchange = Pubkey::new_unique();
-    let (feed_pubkey, feed_bump) = get_feed_pda(&program_id, "refd", &exchange);
-    let feed = Feed {
-        account_type: AccountType::Feed,
-        owner: authority.pubkey(),
-        bump_seed: feed_bump,
-        code: "refd".to_string(),
-        name: "Referenced".to_string(),
-        reference_count: 1,
-        exchange,
-        groups: vec![Pubkey::new_unique()],
-    };
-    program_test.add_account(
-        feed_pubkey,
-        serialized_account(program_id, borsh::to_vec(&feed).unwrap()),
-    );
-
-    program_test.add_account(
-        authority.pubkey(),
-        Account {
-            lamports: 100_000_000,
-            data: vec![],
-            owner: solana_system_interface::program::ID,
-            executable: false,
-            rent_epoch: 0,
-        },
-    );
-
-    let (mut banks_client, _payer, _recent_blockhash) = program_test.start().await;
-
-    let result = try_execute_and_get_error(
-        &mut banks_client,
-        program_id,
-        DoubleZeroInstruction::DeleteFeed(FeedDeleteArgs {}),
-        vec![
-            AccountMeta::new(feed_pubkey, false),
-            AccountMeta::new(globalstate_pubkey, false),
-        ],
-        &authority,
-    )
-    .await;
-
-    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::ReferenceCountNotZero));
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
@@ -1,0 +1,524 @@
+use doublezero_serviceability::{
+    entrypoint::process_instruction,
+    error::DoubleZeroError,
+    instructions::DoubleZeroInstruction,
+    pda::{get_accesspass_pda, get_feed_pda, get_globalstate_pda, get_program_config_pda},
+    processors::{
+        accesspass::{
+            set::SetAccessPassArgs,
+            set_feeds::{FeedSeatConfig, SetAccessPassFeedsArgs},
+        },
+        feed::create::FeedCreateArgs,
+    },
+    state::{
+        accesspass::{AccessPass, AccessPassStatus, AccessPassType, FeedSeat},
+        accounttype::AccountType,
+        feed::Feed,
+        globalstate::GlobalState,
+    },
+};
+use solana_program_test::*;
+use solana_sdk::{
+    account::Account,
+    instruction::{AccountMeta, InstructionError},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    signature::Signer,
+    transaction::TransactionError,
+};
+use std::net::Ipv4Addr;
+
+mod test_helpers;
+use test_helpers::*;
+
+/// The `Custom` code the program returns for `err`, derived from the enum rather than inlined so a
+/// renumbering of the error variants can never silently pass a hard-coded literal.
+fn custom_code(err: DoubleZeroError) -> u32 {
+    match ProgramError::from(err) {
+        ProgramError::Custom(code) => code,
+        other => panic!("expected Custom, got {other:?}"),
+    }
+}
+
+/// Run `instruction` and return the structured `TransactionError` on failure. As documented in
+/// `feed_test.rs`, the native `processor!` harness does not surface the program's `msg!` lines to
+/// BanksClient, so the structured error code at instruction index 0 is the reliable signal for
+/// which check fired.
+async fn try_execute_and_get_error(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    instruction: DoubleZeroInstruction,
+    accounts: Vec<AccountMeta>,
+    payer: &solana_sdk::signature::Keypair,
+) -> Result<(), TransactionError> {
+    let recent_blockhash = wait_for_new_blockhash(banks_client).await;
+    let mut transaction = create_transaction(program_id, &instruction, &accounts, payer);
+    transaction.try_sign(&[payer], recent_blockhash).unwrap();
+
+    banks_client
+        .process_transaction_with_metadata(transaction)
+        .await
+        .expect("banks client failed")
+        .result
+}
+
+/// Assert `result` failed at instruction index 0 with `Custom(expected)`.
+fn assert_custom_at_ix0(result: &Result<(), TransactionError>, expected: u32) {
+    match result {
+        Err(TransactionError::InstructionError(0, InstructionError::Custom(code))) => {
+            assert_eq!(*code, expected, "unexpected custom error code");
+        }
+        other => panic!("expected Custom({expected}) at instruction 0, got {other:?}"),
+    }
+}
+
+fn serialized_account(program_id: Pubkey, data: Vec<u8>) -> Account {
+    Account {
+        lamports: Rent::default().minimum_balance(data.len()).max(1),
+        data,
+        owner: program_id,
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+/// Initialize global state so the default payer is on the foundation allowlist and thus authorized
+/// (via the ACCESS_PASS_ADMIN legacy fallback) for SetAccessPassFeeds.
+async fn init_globalstate(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    payer: &solana_sdk::signature::Keypair,
+    recent_blockhash: solana_program::hash::Hash,
+) -> Pubkey {
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+
+    globalstate_pubkey
+}
+
+async fn create_feed(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    globalstate_pubkey: Pubkey,
+    payer: &solana_sdk::signature::Keypair,
+    recent_blockhash: solana_program::hash::Hash,
+    code: &str,
+) -> Pubkey {
+    let exchange = Pubkey::new_unique();
+    let (feed_pubkey, _) = get_feed_pda(&program_id, code, &exchange);
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateFeed(FeedCreateArgs {
+            code: code.to_string(),
+            name: code.to_string(),
+            exchange,
+            groups: vec![Pubkey::new_unique()],
+        }),
+        vec![
+            AccountMeta::new(feed_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
+    feed_pubkey
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_edge_seat_pass(
+    banks_client: &mut BanksClient,
+    program_id: Pubkey,
+    globalstate_pubkey: Pubkey,
+    payer: &solana_sdk::signature::Keypair,
+    recent_blockhash: solana_program::hash::Hash,
+    client_ip: Ipv4Addr,
+    user_payer: Pubkey,
+    accesspass_type: AccessPassType,
+) -> Pubkey {
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type,
+            client_ip,
+            last_access_epoch: u64::MAX,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 4,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        payer,
+    )
+    .await;
+    accesspass_pubkey
+}
+
+async fn read_accesspass(banks_client: &mut BanksClient, pubkey: Pubkey) -> AccessPass {
+    get_account_data(banks_client, pubkey)
+        .await
+        .expect("accesspass missing")
+        .get_accesspass()
+        .unwrap()
+}
+
+async fn read_feed_reference_count(banks_client: &mut BanksClient, pubkey: Pubkey) -> u32 {
+    let account = banks_client.get_account(pubkey).await.unwrap().unwrap();
+    Feed::try_from(&account.data[..]).unwrap().reference_count
+}
+
+#[tokio::test]
+async fn test_set_access_pass_feeds() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let feed_a = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "feda",
+    )
+    .await;
+    let feed_b = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "fedb",
+    )
+    .await;
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 1);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::EdgeSeat(vec![]),
+    )
+    .await;
+
+    // Provision two feeds.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![
+                FeedSeatConfig { max_users: 5 },
+                FeedSeatConfig { max_users: 3 },
+            ],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+            AccountMeta::new(feed_b, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = read_accesspass(&mut banks_client, accesspass_pubkey).await;
+    assert_eq!(
+        accesspass.accesspass_type,
+        AccessPassType::EdgeSeat(vec![
+            FeedSeat {
+                feed_key: feed_a,
+                max_users: 5,
+                current_users: 0,
+            },
+            FeedSeat {
+                feed_key: feed_b,
+                max_users: 3,
+                current_users: 0,
+            },
+        ])
+    );
+    assert_eq!(
+        read_feed_reference_count(&mut banks_client, feed_a).await,
+        1
+    );
+    assert_eq!(
+        read_feed_reference_count(&mut banks_client, feed_b).await,
+        1
+    );
+
+    // Re-provision with only feed_a at a higher cap: reference_count must not double-bump, feed_b is
+    // dropped from the pass (its reference_count intentionally stays 1), and the seat cap updates.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![FeedSeatConfig { max_users: 7 }],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let accesspass = read_accesspass(&mut banks_client, accesspass_pubkey).await;
+    assert_eq!(
+        accesspass.accesspass_type,
+        AccessPassType::EdgeSeat(vec![FeedSeat {
+            feed_key: feed_a,
+            max_users: 7,
+            current_users: 0,
+        }])
+    );
+    // feed_a already referenced: still 1, not 2.
+    assert_eq!(
+        read_feed_reference_count(&mut banks_client, feed_a).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn test_cannot_set_feeds_on_non_edge_seat() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let feed_a = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "feda",
+    )
+    .await;
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 2);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::Prepaid,
+    )
+    .await;
+
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![FeedSeatConfig { max_users: 5 }],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::InvalidArgument));
+}
+
+#[tokio::test]
+async fn test_cannot_set_duplicate_feed_key() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let feed_a = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "feda",
+    )
+    .await;
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 3);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::EdgeSeat(vec![]),
+    )
+    .await;
+
+    // Same feed listed twice.
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![
+                FeedSeatConfig { max_users: 5 },
+                FeedSeatConfig { max_users: 2 },
+            ],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::InvalidArgument));
+}
+
+#[tokio::test]
+async fn test_cannot_set_max_users_below_current_users() {
+    // A seat with live users can't be re-provisioned below its current_users. current_users is only
+    // ticked by connect-time enforcement (a later PR), so the pass is seeded directly here.
+    let program_id = Pubkey::new_unique();
+    let authority = test_payer();
+
+    let mut program_test = ProgramTest::new(
+        "doublezero_serviceability",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let (globalstate_pubkey, globalstate_bump) = get_globalstate_pda(&program_id);
+    let globalstate = GlobalState {
+        bump_seed: globalstate_bump,
+        foundation_allowlist: vec![authority.pubkey()],
+        ..GlobalState::default()
+    };
+    program_test.add_account(
+        globalstate_pubkey,
+        serialized_account(program_id, borsh::to_vec(&globalstate).unwrap()),
+    );
+
+    let feed_exchange = Pubkey::new_unique();
+    let (feed_pubkey, feed_bump) = get_feed_pda(&program_id, "livd", &feed_exchange);
+    let feed = Feed {
+        account_type: AccountType::Feed,
+        owner: authority.pubkey(),
+        bump_seed: feed_bump,
+        code: "livd".to_string(),
+        name: "Live".to_string(),
+        reference_count: 1,
+        exchange: feed_exchange,
+        groups: vec![Pubkey::new_unique()],
+    };
+    program_test.add_account(
+        feed_pubkey,
+        serialized_account(program_id, borsh::to_vec(&feed).unwrap()),
+    );
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 4);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, accesspass_bump) =
+        get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    let accesspass = AccessPass {
+        account_type: AccountType::AccessPass,
+        owner: authority.pubkey(),
+        bump_seed: accesspass_bump,
+        accesspass_type: AccessPassType::EdgeSeat(vec![FeedSeat {
+            feed_key: feed_pubkey,
+            max_users: 5,
+            current_users: 3,
+        }]),
+        client_ip,
+        user_payer,
+        last_access_epoch: u64::MAX,
+        connection_count: 0,
+        status: AccessPassStatus::Connected,
+        mgroup_pub_allowlist: vec![],
+        mgroup_sub_allowlist: vec![],
+        flags: 0,
+        tenant_allowlist: vec![],
+        unicast_user_count: 0,
+        max_unicast_users: 1,
+        multicast_user_count: 3,
+        max_multicast_users: 4,
+    };
+    program_test.add_account(
+        accesspass_pubkey,
+        serialized_account(program_id, borsh::to_vec(&accesspass).unwrap()),
+    );
+
+    program_test.add_account(
+        authority.pubkey(),
+        Account {
+            lamports: 100_000_000,
+            data: vec![],
+            owner: solana_system_interface::program::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, _payer, _recent_blockhash) = program_test.start().await;
+
+    // max_users (2) below current_users (3) must reject.
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![FeedSeatConfig { max_users: 2 }],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_pubkey, false),
+        ],
+        &authority,
+    )
+    .await;
+
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::InvalidArgument));
+}

--- a/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
@@ -6,7 +6,7 @@ use doublezero_serviceability::{
     processors::{
         accesspass::{
             set::SetAccessPassArgs,
-            set_feeds::{FeedSeatConfig, SetAccessPassFeedsArgs},
+            set_feeds::{FeedSeatConfig, SetAccessPassFeedsArgs, MAX_ACCESS_PASS_FEEDS},
         },
         feed::create::FeedCreateArgs,
     },
@@ -353,6 +353,101 @@ async fn test_cannot_set_feeds_on_non_edge_seat() {
             AccountMeta::new(accesspass_pubkey, false),
             AccountMeta::new(globalstate_pubkey, false),
             AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::InvalidArgument));
+}
+
+#[tokio::test]
+async fn test_cannot_set_feeds_unauthorized_caller() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let feed_a = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "feda",
+    )
+    .await;
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 5);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::EdgeSeat(vec![]),
+    )
+    .await;
+
+    // test_payer() is funded but not on the foundation allowlist and holds no ACCESS_PASS_ADMIN
+    // Permission, so it is not authorized to provision feeds.
+    let unauthorized = test_payer();
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![FeedSeatConfig { max_users: 5 }],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &unauthorized,
+    )
+    .await;
+
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::NotAllowed));
+}
+
+#[tokio::test]
+async fn test_cannot_set_feeds_exceeds_max() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let client_ip = Ipv4Addr::new(100, 0, 0, 6);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::EdgeSeat(vec![]),
+    )
+    .await;
+
+    // MAX_ACCESS_PASS_FEEDS + 1 configs is rejected by the cap check before any Feed account is
+    // read, so no Feed accounts are passed.
+    let too_many = vec![FeedSeatConfig { max_users: 1 }; MAX_ACCESS_PASS_FEEDS + 1];
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: too_many,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,
     )

--- a/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
@@ -183,11 +183,6 @@ async fn read_accesspass(banks_client: &mut BanksClient, pubkey: Pubkey) -> Acce
         .unwrap()
 }
 
-async fn read_feed_reference_count(banks_client: &mut BanksClient, pubkey: Pubkey) -> u32 {
-    let account = banks_client.get_account(pubkey).await.unwrap().unwrap();
-    Feed::try_from(&account.data[..]).unwrap().reference_count
-}
-
 #[tokio::test]
 async fn test_set_access_pass_feeds() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
@@ -266,17 +261,9 @@ async fn test_set_access_pass_feeds() {
             },
         ])
     );
-    assert_eq!(
-        read_feed_reference_count(&mut banks_client, feed_a).await,
-        1
-    );
-    assert_eq!(
-        read_feed_reference_count(&mut banks_client, feed_b).await,
-        1
-    );
 
-    // Re-provision with only feed_a at a higher cap: reference_count must not double-bump, feed_b is
-    // dropped from the pass (its reference_count intentionally stays 1), and the seat cap updates.
+    // Re-provision with only feed_a at a higher cap: feed_b is dropped from the pass and the seat
+    // cap updates.
     execute_transaction(
         &mut banks_client,
         recent_blockhash,
@@ -303,11 +290,6 @@ async fn test_set_access_pass_feeds() {
             max_users: 7,
             current_users: 0,
         }])
-    );
-    // feed_a already referenced: still 1, not 2.
-    assert_eq!(
-        read_feed_reference_count(&mut banks_client, feed_a).await,
-        1
     );
 }
 
@@ -543,7 +525,6 @@ async fn test_cannot_set_max_users_below_current_users() {
         bump_seed: feed_bump,
         code: "livd".to_string(),
         name: "Live".to_string(),
-        reference_count: 1,
         exchange: feed_exchange,
         groups: vec![Pubkey::new_unique()],
     };

--- a/smartcontract/sdk/rs/src/commands/accesspass/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/mod.rs
@@ -3,3 +3,4 @@ pub mod close;
 pub mod get;
 pub mod list;
 pub mod set;
+pub mod set_feeds;

--- a/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
@@ -1,26 +1,35 @@
 use std::net::Ipv4Addr;
 
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction, pda::get_accesspass_pda,
-    processors::accesspass::set_feeds::SetAccessPassFeedsArgs, state::accesspass::FeedSeat,
+    instructions::DoubleZeroInstruction,
+    pda::get_accesspass_pda,
+    processors::accesspass::set_feeds::{FeedSeatConfig, SetAccessPassFeedsArgs},
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
 
 use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 
+/// One feed seat (SKU) to provision: the `Feed` account to reference and its per-feed cap.
+#[derive(Debug, PartialEq, Clone)]
+pub struct FeedSeatProvision {
+    pub feed_key: Pubkey,
+    pub max_users: u16,
+}
+
 /// Provision feed seats (SKUs) onto an EdgeSeat access pass.
 ///
 /// On-chain account layout (see `process_set_access_pass_feeds`):
-///   `[accesspass, globalstate, payer, system, feed_0 .. feed_{N-1}, (optional permission)]`
+///   `[accesspass, globalstate, feed_0 .. feed_{N-1}, payer, system, permission]`
 ///
-/// `DoubleZeroClient::execute_transaction` appends `[payer, system]` after the base accounts
-/// supplied here, so the base list is `[accesspass, globalstate]` followed by one writable `Feed`
-/// account per seat, in the same order as `feeds`.
+/// `DoubleZeroClient::execute_authorized_transaction` appends `[payer, system, permission]` after
+/// the base accounts supplied here, so the base list is `[accesspass, globalstate]` followed by one
+/// writable `Feed` account per seat, in the same order as `feeds`. The provisioning actor is
+/// authorized via its `ACCESS_PASS_ADMIN` Permission, so the authorized variant is required.
 #[derive(Debug, PartialEq, Clone)]
 pub struct SetAccessPassFeedsCommand {
     pub client_ip: Ipv4Addr,
     pub user_payer: Pubkey,
-    pub feeds: Vec<FeedSeat>,
+    pub feeds: Vec<FeedSeatProvision>,
 }
 
 impl SetAccessPassFeedsCommand {
@@ -42,11 +51,17 @@ impl SetAccessPassFeedsCommand {
             accounts.push(AccountMeta::new(seat.feed_key, false));
         }
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
                 client_ip: self.client_ip,
                 user_payer: self.user_payer,
-                feeds: self.feeds.clone(),
+                feeds: self
+                    .feeds
+                    .iter()
+                    .map(|seat| FeedSeatConfig {
+                        max_users: seat.max_users,
+                    })
+                    .collect(),
             }),
             accounts,
         )
@@ -56,14 +71,14 @@ impl SetAccessPassFeedsCommand {
 #[cfg(test)]
 mod tests {
     use crate::{
-        commands::accesspass::set_feeds::SetAccessPassFeedsCommand,
-        tests::utils::create_test_client, DoubleZeroClient,
+        commands::accesspass::set_feeds::{FeedSeatProvision, SetAccessPassFeedsCommand},
+        tests::utils::create_test_client,
+        DoubleZeroClient,
     };
     use doublezero_serviceability::{
         instructions::DoubleZeroInstruction,
         pda::{get_accesspass_pda, get_globalstate_pda},
-        processors::accesspass::set_feeds::SetAccessPassFeedsArgs,
-        state::accesspass::FeedSeat,
+        processors::accesspass::set_feeds::{FeedSeatConfig, SetAccessPassFeedsArgs},
     };
     use mockall::predicate;
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
@@ -80,20 +95,14 @@ mod tests {
         let (accesspass_pubkey, _) =
             get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
 
-        let seats = vec![FeedSeat {
-            feed_key,
-            max_users: 5,
-            current_users: 0,
-        }];
-
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::SetAccessPassFeeds(
                     SetAccessPassFeedsArgs {
                         client_ip,
                         user_payer: payer,
-                        feeds: seats.clone(),
+                        feeds: vec![FeedSeatConfig { max_users: 5 }],
                     },
                 )),
                 predicate::eq(vec![
@@ -107,7 +116,10 @@ mod tests {
         let res = SetAccessPassFeedsCommand {
             client_ip,
             user_payer: payer,
-            feeds: seats,
+            feeds: vec![FeedSeatProvision {
+                feed_key,
+                max_users: 5,
+            }],
         }
         .execute(&client);
         assert!(res.is_ok());

--- a/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
@@ -23,7 +23,7 @@ pub struct FeedSeatProvision {
 ///
 /// `DoubleZeroClient::execute_authorized_transaction` appends `[payer, system, permission]` after
 /// the base accounts supplied here, so the base list is `[accesspass, globalstate]` followed by one
-/// writable `Feed` account per seat, in the same order as `feeds`. The provisioning actor is
+/// read-only `Feed` account per seat, in the same order as `feeds`. The provisioning actor is
 /// authorized via its `ACCESS_PASS_ADMIN` Permission, so the authorized variant is required.
 #[derive(Debug, PartialEq, Clone)]
 pub struct SetAccessPassFeedsCommand {
@@ -46,9 +46,10 @@ impl SetAccessPassFeedsCommand {
             AccountMeta::new_readonly(globalstate_pubkey, false),
         ];
 
-        // One writable Feed account per seat, in the same order as `feeds`.
+        // One read-only Feed account per seat, in the same order as `feeds` (feeds are read to bind
+        // feed_key and confirm existence; they are not mutated).
         for seat in &self.feeds {
-            accounts.push(AccountMeta::new(seat.feed_key, false));
+            accounts.push(AccountMeta::new_readonly(seat.feed_key, false));
         }
 
         client.execute_authorized_transaction(
@@ -108,7 +109,7 @@ mod tests {
                 predicate::eq(vec![
                     AccountMeta::new(accesspass_pubkey, false),
                     AccountMeta::new_readonly(globalstate_pubkey, false),
-                    AccountMeta::new(feed_key, false),
+                    AccountMeta::new_readonly(feed_key, false),
                 ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));

--- a/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set_feeds.rs
@@ -1,0 +1,115 @@
+use std::net::Ipv4Addr;
+
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_accesspass_pda,
+    processors::accesspass::set_feeds::SetAccessPassFeedsArgs, state::accesspass::FeedSeat,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+
+/// Provision feed seats (SKUs) onto an EdgeSeat access pass.
+///
+/// On-chain account layout (see `process_set_access_pass_feeds`):
+///   `[accesspass, globalstate, payer, system, feed_0 .. feed_{N-1}, (optional permission)]`
+///
+/// `DoubleZeroClient::execute_transaction` appends `[payer, system]` after the base accounts
+/// supplied here, so the base list is `[accesspass, globalstate]` followed by one writable `Feed`
+/// account per seat, in the same order as `feeds`.
+#[derive(Debug, PartialEq, Clone)]
+pub struct SetAccessPassFeedsCommand {
+    pub client_ip: Ipv4Addr,
+    pub user_payer: Pubkey,
+    pub feeds: Vec<FeedSeat>,
+}
+
+impl SetAccessPassFeedsCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (accesspass_pubkey, _) =
+            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+
+        let mut accounts = vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ];
+
+        // One writable Feed account per seat, in the same order as `feeds`.
+        for seat in &self.feeds {
+            accounts.push(AccountMeta::new(seat.feed_key, false));
+        }
+
+        client.execute_transaction(
+            DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+                client_ip: self.client_ip,
+                user_payer: self.user_payer,
+                feeds: self.feeds.clone(),
+            }),
+            accounts,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::accesspass::set_feeds::SetAccessPassFeedsCommand,
+        tests::utils::create_test_client, DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_accesspass_pda, get_globalstate_pda},
+        processors::accesspass::set_feeds::SetAccessPassFeedsArgs,
+        state::accesspass::FeedSeat,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_set_accesspass_feeds_command() {
+        let mut client = create_test_client();
+
+        let client_ip = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+        let feed_key = Pubkey::new_unique();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (accesspass_pubkey, _) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+
+        let seats = vec![FeedSeat {
+            feed_key,
+            max_users: 5,
+            current_users: 0,
+        }];
+
+        client
+            .expect_execute_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::SetAccessPassFeeds(
+                    SetAccessPassFeedsArgs {
+                        client_ip,
+                        user_payer: payer,
+                        feeds: seats.clone(),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(accesspass_pubkey, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                    AccountMeta::new(feed_key, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = SetAccessPassFeedsCommand {
+            client_ip,
+            user_payer: payer,
+            feeds: seats,
+        }
+        .execute(&client);
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/feed/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/feed/delete.rs
@@ -1,7 +1,4 @@
-use crate::{
-    commands::{feed::get::GetFeedCommand, globalstate::get::GetGlobalStateCommand},
-    DoubleZeroClient,
-};
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction, processors::feed::delete::FeedDeleteArgs,
 };
@@ -17,20 +14,6 @@ impl DeleteFeedCommand {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
-
-        let (_, feed) = GetFeedCommand {
-            pubkey_or_code: self.pubkey.to_string(),
-            exchange: None,
-        }
-        .execute(client)
-        .map_err(|_err| eyre::eyre!("Feed not found"))?;
-
-        if feed.reference_count > 0 {
-            return Err(eyre::eyre!(
-                "Feed cannot be deleted, it has {} references",
-                feed.reference_count
-            ));
-        }
 
         // Accounts: [feed, globalstate, (payer, system appended by client)].
         client.execute_transaction(
@@ -53,7 +36,6 @@ mod tests {
         instructions::DoubleZeroInstruction,
         pda::{get_feed_pda, get_globalstate_pda},
         processors::feed::delete::FeedDeleteArgs,
-        state::{accountdata::AccountData, accounttype::AccountType, feed::Feed},
     };
     use mockall::predicate;
     use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
@@ -65,21 +47,6 @@ mod tests {
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
         let (pda_pubkey, _) =
             get_feed_pda(&client.get_program_id(), "test_feed", &Pubkey::new_unique());
-        let feed = Feed {
-            account_type: AccountType::Feed,
-            owner: Pubkey::default(),
-            bump_seed: 255,
-            code: "test_feed".to_string(),
-            name: "Test Feed".to_string(),
-            reference_count: 0,
-            exchange: Pubkey::new_unique(),
-            groups: vec![Pubkey::new_unique()],
-        };
-
-        client
-            .expect_get()
-            .with(predicate::eq(pda_pubkey))
-            .returning(move |_| Ok(AccountData::Feed(feed.clone())));
 
         client
             .expect_execute_transaction()

--- a/smartcontract/sdk/rs/src/commands/feed/get.rs
+++ b/smartcontract/sdk/rs/src/commands/feed/get.rs
@@ -83,7 +83,6 @@ mod tests {
             bump_seed: 0,
             code: code.to_string(),
             name: code.to_string(),
-            reference_count: 0,
             exchange,
             groups: vec![Pubkey::new_unique()],
         }

--- a/smartcontract/sdk/rs/src/commands/feed/list.rs
+++ b/smartcontract/sdk/rs/src/commands/feed/list.rs
@@ -48,7 +48,6 @@ mod tests {
             bump_seed: 0,
             code: "feed1_code".to_string(),
             name: "feed1_name".to_string(),
-            reference_count: 0,
             exchange: Pubkey::new_unique(),
             groups: vec![Pubkey::new_unique()],
         };
@@ -60,7 +59,6 @@ mod tests {
             bump_seed: 0,
             code: "feed2_code".to_string(),
             name: "feed2_name".to_string(),
-            reference_count: 0,
             exchange: Pubkey::new_unique(),
             groups: vec![Pubkey::new_unique()],
         };


### PR DESCRIPTION
Rework the `AccessPass` `EdgeSeat` variant into `EdgeSeat(Vec<FeedSeat>)` (feed_key + per-feed cap) and add the `SetAccessPassFeeds` instruction so the oracle provisions feed_keys onto a pass via its `ACCESS_PASS_ADMIN` permission.

Also drops `Feed.reference_count`: feeds are not reference-counted — a deleted-but-referenced feed_key fails closed at connect, so the count can't diverge and never blocks `DeleteFeed`.

EdgeSeat and Feed are new and unused, so the borsh layout changes need no migration.

Part of malbeclabs/infra#1700.
