### PR TITLE
client: add multicast subscriptions to doublezero status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Client
   - Add a `-route-liveness-backoff-max` daemon flag to cap the Down-state liveness probe interval. Defaults to 60s (production behavior unchanged); the e2e harness pins a small value to avoid a probe gap that flaked the multi-client IBRL tests. (#3949)
+  - Add a structured `subscriptions` array to `doublezero status` (after `multicast_groups`) with per-group detail — group pubkey, code, multicast IP, max bandwidth, and `publisher`/`subscriber` booleans — so consumers no longer have to parse the flattened `P:`/`S:` string. (#3964)
 - E2E
   - Pin the e2e ledger `solana-test-validator` to the deploy floor (agave 2.2.16, testnet) so a green e2e proves a change actually deploys and runs on the production cluster runtime. Previously the runtime validator rode the SBF build toolchain version (2.3.13); it is now decoupled and pinned independently. The build toolchain is unchanged. (#3957)
 

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -783,16 +783,27 @@ mod tests {
         assert_eq!(result[0].multicast_groups, "P:solana-lv,S:solana-ams");
 
         // The structured subscriptions list is carried through verbatim.
-        assert_eq!(result[0].subscriptions.len(), 2);
-        assert_eq!(result[0].subscriptions[0].code, "solana-lv");
-        assert_eq!(result[0].subscriptions[0].multicast_ip, "233.84.178.1");
-        assert_eq!(result[0].subscriptions[0].pubkey, "pubLV");
-        assert_eq!(result[0].subscriptions[0].max_bandwidth, 1_000_000_000);
-        assert!(result[0].subscriptions[0].publisher);
-        assert!(!result[0].subscriptions[0].subscriber);
-        assert_eq!(result[0].subscriptions[1].code, "solana-ams");
-        assert!(!result[0].subscriptions[1].publisher);
-        assert!(result[0].subscriptions[1].subscriber);
+        assert_eq!(
+            result[0].subscriptions,
+            vec![
+                Subscription {
+                    pubkey: "pubLV".to_string(),
+                    code: "solana-lv".to_string(),
+                    multicast_ip: "233.84.178.1".to_string(),
+                    max_bandwidth: 1_000_000_000,
+                    publisher: true,
+                    subscriber: false,
+                },
+                Subscription {
+                    pubkey: "pubAMS".to_string(),
+                    code: "solana-ams".to_string(),
+                    multicast_ip: "233.84.178.2".to_string(),
+                    max_bandwidth: 2_000_000_000,
+                    publisher: false,
+                    subscriber: true,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/client/doublezero/src/command/status.rs
+++ b/client/doublezero/src/command/status.rs
@@ -2,7 +2,8 @@ use crate::{
     command::util,
     requirements::check_doublezero,
     servicecontroller::{
-        DoubleZeroStatus, MulticastGroups, ServiceController, ServiceControllerImpl, StatusResponse,
+        DoubleZeroStatus, MulticastGroups, ServiceController, ServiceControllerImpl,
+        StatusResponse, Subscription,
     },
 };
 use backon::{ExponentialBuilder, Retryable};
@@ -37,6 +38,8 @@ struct AppendedStatusResponse {
     network: String,
     #[tabled(rename = "Multicast Groups")]
     multicast_groups: String,
+    #[tabled(skip)]
+    subscriptions: Vec<Subscription>,
 }
 
 fn format_multicast_groups(groups: &MulticastGroups) -> String {
@@ -101,6 +104,7 @@ impl StatusCliCommand {
                     v2_status.network.clone()
                 },
                 multicast_groups: String::new(),
+                subscriptions: Vec::new(),
             }]);
         }
 
@@ -145,6 +149,7 @@ impl StatusCliCommand {
                 network: network.clone(),
                 tenant: svc.tenant.clone(),
                 multicast_groups: format_multicast_groups(&svc.multicast_groups),
+                subscriptions: svc.subscriptions.clone(),
             });
         }
 
@@ -157,7 +162,8 @@ impl StatusCliCommand {
 mod tests {
     use super::*;
     use crate::servicecontroller::{
-        DoubleZeroStatus, MockServiceController, MulticastGroups, V2ServiceStatus, V2StatusResponse,
+        DoubleZeroStatus, MockServiceController, MulticastGroups, Subscription, V2ServiceStatus,
+        V2StatusResponse,
     };
     use doublezero_serviceability_cli::doublezerocommand::MockCliCommand;
     use std::sync::{
@@ -195,6 +201,7 @@ mod tests {
             metro: metro.to_string(),
             tenant: tenant.to_string(),
             multicast_groups: MulticastGroups::default(),
+            subscriptions: Vec::new(),
         }
     }
 
@@ -274,6 +281,7 @@ mod tests {
                     metro: String::new(),
                     tenant: String::new(),
                     multicast_groups: MulticastGroups::default(),
+                    subscriptions: Vec::new(),
                 }],
             })
         });
@@ -365,6 +373,7 @@ mod tests {
                     metro: "metro".to_string(),
                     tenant: String::new(),
                     multicast_groups: MulticastGroups::default(),
+                    subscriptions: Vec::new(),
                 }],
             })
         });
@@ -411,6 +420,14 @@ mod tests {
             network: "Testnet".to_string(),
             tenant: "".to_string(),
             multicast_groups: String::new(),
+            subscriptions: vec![Subscription {
+                pubkey: "pubLV".to_string(),
+                code: "solana-lv".to_string(),
+                multicast_ip: "233.84.178.1".to_string(),
+                max_bandwidth: 1_000_000_000,
+                publisher: true,
+                subscriber: false,
+            }],
         };
 
         // JSON output is an array of status responses
@@ -446,6 +463,17 @@ mod tests {
             "Missing 'multicast_groups' field"
         );
         assert_eq!(status.get("multicast_groups").unwrap(), "");
+        let subscriptions = status
+            .get("subscriptions")
+            .expect("Missing 'subscriptions' field");
+        assert!(subscriptions.is_array(), "subscriptions should be an array");
+        let sub = &subscriptions.as_array().unwrap()[0];
+        assert_eq!(sub.get("pubkey").unwrap(), "pubLV");
+        assert_eq!(sub.get("code").unwrap(), "solana-lv");
+        assert_eq!(sub.get("multicast_ip").unwrap(), "233.84.178.1");
+        assert_eq!(sub.get("max_bandwidth").unwrap(), 1_000_000_000);
+        assert_eq!(sub.get("publisher").unwrap(), true);
+        assert_eq!(sub.get("subscriber").unwrap(), false);
 
         // Validate response nested fields
         let response = status.get("response").unwrap();
@@ -526,6 +554,7 @@ mod tests {
             network: "Testnet".to_string(),
             tenant: "".to_string(),
             multicast_groups: String::new(),
+            subscriptions: Vec::new(),
         };
 
         // JSON output is an array of status responses
@@ -722,6 +751,24 @@ mod tests {
                         publisher: vec!["solana-lv".to_string()],
                         subscriber: vec!["solana-ams".to_string()],
                     },
+                    subscriptions: vec![
+                        Subscription {
+                            pubkey: "pubLV".to_string(),
+                            code: "solana-lv".to_string(),
+                            multicast_ip: "233.84.178.1".to_string(),
+                            max_bandwidth: 1_000_000_000,
+                            publisher: true,
+                            subscriber: false,
+                        },
+                        Subscription {
+                            pubkey: "pubAMS".to_string(),
+                            code: "solana-ams".to_string(),
+                            multicast_ip: "233.84.178.2".to_string(),
+                            max_bandwidth: 2_000_000_000,
+                            publisher: false,
+                            subscriber: true,
+                        },
+                    ],
                 }],
             })
         });
@@ -734,6 +781,18 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].multicast_groups, "P:solana-lv,S:solana-ams");
+
+        // The structured subscriptions list is carried through verbatim.
+        assert_eq!(result[0].subscriptions.len(), 2);
+        assert_eq!(result[0].subscriptions[0].code, "solana-lv");
+        assert_eq!(result[0].subscriptions[0].multicast_ip, "233.84.178.1");
+        assert_eq!(result[0].subscriptions[0].pubkey, "pubLV");
+        assert_eq!(result[0].subscriptions[0].max_bandwidth, 1_000_000_000);
+        assert!(result[0].subscriptions[0].publisher);
+        assert!(!result[0].subscriptions[0].subscriber);
+        assert_eq!(result[0].subscriptions[1].code, "solana-ams");
+        assert!(!result[0].subscriptions[1].publisher);
+        assert!(result[0].subscriptions[1].subscriber);
     }
 
     #[test]

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -159,7 +159,7 @@ pub struct MulticastGroups {
 /// A single multicast group the user participates in, with the group's onchain
 /// details and the user's role(s). A user that is both publisher and subscriber
 /// of a group appears once with both booleans set.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Subscription {
     #[serde(default)]
     pub pubkey: String,

--- a/client/doublezero/src/servicecontroller.rs
+++ b/client/doublezero/src/servicecontroller.rs
@@ -156,6 +156,25 @@ pub struct MulticastGroups {
     pub subscriber: Vec<String>,
 }
 
+/// A single multicast group the user participates in, with the group's onchain
+/// details and the user's role(s). A user that is both publisher and subscriber
+/// of a group appears once with both booleans set.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct Subscription {
+    #[serde(default)]
+    pub pubkey: String,
+    #[serde(default)]
+    pub code: String,
+    #[serde(default)]
+    pub multicast_ip: String,
+    #[serde(default)]
+    pub max_bandwidth: u64,
+    #[serde(default)]
+    pub publisher: bool,
+    #[serde(default)]
+    pub subscriber: bool,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct V2ServiceStatus {
     #[serde(flatten)]
@@ -170,6 +189,8 @@ pub struct V2ServiceStatus {
     pub tenant: String,
     #[serde(default)]
     pub multicast_groups: MulticastGroups,
+    #[serde(default)]
+    pub subscriptions: Vec<Subscription>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/client/doublezerod/internal/manager/http.go
+++ b/client/doublezerod/internal/manager/http.go
@@ -12,12 +12,25 @@ import (
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/api"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/latency"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/mr-tron/base58"
 )
 
 // MulticastGroups contains the group codes a user publishes to and subscribes to.
 type MulticastGroups struct {
 	Publisher  []string `json:"publisher"`
 	Subscriber []string `json:"subscriber"`
+}
+
+// Subscription describes one multicast group the user participates in, with the
+// group's onchain details and the user's role(s) in it. A user that is both
+// publisher and subscriber of a group appears once with both booleans set.
+type Subscription struct {
+	Pubkey       string `json:"pubkey"`
+	Code         string `json:"code"`
+	MulticastIp  string `json:"multicast_ip"`
+	MaxBandwidth uint64 `json:"max_bandwidth"`
+	Publisher    bool   `json:"publisher"`
+	Subscriber   bool   `json:"subscriber"`
 }
 
 // V2ServiceStatus wraps a StatusResponse with enriched fields.
@@ -30,6 +43,7 @@ type V2ServiceStatus struct {
 	Metro                       string          `json:"metro"`
 	Tenant                      string          `json:"tenant"`
 	MulticastGroups             MulticastGroups `json:"multicast_groups"`
+	Subscriptions               []Subscription  `json:"subscriptions"`
 }
 
 // V2StatusResponse is the response for the /v2/status endpoint.
@@ -295,6 +309,7 @@ func (n *NetlinkManager) enrichStatuses(statuses []*api.StatusResponse) []V2Serv
 				Publisher:  []string{},
 				Subscriber: []string{},
 			},
+			Subscriptions: []Subscription{},
 		}
 
 		if data == nil {
@@ -371,15 +386,41 @@ func (n *NetlinkManager) enrichStatuses(statuses []*api.StatusResponse) []V2Serv
 					es.Tenant = t.Code
 				}
 			}
+			// Build the structured subscriptions list (one entry per group,
+			// deduplicated) alongside the flat code lists. Iterate publishers
+			// first, then subscribers, to keep a publishers-first ordering.
+			subIdxByPK := make(map[[32]byte]int)
+			addRole := func(pk [32]byte, pub, sub bool) {
+				if idx, ok := subIdxByPK[pk]; ok {
+					es.Subscriptions[idx].Publisher = es.Subscriptions[idx].Publisher || pub
+					es.Subscriptions[idx].Subscriber = es.Subscriptions[idx].Subscriber || sub
+					return
+				}
+				mg, ok := mcastGroupsByPK[pk]
+				if !ok {
+					return
+				}
+				subIdxByPK[pk] = len(es.Subscriptions)
+				es.Subscriptions = append(es.Subscriptions, Subscription{
+					Pubkey:       base58.Encode(mg.PubKey[:]),
+					Code:         mg.Code,
+					MulticastIp:  net.IP(mg.MulticastIp[:]).String(),
+					MaxBandwidth: mg.MaxBandwidth,
+					Publisher:    pub,
+					Subscriber:   sub,
+				})
+			}
 			for _, pk := range matchedUser.Publishers {
 				if mg, ok := mcastGroupsByPK[pk]; ok {
 					es.MulticastGroups.Publisher = append(es.MulticastGroups.Publisher, mg.Code)
 				}
+				addRole(pk, true, false)
 			}
 			for _, pk := range matchedUser.Subscribers {
 				if mg, ok := mcastGroupsByPK[pk]; ok {
 					es.MulticastGroups.Subscriber = append(es.MulticastGroups.Subscriber, mg.Code)
 				}
+				addRole(pk, false, true)
 			}
 		}
 

--- a/client/doublezerod/internal/manager/reconciler_test.go
+++ b/client/doublezerod/internal/manager/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/pim"
 	"github.com/malbeclabs/doublezero/client/doublezerod/internal/routing"
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/mr-tron/base58"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -1217,9 +1218,23 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 	device.Status = serviceability.DeviceStatusActivated
 
 	mcastGroup := serviceability.MulticastGroup{
-		PubKey:      mcastGroupPK,
-		MulticastIp: [4]uint8{239, 0, 0, 1},
-		Code:        "solana-ams",
+		PubKey:       mcastGroupPK,
+		MulticastIp:  [4]uint8{239, 0, 0, 1},
+		MaxBandwidth: 1_000_000_000,
+		Code:         "solana-ams",
+	}
+
+	// wantSub builds the expected structured subscription for mcastGroup with
+	// the given roles.
+	wantSub := func(pub, sub bool) Subscription {
+		return Subscription{
+			Pubkey:       base58.Encode(mcastGroupPK[:]),
+			Code:         "solana-ams",
+			MulticastIp:  "239.0.0.1",
+			MaxBandwidth: 1_000_000_000,
+			Publisher:    pub,
+			Subscriber:   sub,
+		}
 	}
 
 	type wantService struct {
@@ -1230,6 +1245,7 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 		hasDzIP       bool // whether DoubleZeroIP should be non-empty
 		pubGroups     []string
 		subGroups     []string
+		subs          []Subscription
 	}
 
 	tests := []struct {
@@ -1247,7 +1263,7 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}(),
 			},
 			want: []wantService{
-				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}},
+				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}, subs: nil},
 			},
 		},
 		{
@@ -1261,7 +1277,7 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}(),
 			},
 			want: []wantService{
-				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{"solana-ams"}, subGroups: []string{}},
+				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{"solana-ams"}, subGroups: []string{}, subs: []Subscription{wantSub(true, false)}},
 			},
 		},
 		{
@@ -1277,7 +1293,7 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}(),
 			},
 			want: []wantService{
-				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: false, pubGroups: []string{}, subGroups: []string{"solana-ams"}},
+				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: false, pubGroups: []string{}, subGroups: []string{"solana-ams"}, subs: []Subscription{wantSub(false, true)}},
 			},
 		},
 		{
@@ -1298,8 +1314,8 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}(),
 			},
 			want: []wantService{
-				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}},
-				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: false, pubGroups: []string{}, subGroups: []string{"solana-ams"}},
+				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}, subs: nil},
+				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: false, pubGroups: []string{}, subGroups: []string{"solana-ams"}, subs: []Subscription{wantSub(false, true)}},
 			},
 		},
 		{
@@ -1318,8 +1334,25 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}(),
 			},
 			want: []wantService{
-				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}},
-				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{"solana-ams"}, subGroups: []string{}},
+				{userType: "IBRL", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{}, subGroups: []string{}, subs: nil},
+				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{"solana-ams"}, subGroups: []string{}, subs: []Subscription{wantSub(true, false)}},
+			},
+		},
+		{
+			name: "multicast_publisher_and_subscriber",
+			users: []serviceability.User{
+				func() serviceability.User {
+					u := testUser(clientIPBytes, devicePK, serviceability.UserTypeMulticast, serviceability.UserStatusActivated)
+					u.TenantPubKey = tenantPK
+					u.Publishers = [][32]byte{mcastGroupPK}
+					u.Subscribers = [][32]byte{mcastGroupPK}
+					return u
+				}(),
+			},
+			// A user that is both publisher and subscriber of the same group
+			// appears once in subscriptions with both booleans set.
+			want: []wantService{
+				{userType: "Multicast", currentDevice: "dz1", metro: "Amsterdam", tenant: "acme", hasDzIP: true, pubGroups: []string{"solana-ams"}, subGroups: []string{"solana-ams"}, subs: []Subscription{wantSub(true, true)}},
 			},
 		},
 	}
@@ -1401,6 +1434,9 @@ func TestServeV2Status_Enrichment(t *testing.T) {
 				}
 				if !slices.Equal(svc.MulticastGroups.Subscriber, w.subGroups) {
 					t.Errorf("[%s] expected sub groups %v, got %v", w.userType, w.subGroups, svc.MulticastGroups.Subscriber)
+				}
+				if !slices.Equal(svc.Subscriptions, w.subs) {
+					t.Errorf("[%s] expected subscriptions %+v, got %+v", w.userType, w.subs, svc.Subscriptions)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary of Changes
- Add a structured `subscriptions` array to the `doublezero status` (`/v2/status`) output, placed right after `multicast_groups`, giving programmatic consumers per-group detail instead of the flattened `"P:code,S:code"` string.
- Each entry describes one multicast group the user participates in (deduplicated across roles): group `pubkey`, `code`, `multicast_ip`, `max_bandwidth`, and `publisher`/`subscriber` booleans. A user who is both publisher and subscriber of the same group appears once with both booleans set.
- The daemon (`doublezerod`) builds the list in `enrichStatuses()`, reusing the already-resolved onchain multicast groups; the existing `multicast_groups` string is left unchanged for backward compatibility (table view and current consumers).

## Diff Breakdown
| Category     | Files | Lines (+/-)  | Net  |
|--------------|-------|--------------|------|
| Core logic   |     3 | +123 / -2    | +121 |
| Tests        |     1 | +46 / -10    |  +36 |
| **Total**    |     4 | +169 / -12   | +157 |

Mostly a small, additive core change across the daemon and CLI, with the remainder in test coverage (including inline tests within `status.rs`).

<details>
<summary>Key files (click to expand)</summary>

- `client/doublezero/src/command/status.rs` — add `subscriptions` field to the status response (skipped in the table, serialized in JSON); populate it and add coverage.
- `client/doublezerod/internal/manager/http.go` — add `Subscription` struct and `Subscriptions` field; build the deduplicated per-group list in `enrichStatuses()`.
- `client/doublezerod/internal/manager/reconciler_test.go` — extend `TestServeV2Status_Enrichment` with subscription expectations and a publisher+subscriber dual-role case.
- `client/doublezero/src/servicecontroller.rs` — mirror `Subscription` struct and add `subscriptions` to `V2ServiceStatus` for deserialization.

</details>

## Testing Verification
- `cargo test -p doublezero status` — 17/17 pass, including JSON-contract assertions that `subscriptions` serializes as an array of objects after `multicast_groups`.
- Extended `TestServeV2Status_Enrichment` covers the dual-role case (single entry, both booleans `true`); the subscriber-role subtests require `CAP_NET_RAW` (PIM socket) and run under `sudo`/CI, matching the pre-existing `multicast_subscriber` subtest.
