### PR TITLE
e2e/qa: fix settlement ack-wait short-circuiting on stale seat read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- E2E
+  - Fix the multicast settlement QA test's seat-allocation ack wait. It read the reused client seat at finalized commitment and could accept the previous run's already-acked state, then withdraw while the current request was still pending. It now waits to observe the request pending before treating a cleared flag as the ack. (#3972)
+
 ## [v0.29.0](https://github.com/malbeclabs/doublezero/compare/client/v0.28.0...client/v0.29.0) - 2026-07-02
 
 ### Breaking

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -340,11 +340,18 @@ func (c *Client) IsProgramPaused(ctx context.Context) (bool, error) {
 	return cfg.IsPaused(), nil
 }
 
-// WaitForSeatAllocationAcked polls the onchain client seat until the pending
-// instant-allocation flag clears (the oracle has acked the request). Withdraw
-// is blocked onchain while the flag is set, so callers should wait between
-// FeedSeatPay and FeedSeatWithdraw. On timeout the error includes the current
-// program-paused state to surface migration windows as the likely cause.
+// WaitForSeatAllocationAcked waits for the oracle to ack this run's instant
+// allocation request. Withdraw is blocked onchain while the pending flag is set,
+// so callers should wait between FeedSeatPay and FeedSeatWithdraw.
+//
+// The client seat account is reused across runs and FetchClientSeat reads at the
+// default (finalized) commitment, so a read taken right after FeedSeatPay can
+// return the previous run's already-acked (pending=false) state and short-circuit
+// before this run's request is even visible. To avoid mistaking stale state for
+// an ack, we require observing the pending flag set first, then wait for the
+// oracle to clear it. On timeout the error includes whether the request was ever
+// observed and the current program-paused state, to surface a slow oracle or a
+// migration window as the likely cause.
 func (c *Client) WaitForSeatAllocationAcked(ctx context.Context, devicePubkey string, timeout time.Duration) error {
 	deviceKey, err := solana.PublicKeyFromBase58(devicePubkey)
 	if err != nil {
@@ -360,23 +367,28 @@ func (c *Client) WaitForSeatAllocationAcked(ctx context.Context, devicePubkey st
 	c.log.Debug("Waiting for seat allocation ack", "host", c.Host, "device", devicePubkey, "timeout", timeout)
 	deadline := time.Now().Add(timeout)
 	var lastErr error
+	sawPending := false
 	for {
 		seat, err := shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
-		if err == nil && !seat.HasPendingInstantRequest() {
-			c.log.Debug("Seat allocation acked", "host", c.Host, "device", devicePubkey)
-			return nil
+		if err == nil {
+			if seat.HasPendingInstantRequest() {
+				sawPending = true
+			} else if sawPending {
+				c.log.Debug("Seat allocation acked", "host", c.Host, "device", devicePubkey)
+				return nil
+			}
 		}
 		lastErr = err
 		if time.Now().After(deadline) {
 			cfg, cfgErr := shredsClient.FetchProgramConfig(ctx)
 			paused := cfgErr == nil && cfg.IsPaused()
-			return fmt.Errorf("seat allocation not acked within %s on host %s (program_paused=%t, last_fetch_err=%v)",
-				timeout, c.Host, paused, lastErr)
+			return fmt.Errorf("seat allocation not acked within %s on host %s (saw_pending=%t, program_paused=%t, last_fetch_err=%v)",
+				timeout, c.Host, sawPending, paused, lastErr)
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(2 * time.Second):
+		case <-time.After(1 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `WaitForSeatAllocationAcked` can return immediately and falsely report the seat as acked. It reads the client seat at the default finalized commitment, and the client seat account is reused across runs, so a read taken right after `FeedSeatPay` can observe the previous run's already-acked (`pending=false`) state before this run's allocation request is visible at that commitment.
- When that happens the test proceeds to `withdraw_seat` while this run's allocation is still pending, and the withdrawal is rejected onchain (`Client seat has a pending instant seat allocation request`), surfacing as a confusing `withdraw_seat` failure.
- Fix: require observing the pending flag *set* before accepting a cleared flag as the ack, so stale finalized state can no longer be mistaken for an ack. The timeout error now reports `saw_pending`, distinguishing a request that was never acked from an RPC/visibility problem.

## Behavior change

- Happy path: the ack-wait blocks until it observes the request go pending and then clear, instead of potentially returning before this run's request is visible.
- If the request is not acked before the caller's timeout, the test fails at `wait_for_seat_allocation_acked` with `saw_pending=true`, attributing the failure to the ack step rather than surfacing later as a withdraw rejection.

## Testing

- `go build -tags qa ./e2e/internal/qa/` passes; `gofmt` clean.
- Not yet exercised against a live settlement run.
