### PR TITLE
internet-latency-collector: bound ledger RPC timeout and add per-attempt deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Collector
+  - Harden ledger writes against a slow/degraded RPC endpoint: bound each RPC request (default 15s, `--ledger-rpc-timeout`), size the connection pool above the submitter concurrency (default 128, `--ledger-rpc-max-conns`), and deadline each submission attempt so it fails fast and retries with a fresh blockhash instead of sending an expired one and failing preflight with `BlockhashNotFound`. (#3973)
 - E2E
   - Fix the multicast settlement QA test's seat-allocation ack wait. It read the reused client seat at finalized commitment and could accept the previous run's already-acked state, then withdraw while the current request was still pending. It now waits to observe the request pending before treating a cleared flag as the ack. (#3972)
 

--- a/controlplane/internet-latency-collector/cmd/collector/main.go
+++ b/controlplane/internet-latency-collector/cmd/collector/main.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -13,6 +15,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+	"github.com/klauspost/compress/gzhttp"
 	"github.com/spf13/cobra"
 
 	"github.com/malbeclabs/doublezero/config"
@@ -36,6 +40,20 @@ const (
 	defaultLedgerSubmissionInterval     = 1 * time.Minute
 	defaultWheresitupStateFile          = "wheresitup_jobs_to_process.json"
 	defaultLogLevel                     = "info"
+
+	// defaultLedgerRPCTimeout bounds each individual ledger RPC request. The default solana-go
+	// client uses a 5-minute timeout, which lets a request block long enough for a fetched
+	// (finalized) blockhash to expire before the send's preflight runs, surfacing as
+	// BlockhashNotFound. A short timeout fails fast so the submitter retries with a fresh
+	// blockhash. It is set above the observed slow-but-healthy latency (~12s) yet well under the
+	// blockhash validity window (~56s).
+	defaultLedgerRPCTimeout = 15 * time.Second
+
+	// defaultLedgerRPCMaxConns caps concurrent connections to the ledger RPC host. The solana-go
+	// default of 9 is far below the submitter's concurrency (100), so submissions queue for a
+	// connection and their blockhashes go stale in flight. Size the pool above the submitter
+	// concurrency to avoid that bottleneck.
+	defaultLedgerRPCMaxConns = 128
 )
 
 var (
@@ -49,6 +67,8 @@ var (
 	ripeatlasProbesPerLocation   int
 	ripeatlasMeasurementInterval time.Duration
 	ledgerSubmissionInterval     time.Duration
+	ledgerRPCTimeout             time.Duration
+	ledgerRPCMaxConns            int
 	metricsAddr                  string
 
 	version = "dev"
@@ -77,7 +97,7 @@ and Wheresitup services for the DoubleZero network.`,
 			os.Exit(1)
 		}
 
-		solanaRPCClient = solanarpc.New(networkConfig.LedgerPublicRPCURL)
+		solanaRPCClient = newLedgerRPCClient(networkConfig.LedgerPublicRPCURL, ledgerRPCTimeout, ledgerRPCMaxConns)
 		serviceabilityClient = serviceability.New(solanaRPCClient, networkConfig.ServiceabilityProgramID)
 	},
 }
@@ -137,7 +157,8 @@ RIPE Atlas measurements hourly, and exports RIPE Atlas results periodically.`,
 				exporter.DataProviderNameWheresitup: defaultWheresitupSamplingInterval,
 				exporter.DataProviderNameRIPEAtlas:  defaultRipeAtlasSamplingInterval,
 			},
-			EpochFinder: epochFinder,
+			EpochFinder:    epochFinder,
+			AttemptTimeout: 2 * ledgerRPCTimeout,
 		})
 		if err != nil {
 			log.Error("failed to create exporter", "error", err)
@@ -386,8 +407,35 @@ func loadLocations(ctx context.Context, logger *slog.Logger, serviceabilityClien
 	}
 }
 
+// newLedgerRPCClient builds a Solana RPC client with a bounded per-request timeout and a
+// connection pool sized for the submitter's concurrency. The solana-go default client uses a
+// 5-minute timeout and caps connections per host at 9, which under concurrent submission lets a
+// fetched finalized blockhash (valid only ~56s) expire while the send is queued or in flight,
+// surfacing as a BlockhashNotFound preflight failure.
+func newLedgerRPCClient(url string, timeout time.Duration, maxConns int) *solanarpc.Client {
+	transport := &http.Transport{
+		MaxConnsPerHost:     maxConns,
+		MaxIdleConns:        maxConns,
+		MaxIdleConnsPerHost: maxConns,
+		IdleConnTimeout:     90 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	httpClient := &http.Client{
+		Timeout:   timeout,
+		Transport: gzhttp.Transport(transport),
+	}
+	rpcClient := jsonrpc.NewClientWithOpts(url, &jsonrpc.RPCClientOpts{HTTPClient: httpClient})
+	return solanarpc.NewWithCustomRPCClient(rpcClient)
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringVar(&env, "env", "", "Environment to run in (devnet, testnet, mainnet-beta)")
+	rootCmd.PersistentFlags().DurationVar(&ledgerRPCTimeout, "ledger-rpc-timeout", defaultLedgerRPCTimeout, "Per-request timeout for ledger RPC calls; bounds how long a request may block so a stale blockhash fails fast and retries")
+	rootCmd.PersistentFlags().IntVar(&ledgerRPCMaxConns, "ledger-rpc-max-conns", defaultLedgerRPCMaxConns, "Maximum concurrent connections to the ledger RPC host")
 	rootCmd.PersistentFlags().StringVar(&keypairPath, "keypair", "", "Path to keypair for publishing metrics")
 	rootCmd.PersistentFlags().StringVar(&stateDir, "state-dir", defaultStateDir, "Directory to store state files (timestamps, processed job IDs)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", defaultLogLevel, "Log level (debug, info, warn, error)")

--- a/controlplane/internet-latency-collector/internal/exporter/ledger.go
+++ b/controlplane/internet-latency-collector/internal/exporter/ledger.go
@@ -52,6 +52,7 @@ type BufferedLedgerExporterConfig struct {
 	MaxAttempts                   int
 	BackoffFunc                   func(attempt int) time.Duration
 	EpochFinder                   epoch.Finder
+	AttemptTimeout                time.Duration
 }
 
 func (c *BufferedLedgerExporterConfig) Validate() error {
@@ -100,6 +101,7 @@ func NewBufferedLedgerExporter(cfg BufferedLedgerExporterConfig) (*BufferedLedge
 		MaxAttempts:                   cfg.MaxAttempts,
 		BackoffFunc:                   cfg.BackoffFunc,
 		EpochFinder:                   cfg.EpochFinder,
+		AttemptTimeout:                cfg.AttemptTimeout,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create submitter: %w", err)

--- a/controlplane/internet-latency-collector/internal/exporter/submitter.go
+++ b/controlplane/internet-latency-collector/internal/exporter/submitter.go
@@ -19,6 +19,13 @@ import (
 
 const (
 	defaultMaxConcurrency = 100
+
+	// defaultAttemptTimeout bounds how long a single submission attempt may run before it is
+	// abandoned and retried. Without a per-attempt deadline, a slow or degraded ledger RPC can
+	// leave an attempt blocked long enough for its (finalized) blockhash to expire, causing the
+	// send to fail preflight with BlockhashNotFound. Failing fast and retrying re-fetches a fresh
+	// blockhash on the next attempt.
+	defaultAttemptTimeout = 30 * time.Second
 )
 
 type SubmitterConfig struct {
@@ -30,7 +37,8 @@ type SubmitterConfig struct {
 	BackoffFunc                   func(attempt int) time.Duration // optional, defaults to exponential backoff
 	MaxAttempts                   int                             // optional, defaults to 5
 	EpochFinder                   epoch.Finder
-	MaxConcurrency                int // optional, defaults to 100
+	MaxConcurrency                int           // optional, defaults to 100
+	AttemptTimeout                time.Duration // optional, defaults to defaultAttemptTimeout
 }
 
 func (c *SubmitterConfig) Validate() error {
@@ -177,6 +185,11 @@ func (s *Submitter) Tick(ctx context.Context) {
 		maxAttempts = 5
 	}
 
+	attemptTimeout := s.cfg.AttemptTimeout
+	if attemptTimeout <= 0 {
+		attemptTimeout = defaultAttemptTimeout
+	}
+
 	partitions := s.cfg.Buffer.FlushWithoutReset()
 
 	if len(partitions) == 0 {
@@ -221,7 +234,12 @@ func (s *Submitter) Tick(ctx context.Context) {
 
 			success := false
 			for attempt := 1; attempt <= maxAttempts; attempt++ {
-				err := s.SubmitSamples(ctx, partitionKey, tmp)
+				// Bound each attempt so a slow/degraded ledger RPC can't leave the submission
+				// blocked past its blockhash's validity window; the next attempt re-fetches a
+				// fresh blockhash.
+				attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+				err := s.SubmitSamples(attemptCtx, partitionKey, tmp)
+				cancel()
 				if err == nil {
 					log.Debug("Submitted samples", "count", len(tmp), "attempt", attempt)
 					success = true

--- a/controlplane/internet-latency-collector/internal/exporter/submitter_test.go
+++ b/controlplane/internet-latency-collector/internal/exporter/submitter_test.go
@@ -199,6 +199,64 @@ func TestInternetLatency_Submitter(t *testing.T) {
 		assert.Equal(t, int32(3), attempts, "should have retried exactly MaxAttempts times")
 	})
 
+	t.Run("bounds_each_attempt_with_attempt_timeout", func(t *testing.T) {
+		t.Parallel()
+
+		log := logger.With("test", t.Name())
+
+		key := newTestPartitionKey()
+		sample := newTestSample()
+
+		var attempts int32
+		var sawCancel int32
+		telemetryProgram := &mockTelemetryProgramClient{
+			WriteInternetLatencySamplesFunc: func(ctx context.Context, config sdktelemetry.WriteInternetLatencySamplesInstructionConfig) (solana.Signature, *solanarpc.GetTransactionResult, error) {
+				atomic.AddInt32(&attempts, 1)
+				// Emulate a slow/degraded RPC that never returns; the per-attempt deadline must
+				// abandon the attempt so the submitter retries with a fresh blockhash.
+				<-ctx.Done()
+				atomic.AddInt32(&sawCancel, 1)
+				return solana.Signature{}, nil, ctx.Err()
+			},
+		}
+
+		buffer := buffer.NewMemoryPartitionedBuffer[exporter.PartitionKey, exporter.Sample](128)
+		buffer.Add(key, sample)
+
+		submitter, err := exporter.NewSubmitter(log, &exporter.SubmitterConfig{
+			OracleAgentPK:  solana.NewWallet().PublicKey(),
+			Interval:       time.Hour,
+			Buffer:         buffer,
+			Telemetry:      telemetryProgram,
+			MaxAttempts:    3,
+			AttemptTimeout: 20 * time.Millisecond,
+			BackoffFunc:    func(_ int) time.Duration { return 0 },
+			EpochFinder: &mockEpochFinder{ApproximateAtTimeFunc: func(ctx context.Context, target time.Time) (uint64, error) {
+				return 0, nil
+			}},
+		})
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		go func() {
+			submitter.Tick(t.Context())
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Tick did not return; per-attempt timeout is not bounding a hung submission")
+		}
+
+		assert.Equal(t, int32(3), atomic.LoadInt32(&attempts), "each attempt should time out and retry MaxAttempts times")
+		assert.Equal(t, int32(3), atomic.LoadInt32(&sawCancel), "each attempt's context should be cancelled by the attempt timeout")
+
+		samplesAfter := buffer.CopyAndReset(key)
+		require.Len(t, samplesAfter, 1, "samples should be preserved after all attempts time out")
+		assert.Equal(t, sample.RTT, samplesAfter[0].RTT)
+	})
+
 	t.Run("drops_samples_after_successful_submission", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary of Changes

- Build the internet-latency-collector's ledger RPC client with a **bounded per-request timeout** (default 15s, `--ledger-rpc-timeout`) instead of the solana-go default of 5 minutes, so a slow/degraded endpoint fails fast rather than holding a request until its blockhash expires.
- **Size the RPC connection pool** above the submitter's concurrency (default 128, `--ledger-rpc-max-conns`); the solana-go default caps connections per host at 9 while the submitter runs 100 concurrent submissions, so sends queued behind the pool long enough for their finalized blockhash (valid ~56s) to expire.
- Wrap **each submission attempt in a deadline** so a hung attempt is abandoned and retried with a freshly fetched blockhash instead of pinning a goroutine indefinitely.

Together these make the collector resilient to a slow/flapping ledger endpoint. Without them, transient endpoint degradation drove sends to fail preflight with `BlockhashNotFound` and collapse into sustained failure that a process restart did not clear.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +20 / -2    |  +18 |
| Scaffolding  |     2 | +52 / -2    |  +50 |
| Tests        |     1 | +58 / -0    |  +58 |
| **Total**    |     4 | +130 / -4   | +126 |

Small change: one behavioral change (per-attempt deadline) plus RPC-client construction/config wiring, covered by a new test.

<details>
<summary>Key files (click to expand)</summary>

- `controlplane/internet-latency-collector/cmd/collector/main.go` — add `newLedgerRPCClient` (bounded timeout + sized connection pool), `--ledger-rpc-timeout` / `--ledger-rpc-max-conns` flags, and pass `AttemptTimeout` to the exporter.
- `controlplane/internet-latency-collector/internal/exporter/submitter.go` — add `AttemptTimeout` and wrap each retry attempt in `context.WithTimeout`.
- `controlplane/internet-latency-collector/internal/exporter/submitter_test.go` — new test asserting a hung submission is bounded per attempt, retried `MaxAttempts` times, and samples are preserved.
- `controlplane/internet-latency-collector/internal/exporter/ledger.go` — thread `AttemptTimeout` through the exporter config.

</details>

## Testing Verification
- New unit test `TestInternetLatency_Submitter/bounds_each_attempt_with_attempt_timeout`: a write that blocks until its context is cancelled is abandoned per attempt (observing `context deadline exceeded`), retried exactly `MaxAttempts` times, with samples preserved for the next tick.
- Deployed to `aws-mn-internet-latency-collector1` during the live incident: submission failures dropped from ~15k/hour to zero, no ERROR-level log lines, and partition buffers drained to ≤2 samples (were backing up).
- Verified no duplicate appends resulted: scanned epoch-179 partition write histories onchain and found zero writes with identical `(start_timestamp, samples)` landing close together.
