### PR TITLE
e2e: tolerate multiple tunnel statuses in all-devices unicast QA test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - Harden ledger writes against a slow/degraded RPC endpoint: bound each RPC request (default 15s, `--ledger-rpc-timeout`), size the connection pool above the submitter concurrency (default 128, `--ledger-rpc-max-conns`), and deadline each submission attempt so it fails fast and retries with a fresh blockhash instead of sending an expired one and failing preflight with `BlockhashNotFound`. (#3973)
 - E2E
   - Fix the multicast settlement QA test's seat-allocation ack wait. It read the reused client seat at finalized commitment and could accept the previous run's already-acked state, then withdraw while the current request was still pending. It now waits to observe the request pending before treating a cleared flag as the ack. (#3972)
+  - Make the all-devices unicast QA test tolerate a host reporting multiple tunnel statuses. It now selects the IBRL status via `GetUserStatuses`/`FindIBRLStatus` instead of erroring on a lingering Multicast tunnel and dropping the host, and logs a warning when a host reports more than one status. (#3976)
 
 ## [v0.29.0](https://github.com/malbeclabs/doublezero/compare/client/v0.28.0...client/v0.29.0) - 2026-07-02
 

--- a/e2e/internal/qa/client_unicast_test.go
+++ b/e2e/internal/qa/client_unicast_test.go
@@ -3,6 +3,7 @@ package qa
 import (
 	"testing"
 
+	pb "github.com/malbeclabs/doublezero/e2e/proto/qa/gen/pb-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -288,6 +289,36 @@ this shouldn't match
 				require.Equal(t, tc.wantNums[i], hops[i].Num, "hop index %d Num mismatch", i)
 				require.InDelta(t, tc.wantLoss[i], hops[i].Loss, 0.0001, "hop %d loss mismatch", hops[i].Num)
 			}
+		})
+	}
+}
+
+func TestFindIBRLStatus(t *testing.T) {
+	t.Parallel()
+
+	ibrl := &pb.Status{UserType: "IBRL", SessionStatus: UserStatusUp}
+	ibrlAllocated := &pb.Status{UserType: "IBRLWithAllocatedIP", SessionStatus: UserStatusUp}
+	multicast := &pb.Status{UserType: "Multicast", SessionStatus: UserStatusUp}
+
+	tests := []struct {
+		name     string
+		statuses []*pb.Status
+		want     *pb.Status
+	}{
+		{"nil list returns nil", nil, nil},
+		{"single multicast returns sole status", []*pb.Status{multicast}, multicast},
+		{"ibrl plus lingering multicast returns ibrl", []*pb.Status{multicast, ibrl}, ibrl},
+		{"ibrl-allocated plus multicast returns ibrl", []*pb.Status{multicast, ibrlAllocated}, ibrlAllocated},
+		{"multiple with no ibrl returns nil", []*pb.Status{multicast, multicast}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindIBRLStatus(tt.statuses)
+			if tt.want == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.Same(t, tt.want, got)
 		})
 	}
 }

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -169,7 +169,7 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 						return "", err
 					}
 					if len(statuses) > 1 {
-						log.Warn("Host reported multiple tunnel statuses; selecting IBRL", "client", c.Host, "count", len(statuses))
+						log.Warn("Host reported multiple tunnel statuses", "client", c.Host, "count", len(statuses))
 					}
 					// A host may report multiple tunnel statuses (an IBRL and
 					// a Multicast tunnel). Select the IBRL status, or the sole
@@ -406,7 +406,7 @@ func connectClientsAndWaitForRoutes(
 			continue
 		}
 		if len(userStatuses) > 1 {
-			log.Warn("Host reported multiple tunnel statuses; selecting IBRL", "client", c.Host, "count", len(userStatuses))
+			log.Warn("Host reported multiple tunnel statuses", "client", c.Host, "count", len(userStatuses))
 		}
 		// A host may report multiple tunnel statuses (an IBRL and a
 		// Multicast tunnel). Select the IBRL status, or the sole status

--- a/e2e/qa_alldevices_unicast_test.go
+++ b/e2e/qa_alldevices_unicast_test.go
@@ -164,11 +164,22 @@ func TestQA_AllDevices_UnicastConnectivity(t *testing.T) {
 		getStatus := func(hostname string) (string, error) {
 			for _, c := range clients {
 				if c.Host == hostname {
-					status, err := c.GetUserStatus(ctx)
+					statuses, err := c.GetUserStatuses(ctx)
 					if err != nil {
 						return "", err
 					}
-					return status.SessionStatus, nil
+					if len(statuses) > 1 {
+						log.Warn("Host reported multiple tunnel statuses; selecting IBRL", "client", c.Host, "count", len(statuses))
+					}
+					// A host may report multiple tunnel statuses (an IBRL and
+					// a Multicast tunnel). Select the IBRL status, or the sole
+					// status on single-tunnel hosts. A nil result means no IBRL
+					// tunnel, reported as empty so the client reconnects.
+					ibrl := qa.FindIBRLStatus(statuses)
+					if ibrl == nil {
+						return "", nil
+					}
+					return ibrl.SessionStatus, nil
 				}
 			}
 			return "", fmt.Errorf("client %s not found", hostname)
@@ -389,14 +400,26 @@ func connectClientsAndWaitForRoutes(
 		if _, ok := batch[c.Host]; !ok {
 			continue
 		}
-		status, err := c.GetUserStatus(ctx)
+		userStatuses, err := c.GetUserStatuses(ctx)
 		if err != nil {
 			log.Error("Failed to get user status", "client", c.Host, "error", err)
 			continue
 		}
-		statuses[c.Host] = status.SessionStatus
-		if !qa.IsStatusUp(status.SessionStatus) {
-			log.Warn("Client not up", "client", c.Host, "status", status.SessionStatus)
+		if len(userStatuses) > 1 {
+			log.Warn("Host reported multiple tunnel statuses; selecting IBRL", "client", c.Host, "count", len(userStatuses))
+		}
+		// A host may report multiple tunnel statuses (an IBRL and a
+		// Multicast tunnel). Select the IBRL status, or the sole status
+		// on single-tunnel hosts. A nil result means no IBRL tunnel, so
+		// the host is excluded from routing.
+		ibrl := qa.FindIBRLStatus(userStatuses)
+		if ibrl == nil {
+			log.Warn("Client has no IBRL status", "client", c.Host)
+			continue
+		}
+		statuses[c.Host] = ibrl.SessionStatus
+		if !qa.IsStatusUp(ibrl.SessionStatus) {
+			log.Warn("Client not up", "client", c.Host, "status", ibrl.SessionStatus)
 		}
 	}
 	connectedClients := qa.FilterStatusUpClients(allClients, batch, statuses)


### PR DESCRIPTION
## Summary

- `TestQA_AllDevices_UnicastConnectivity` called the deprecated `GetUserStatus`, which returns an error when a host reports more than one tunnel status. A host that holds both an IBRL and a Multicast tunnel therefore errored and was dropped from the batch, and a batch with fewer than two connected clients times out.
- Switch the two remaining call sites to `GetUserStatuses` + `FindIBRLStatus`, which select the IBRL status (and return the sole status on single-tunnel hosts). A host with a lingering Multicast tunnel is now kept via its IBRL status; a host with no IBRL status is excluded from routing.
- Log a warning when a host reports more than one tunnel status, so the multi-tunnel condition stays visible without failing the sweep.

## Testing Verification

- Added `TestFindIBRLStatus` covering: single status returned as-is, IBRL selected when an IBRL and a Multicast status are both present (including `IBRLWithAllocatedIP`), and nil when no IBRL status exists.
- `go test ./e2e/internal/qa/ -run TestFindIBRLStatus` passes; `go vet -tags qa ./e2e/...` clean.
