### PR TITLE
serviceability: authorize contributor instructions via Permission accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Serviceability
+  - Gate Contributor instructions (create/update/suspend/resume/delete) on `CONTRIBUTOR_ADMIN` or foundation; the contributor owner retains the ops-manager-only update path. (#3978)
 - Collector
   - Harden ledger writes against a slow/degraded RPC endpoint: bound each RPC request (default 15s, `--ledger-rpc-timeout`), size the connection pool above the submitter concurrency (default 128, `--ledger-rpc-max-conns`), and deadline each submission attempt so it fails fast and retries with a fresh blockhash instead of sending an expired one and failing preflight with `BlockhashNotFound`. (#3973)
 - E2E

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/create.rs
@@ -1,9 +1,13 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     pda::*,
     seeds::{SEED_CONTRIBUTOR, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
-    state::{accounttype::AccountType, contributor::*, globalstate::GlobalState},
+    state::{
+        accounttype::AccountType, contributor::*, globalstate::GlobalState,
+        permission::permission_flags,
+    },
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -82,9 +86,14 @@ pub fn process_create_contributor(
     let mut globalstate = GlobalState::try_from(globalstate_account)?;
     globalstate.account_index += 1;
 
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    // Authorization: CONTRIBUTOR_ADMIN (Permission account) or foundation (legacy).
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::CONTRIBUTOR_ADMIN,
+    )?;
     // get the PDA pubkey and bump seed for the account contributor & check if it matches the account
     let (expected_pda_account, bump_seed) =
         get_contributor_pda(program_id, globalstate.account_index);

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/delete.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_close,
-    state::{contributor::*, globalstate::GlobalState},
+    state::{contributor::*, globalstate::GlobalState, permission::permission_flags},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -65,11 +66,15 @@ pub fn process_delete_contributor(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Authorization: CONTRIBUTOR_ADMIN (Permission account) or foundation (legacy).
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::CONTRIBUTOR_ADMIN,
+    )?;
 
     let contributor = Contributor::try_from(contributor_account)?;
     if matches!(contributor.status, ContributorStatus::Deleting) {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/resume.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_write,
-    state::{contributor::*, globalstate::GlobalState},
+    state::{contributor::*, globalstate::GlobalState, permission::permission_flags},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -65,11 +66,15 @@ pub fn process_resume_contributor(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Authorization: CONTRIBUTOR_ADMIN (Permission account) or foundation (legacy).
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::CONTRIBUTOR_ADMIN,
+    )?;
 
     let mut contributor: Contributor = Contributor::try_from(contributor_account)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/suspend.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_write,
-    state::{contributor::*, globalstate::GlobalState},
+    state::{contributor::*, globalstate::GlobalState, permission::permission_flags},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -65,11 +66,15 @@ pub fn process_suspend_contributor(
         "Invalid System Program Account Owner"
     );
 
-    // Parse the global state account & check if the payer is in the allowlist
+    // Authorization: CONTRIBUTOR_ADMIN (Permission account) or foundation (legacy).
     let globalstate = GlobalState::try_from(globalstate_account)?;
-    if !globalstate.foundation_allowlist.contains(payer_account.key) {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::CONTRIBUTOR_ADMIN,
+    )?;
 
     let mut contributor: Contributor = Contributor::try_from(contributor_account)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/contributor/update.rs
@@ -1,7 +1,8 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     serializer::try_acc_write,
-    state::{contributor::*, globalstate::GlobalState},
+    state::{contributor::*, globalstate::GlobalState, permission::permission_flags},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -79,13 +80,21 @@ pub fn process_update_contributor(
     let only_ops_manager_update =
         value.code.is_none() && value.owner.is_none() && value.ops_manager_pk.is_some();
 
-    // If only ops_manager_pk is being updated, allow contributor owner or foundation allowlist
-    // Otherwise, only allow foundation allowlist
+    // Authorization: CONTRIBUTOR_ADMIN (Permission account) or foundation (legacy).
+    // When only ops_manager_pk is being updated, the contributor owner may also
+    // perform the update without holding CONTRIBUTOR_ADMIN.
+    let is_privileged = authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::CONTRIBUTOR_ADMIN,
+    )
+    .is_ok();
     let is_authorized = if only_ops_manager_update {
-        globalstate.foundation_allowlist.contains(payer_account.key)
-            || contributor.owner == *payer_account.key
+        is_privileged || contributor.owner == *payer_account.key
     } else {
-        globalstate.foundation_allowlist.contains(payer_account.key)
+        is_privileged
     };
 
     if !is_authorized {

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -1,8 +1,11 @@
 use doublezero_serviceability::{
     instructions::*,
     pda::*,
-    processors::contributor::{create::*, delete::*, resume::*, suspend::*, update::*},
-    state::{accounttype::AccountType, contributor::*},
+    processors::{
+        contributor::{create::*, delete::*, resume::*, suspend::*, update::*},
+        permission::create::PermissionCreateArgs,
+    },
+    state::{accounttype::AccountType, contributor::*, permission::permission_flags},
 };
 use solana_program_test::*;
 use solana_sdk::{
@@ -475,4 +478,91 @@ async fn test_contributor_delete_from_suspended() {
 
     let contributor_la = get_account_data(&mut banks_client, contributor_pubkey).await;
     assert_eq!(contributor_la, None);
+}
+
+/// A non-foundation key holding a CONTRIBUTOR_ADMIN Permission account can create a
+/// contributor — exercises the new Permission-account authorization path.
+#[tokio::test]
+async fn test_contributor_create_with_permission_account_allowed() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // A key that is NOT in the foundation allowlist, granted CONTRIBUTOR_ADMIN.
+    let contrib_admin = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &contrib_admin.pubkey(),
+        2_000_000_000,
+    )
+    .await;
+
+    let (permission_pda, _) = get_permission_pda(&program_id, &contrib_admin.pubkey());
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: contrib_admin.pubkey(),
+            permissions: permission_flags::CONTRIBUTOR_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // contrib_admin creates a contributor, passing its Permission PDA as the
+    // optional trailing account that authorize() reads.
+    let globalstate = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, globalstate.account_index + 1);
+    let owner = Pubkey::new_unique();
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx = create_transaction_with_extra_accounts(
+        program_id,
+        &DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "permctrb".to_string(),
+        }),
+        &vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(owner, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &contrib_admin,
+        &[AccountMeta::new_readonly(permission_pda, false)],
+    );
+    tx.try_sign(&[&contrib_admin], recent_blockhash).unwrap();
+    banks_client
+        .process_transaction(tx)
+        .await
+        .expect("CONTRIBUTOR_ADMIN permission holder should be able to create a contributor");
+
+    let contributor = get_account_data(&mut banks_client, contributor_pubkey)
+        .await
+        .expect("contributor")
+        .get_contributor()
+        .unwrap();
+    assert_eq!(contributor.account_type, AccountType::Contributor);
+    assert_eq!(contributor.owner, owner);
+    assert_eq!(contributor.code, "permctrb".to_string());
+
+    println!("✅ CreateContributor with CONTRIBUTOR_ADMIN permission succeeded");
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/contributor_test.rs
@@ -566,3 +566,222 @@ async fn test_contributor_create_with_permission_account_allowed() {
 
     println!("✅ CreateContributor with CONTRIBUTOR_ADMIN permission succeeded");
 }
+
+/// A non-foundation key holding a CONTRIBUTOR_ADMIN Permission account can perform a
+/// FULL update (code + owner + ops_manager_pk) — exercises the `else` arm of
+/// process_update_contributor where authorization requires `is_privileged`, a path the
+/// create/suspend/resume/delete tests don't reach.
+#[tokio::test]
+async fn test_contributor_update_full_with_permission_account_allowed() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create a contributor via the foundation payer (legacy path).
+    let globalstate = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, globalstate.account_index + 1);
+    let original_owner = Pubkey::new_unique();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "ctrb".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(original_owner, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // A key that is NOT in the foundation allowlist, granted CONTRIBUTOR_ADMIN.
+    let contrib_admin = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &contrib_admin.pubkey(),
+        2_000_000_000,
+    )
+    .await;
+
+    let (permission_pda, _) = get_permission_pda(&program_id, &contrib_admin.pubkey());
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: contrib_admin.pubkey(),
+            permissions: permission_flags::CONTRIBUTOR_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // contrib_admin performs a FULL update (code + owner + ops_manager_pk), passing its
+    // Permission PDA as the trailing account authorize() reads. On-wire layout:
+    // [contributor, globalstate, payer, system, permission].
+    let new_owner = Pubkey::new_unique();
+    let new_ops_manager = Pubkey::new_unique();
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx = create_transaction_with_extra_accounts(
+        program_id,
+        &DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
+            code: Some("ctrb2".to_string()),
+            owner: Some(new_owner),
+            ops_manager_pk: Some(new_ops_manager),
+        }),
+        &vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &contrib_admin,
+        &[AccountMeta::new_readonly(permission_pda, false)],
+    );
+    tx.try_sign(&[&contrib_admin], recent_blockhash).unwrap();
+    banks_client
+        .process_transaction(tx)
+        .await
+        .expect("CONTRIBUTOR_ADMIN permission holder should be able to fully update a contributor");
+
+    let contributor = get_account_data(&mut banks_client, contributor_pubkey)
+        .await
+        .expect("contributor")
+        .get_contributor()
+        .unwrap();
+    assert_eq!(contributor.code, "ctrb2".to_string());
+    assert_eq!(contributor.owner, new_owner);
+    assert_eq!(contributor.ops_manager_pk, new_ops_manager);
+
+    println!("✅ Full UpdateContributor with CONTRIBUTOR_ADMIN permission succeeded");
+}
+
+/// A non-foundation key whose Permission account holds an unrelated flag (not
+/// CONTRIBUTOR_ADMIN) cannot perform a full update. Pins the update call site's flag
+/// gate against being wired to the wrong flag in a way the positive test can't catch.
+#[tokio::test]
+async fn test_contributor_update_full_with_wrong_permission_denied() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let globalstate = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (contributor_pubkey, _) = get_contributor_pda(&program_id, globalstate.account_index + 1);
+    let original_owner = Pubkey::new_unique();
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateContributor(ContributorCreateArgs {
+            code: "ctrb".to_string(),
+        }),
+        vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(original_owner, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // A non-foundation key granted an UNRELATED flag (USER_ADMIN), not CONTRIBUTOR_ADMIN.
+    let wrong_admin = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &wrong_admin.pubkey(),
+        2_000_000_000,
+    )
+    .await;
+
+    let (permission_pda, _) = get_permission_pda(&program_id, &wrong_admin.pubkey());
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: wrong_admin.pubkey(),
+            permissions: permission_flags::USER_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Full update must be rejected: USER_ADMIN does not satisfy CONTRIBUTOR_ADMIN, and
+    // wrong_admin is not in the foundation allowlist, so the legacy fallback denies too.
+    let recent_blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx = create_transaction_with_extra_accounts(
+        program_id,
+        &DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
+            code: Some("ctrb2".to_string()),
+            owner: Some(Pubkey::new_unique()),
+            ops_manager_pk: Some(Pubkey::new_unique()),
+        }),
+        &vec![
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &wrong_admin,
+        &[AccountMeta::new_readonly(permission_pda, false)],
+    );
+    tx.try_sign(&[&wrong_admin], recent_blockhash).unwrap();
+    let result = banks_client.process_transaction(tx).await;
+
+    let error_string = format!("{:?}", result.unwrap_err());
+    assert!(
+        error_string.contains("Custom(8)"),
+        "Expected error to contain 'Custom(8)' (NotAllowed), but got: {}",
+        error_string
+    );
+
+    // Contributor must be unchanged.
+    let contributor = get_account_data(&mut banks_client, contributor_pubkey)
+        .await
+        .expect("contributor")
+        .get_contributor()
+        .unwrap();
+    assert_eq!(contributor.code, "ctrb".to_string());
+    assert_eq!(contributor.owner, original_owner);
+
+    println!("✅ Full UpdateContributor without CONTRIBUTOR_ADMIN correctly denied");
+}

--- a/smartcontract/sdk/rs/src/commands/contributor/create.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/create.rs
@@ -24,7 +24,7 @@ impl CreateContributorCommand {
         let (pda_pubkey, _) =
             get_contributor_pda(&client.get_program_id(), globalstate.account_index + 1);
         client
-            .execute_transaction(
+            .execute_authorized_transaction(
                 DoubleZeroInstruction::CreateContributor(ContributorCreateArgs { code }),
                 vec![
                     AccountMeta::new(pda_pubkey, false),
@@ -54,7 +54,7 @@ mod tests {
         let owner = Pubkey::new_unique();
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CreateContributor(
                     ContributorCreateArgs {

--- a/smartcontract/sdk/rs/src/commands/contributor/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/delete.rs
@@ -31,7 +31,7 @@ impl DeleteContributorCommand {
             ));
         }
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::DeleteContributor(ContributorDeleteArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -83,7 +83,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::Contributor(contributor.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteContributor(
                     ContributorDeleteArgs {},

--- a/smartcontract/sdk/rs/src/commands/contributor/resume.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/resume.rs
@@ -15,7 +15,7 @@ impl ResumeContributorCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::ResumeContributor(ContributorResumeArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -47,7 +47,7 @@ mod tests {
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::ResumeContributor(
                     ContributorResumeArgs {},

--- a/smartcontract/sdk/rs/src/commands/contributor/suspend.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/suspend.rs
@@ -15,7 +15,7 @@ impl SuspendContributorCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::SuspendContributor(ContributorSuspendArgs {}),
             vec![
                 AccountMeta::new(self.pubkey, false),
@@ -47,7 +47,7 @@ mod tests {
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::SuspendContributor(
                     ContributorSuspendArgs {},

--- a/smartcontract/sdk/rs/src/commands/contributor/update.rs
+++ b/smartcontract/sdk/rs/src/commands/contributor/update.rs
@@ -25,7 +25,7 @@ impl UpdateContributorCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::UpdateContributor(ContributorUpdateArgs {
                 code,
                 owner: self.owner.to_owned(),
@@ -61,7 +61,7 @@ mod tests {
         let (pda_pubkey, _) = get_contributor_pda(&client.get_program_id(), 1);
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::UpdateContributor(
                     ContributorUpdateArgs {


### PR DESCRIPTION
## Summary

Gate Contributor instructions (`create`, `update`, `suspend`, `resume`, `delete`) on the `CONTRIBUTOR_ADMIN` flag via `authorize()`. Behavior is preserved: the legacy foundation-allowlist check still authorizes while `RequirePermissionAccounts` is off, and the contributor owner retains the ops-manager-only update path.

One PR per domain in the incremental Permission-system rollout. See `smartcontract/programs/doublezero-serviceability/PERMISSION.md`.

## Testing Verification

- New CONTRIBUTOR_ADMIN permission-account test plus the existing `test_contributor` coverage (owner ops-manager update, non-owner rejection).
- `cargo test -p doublezero-serviceability`, `cargo test -p doublezero_sdk`, `make rust-lint` pass.

---

## Permission migration series

One of 8 per-domain PRs migrating serviceability instructions to the Permission (`authorize()`) system. The branches partition the change set with no overlap and can be reviewed and merged independently (only the CHANGELOG entry conflicts trivially).

| PR | Domain | Flag(s) |
|----|--------|---------|
| #3977 | Governance (globalstate/globalconfig/allowlists) | GLOBALSTATE_ADMIN |
| #3978 | Contributor | CONTRIBUTOR_ADMIN ← this PR |
| #3979 | Infra (location/exchange) | INFRA_ADMIN |
| #3980 | Devices + interfaces | NETWORK_ADMIN, HEALTH_ORACLE |
| #3981 | Links | NETWORK_ADMIN, HEALTH_ORACLE |
| #3982 | Multicast | MULTICAST_ADMIN, ACCESS_PASS_ADMIN |
| #3983 | Tenant | TENANT_ADMIN |
| #3984 | User (update / check_access_pass / check_status) | USER_ADMIN, ACTIVATOR |
