### PR TITLE
serviceability: authorize link instructions via Permission accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - Require a Permission account (or the legacy foundation authority) for GlobalState, GlobalConfig, and foundation/QA allowlist admin instructions, gated on `GLOBALSTATE_ADMIN` via `authorize()`. (#3977)
   - Gate Contributor instructions (create/update/suspend/resume/delete) on `CONTRIBUTOR_ADMIN` or foundation; the contributor owner retains the ops-manager-only update path. (#3978)
   - Gate Location and Exchange instructions (create/update/suspend/resume/delete, exchange setdevice) on `INFRA_ADMIN` or foundation via `authorize()`. (#3979)
+  - Gate Link instructions (create/update/delete/suspend/resume/accept/sethealth) on `NETWORK_ADMIN` (and `HEALTH_ORACLE` for sethealth) or the contributor owner via `authorize()`; variable-length delete/update use split_trailing_permission. (#3981)
 - Collector
   - Harden ledger writes against a slow/degraded RPC endpoint: bound each RPC request (default 15s, `--ledger-rpc-timeout`), size the connection pool above the submitter concurrency (default 128, `--ledger-rpc-max-conns`), and deadline each submission attempt so it fails fast and retries with a fresh blockhash instead of sending an expired one and failing preflight with `BlockhashNotFound`. (#3973)
 - E2E

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
@@ -58,7 +58,9 @@ pub fn process_accept_link(
     let accounts_iter = &mut accounts.iter();
 
     // Account layout: [link, contributor, side_z_dev, globalstate, side_a_dev,
-    //                  device_tunnel_block, link_ids, payer, system]
+    //                  device_tunnel_block, link_ids, payer, system, permission?]
+    // The trailing optional permission account (the payer's Permission PDA, appended
+    // by the SDK when it exists on-chain) is consumed by authorize() below.
     let link_account = next_account_info(accounts_iter)?;
     let contributor_account = next_account_info(accounts_iter)?;
     let side_z_account = next_account_info(accounts_iter)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/accept.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     processors::{
         link::resource_onchain_helpers::validate_and_allocate_link_resources,
@@ -8,8 +9,10 @@ use crate::{
     state::{
         contributor::Contributor,
         device::Device,
+        globalstate::GlobalState,
         interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus},
         link::*,
+        permission::permission_flags,
     },
 };
 use borsh::BorshSerialize;
@@ -59,7 +62,7 @@ pub fn process_accept_link(
     let link_account = next_account_info(accounts_iter)?;
     let contributor_account = next_account_info(accounts_iter)?;
     let side_z_account = next_account_info(accounts_iter)?;
-    let _globalstate_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
 
     let side_a_device_account = next_account_info(accounts_iter)?;
     let device_tunnel_block_ext = next_account_info(accounts_iter)?;
@@ -86,7 +89,19 @@ pub fn process_accept_link(
 
     // Validate Contributor Owner
     let contributor = Contributor::try_from(contributor_account)?;
-    if contributor.owner != *payer_account.key {
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy) as an additional bypass.
+    if contributor.owner != *payer_account.key
+        && authorize(
+            program_id,
+            accounts_iter,
+            payer_account.key,
+            &globalstate,
+            permission_flags::NETWORK_ADMIN,
+        )
+        .is_err()
+    {
         return Err(DoubleZeroError::NotAllowed.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/create.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     pda::{get_link_pda, get_topology_pda},
     processors::validation::validate_program_account,
@@ -11,6 +12,7 @@ use crate::{
         globalstate::GlobalState,
         interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus, LINK_MTU},
         link::*,
+        permission::permission_flags,
         topology::TopologyInfo,
     },
 };
@@ -121,8 +123,17 @@ pub fn process_create_link(
 
     let mut contributor = Contributor::try_from(contributor_account)?;
 
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy).
     if contributor.owner != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
+        && authorize(
+            program_id,
+            accounts_iter,
+            payer_account.key,
+            &globalstate,
+            permission_flags::NETWORK_ADMIN,
+        )
+        .is_err()
     {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/delete.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::{authorize, split_trailing_permission},
     error::DoubleZeroError,
     processors::validation::validate_program_account,
     serializer::{try_acc_close, try_acc_write},
@@ -9,6 +10,7 @@ use crate::{
         globalstate::GlobalState,
         interface::{InterfaceCYOA, InterfaceDIA, InterfaceStatus, InterfaceType},
         link::*,
+        permission::permission_flags,
         topology::TopologyInfo,
     },
 };
@@ -71,14 +73,13 @@ pub fn process_delete_link(
     let link_ids_ext = next_account_info(accounts_iter)?;
     let owner_account = next_account_info(accounts_iter)?;
 
-    // Remaining accounts: topology union + payer + system.
+    // Remaining accounts: [topology_union.., payer, system, permission?].
+    // split_trailing_permission peels payer/system — and the optional payer
+    // Permission PDA the SDK appends when it exists — off the tail, leaving the
+    // caller's topology union as `topology_accounts`.
     let rest: Vec<&AccountInfo> = accounts_iter.collect();
-    if rest.len() < 2 {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    }
-    let (topology_accounts, tail) = rest.split_at(rest.len() - 2);
-    let payer_account = tail[0];
-    let system_program = tail[1];
+    let (payer_account, system_program, topology_accounts, permission_account) =
+        split_trailing_permission(program_id, &rest)?;
 
     #[cfg(test)]
     msg!("process_delete_link({:?})", value);
@@ -111,9 +112,18 @@ pub fn process_delete_link(
 
     let mut contributor = Contributor::try_from(contributor_account)?;
 
-    let payer_in_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy). Privileged callers bypass the per-link contributor binding.
+    let is_privileged = authorize(
+        program_id,
+        &mut permission_account.into_iter(),
+        payer_account.key,
+        &globalstate,
+        permission_flags::NETWORK_ADMIN,
+    )
+    .is_ok();
 
-    if contributor.owner != *payer_account.key && !payer_in_foundation {
+    if contributor.owner != *payer_account.key && !is_privileged {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
@@ -124,7 +134,7 @@ pub fn process_delete_link(
         return Err(DoubleZeroError::InvalidStatus.into());
     }
 
-    if !payer_in_foundation && link.contributor_pk != *contributor_account.key {
+    if !is_privileged && link.contributor_pk != *contributor_account.key {
         return Err(DoubleZeroError::NotAllowed.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/resume.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/resume.rs
@@ -1,8 +1,11 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     processors::validation::validate_program_account,
     serializer::try_acc_write,
-    state::{contributor::Contributor, globalstate::GlobalState, link::*},
+    state::{
+        contributor::Contributor, globalstate::GlobalState, link::*, permission::permission_flags,
+    },
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -55,15 +58,24 @@ pub fn process_resume_link(
     let globalstate = GlobalState::try_from(globalstate_account)?;
     let contributor = Contributor::try_from(contributor_account)?;
 
-    let payer_in_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy). Privileged callers bypass the per-link contributor binding.
+    let is_privileged = authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::NETWORK_ADMIN,
+    )
+    .is_ok();
 
-    if contributor.owner != *payer_account.key && !payer_in_foundation {
+    if contributor.owner != *payer_account.key && !is_privileged {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
     let mut link: Link = Link::try_from(link_account)?;
 
-    if !payer_in_foundation && link.contributor_pk != *contributor_account.key {
+    if !is_privileged && link.contributor_pk != *contributor_account.key {
         return Err(DoubleZeroError::NotAllowed.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/sethealth.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/sethealth.rs
@@ -1,8 +1,8 @@
 use crate::{
-    error::DoubleZeroError,
+    authorize::authorize,
     processors::validation::validate_program_account,
     serializer::try_acc_write,
-    state::{globalstate::GlobalState, link::*},
+    state::{globalstate::GlobalState, link::*, permission::permission_flags},
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -59,11 +59,16 @@ pub fn process_set_health_link(
 
     let globalstate = GlobalState::try_from(globalstate_account)?;
 
-    if globalstate.health_oracle_pk != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
-        return Err(DoubleZeroError::NotAllowed.into());
-    }
+    // Authorization: HEALTH_ORACLE or foundation, via a Permission account or the
+    // legacy health_oracle_pk / foundation_allowlist (HEALTH_ORACLE covers the
+    // oracle key, NETWORK_ADMIN covers foundation).
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::HEALTH_ORACLE | permission_flags::NETWORK_ADMIN,
+    )?;
 
     let mut link: Link = Link::try_from(link_account)?;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/suspend.rs
@@ -1,8 +1,11 @@
 use crate::{
+    authorize::authorize,
     error::DoubleZeroError,
     processors::validation::validate_program_account,
     serializer::try_acc_write,
-    state::{contributor::Contributor, globalstate::GlobalState, link::*},
+    state::{
+        contributor::Contributor, globalstate::GlobalState, link::*, permission::permission_flags,
+    },
 };
 use borsh::BorshSerialize;
 use borsh_incremental::BorshDeserializeIncremental;
@@ -55,14 +58,23 @@ pub fn process_suspend_link(
     let globalstate = GlobalState::try_from(globalstate_account)?;
     let contributor = Contributor::try_from(contributor_account)?;
 
-    let payer_in_foundation = globalstate.foundation_allowlist.contains(payer_account.key);
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy). Privileged callers bypass the per-link contributor binding.
+    let is_privileged = authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::NETWORK_ADMIN,
+    )
+    .is_ok();
 
-    if contributor.owner != *payer_account.key && !payer_in_foundation {
+    if contributor.owner != *payer_account.key && !is_privileged {
         return Err(DoubleZeroError::InvalidOwnerPubkey.into());
     }
 
     let mut link: Link = Link::try_from(link_account)?;
-    if !payer_in_foundation && link.contributor_pk != *contributor_account.key {
+    if !is_privileged && link.contributor_pk != *contributor_account.key {
         return Err(DoubleZeroError::NotAllowed.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/link/update.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authorize::{authorize, split_trailing_permission},
     error::{DoubleZeroError, Validate},
     pda::{get_globalstate_pda, get_resource_extension_pda},
     processors::{
@@ -9,7 +10,7 @@ use crate::{
     serializer::try_acc_write,
     state::{
         contributor::Contributor, device::Device, globalstate::GlobalState, link::*,
-        topology::TopologyInfo,
+        permission::permission_flags, topology::TopologyInfo,
     },
 };
 use borsh::BorshSerialize;
@@ -158,14 +159,13 @@ pub fn process_update_link(
         }
     }
 
-    // Remaining accounts are the topology union followed by payer and system_program.
+    // Remaining accounts: [topology_union.., payer, system, permission?].
+    // split_trailing_permission peels payer/system — and the optional payer
+    // Permission PDA the SDK appends when it exists — off the tail, leaving the
+    // caller's topology union as `topology_accounts`.
     let rest: Vec<&AccountInfo> = accounts_iter.collect();
-    if rest.len() < 2 {
-        return Err(solana_program::program_error::ProgramError::NotEnoughAccountKeys);
-    }
-    let (topology_accounts, tail) = rest.split_at(rest.len() - 2);
-    let payer_account = tail[0];
-    let system_program = tail[1];
+    let (payer_account, system_program, topology_accounts, permission_account) =
+        split_trailing_permission(program_id, &rest)?;
 
     #[cfg(test)]
     msg!("process_update_link({:?})", value);
@@ -194,9 +194,18 @@ pub fn process_update_link(
     let globalstate = GlobalState::try_from(globalstate_account)?;
     let contributor = Contributor::try_from(contributor_account)?;
 
-    if contributor.owner != *payer_account.key
-        && !globalstate.foundation_allowlist.contains(payer_account.key)
-    {
+    // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
+    // foundation (legacy). Privileged callers bypass the per-link contributor binding
+    // and the foundation-only field gates below.
+    let is_privileged = authorize(
+        program_id,
+        &mut permission_account.into_iter(),
+        payer_account.key,
+        &globalstate,
+        permission_flags::NETWORK_ADMIN,
+    )
+    .is_ok();
+    if contributor.owner != *payer_account.key && !is_privileged {
         msg!("contributor owner: {:?}", contributor.owner);
         return Err(DoubleZeroError::NotAllowed.into());
     }
@@ -275,8 +284,8 @@ pub fn process_update_link(
     // Handle tunnel_id/tunnel_net reallocation (foundation-only).
     // The earlier check guarantees `resource_accounts` is `Some` when either field is set.
     if value.tunnel_id.is_some() || value.tunnel_net.is_some() {
-        if !globalstate.foundation_allowlist.contains(payer_account.key) {
-            msg!("tunnel field updates require foundation allowlist");
+        if !is_privileged {
+            msg!("tunnel field updates require foundation or network-admin authority");
             return Err(DoubleZeroError::NotAllowed.into());
         }
 
@@ -371,8 +380,8 @@ pub fn process_update_link(
     // link_topologies as writable accounts; the processor diffs on-chain and
     // increments/decrements each topology's reference_count accordingly.
     if let Some(new_topologies) = &value.link_topologies {
-        if !globalstate.foundation_allowlist.contains(payer_account.key) {
-            msg!("link_topologies update requires foundation allowlist");
+        if !is_privileged {
+            msg!("link_topologies update requires foundation or network-admin authority");
             return Err(DoubleZeroError::NotAllowed.into());
         }
 
@@ -426,10 +435,8 @@ pub fn process_update_link(
 
     // unicast_drained (LINK_FLAG_UNICAST_DRAINED bit 0): contributor A or foundation
     if let Some(unicast_drained) = value.unicast_drained {
-        if link.contributor_pk != *contributor_account.key
-            && !globalstate.foundation_allowlist.contains(payer_account.key)
-        {
-            msg!("unicast_drained update requires contributor A or foundation allowlist");
+        if link.contributor_pk != *contributor_account.key && !is_privileged {
+            msg!("unicast_drained update requires contributor A or foundation/network-admin authority");
             return Err(DoubleZeroError::NotAllowed.into());
         }
         if unicast_drained {

--- a/smartcontract/programs/doublezero-serviceability/tests/link_onchain_allocation_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/link_onchain_allocation_test.rs
@@ -19,6 +19,8 @@ use doublezero_serviceability::{
         device::{DeviceDesiredStatus, DeviceType},
         interface::{InterfaceCYOA, InterfaceDIA, LoopbackType, RoutingMode},
         link::*,
+        permission::permission_flags,
+        topology::TopologyConstraint,
     },
 };
 use solana_program_test::*;
@@ -1276,4 +1278,327 @@ async fn test_accept_link_with_onchain_allocation() {
         link.tunnel_id, link.tunnel_net
     );
     println!("test_accept_link_with_onchain_allocation PASSED");
+}
+
+/// A `NETWORK_ADMIN` Permission holder — who is neither the contributor owner nor
+/// a foundation member — can delete a link whose topology union is non-empty.
+///
+/// This drives the variable-length `delete` path end-to-end through an appended
+/// Permission account, exercising `split_trailing_permission`: the payer's
+/// Permission PDA must be peeled off the *tail* past the caller-controlled
+/// topology accounts (`[topology_union.., payer, system, permission]`). The
+/// negative half proves the disambiguation isn't a blanket allow — with no
+/// Permission account appended, the same non-owner caller is denied because the
+/// legacy `NETWORK_ADMIN` mapping is foundation-only.
+#[tokio::test]
+async fn test_delete_link_via_network_admin_permission_with_topology_union() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let (
+        device_a_pubkey,
+        device_z_pubkey,
+        contributor_pubkey,
+        device_tunnel_block_pda,
+        link_ids_pda,
+    ) = setup_wan_link_infra(&mut banks_client, &payer, program_id, globalstate_pubkey).await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (link_pubkey, _) = get_link_pda(&program_id, globalstate_account.account_index + 1);
+
+    let unicast_default_pda = create_unicast_default_topology(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    // Create + activate the link (tagged into the unicast-default topology).
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "wan1".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 10_000_000_000,
+            mtu: 9000,
+            delay_ns: 500_000,
+            jitter_ns: 50000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(unicast_default_pda, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Drain the link (delete rejects Activated) — done by the contributor owner.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
+            status: Some(LinkStatus::SoftDrained),
+            use_onchain_allocation: true,
+            ..Default::default()
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let link = get_account_data(&mut banks_client, link_pubkey)
+        .await
+        .expect("Link not found")
+        .get_tunnel()
+        .unwrap();
+    let owner = link.owner;
+    assert_eq!(
+        link.link_topologies,
+        vec![unicast_default_pda],
+        "link should be tagged into exactly the unicast-default topology"
+    );
+
+    // A network admin that is neither the contributor owner nor a foundation member.
+    let admin = solana_sdk::signer::keypair::Keypair::new();
+    transfer(&mut banks_client, &payer, &admin.pubkey(), 1_000_000_000).await;
+    let (admin_permission_pda, _) = get_permission_pda(&program_id, &admin.pubkey());
+
+    // Grant NETWORK_ADMIN to the admin (the foundation payer authorizes the create).
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(permission::create::PermissionCreateArgs {
+            user_payer: admin.pubkey(),
+            permissions: permission_flags::NETWORK_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(admin_permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let delete_ix = DoubleZeroInstruction::DeleteLink(LinkDeleteArgs {
+        use_onchain_deallocation: true,
+    });
+    // The topology union (unicast-default) trails the fixed accounts; payer/system/
+    // permission are appended after it, matching the on-wire layout the SDK emits.
+    let delete_accounts = vec![
+        AccountMeta::new(link_pubkey, false),
+        AccountMeta::new(contributor_pubkey, false),
+        AccountMeta::new(globalstate_pubkey, false),
+        AccountMeta::new(device_a_pubkey, false),
+        AccountMeta::new(device_z_pubkey, false),
+        AccountMeta::new(device_tunnel_block_pda, false),
+        AccountMeta::new(link_ids_pda, false),
+        AccountMeta::new(owner, false),
+        AccountMeta::new(unicast_default_pda, false),
+    ];
+
+    // Negative: without the Permission account on the tail, the non-owner admin is
+    // denied (legacy NETWORK_ADMIN = foundation only).
+    let blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx =
+        create_authorized_transaction(program_id, &delete_ix, &delete_accounts, &admin, None);
+    tx.try_sign(&[&admin], blockhash).unwrap();
+    let result = banks_client.process_transaction(tx).await;
+    match result {
+        Err(BanksClientError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(1),
+        ))) => {} // InvalidOwnerPubkey
+        _ => panic!("Expected InvalidOwnerPubkey (Custom(1)) without permission, got {result:?}"),
+    }
+    assert!(
+        get_account_data(&mut banks_client, link_pubkey)
+            .await
+            .is_some(),
+        "link must survive the unauthorized delete"
+    );
+
+    // Positive: with the Permission account appended after the topology union, the
+    // network admin can delete the link.
+    let blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx = create_authorized_transaction(
+        program_id,
+        &delete_ix,
+        &delete_accounts,
+        &admin,
+        Some(AccountMeta::new_readonly(admin_permission_pda, false)),
+    );
+    tx.try_sign(&[&admin], blockhash).unwrap();
+    banks_client.process_transaction(tx).await.unwrap();
+
+    assert!(
+        get_account_data(&mut banks_client, link_pubkey)
+            .await
+            .is_none(),
+        "link should be closed by the network admin"
+    );
+
+    println!("test_delete_link_via_network_admin_permission_with_topology_union PASSED");
+}
+
+/// A `NETWORK_ADMIN` Permission holder can update a link's `link_topologies` — a
+/// foundation/network-admin-only field — while a non-empty topology union rides in
+/// the same account tail as the appended Permission account. This is the `update`
+/// counterpart to the delete test above: it proves `split_trailing_permission`
+/// disambiguates the Permission PDA from the caller-controlled topology accounts on
+/// the update path too.
+#[tokio::test]
+async fn test_update_link_topologies_via_network_admin_permission() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, globalconfig_pubkey) =
+        setup_program_with_globalconfig().await;
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    let (
+        device_a_pubkey,
+        device_z_pubkey,
+        contributor_pubkey,
+        device_tunnel_block_pda,
+        link_ids_pda,
+    ) = setup_wan_link_infra(&mut banks_client, &payer, program_id, globalstate_pubkey).await;
+
+    let globalstate_account = get_globalstate(&mut banks_client, globalstate_pubkey).await;
+    let (link_pubkey, _) = get_link_pda(&program_id, globalstate_account.account_index + 1);
+
+    let unicast_default_pda = create_unicast_default_topology(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        globalconfig_pubkey,
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateLink(LinkCreateArgs {
+            code: "wan1".to_string(),
+            link_type: LinkLinkType::WAN,
+            bandwidth: 10_000_000_000,
+            mtu: 9000,
+            delay_ns: 500_000,
+            jitter_ns: 50000,
+            side_a_iface_name: "Ethernet0".to_string(),
+            side_z_iface_name: Some("Ethernet1".to_string()),
+            desired_status: Some(LinkDesiredStatus::Activated),
+            use_onchain_allocation: true,
+        }),
+        vec![
+            AccountMeta::new(link_pubkey, false),
+            AccountMeta::new(contributor_pubkey, false),
+            AccountMeta::new(device_a_pubkey, false),
+            AccountMeta::new(device_z_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(unicast_default_pda, false),
+            AccountMeta::new(device_tunnel_block_pda, false),
+            AccountMeta::new(link_ids_pda, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create a second topology to add to the link's topology set.
+    let (admin_group_bits_pda, _, _) =
+        get_resource_extension_pda(&program_id, ResourceType::AdminGroupBits);
+    let (second_topology_pda, _) = get_topology_pda(&program_id, "unicast-alt");
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreateTopology(topology::create::TopologyCreateArgs {
+            name: "unicast-alt".to_string(),
+            constraint: TopologyConstraint::IncludeAny,
+        }),
+        vec![
+            AccountMeta::new(second_topology_pda, false),
+            AccountMeta::new(admin_group_bits_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // A network admin that is neither the contributor owner nor a foundation member.
+    let admin = solana_sdk::signer::keypair::Keypair::new();
+    transfer(&mut banks_client, &payer, &admin.pubkey(), 1_000_000_000).await;
+    let (admin_permission_pda, _) = get_permission_pda(&program_id, &admin.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(permission::create::PermissionCreateArgs {
+            user_payer: admin.pubkey(),
+            permissions: permission_flags::NETWORK_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(admin_permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Add the second topology via UpdateLink. The caller passes the union of old ∪ new
+    // link_topologies (both PDAs) as writable accounts; they trail the fixed accounts,
+    // and payer/system/permission are appended after them.
+    let update_ix = DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
+        link_topologies: Some(vec![unicast_default_pda, second_topology_pda]),
+        ..Default::default()
+    });
+    let update_accounts = vec![
+        AccountMeta::new(link_pubkey, false),
+        AccountMeta::new(contributor_pubkey, false),
+        AccountMeta::new_readonly(globalstate_pubkey, false),
+        AccountMeta::new(unicast_default_pda, false),
+        AccountMeta::new(second_topology_pda, false),
+    ];
+    let blockhash = wait_for_new_blockhash(&mut banks_client).await;
+    let mut tx = create_authorized_transaction(
+        program_id,
+        &update_ix,
+        &update_accounts,
+        &admin,
+        Some(AccountMeta::new_readonly(admin_permission_pda, false)),
+    );
+    tx.try_sign(&[&admin], blockhash).unwrap();
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let link = get_account_data(&mut banks_client, link_pubkey)
+        .await
+        .expect("Link not found")
+        .get_tunnel()
+        .unwrap();
+    assert_eq!(
+        link.link_topologies,
+        vec![unicast_default_pda, second_topology_pda],
+        "network admin should have added the second topology to link_topologies"
+    );
+
+    println!("test_update_link_topologies_via_network_admin_permission PASSED");
 }

--- a/smartcontract/sdk/rs/src/commands/link/accept.rs
+++ b/smartcontract/sdk/rs/src/commands/link/accept.rs
@@ -53,7 +53,7 @@ impl AcceptLinkCommand {
             AccountMeta::new(link_ids_ext, false),
         ];
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::AcceptLink(LinkAcceptArgs {
                 side_z_iface_name: self.side_z_iface_name.clone(),
                 use_onchain_allocation: true,
@@ -140,7 +140,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::Device(device_z.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::AcceptLink(LinkAcceptArgs {
                     side_z_iface_name: "Ethernet1".to_string(),

--- a/smartcontract/sdk/rs/src/commands/link/create.rs
+++ b/smartcontract/sdk/rs/src/commands/link/create.rs
@@ -57,7 +57,7 @@ impl CreateLinkCommand {
         ];
 
         client
-            .execute_transaction(
+            .execute_authorized_transaction(
                 DoubleZeroInstruction::CreateLink(LinkCreateArgs {
                     code,
                     link_type: self.link_type,
@@ -107,7 +107,7 @@ mod tests {
         let side_z_pk = Pubkey::new_unique();
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::CreateLink(LinkCreateArgs {
                     code: "test".to_string(),

--- a/smartcontract/sdk/rs/src/commands/link/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/link/delete.rs
@@ -45,7 +45,7 @@ impl DeleteLinkCommand {
             accounts.push(AccountMeta::new(*topology_pk, false));
         }
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::DeleteLink(LinkDeleteArgs {
                 use_onchain_deallocation: true,
             }),
@@ -124,7 +124,7 @@ mod tests {
             .returning(move |_| Ok(AccountData::Link(link.clone())));
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .with(
                 predicate::eq(DoubleZeroInstruction::DeleteLink(LinkDeleteArgs {
                     use_onchain_deallocation: true,

--- a/smartcontract/sdk/rs/src/commands/link/sethealth.rs
+++ b/smartcontract/sdk/rs/src/commands/link/sethealth.rs
@@ -17,7 +17,7 @@ impl SetLinkHealthCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::SetLinkHealth(LinkSetHealthArgs {
                 health: self.health,
             }),

--- a/smartcontract/sdk/rs/src/commands/link/update.rs
+++ b/smartcontract/sdk/rs/src/commands/link/update.rs
@@ -123,7 +123,7 @@ impl UpdateLinkCommand {
             }
         }
 
-        client.execute_transaction(
+        client.execute_authorized_transaction(
             DoubleZeroInstruction::UpdateLink(LinkUpdateArgs {
                 code,
                 contributor_pk: self.contributor_pk,
@@ -247,7 +247,7 @@ mod tests {
             setup_link_and_contributors(&mut client, payer);
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .withf(move |_, accounts| {
                 accounts.len() == 4
                     && accounts[0].pubkey == link_pubkey
@@ -271,7 +271,7 @@ mod tests {
             setup_link_and_contributors(&mut client, Pubkey::new_unique());
 
         client
-            .expect_execute_transaction()
+            .expect_execute_authorized_transaction()
             .withf(move |_, accounts| {
                 accounts.len() == 3
                     && accounts[0].pubkey == link_pubkey


### PR DESCRIPTION
## Summary

Gate Link instructions on `NETWORK_ADMIN` (and `HEALTH_ORACLE` for `sethealth`) via `authorize()`, preserving the contributor-owner path:

- `create`, `update`, `delete`, `suspend`, `resume`, `accept`, `sethealth`

Owner-or-admin handlers become `owner OR authorize(NETWORK_ADMIN)`; `accept` (previously owner-only) gains a NETWORK_ADMIN bypass; `sethealth` composes `HEALTH_ORACLE | NETWORK_ADMIN`. `delete` and `update` are variable-length (topology union parsed off the tail) and use `split_trailing_permission` so the trailing Permission PDA is disambiguated by PDA match. Internal foundation-only sub-gates (per-link contributor binding, tunnel-field / topology / unicast_drained edits) are extended to `NETWORK_ADMIN` holders.

Behavior preserved via the legacy fallback while `RequirePermissionAccounts` is off. One PR per domain; see PERMISSION.md.

## Testing Verification

- Link WAN / onchain-allocation / bandwidth-validation integration suites and SDK command tests pass.
- `cargo test -p doublezero-serviceability`, `cargo test -p doublezero_sdk`, `make rust-lint` pass.

---

## Permission migration series

One of 8 per-domain PRs migrating serviceability instructions to the Permission (`authorize()`) system. The branches partition the change set with no overlap and can be reviewed and merged independently (only the CHANGELOG entry conflicts trivially).

| PR | Domain | Flag(s) |
|----|--------|---------|
| #3977 | Governance (globalstate/globalconfig/allowlists) | GLOBALSTATE_ADMIN |
| #3978 | Contributor | CONTRIBUTOR_ADMIN |
| #3979 | Infra (location/exchange) | INFRA_ADMIN |
| #3980 | Devices + interfaces | NETWORK_ADMIN, HEALTH_ORACLE |
| #3981 | Links | NETWORK_ADMIN, HEALTH_ORACLE ← this PR |
| #3982 | Multicast | MULTICAST_ADMIN, ACCESS_PASS_ADMIN |
| #3983 | Tenant | TENANT_ADMIN |
| #3984 | User (update / check_access_pass / check_status) | USER_ADMIN, ACTIVATOR |
