### PR TITLE
client/doublezero connect: surface underlying CreateUser error

### DIFF
--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -746,7 +746,9 @@ impl ProvisioningCliCommand {
                             Err(e) => {
                                 spinner.println("❌ Error adding publisher subscription");
                                 spinner.println(format!("\n{}: {:?}\n", "Error", e));
-                                eyre::bail!("Error adding publisher subscription to existing user");
+                                eyre::bail!(
+                                    "Error adding publisher subscription to existing user: {e:?}"
+                                );
                             }
                         }
                     }
@@ -776,7 +778,7 @@ impl ProvisioningCliCommand {
                                 spinner.println("❌ Error adding subscriber subscription");
                                 spinner.println(format!("\n{}: {:?}\n", "Error", e));
                                 eyre::bail!(
-                                    "Error adding subscriber subscription to existing user"
+                                    "Error adding subscriber subscription to existing user: {e:?}"
                                 );
                             }
                         }

--- a/client/doublezero/src/command/connect.rs
+++ b/client/doublezero/src/command/connect.rs
@@ -583,7 +583,7 @@ impl ProvisioningCliCommand {
                         spinner.println("❌ Error creating user");
                         spinner.println(format!("\n{}: {:?}\n", "Error", e));
 
-                        Err(eyre::eyre!("Error creating user"))
+                        Err(eyre::eyre!("Error creating user: {e:?}"))
                     }
                 }
             }?,
@@ -829,7 +829,7 @@ impl ProvisioningCliCommand {
                     Err(e) => {
                         spinner.println("❌ Error creating user");
                         spinner.println(format!("\n{}: {:?}\n", "Error", e));
-                        return Err(eyre::eyre!("Error creating user"));
+                        return Err(eyre::eyre!("Error creating user: {e:?}"));
                     }
                 };
 


### PR DESCRIPTION
## Summary of Changes

- `doublezero connect` swallowed the real error on `CreateUser` failure: both arms returned a bare `eyre::eyre!("Error creating user")` and dropped `e`, so the underlying cause (e.g. `unable to confirm transaction`, an access-pass/allowlist rejection, etc.) only went to the suppressed spinner `println` and never reached the returned error / caller logs.
- Include `{e:?}` in the returned error at both sites (`connect.rs:586`, `connect.rs:832`) so the cause is visible to callers (the QA e2e harness surfaces it directly; interactive users still get the spinner detail too).

## Testing Verification

- `cargo build` of the client with this change was exercised earlier as a snapshot (`0.29.0-SNAPSHOT`) deployed to the QA hosts; it's what made the underlying `CreateUser` failure legible ("Error creating user: unable to confirm transaction …") that led to the DZ-ledger cluster + oracle root causes.
