### PR TITLE
cli: block device delete while enabled in shred-subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- SDK
-  - Rename serviceability permission-flag bit 6 from `PERMISSION_FLAG_RESERVATION` to `PERMISSION_FLAG_FEED_AUTHORITY` in the TypeScript and Python SDKs, matching the on-chain program and Go SDK (bit value unchanged). (#3985)
 - Serviceability
   - Gate Device and device-interface instructions on `NETWORK_ADMIN` (and `HEALTH_ORACLE` for sethealth) or the contributor owner via `authorize()`; internal foundation-only sub-gates now also accept NETWORK_ADMIN holders. (#3980)
   - Gate UpdateUser on `USER_ADMIN`, CheckAccessPass on `ACTIVATOR`, and accesspass CheckStatus on `ACTIVATOR|USER_ADMIN` via `authorize()`; user create and set_bgp_status remain owner-authorized (not part of the admin Permission system). (#3984)
@@ -25,6 +23,7 @@ All notable changes to this project will be documented in this file.
   - Restrict granting the `FOUNDATION` permission flag: a plain `PERMISSION_ADMIN` holder can no longer grant `FOUNDATION` (a privilege escalation). Only a `foundation_allowlist` member or an existing `FOUNDATION` holder may grant it, enforced independently of `RequirePermissionAccounts` so foundation members are never locked out.
 - CLI
   - Add `doublezero permission audit` to check legacy→Permission parity before enabling `require-permission-accounts`: it reports which legacy keys would lose access to migrated instructions (coverage gaps, non-zero exit), super-admin holders, and the non-migrated subsystems that still depend on the GlobalState allowlists.
+  - Block `doublezero device delete` when the device is still enabled in the shred-subscription program (checked via its `DeviceHistory` account on Solana L1), preventing an orphaned device that deadlocks shred oracle epoch settlement. (#3989)
 - E2E
   - Fix the multicast settlement QA test's seat-allocation ack wait. It read the reused client seat at finalized commitment and could accept the previous run's already-acked state, then withdraw while the current request was still pending. It now waits to observe the request pending before treating a cleared flag as the ack. (#3972)
 - Sentinel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,7 @@ name = "doublezero-serviceability-cli"
 version = "0.29.0"
 dependencies = [
  "anyhow",
+ "borsh",
  "chrono",
  "clap",
  "console",

--- a/config/src/constants.rs
+++ b/config/src/constants.rs
@@ -10,6 +10,13 @@ pub const ENV_TESTNET_SHORT_NAME: &str = "t";
 pub const ENV_DEVNET_SHORT_NAME: &str = "d";
 pub const ENV_LOCALNET_SHORT_NAME: &str = "l";
 
+// The shred-subscription program is deployed on Solana mainnet-beta and Solana
+// devnet under this same ID. Which cluster a DoubleZero environment queries is
+// captured by the `*_SHRED_SOLANA_RPC_URL` constants (DZ mainnet-beta -> Solana
+// mainnet-beta, DZ testnet -> Solana devnet).
+pub const SHRED_SUBSCRIPTION_PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("dzshrr3yL57SB13sJPYHYo3TV8Bo1i1FxkyrZr3bKNE");
+
 // Constants related to DoubleZero mainnet-beta configuration
 pub const ENV_MAINNET_BETA_DOUBLEZERO_LEDGER_RPC_URL: &str =
     "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab";
@@ -24,6 +31,8 @@ pub const ENV_MAINNET_BETA_INTERNET_LATENCY_COLLECTOR_PUBKEY: Pubkey =
     Pubkey::from_str_const("8xHn4r7oQuqNZ5cLYwL5YZcDy1JjDQcpVkyoA8Dw5uXH");
 pub const ENV_MAINNET_BETA_GEOLOCATION_PUBKEY: Pubkey =
     Pubkey::from_str_const("8H7nS6eZiuf7rGQtz3PPz2q9m4eJRL37PPM678KHnspG");
+// The shred-subscription program for mainnet-beta runs on Solana mainnet-beta.
+pub const ENV_MAINNET_BETA_SHRED_SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 
 // Constants related to DoubleZero testnet configuration
 pub const ENV_TESTNET_DOUBLEZERO_LEDGER_RPC_URL: &str =
@@ -39,6 +48,10 @@ pub const ENV_TESTNET_INTERNET_LATENCY_COLLECTOR_PUBKEY: Pubkey =
     Pubkey::from_str_const("HWGQSTmXWMB85NY2vFLhM1nGpXA8f4VCARRyeGNbqDF1");
 pub const ENV_TESTNET_GEOLOCATION_PUBKEY: Pubkey =
     Pubkey::from_str_const("3AG2BCA7gAm47Q6xZzPQcUUYvnBjxAvPKnPz919cxHF4");
+// The shred-subscription program for DZ testnet runs on Solana devnet, so the
+// DeviceHistory guard must query Solana devnet — not Solana testnet, where
+// ENV_TESTNET_SOLANA_L1_RPC_URL points.
+pub const ENV_TESTNET_SHRED_SOLANA_RPC_URL: &str = "https://api.devnet.solana.com";
 
 // Constants related to DoubleZero devnet configuration
 //

--- a/config/src/env.rs
+++ b/config/src/env.rs
@@ -109,6 +109,46 @@ impl Environment {
 
         Ok(config)
     }
+
+    /// Connection details for the shred-subscription program on Solana L1.
+    ///
+    /// Returns `None` for environments where the shred-subscription program is
+    /// not deployed (devnet, local). Note the Solana cluster differs from
+    /// [`NetworkConfig::solana_l1_rpc_url`]: DZ testnet's shred-subscription
+    /// program runs on Solana devnet, not Solana testnet.
+    pub fn shred_subscription_config(&self) -> Option<ShredSubscriptionConfig> {
+        let mut config = match self {
+            Environment::MainnetBeta => ShredSubscriptionConfig {
+                program_id: SHRED_SUBSCRIPTION_PROGRAM_ID,
+                solana_rpc_url: ENV_MAINNET_BETA_SHRED_SOLANA_RPC_URL.to_string(),
+            },
+            Environment::Testnet => ShredSubscriptionConfig {
+                program_id: SHRED_SUBSCRIPTION_PROGRAM_ID,
+                solana_rpc_url: ENV_TESTNET_SHRED_SOLANA_RPC_URL.to_string(),
+            },
+            Environment::Devnet | Environment::Local => return None,
+        };
+
+        // Allow overriding the Solana RPC endpoint (mirrors DZ_SOLANA_RPC_URL in
+        // config()): lets operators avoid the rate-limited public RPC and lets
+        // the e2e harness point the check at a local validator.
+        if std::env::var("DZ_SHRED_SOLANA_RPC_URL").is_ok() {
+            config.solana_rpc_url = std::env::var("DZ_SHRED_SOLANA_RPC_URL").unwrap();
+        }
+
+        Some(config)
+    }
+}
+
+/// Connection details for the shred-subscription program on Solana L1.
+///
+/// Distinct from [`NetworkConfig`] because the shred-subscription program can
+/// live on a different Solana cluster than the one used for general L1 access
+/// (e.g. DZ testnet's shred-subscription runs on Solana devnet).
+#[derive(Debug, Clone)]
+pub struct ShredSubscriptionConfig {
+    pub program_id: Pubkey,
+    pub solana_rpc_url: String,
 }
 
 #[derive(Debug, Clone)]
@@ -291,6 +331,55 @@ mod tests {
         let config = Environment::MainnetBeta.config().unwrap();
         assert_eq!(config.solana_l1_rpc_url, "https://custom-solana.example/");
         std::env::remove_var("DZ_SOLANA_RPC_URL");
+    }
+
+    #[test]
+    #[serial]
+    fn test_shred_subscription_config() {
+        std::env::remove_var("DZ_SHRED_SOLANA_RPC_URL");
+
+        // Mainnet-beta shred-subscription lives on Solana mainnet-beta.
+        let mainnet = Environment::MainnetBeta
+            .shred_subscription_config()
+            .unwrap();
+        assert_eq!(
+            mainnet.program_id.to_string(),
+            "dzshrr3yL57SB13sJPYHYo3TV8Bo1i1FxkyrZr3bKNE",
+        );
+        assert_eq!(
+            mainnet.solana_rpc_url,
+            "https://api.mainnet-beta.solana.com"
+        );
+
+        // DZ testnet's shred-subscription runs on Solana devnet (not Solana
+        // testnet, where solana_l1_rpc_url points).
+        let testnet = Environment::Testnet.shred_subscription_config().unwrap();
+        assert_eq!(
+            testnet.program_id.to_string(),
+            "dzshrr3yL57SB13sJPYHYo3TV8Bo1i1FxkyrZr3bKNE",
+        );
+        assert_eq!(testnet.solana_rpc_url, "https://api.devnet.solana.com");
+        assert_ne!(
+            testnet.solana_rpc_url,
+            Environment::Testnet.config().unwrap().solana_l1_rpc_url,
+        );
+
+        // Shred-subscription is not deployed on devnet or local.
+        assert!(Environment::Devnet.shred_subscription_config().is_none());
+        assert!(Environment::Local.shred_subscription_config().is_none());
+
+        // DZ_SHRED_SOLANA_RPC_URL overrides the endpoint, but does not resurrect
+        // environments without a deployed program.
+        std::env::set_var("DZ_SHRED_SOLANA_RPC_URL", "http://localhost:8899");
+        assert_eq!(
+            Environment::MainnetBeta
+                .shred_subscription_config()
+                .unwrap()
+                .solana_rpc_url,
+            "http://localhost:8899"
+        );
+        assert!(Environment::Devnet.shred_subscription_config().is_none());
+        std::env::remove_var("DZ_SHRED_SOLANA_RPC_URL");
     }
 
     #[test]

--- a/e2e/internal/devnet/manager.go
+++ b/e2e/internal/devnet/manager.go
@@ -191,6 +191,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			"DZ_LEDGER_WS":                           m.dn.Ledger.InternalRPCWSURL,
 			"DZ_SERVICEABILITY_PROGRAM_KEYPAIR_PATH": serviceabilityProgramContainerKeypairPath,
 			"DZ_TELEMETRY_PROGRAM_KEYPAIR_PATH":      telemetryProgramContainerKeypairPath,
+			"DZ_SHRED_SOLANA_RPC_URL":                m.dn.Ledger.InternalRPCURL,
 		},
 		Files: []testcontainers.ContainerFile{
 			{

--- a/smartcontract/cli/Cargo.toml
+++ b/smartcontract/cli/Cargo.toml
@@ -14,6 +14,7 @@ name = "doublezero_serviceability_cli"
 
 [dependencies]
 anyhow.workspace = true
+borsh.workspace = true
 ipnetwork.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/smartcontract/cli/src/device/delete.rs
+++ b/smartcontract/cli/src/device/delete.rs
@@ -1,4 +1,5 @@
 use crate::{
+    device::shred_guard::ensure_device_not_enabled_in_shred_subscription,
     doublezerocommand::CliCommand,
     requirements::{CHECK_BALANCE, CHECK_ID_JSON},
     validators::validate_pubkey_or_code,
@@ -18,7 +19,7 @@ pub struct DeleteDeviceCliCommand {
 impl DeleteDeviceCliCommand {
     pub async fn execute<C: CliCommand, W: Write>(
         self,
-        _ctx: &CliContext,
+        ctx: &CliContext,
         client: &C,
         out: &mut W,
     ) -> eyre::Result<()> {
@@ -30,6 +31,8 @@ impl DeleteDeviceCliCommand {
                 pubkey_or_code: self.pubkey,
             })
             .map_err(|_| eyre::eyre!("Device not found"))?;
+
+        ensure_device_not_enabled_in_shred_subscription(ctx.env, &pubkey).await?;
 
         let signature = client.delete_device(DeleteDeviceCommand { pubkey })?;
         writeln!(out, "Signature: {signature}",)?;

--- a/smartcontract/cli/src/device/mod.rs
+++ b/smartcontract/cli/src/device/mod.rs
@@ -6,4 +6,5 @@ pub mod list;
 pub mod migrate_multicast_counts;
 pub mod migrate_unicast_counts;
 pub mod sethealth;
+pub mod shred_guard;
 pub mod update;

--- a/smartcontract/cli/src/device/shred_guard.rs
+++ b/smartcontract/cli/src/device/shred_guard.rs
@@ -1,0 +1,378 @@
+//! Guard that prevents deleting a serviceability device while it is still
+//! enabled in the shred-subscription program.
+
+use borsh::BorshDeserialize;
+use doublezero_config::{Environment, ShredSubscriptionConfig};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    account::Account, commitment_config::CommitmentConfig, hash::hash, pubkey::Pubkey,
+};
+use std::{future::Future, sync::LazyLock, time::Duration};
+
+/// PDA seed for DeviceHistory accounts (see `sdk/shreds/go/pda.go`).
+const DEVICE_HISTORY_SEED: &[u8] = b"device_history";
+
+/// Length of a shred-subscription account discriminator.
+const DISCRIMINATOR_LEN: usize = 8;
+
+/// `enabled` is bit 1 of `DeviceHistory::flags` (see `DeviceHistory::IsEnabled`
+/// in `sdk/shreds/go/state.go`).
+const ENABLED_FLAG: u64 = 1 << 1;
+
+/// Bounds each Solana RPC call so a hung endpoint can't hang the delete.
+const SHRED_RPC_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Number of attempts for the DeviceHistory lookup before failing closed. The
+/// default RPC is the public, rate-limited Solana endpoint, so a transient 429
+/// or timeout should retry rather than abort a legitimate delete.
+const SHRED_RPC_ATTEMPTS: usize = 3;
+
+/// Delay between DeviceHistory RPC retry attempts.
+const SHRED_RPC_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// Account discriminator: first 8 bytes of `sha256("dz::account::device_history")`
+/// (Solana's `hash` is SHA-256), matching `sdk/shreds/go/discriminator.go`.
+static DEVICE_HISTORY_DISCRIMINATOR: LazyLock<[u8; DISCRIMINATOR_LEN]> = LazyLock::new(|| {
+    hash(b"dz::account::device_history").to_bytes()[..DISCRIMINATOR_LEN]
+        .try_into()
+        .expect("sha256 digest is 32 bytes")
+});
+
+/// Leading fields of the shred-subscription `DeviceHistory` account, up to the
+/// `flags` we read. Mirrors `DeviceHistory` in `sdk/shreds/go/state.go`.
+///
+/// Do NOT add fields past `flags`: the onchain account is a fixed C-style layout
+/// (read via `binary.Read` in the Go SDK) with padding after `flags`. Borsh
+/// coincides with that layout only for these leading, unpadded fields; anything
+/// added after would decode at the wrong offset. `deserialize` (not
+/// `try_from_slice`) is used so the trailing account bytes are ignored.
+#[derive(BorshDeserialize)]
+struct DeviceHistoryHeader {
+    #[allow(dead_code)]
+    device_key: [u8; 32],
+    flags: u64,
+}
+
+/// Errors out if `device_pubkey` still has an enabled DeviceHistory account in
+/// the shred-subscription program.
+///
+/// Fail-closed: any RPC failure aborts (returns an error) rather than allowing
+/// a potentially unsafe delete. Environments without a deployed
+/// shred-subscription program (devnet, local) are skipped.
+pub async fn ensure_device_not_enabled_in_shred_subscription(
+    env: Environment,
+    device_pubkey: &Pubkey,
+) -> eyre::Result<()> {
+    let Some(cfg) = env.shred_subscription_config() else {
+        // Shred-subscription is not deployed for this environment.
+        return Ok(());
+    };
+
+    let rpc = RpcClient::new_with_timeout(cfg.solana_rpc_url.clone(), SHRED_RPC_TIMEOUT);
+    let rpc_url = cfg.solana_rpc_url.clone();
+
+    check_device_history(&cfg, device_pubkey, move |history_pda| async move {
+        fetch_with_retry(SHRED_RPC_ATTEMPTS, SHRED_RPC_RETRY_DELAY, || async {
+            rpc.get_account_with_commitment(&history_pda, CommitmentConfig::confirmed())
+                .await
+                .map(|response| response.value)
+        })
+        .await
+        .map_err(|e| {
+            eyre::eyre!(
+                "failed to query shred-subscription DeviceHistory {history_pda} on {rpc_url} \
+                 after {SHRED_RPC_ATTEMPTS} attempts: {e}"
+            )
+        })
+    })
+    .await
+}
+
+/// Runs `fetch` up to `attempts` times, sleeping `delay` between failures, and
+/// returns the first success or the last error. Bounds transient RPC failures
+/// (e.g. a 429 from the public Solana endpoint) without silently allowing the
+/// delete.
+async fn fetch_with_retry<T, E, F, Fut>(attempts: usize, delay: Duration, fetch: F) -> Result<T, E>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match fetch().await {
+            Ok(value) => return Ok(value),
+            Err(e) if attempt >= attempts => return Err(e),
+            Err(_) => std::thread::sleep(delay),
+        }
+    }
+}
+
+/// Derives the DeviceHistory PDA, fetches it via `fetch`, and decides whether the
+/// delete may proceed. Split from the RPC client so the fetch can be mocked.
+async fn check_device_history<F, Fut>(
+    cfg: &ShredSubscriptionConfig,
+    device_pubkey: &Pubkey,
+    fetch: F,
+) -> eyre::Result<()>
+where
+    F: FnOnce(Pubkey) -> Fut,
+    Fut: Future<Output = eyre::Result<Option<Account>>>,
+{
+    let (history_pda, _bump) = Pubkey::find_program_address(
+        &[DEVICE_HISTORY_SEED, device_pubkey.as_ref()],
+        &cfg.program_id,
+    );
+
+    let account = fetch(history_pda).await?;
+
+    evaluate_device_history(
+        account.as_ref(),
+        &cfg.program_id,
+        device_pubkey,
+        &history_pda,
+        &cfg.solana_rpc_url,
+    )
+}
+
+/// Decides whether a delete may proceed given the fetched DeviceHistory account.
+///
+/// Fails only when the account exists, is owned by the shred-subscription
+/// program, and is enabled. An absent account, or one owned by another program,
+/// is treated as "not enabled" (safe to delete).
+fn evaluate_device_history(
+    account: Option<&Account>,
+    program_id: &Pubkey,
+    device_pubkey: &Pubkey,
+    history_pda: &Pubkey,
+    solana_rpc_url: &str,
+) -> eyre::Result<()> {
+    let Some(account) = account else {
+        // No DeviceHistory account: the device was never enrolled in
+        // shred-subscription, so it is safe to delete.
+        return Ok(());
+    };
+
+    // Only trust accounts actually owned by the shred-subscription program.
+    if account.owner != *program_id {
+        return Ok(());
+    }
+
+    if device_history_enabled(&account.data)? {
+        eyre::bail!(
+            "Device {device_pubkey} is still enabled in the shred-subscription program \
+             (DeviceHistory {history_pda} on {solana_rpc_url}). Disable it there before deleting \
+             the device."
+        );
+    }
+
+    Ok(())
+}
+
+/// Parses a raw DeviceHistory account and returns whether it is enabled.
+///
+/// Validates the discriminator and length so an unexpected account layout is
+/// reported as an error rather than silently misread.
+fn device_history_enabled(data: &[u8]) -> eyre::Result<bool> {
+    if data.len() < DISCRIMINATOR_LEN {
+        eyre::bail!(
+            "shred-subscription DeviceHistory account is too small: {} bytes",
+            data.len()
+        );
+    }
+    if data[..DISCRIMINATOR_LEN] != *DEVICE_HISTORY_DISCRIMINATOR {
+        eyre::bail!("shred-subscription DeviceHistory account has an unexpected discriminator");
+    }
+    let header = DeviceHistoryHeader::deserialize(&mut &data[DISCRIMINATOR_LEN..])?;
+    Ok(header.flags & ENABLED_FLAG != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use doublezero_cli_core::testing::block_on;
+
+    fn make_account(flags: u64, discriminator: [u8; DISCRIMINATOR_LEN]) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&discriminator);
+        data.extend_from_slice(&[0u8; 32]); // device_key
+        data.extend_from_slice(&flags.to_le_bytes());
+        data.extend_from_slice(&[0u8; 16]); // trailing bytes are tolerated
+        data
+    }
+
+    #[test]
+    fn test_enabled_flag_set() {
+        let data = make_account(ENABLED_FLAG, *DEVICE_HISTORY_DISCRIMINATOR);
+        assert!(device_history_enabled(&data).unwrap());
+    }
+
+    #[test]
+    fn test_enabled_flag_clear() {
+        let data = make_account(0, *DEVICE_HISTORY_DISCRIMINATOR);
+        assert!(!device_history_enabled(&data).unwrap());
+        // Other flag bits set, but not the enabled bit.
+        let data = make_account((1 << 0) | (1 << 2), *DEVICE_HISTORY_DISCRIMINATOR);
+        assert!(!device_history_enabled(&data).unwrap());
+    }
+
+    #[test]
+    fn test_wrong_discriminator_errors() {
+        let data = make_account(ENABLED_FLAG, [0; DISCRIMINATOR_LEN]);
+        assert!(device_history_enabled(&data).is_err());
+    }
+
+    #[test]
+    fn test_too_short_errors() {
+        assert!(device_history_enabled(&[0u8; 4]).is_err());
+    }
+
+    #[test]
+    fn test_truncated_body_errors() {
+        // Correct discriminator but not enough bytes for device_key + flags.
+        let mut data = DEVICE_HISTORY_DISCRIMINATOR.to_vec();
+        data.extend_from_slice(&[0u8; 10]);
+        assert!(device_history_enabled(&data).is_err());
+    }
+
+    fn account_with(flags: u64, owner: Pubkey) -> Account {
+        Account {
+            data: make_account(flags, *DEVICE_HISTORY_DISCRIMINATOR),
+            owner,
+            ..Default::default()
+        }
+    }
+
+    fn test_cfg(program_id: Pubkey) -> ShredSubscriptionConfig {
+        ShredSubscriptionConfig {
+            program_id,
+            solana_rpc_url: "http://mock".to_string(),
+        }
+    }
+
+    // The following tests drive the full check_device_history wiring (derive PDA
+    // → fetch → decide) with a mocked fetcher, exercising the bail/allow paths
+    // without a real RPC.
+
+    #[test]
+    fn test_enabled_account_blocks_delete() {
+        let cfg = test_cfg(Pubkey::new_unique());
+        let account = account_with(ENABLED_FLAG, cfg.program_id);
+        let res = block_on(check_device_history(
+            &cfg,
+            &Pubkey::new_unique(),
+            move |_pda| async move { Ok(Some(account)) },
+        ));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_disabled_account_allows_delete() {
+        let cfg = test_cfg(Pubkey::new_unique());
+        let account = account_with(0, cfg.program_id);
+        let res = block_on(check_device_history(
+            &cfg,
+            &Pubkey::new_unique(),
+            move |_pda| async move { Ok(Some(account)) },
+        ));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_absent_account_allows_delete() {
+        let cfg = test_cfg(Pubkey::new_unique());
+        let res = block_on(check_device_history(
+            &cfg,
+            &Pubkey::new_unique(),
+            |_pda| async move { Ok(None) },
+        ));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_wrong_owner_allows_delete() {
+        // Enabled data, but owned by a different program → not a real
+        // DeviceHistory, so the delete is allowed.
+        let cfg = test_cfg(Pubkey::new_unique());
+        let account = account_with(ENABLED_FLAG, Pubkey::new_unique());
+        let res = block_on(check_device_history(
+            &cfg,
+            &Pubkey::new_unique(),
+            move |_pda| async move { Ok(Some(account)) },
+        ));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_fetch_error_fails_closed() {
+        // An RPC failure must abort the delete (fail-closed), not allow it.
+        let cfg = test_cfg(Pubkey::new_unique());
+        let res = block_on(check_device_history(
+            &cfg,
+            &Pubkey::new_unique(),
+            |_pda| async move { Err(eyre::eyre!("rpc unavailable")) },
+        ));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_fetch_with_retry_recovers_after_transient_errors() {
+        let calls = std::cell::Cell::new(0u32);
+        let res: Result<u8, &str> = block_on(fetch_with_retry(3, Duration::ZERO, || {
+            let n = calls.get();
+            calls.set(n + 1);
+            async move {
+                if n < 2 {
+                    Err("transient")
+                } else {
+                    Ok(7)
+                }
+            }
+        }));
+        assert_eq!(res.unwrap(), 7);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn test_fetch_with_retry_gives_up_after_attempts() {
+        let calls = std::cell::Cell::new(0u32);
+        let res: Result<u8, &str> = block_on(fetch_with_retry(3, Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            async move { Err("always") }
+        }));
+        assert!(res.is_err());
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn test_device_history_pda_matches_known_incident() {
+        // The DeviceHistory PDA is derived from the serviceability device pubkey.
+        // Confirm that assumption against the real orphaned device and its
+        // DeviceHistory PDA observed in the incident that motivated this guard.
+        let device = Pubkey::from_str_const("4gK6BJ14TBSdSaAFLJyWaiZFkuxztvWzBz2suUSTKMYo");
+        let program = Pubkey::from_str_const("dzshrr3yL57SB13sJPYHYo3TV8Bo1i1FxkyrZr3bKNE");
+        let (pda, _bump) =
+            Pubkey::find_program_address(&[DEVICE_HISTORY_SEED, device.as_ref()], &program);
+        assert_eq!(
+            pda,
+            Pubkey::from_str_const("8kBDWyUxWSEGXGu4HTxJysj7r9PKDG6te2Na6XrCvSe8")
+        );
+    }
+
+    #[test]
+    fn test_skips_when_shred_not_deployed() {
+        // Devnet and local have no shred-subscription program, so the guard is
+        // a no-op and makes no network call.
+        let device = Pubkey::new_unique();
+        assert!(block_on(ensure_device_not_enabled_in_shred_subscription(
+            Environment::Devnet,
+            &device
+        ))
+        .is_ok());
+        assert!(block_on(ensure_device_not_enabled_in_shred_subscription(
+            Environment::Local,
+            &device
+        ))
+        .is_ok());
+    }
+}

--- a/smartcontract/cli/src/device/shred_guard.rs
+++ b/smartcontract/cli/src/device/shred_guard.rs
@@ -4,9 +4,7 @@
 use borsh::BorshDeserialize;
 use doublezero_config::{Environment, ShredSubscriptionConfig};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    account::Account, commitment_config::CommitmentConfig, hash::hash, pubkey::Pubkey,
-};
+use solana_sdk::{account::Account, hash::hash, pubkey::Pubkey};
 use std::{future::Future, sync::LazyLock, time::Duration};
 
 /// PDA seed for DeviceHistory accounts (see `sdk/shreds/go/pda.go`).
@@ -73,7 +71,7 @@ pub async fn ensure_device_not_enabled_in_shred_subscription(
 
     check_device_history(&cfg, device_pubkey, move |history_pda| async move {
         fetch_with_retry(SHRED_RPC_ATTEMPTS, SHRED_RPC_RETRY_DELAY, || async {
-            rpc.get_account_with_commitment(&history_pda, CommitmentConfig::confirmed())
+            rpc.get_account_with_commitment(&history_pda, rpc.commitment())
                 .await
                 .map(|response| response.value)
         })


### PR DESCRIPTION
## Summary

- `doublezero device delete` now refuses to delete a serviceability device that is still **enabled** in the shred-subscription program. Deleting such a device orphans it: the shred oracle only settles `Activated` serviceability devices, so it can never settle the orphan, yet the orphan still counts toward `total_enabled_devices` and permanently deadlocks epoch advance. This implements step N3 ("prevent recurrence") of malbeclabs/infra#1769.
- The guard derives the device's `DeviceHistory` PDA and checks its `enabled` flag on the correct Solana L1 cluster before submitting the delete: DZ mainnet-beta → Solana mainnet-beta, DZ testnet → Solana **devnet** (testnet's shred-subscription runs on Solana devnet, not Solana testnet). On devnet/local, where the program isn't deployed, the check is skipped.
- Fail-closed: any RPC error aborts the delete (no bypass flag). A device whose `DeviceHistory` exists but is already disabled is still allowed to be deleted.

## Design notes

- This is a CLI-side guard (advisory): it prevents the operator accident that caused the incident without coupling the serviceability program to shred-subscription onchain or requiring a program redeploy. The issue also lists an onchain guard/CPI and oracle-side reconciliation as alternatives; those remain open as separate hardening options.
- Scope is `device delete` only (not drain / `device update`→Drained), per discussion.
- The shred-subscription program has no Rust SDK in-repo; the account layout (PDA seeds `["device_history", device_pubkey]`, discriminator, and `enabled` = flag bit 1 at offset 40) is mirrored from the Go SDK at `sdk/shreds/go/`.

## Testing Verification

- Added a config mapping test asserting DZ testnet resolves the shred check to Solana devnet (and that it differs from the testnet `solana_l1_rpc_url`, which is Solana testnet), and that devnet/local return no config.
- Added unit tests for the `DeviceHistory` flag parser: enabled bit set/clear, wrong discriminator, and too-short account.
- Confirmed the guard short-circuits with no network call on devnet/local — the existing `device delete` CLI test runs under `Environment::Local` and stays green.

Implements step N3 of malbeclabs/infra#1769.
