### PR TITLE
ci(release.docker.client): auto-publish mainnet-beta base + notify edge-connect

### DIFF
--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -8,6 +8,11 @@ on:
   workflow_run:
     workflows: ["releaser.client"]
     types: [completed]
+  # Daily auto-publish of the mainnet-beta image when the stable Cloudsmith channel
+  # advances (guarded below so a run with no new version is a no-op). This removes
+  # the manual-only gate that previously left :mainnet-beta lagging the release.
+  schedule:
+    - cron: "37 5 * * *" # daily 05:37 UTC
   pull_request:
     paths:
       - "client/Dockerfile"
@@ -103,10 +108,26 @@ jobs:
             ${{ env.IMAGE }}:testnet
             ${{ env.IMAGE }}:testnet-${{ steps.v.outputs.version }}
 
-  # Manual dispatch path: publish mainnet-beta tags (:mainnet-beta, :version, :latest).
-  # The version can be supplied directly or resolved from the public Cloudsmith repo.
+      # Tell doublezero-edge-connect to rebuild its :testnet variant against the
+      # base image we just published (event-driven; its daily poll is the fallback).
+      - name: Notify edge-connect to rebuild (testnet)
+        if: steps.v.outputs.publish == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'doublezero-edge-connect',
+              event_type: 'doublezero-base-published',
+              client_payload: { env: 'testnet', version: '${{ steps.v.outputs.version }}' },
+            });
+
+  # mainnet-beta image publish: manual (workflow_dispatch) or automatic (schedule).
+  # The version is resolved from the mainnet-beta stable Cloudsmith channel (the
+  # deliberate promotion gate), so this is NOT chained off every client/v* tag.
   publish-mainnet-beta:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,7 +157,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Idempotency guard: skip the (re)publish when the already-published
+      # :mainnet-beta image is at the same version the stable channel resolves to.
+      # A manual workflow_dispatch always publishes (override).
+      - name: Decide whether a publish is needed
+        id: gate
+        shell: bash
+        run: |
+          want='${{ steps.v.outputs.version }}'
+          have="$(docker buildx imagetools inspect \
+            --format '{{ index .Image.Config.Labels "org.opencontainers.image.version" }}' \
+            '${{ env.IMAGE }}:mainnet-beta' 2>/dev/null || true)"
+          echo "published mainnet-beta version: ${have:-<none>} ; stable channel latest: $want"
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$want" != "$have" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "mainnet-beta image already at $have; nothing to do"
+          fi
+
       - name: Build & push (:mainnet-beta + version + :latest)
+        if: steps.gate.outputs.changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./client
@@ -156,6 +199,21 @@ jobs:
             ${{ env.IMAGE }}:mainnet-beta
             ${{ env.IMAGE }}:mainnet-beta-${{ steps.v.outputs.tag }}
             ${{ env.IMAGE }}:latest
+
+      # Tell doublezero-edge-connect to rebuild its :mainnet-beta variant against
+      # the base image we just published (event-driven; poll is the fallback).
+      - name: Notify edge-connect to rebuild (mainnet-beta)
+        if: steps.gate.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'doublezero-edge-connect',
+              event_type: 'doublezero-base-published',
+              client_payload: { env: 'mainnet-beta', version: '${{ steps.v.outputs.version }}' },
+            });
 
   # Validation path: on PRs touching the image, build all three variants for
   # amd64 but do NOT push, to catch Dockerfile/entrypoint regressions before

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -39,6 +39,11 @@ jobs:
   publish:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    # Serialize testnet publishes so two closely-spaced releases don't race the
+    # mutable :testnet tag.
+    concurrency:
+      group: release-docker-client-testnet
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,7 +117,12 @@ jobs:
       # base image we just published (event-driven; its daily poll is the fallback).
       - name: Notify edge-connect to rebuild (testnet)
         if: steps.v.outputs.publish == 'true'
+        # A failed cross-repo dispatch must not fail an already-successful publish;
+        # edge-connect's daily poll is the fallback.
+        continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          DZ_VERSION: ${{ steps.v.outputs.version }}
         with:
           github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
           script: |
@@ -120,7 +130,7 @@ jobs:
               owner: context.repo.owner,
               repo: 'doublezero-edge-connect',
               event_type: 'doublezero-base-published',
-              client_payload: { env: 'testnet', version: '${{ steps.v.outputs.version }}' },
+              client_payload: { env: 'testnet', version: process.env.DZ_VERSION },
             });
 
   # mainnet-beta image publish: manual (workflow_dispatch) or automatic (schedule).
@@ -129,24 +139,39 @@ jobs:
   publish-mainnet-beta:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    # Serialize mainnet-beta publishes so a scheduled run and a manual dispatch
+    # don't race the mutable :mainnet-beta / :latest tags.
+    concurrency:
+      group: release-docker-client-mainnet-beta
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 
       - name: Resolve mainnet-beta version
         id: v
         shell: bash
+        # Pass the operator-supplied input via env rather than interpolating it
+        # directly into the bash script.
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="$INPUT_VERSION"
           if [[ -z "$VERSION" ]]; then
+            # Resolve the newest version from the stable `doublezero` channel.
+            # Exclude Debian pre-release markers (~) defensively so an RC/pre-release
+            # is never auto-promoted to :mainnet-beta/:latest; the channel is
+            # otherwise expected to hold only promoted stable releases.
             VERSION="$(docker run --rm --entrypoint bash ubuntu:24.04 -c '
               apt-get update -qq >/dev/null 2>&1
               apt-get install -y -qq --no-install-recommends ca-certificates curl >/dev/null 2>&1
               curl -1sLf "https://dl.cloudsmith.io/public/malbeclabs/doublezero/setup.deb.sh" | bash >/dev/null 2>&1
               apt-get update -qq >/dev/null 2>&1
-              apt-cache madison doublezero | head -1 | awk "{print \$3}"')"
+              apt-cache madison doublezero | awk "{print \$3}" | grep -v "~" | head -1')"
           fi
           [[ -n "$VERSION" ]] || { echo "could not resolve mainnet-beta version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Docker tags can't contain ~ or :, so sanitize them for the immutable
+          # version-suffixed tag only; the label and dispatch payload keep the raw version.
           echo "tag=$(printf '%s' "$VERSION" | tr '~:' '--')" >> "$GITHUB_OUTPUT"
           echo "Resolved mainnet-beta version: $VERSION"
 
@@ -204,7 +229,12 @@ jobs:
       # the base image we just published (event-driven; poll is the fallback).
       - name: Notify edge-connect to rebuild (mainnet-beta)
         if: steps.gate.outputs.changed == 'true'
+        # A failed cross-repo dispatch must not fail an already-successful publish;
+        # edge-connect's daily poll is the fallback.
+        continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          DZ_VERSION: ${{ steps.v.outputs.version }}
         with:
           github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
           script: |
@@ -212,7 +242,7 @@ jobs:
               owner: context.repo.owner,
               repo: 'doublezero-edge-connect',
               event_type: 'doublezero-base-published',
-              client_payload: { env: 'mainnet-beta', version: '${{ steps.v.outputs.version }}' },
+              client_payload: { env: 'mainnet-beta', version: process.env.DZ_VERSION },
             });
 
   # Validation path: on PRs touching the image, build all three variants for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - E2E
   - Fix the multicast settlement QA test's seat-allocation ack wait. It read the reused client seat at finalized commitment and could accept the previous run's already-acked state, then withdraw while the current request was still pending. It now waits to observe the request pending before treating a cleared flag as the ack. (#3972)
   - Make the all-devices unicast QA test tolerate a host reporting multiple tunnel statuses. It now selects the IBRL status via `GetUserStatuses`/`FindIBRLStatus` instead of erroring on a lingering Multicast tunnel and dropping the host, and logs a warning when a host reports more than one status. (#3976)
+- CI
+  - Auto-publish the mainnet-beta client base image daily when the stable Cloudsmith channel advances (idempotency-gated so a run with no new version is a no-op), and notify `doublezero-edge-connect` to rebuild its testnet and mainnet-beta variants when a new base image is published. Serialize publishes with per-job concurrency groups, keep the notify steps non-fatal to the publish, and skip Debian pre-release versions when resolving the mainnet-beta tag. (#3990)
 
 ## [v0.29.0](https://github.com/malbeclabs/doublezero/compare/client/v0.28.0...client/v0.29.0) - 2026-07-02
 


### PR DESCRIPTION
## What

Two changes to `release.docker.client.yml`:

1. **Auto-publish the mainnet-beta base image.** `publish-mainnet-beta` was `workflow_dispatch`-only. This adds a daily `schedule` plus an **idempotency guard**: it resolves the latest version from the mainnet-beta stable Cloudsmith channel and compares it to the `org.opencontainers.image.version` label on the currently-published `:mainnet-beta` image, publishing **only when they differ**. Manual dispatch still forces a publish. (Version resolution stays tied to the stable channel — this is *not* chained off every `client/v*` tag.)
2. **Notify edge-connect.** After each successful base publish (both testnet and mainnet-beta), fire a `repository_dispatch` (`doublezero-base-published`, payload `{env, version}`) at `malbeclabs/doublezero-edge-connect` so it rebuilds the matching variant immediately.

## Why

The `doublezero:mainnet-beta` image was stuck at **0.27.1** while **0.28.0** was already in the mainnet-beta stable channel, because the image only rebuilt on a manual dispatch that nobody ran. edge-connect layers on this base and tracks it, so it was stuck too. This makes the base self-heal (schedule + guard) and propagate to edge-connect event-driven instead of via its ~24h poll.

## Methodology notes (matches existing workflows)

- Cross-repo trigger uses **`actions/github-script@v7`** with `github.rest.repos.createDispatchEvent`, same idiom as `trusted-fork-e2e.yml` (the repo does not use the `gh` CLI in workflows).
- New scoped secret **`EDGE_CONNECT_DISPATCH_TOKEN`** (fine-grained PAT with `actions: write` on edge-connect), consistent with the repo's purpose-scoped secrets (`MALBEC_INFRA_RO`, `GA_ANSIBLE_REPO_RO`, …). Alternative: reuse the existing `DOUBLEZERO_PAT` **iff** its scope already includes edge-connect `actions: write` — say the word and I'll switch it.
- Docker actions kept at the repo's `@vN` pinning style.

## Sequence & prerequisites (important)

`repository_dispatch` only triggers workflows on the target repo's **default branch**, so order matters:

- [ ] 1. Merge the receiver PR first: **malbeclabs/doublezero-edge-connect#74**
- [ ] 2. Create the `EDGE_CONNECT_DISPATCH_TOKEN` secret in this repo
- [ ] 3. Merge **this** PR
- [ ] 4. (Runbook) add a step after "Promote client packages → doublezero" in the release checklist to run `publish-mainnet-beta` for an immediate publish; the daily schedule is the backstop.

## Validation

- `actionlint` clean.
- Guard verified against the live registry: currently `have=0.27.1-1` ≠ `want=0.28.0-1` → first run publishes 0.28.0; a second run is a no-op.