### PR TITLE
serviceability: guard permission suspend/update against self-lockout

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/suspend.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/suspend.rs
@@ -61,6 +61,13 @@ pub fn process_suspend_permission(
         return Err(ProgramError::InvalidArgument);
     }
 
+    // Prevent self-suspension: a caller with PERMISSION_ADMIN cannot suspend their own
+    // permission, as that would lock them out (recovery is foundation-only). Mirrors the
+    // self-removal guard in delete.
+    if &permission.user_payer == payer_account.key {
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
     if permission.status != PermissionStatus::Activated {
         return Err(DoubleZeroError::InvalidStatus.into());
     }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/permission/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/permission/update.rs
@@ -66,6 +66,13 @@ pub fn process_update_permission(
         return Err(ProgramError::InvalidArgument);
     }
 
+    // Prevent self-modification: a caller with PERMISSION_ADMIN cannot modify their own
+    // permission, since removing their own flags would lock them out (recovery is
+    // foundation-only). Mirrors the self-removal guard in delete.
+    if &permission.user_payer == payer_account.key {
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
     if value.add & value.remove != 0 {
         return Err(DoubleZeroError::InvalidArgument.into());
     }
@@ -103,6 +110,14 @@ pub fn process_update_permission(
     }
 
     permission.permissions = (permission.permissions | value.add) & !value.remove;
+
+    // A Permission account must always grant at least one flag. `create` enforces this
+    // with `!= 0`; `update` must preserve it, as an Activated permission that grants
+    // nothing is meaningless (and would masquerade as a privileged account in audits).
+    if permission.permissions == 0 {
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
     try_acc_write(&permission, permission_account, payer_account, accounts)?;
 
     Ok(())

--- a/smartcontract/programs/doublezero-serviceability/tests/permission_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/permission_test.rs
@@ -698,6 +698,157 @@ async fn test_delete_self_removal_rejected() {
     );
 }
 
+#[tokio::test]
+async fn test_suspend_self_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Create a permission for the payer itself (the foundation key).
+    let (permission_pda, _) = get_permission_pda(&program_id, &payer.pubkey());
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: payer.pubkey(),
+            permissions: permission_flags::PERMISSION_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let recent_blockhash2 = banks_client.get_latest_blockhash().await.unwrap();
+
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash2,
+        program_id,
+        DoubleZeroInstruction::SuspendPermission(PermissionSuspendArgs {}),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Caller should not be able to suspend their own permission"
+    );
+}
+
+#[tokio::test]
+async fn test_update_self_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Create a permission for the payer itself (the foundation key).
+    let (permission_pda, _) = get_permission_pda(&program_id, &payer.pubkey());
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: payer.pubkey(),
+            permissions: permission_flags::PERMISSION_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let recent_blockhash2 = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Attempting to remove one's own PERMISSION_ADMIN (a self-lockout) must be rejected.
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash2,
+        program_id,
+        DoubleZeroInstruction::UpdatePermission(PermissionUpdateArgs {
+            add: 0,
+            remove: permission_flags::PERMISSION_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Caller should not be able to modify their own permission"
+    );
+}
+
+#[tokio::test]
+async fn test_update_permission_to_zero_rejected() {
+    let (mut banks_client, payer, program_id, globalstate_pubkey, _) =
+        setup_program_with_globalconfig().await;
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Permission for a third party (not the signer), so the self-modification guard
+    // does not fire and we isolate the "must grant at least one flag" invariant.
+    let user_payer = Pubkey::new_unique();
+    let (permission_pda, _) = get_permission_pda(&program_id, &user_payer);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer,
+            permissions: permission_flags::USER_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let recent_blockhash2 = banks_client.get_latest_blockhash().await.unwrap();
+
+    // Removing the only flag would leave an Activated permission granting nothing.
+    let result = try_execute_transaction(
+        &mut banks_client,
+        recent_blockhash2,
+        program_id,
+        DoubleZeroInstruction::UpdatePermission(PermissionUpdateArgs {
+            add: 0,
+            remove: permission_flags::USER_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Update that clears the last flag (permissions == 0) should be rejected"
+    );
+}
+
 // Grants admin a plain PERMISSION_ADMIN permission and returns (admin keypair, its PDA).
 async fn grant_permission_admin(
     banks_client: &mut BanksClient,


### PR DESCRIPTION
Resolves: #3996 (item 1)

## Summary of Changes
- Block a `PERMISSION_ADMIN` caller from suspending or modifying **their own** Permission account, mirroring the existing self-removal guard in `delete`. Since foundation lockout recovery is foundation-only, a sole non-foundation admin could otherwise permanently lock itself out.
- Reject a post-state `permissions == 0` in `update`, preserving the create-time invariant that an Activated Permission account always grants at least one flag (an all-zero Activated account is meaningless and misleads audits).
- Add integration tests for self-suspend, self-update, and clear-last-flag rejection.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +22 / -0    |  +22 |
| Tests        |     1 | +151 / -0   | +151 |
| **Total**    |     3 | +173 / -0   | +173 |

Small, behavior-preserving authorization hardening; the bulk of the diff is test coverage.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/processors/permission/update.rs` — self-modification guard (`user_payer == payer`) plus post-state `permissions == 0` rejection.
- `smartcontract/programs/doublezero-serviceability/src/processors/permission/suspend.rs` — self-suspension guard mirroring `delete`.
- `smartcontract/programs/doublezero-serviceability/tests/permission_test.rs` — `test_suspend_self_rejected`, `test_update_self_rejected`, `test_update_permission_to_zero_rejected`.

</details>

## Testing Verification
- `cargo test -p doublezero-serviceability --test permission_test` — 20/20 pass, including the 3 new cases.
- New tests assert the guards specifically: a foundation key that self-suspends / self-updates is denied, and removing the last flag of a third-party permission is rejected while the sibling enable/disable paths still succeed.
