### PR TITLE
serviceability: fix device update account parsing vs trailing permission

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs
@@ -1,5 +1,5 @@
 use crate::{
-    authorize::authorize,
+    authorize::{authorize, split_trailing_permission},
     error::DoubleZeroError,
     pda::get_resource_extension_pda,
     processors::resource::create_resource,
@@ -132,28 +132,60 @@ pub fn process_update_device(
     accounts: &[AccountInfo],
     value: &DeviceUpdateArgs,
 ) -> ProgramResult {
-    let accounts_iter = &mut accounts.iter();
+    // Account layout:
+    //   [device, contributor, (location_old, location_new)?, globalstate,
+    //    (globalconfig)?, resource_0..resource_n, payer, system, (permission)?]
+    //
+    // Peel [payer, system, permission] off the tail FIRST. The SDK appends the payer's
+    // Permission PDA whenever one exists on-chain; peeling it here means its presence
+    // can never be mistaken for a leading account. (The previous `accounts.len() > 5`
+    // heuristic counted the whole slice — including that trailing Permission account —
+    // and would misparse the minimal no-location update.)
+    let remaining: Vec<&AccountInfo> = accounts.iter().collect();
+    let (payer_account, system_program, leading, permission_account) =
+        split_trailing_permission(program_id, &remaining)?;
 
-    let device_account = next_account_info(accounts_iter)?;
-    let contributor_account = next_account_info(accounts_iter)?;
+    // Whether the optional (location_old, location_new) pair is present, derived from the
+    // leading length — now independent of the Permission account. The non-location prefix
+    // is [device, contributor, globalstate, globalconfig?, resources..]; the location pair
+    // adds exactly two accounts.
+    let leading_without_locations =
+        3 + usize::from(value.resource_count > 0) + value.resource_count;
+    let has_locations = if leading.len() == leading_without_locations {
+        false
+    } else if leading.len() == leading_without_locations + 2 {
+        true
+    } else {
+        msg!(
+            "Unexpected account count: {} leading accounts, expected {} or {}",
+            leading.len(),
+            leading_without_locations,
+            leading_without_locations + 2
+        );
+        return Err(DoubleZeroError::InvalidArgument.into());
+    };
+
+    let leading_iter = &mut leading.iter().copied();
+
+    let device_account = next_account_info(leading_iter)?;
+    let contributor_account = next_account_info(leading_iter)?;
     // Update location accounts (old and new)
-
-    let (location_old_account, location_new_account) = if accounts.len() > 5 {
+    let (location_old_account, location_new_account) = if has_locations {
         (
-            Some(next_account_info(accounts_iter)?),
-            Some(next_account_info(accounts_iter)?),
+            Some(next_account_info(leading_iter)?),
+            Some(next_account_info(leading_iter)?),
         )
     } else {
         (None, None)
     };
 
-    let globalstate_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(leading_iter)?;
     let globalconfig_account = if value.resource_count > 0 {
         assert!(
             value.resource_count >= 2,
             "Resource count must be at least 2 (TunnelIds and at least one DzPrefixBlock)"
         );
-        let account = next_account_info(accounts_iter)?;
+        let account = next_account_info(leading_iter)?;
         assert_eq!(
             account.owner, program_id,
             "Invalid GlobalConfig Account Owner"
@@ -165,7 +197,7 @@ pub fn process_update_device(
     let mut resource_accounts = vec![];
     for idx in 0..value.resource_count {
         // first resource account is the TunnelIds resource, followed by DzPrefixBlock resources
-        let resource_account = next_account_info(accounts_iter)?;
+        let resource_account = next_account_info(leading_iter)?;
         assert!(
             resource_account.data_is_empty() || resource_account.owner == program_id,
             "Invalid Resource Account Owner"
@@ -180,8 +212,6 @@ pub fn process_update_device(
         );
         assert_eq!(pda, *resource_account.key, "Invalid Resource Account PDA");
     }
-    let payer_account = next_account_info(accounts_iter)?;
-    let system_program = next_account_info(accounts_iter)?;
 
     #[cfg(test)]
     msg!("process_update_device({:?})", value);
@@ -221,12 +251,12 @@ pub fn process_update_device(
     let contributor = Contributor::try_from(contributor_account)?;
 
     // Authorization: the contributor owner, or NETWORK_ADMIN (Permission account) /
-    // foundation (legacy). The permission is the optional trailing account (payer and
-    // system_program were already consumed above). Privileged callers bypass the
-    // contributor binding and may edit the privileged fields / set any status below.
+    // foundation (legacy). `permission_account` is the optional trailing account peeled
+    // off by split_trailing_permission above. Privileged callers bypass the contributor
+    // binding and may edit the privileged fields / set any status below.
     let is_privileged = authorize(
         program_id,
-        accounts_iter,
+        &mut permission_account.into_iter(),
         payer_account.key,
         &globalstate,
         permission_flags::NETWORK_ADMIN,

--- a/smartcontract/programs/doublezero-serviceability/tests/device_contributor_binding_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/device_contributor_binding_test.rs
@@ -16,12 +16,14 @@ use doublezero_serviceability::{
             },
             update::DeviceUpdateArgs,
         },
+        permission::create::PermissionCreateArgs,
         *,
     },
     resource::ResourceType,
     state::{
         device::*,
         interface::{InterfaceCYOA, InterfaceDIA, LoopbackType, RoutingMode, INTERFACE_MTU},
+        permission::permission_flags,
     },
 };
 use solana_program_test::*;
@@ -323,6 +325,67 @@ async fn test_update_device_foundation_may_use_any_contributor() {
         .await
         .unwrap();
     assert_eq!(device.max_users, 64);
+}
+
+#[tokio::test]
+async fn test_update_device_network_admin_minimal_shape_with_permission_account() {
+    // Regression: a minimal no-location device update (leading accounts
+    // [device, contributor, globalstate]) by a NETWORK_ADMIN Permission holder who is
+    // NOT the device's contributor owner. The SDK appends the caller's Permission PDA as
+    // the trailing account, so the full list is [device, contributor, globalstate, payer,
+    // system, permission] = 6. The previous `accounts.len() > 5` heuristic misparsed that
+    // 6th (Permission) account as a location account and reverted; the
+    // split_trailing_permission-based parsing must handle it.
+    let mut s = setup_device_with_two_contributors().await;
+
+    // Foundation grants the non-owner `other_payer` a NETWORK_ADMIN permission.
+    let (other_perm_pda, _) = get_permission_pda(&s.program_id, &s.other_payer.pubkey());
+    let rb = s.banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction(
+        &mut s.banks_client,
+        rb,
+        s.program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: s.other_payer.pubkey(),
+            permissions: permission_flags::NETWORK_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(other_perm_pda, false),
+            AccountMeta::new_readonly(s.globalstate_pubkey, false),
+        ],
+        &s.payer,
+    )
+    .await;
+
+    // other_payer updates a device it does NOT own, in the minimal no-location shape,
+    // with its Permission PDA appended as the trailing account. NETWORK_ADMIN bypasses
+    // the contributor binding, so this must succeed.
+    let rb2 = s.banks_client.get_latest_blockhash().await.unwrap();
+    execute_transaction_with_extra_accounts(
+        &mut s.banks_client,
+        rb2,
+        s.program_id,
+        DoubleZeroInstruction::UpdateDevice(DeviceUpdateArgs {
+            max_users: Some(64),
+            ..DeviceUpdateArgs::default()
+        }),
+        vec![
+            AccountMeta::new(s.device_pubkey, false),
+            AccountMeta::new(s.other_contributor_pubkey, false),
+            AccountMeta::new(s.globalstate_pubkey, false),
+        ],
+        &s.other_payer,
+        &[AccountMeta::new_readonly(other_perm_pda, false)],
+    )
+    .await;
+
+    let device = get_device(&mut s.banks_client, s.device_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(
+        device.max_users, 64,
+        "NETWORK_ADMIN permission holder must update in the minimal (no-location) shape"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Resolves: #3996 (item 2)

## Summary of Changes
- Fix `process_update_device`'s optional-location detection. It used `accounts.len() > 5`, which counts the entire account slice — including the Permission PDA the SDK appends as the trailing account. A minimal update (no location change, no resources) by a caller who holds a Permission account produces 6 accounts, so `6 > 5` was true and `globalstate`/`payer` were misparsed as the two location accounts, reverting the instruction.
- The parser now peels `[payer, system, permission]` off the tail with `split_trailing_permission` (the same helper the other variable-length instructions use), then derives location presence from the leading length — which no longer includes the Permission account — and validates it against the expected count, erroring clearly on any other shape.
- Add a regression test exercising the previously-broken path: a NETWORK_ADMIN Permission holder updating a device it doesn't own in the minimal no-location shape, with its Permission PDA appended.

Latent on `origin/main` (the SDK always sends both location accounts, so the count never landed on the broken value), but the heuristic was unsound for any hand-built instruction or future SDK change.

## Diff Breakdown
| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +47 / -17   |  +30 |
| Tests        |     1 | +63 / -0    |  +63 |
| **Total**    |     2 | +110 / -17  |  +93 |

Account-parsing correctness fix plus a targeted regression test.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/processors/device/update.rs` — replace the `accounts.len() > 5` location heuristic with `split_trailing_permission` + leading-length detection.
- `smartcontract/programs/doublezero-serviceability/tests/device_contributor_binding_test.rs` — `test_update_device_network_admin_minimal_shape_with_permission_account`.

</details>

## Testing Verification
- `cargo test -p doublezero-serviceability` across `device_contributor_binding_test` (6/6, incl. the new case), `device_update_location_test`, `device_test` (9/9), and `device_onchain_allocation_test` (2/2) — covering the no-location, location-present, and resource-bearing shapes.
- The new test fails on `origin/main`'s parser (the trailing Permission account is misread as a location) and passes with this change.
