### PR TITLE
ci: add dependabot ignores for testcontainers minors and solana majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
       - "skip-changelog"
       - "dependencies"
       - "go"
+    ignore:
+      # testcontainers >=0.41 switched docker/docker types to moby/moby, which
+      # breaks e2e/internal/devnet. Remove after migrating the e2e harness.
+      - dependency-name: "github.com/testcontainers/testcontainers-go*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       go-minor-patch:
         update-types:
@@ -37,6 +44,15 @@ updates:
       - "skip-changelog"
       - "dependencies"
       - "rust"
+    ignore:
+      # Solana major bumps are deliberate migrations (e.g. #3830), not
+      # dependabot fodder.
+      - dependency-name: "solana-*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "spl-*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       rust-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary of Changes
- Ignore minor/major updates of `github.com/testcontainers/testcontainers-go*` (core + modules) in gomod updates. testcontainers >=0.41 switched `docker/docker` types to `moby/moby`, which breaks `e2e/internal/devnet` (~11 compile errors across 5 files) — this has poisoned every go-minor-patch group PR, most recently #3960. Patch releases within 0.40.x still flow. Remove the ignore after migrating the e2e harness.
- Ignore `semver-major` updates of `solana-*`/`spl-*` in cargo updates. Solana major bumps are deliberate hand-built migrations (e.g. #3830), not dependabot fodder; this stops PRs like #3963 (solana-pubkey 3.x → 4.x) from recurring.

After this merges, `@dependabot recreate` on #3960 regenerates the go group without testcontainers so the remaining ~18 updates can land.

## Diff Breakdown
| Category          | Files | Lines (+/-)     | Net    |
|-------------------|-------|-----------------|--------|
| Config/build      |     1 | +16    / -0     |    +16 |
| **Total**         |     1 | +16    / -0     |    +16 |

Config-only change: two `ignore` blocks in `.github/dependabot.yml`.

## Testing Verification
- Validated against the dependabot v2 schema (`dependency-name` globs cover the three testcontainers module paths).
- Behavioral proof comes from dependabot itself: after merge, `@dependabot recreate` on #3960 should produce a group PR with no testcontainers entries.
