### PR TITLE
ci: skip e2e for rfcs image changes in docs-only PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,7 +133,7 @@ jobs:
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
       # Version-bump PRs (only version lines change in Cargo.toml/Cargo.lock)
-      # and markdown-only PRs (docs, RFCs) get no signal from e2e. When
+      # and docs-only PRs (markdown plus rfcs images) get no signal from e2e. When
       # skipping, report the required shard checks as successful on the PR
       # head, because the gated matrix job never creates its check runs and
       # branch protection would otherwise block the merge. Keep in sync with
@@ -162,11 +162,16 @@ jobs:
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
               const isMd = (name) => typeof name === 'string' && name.endsWith('.md');
-              // Markdown is inert for e2e; a rename/copy must come from
-              // markdown too, since a rename also deletes the source path.
+              // Images under rfcs/ are figures for markdown RFCs; inert for e2e.
+              const isRfcImage = (name) => typeof name === 'string' &&
+                name.startsWith('rfcs/') && /\.(png|jpe?g|gif|svg|webp)$/i.test(name);
+              const isInert = (name) => isMd(name) || isRfcImage(name);
+              // Markdown and rfcs images are inert for e2e; a rename/copy must
+              // come from an inert path too, since a rename also deletes the
+              // source path.
               const fileOk = (f) => {
-                if (isMd(f.filename)) {
-                  return (f.status !== 'renamed' && f.status !== 'copied') || isMd(f.previous_filename);
+                if (isInert(f.filename)) {
+                  return (f.status !== 'renamed' && f.status !== 'copied') || isInert(f.previous_filename);
                 }
                 return (f.filename === 'Cargo.toml' || f.filename === 'Cargo.lock') &&
                   f.status === 'modified' &&
@@ -194,7 +199,7 @@ jobs:
                   details_url: runUrl,
                   output: {
                     title: 'Skipped: docs/version-bump-only PR',
-                    summary: 'Only markdown files and version lines in Cargo.toml/Cargo.lock changed, so e2e was skipped.',
+                    summary: 'Only markdown files, rfcs images, and version lines in Cargo.toml/Cargo.lock changed, so e2e was skipped.',
                   },
                 });
               }

--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -43,7 +43,7 @@ jobs:
       matrix: ${{ steps.shard.outputs.matrix }}
     steps:
       # Version-bump PRs (only version lines change in Cargo.toml/Cargo.lock)
-      # and markdown-only PRs (docs, RFCs) get no signal from e2e. When
+      # and docs-only PRs (markdown plus rfcs images) get no signal from e2e. When
       # skipping, report the required shard checks as successful on the PR
       # head, because the gated matrix job never creates its check runs and
       # branch protection would otherwise block the merge. Keep in sync with
@@ -72,11 +72,16 @@ jobs:
                 .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
                 .every((l) => /^[+-]version = "/.test(l));
               const isMd = (name) => typeof name === 'string' && name.endsWith('.md');
-              // Markdown is inert for e2e; a rename/copy must come from
-              // markdown too, since a rename also deletes the source path.
+              // Images under rfcs/ are figures for markdown RFCs; inert for e2e.
+              const isRfcImage = (name) => typeof name === 'string' &&
+                name.startsWith('rfcs/') && /\.(png|jpe?g|gif|svg|webp)$/i.test(name);
+              const isInert = (name) => isMd(name) || isRfcImage(name);
+              // Markdown and rfcs images are inert for e2e; a rename/copy must
+              // come from an inert path too, since a rename also deletes the
+              // source path.
               const fileOk = (f) => {
-                if (isMd(f.filename)) {
-                  return (f.status !== 'renamed' && f.status !== 'copied') || isMd(f.previous_filename);
+                if (isInert(f.filename)) {
+                  return (f.status !== 'renamed' && f.status !== 'copied') || isInert(f.previous_filename);
                 }
                 return (f.filename === 'Cargo.toml' || f.filename === 'Cargo.lock') &&
                   f.status === 'modified' &&
@@ -104,7 +109,7 @@ jobs:
                   details_url: runUrl,
                   output: {
                     title: 'Skipped: docs/version-bump-only PR',
-                    summary: 'Only markdown files and version lines in Cargo.toml/Cargo.lock changed, so shreds e2e was skipped.',
+                    summary: 'Only markdown files, rfcs images, and version lines in Cargo.toml/Cargo.lock changed, so shreds e2e was skipped.',
                   },
                 });
               }


### PR DESCRIPTION
## Summary of Changes
* Treat images under `rfcs/` (png/jpe?g/gif/svg/webp, case-insensitive) as inert in the e2e and shreds-e2e docs-only skip gates, alongside markdown.
* RFC PRs that add figures alongside a markdown RFC (e.g. #2519) no longer run the full self-hosted e2e + shreds-e2e matrices (9 jobs) for zero signal.
* Identical predicate edit applied to both `.github/workflows/e2e.yml` and `.github/workflows/shreds-e2e.yml` (kept in sync per the "Keep in sync with" contract); prose/comments/summaries reworded.
* Fixes #4004

## Testing Verification
Extracted the updated predicate (`isMd`/`isRfcImage`/`isInert`/`fileOk` + the `skippable` expression) verbatim into a node script and ran a case table — all 14 pass:

| case | verdict |
| --- | --- |
| added `rfcs/foo.md` | skip |
| added `rfcs/images/x/F1.png` | skip |
| added `rfcs/images/x/F1.PNG` | skip |
| added `rfcs/images/x/F1.jpeg` | skip |
| added `rfcs/images/x/F1.svg` | skip |
| added `images/F1.png` (outside `rfcs/`) | run |
| added `telemetry/x.go` | run |
| renamed `rfcs/a.md` → `rfcs/b.md` | skip |
| renamed `x.go` → `rfcs/b.md` | run |
| renamed `rfcs/images/a.png` → `rfcs/images/b.png` | skip |
| renamed `x.bin` → `rfcs/images/b.png` | run |
| Cargo.toml+Cargo.lock version-only bump | skip |
| Cargo.toml alone | run |
| empty file list | run |

Confirmed the two script bodies are identical apart from the pre-existing `CHECK_NAME`/`CHECK_SHARDS` env values and the "e2e" vs "shreds e2e" wording (diff of the extracted bodies shows only those two lines). `actionlint` not available in the environment.
