### PR TITLE
ci: enable Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,22 @@ updates:
       serde:
         patterns:
           - "serde*"
+
+  - package-ecosystem: "github-actions"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    labels:
+      - "skip-changelog"
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary of Changes
Adds a `github-actions` entry to `.github/dependabot.yml`. Previously Dependabot watched only `gomod` and `cargo`, so no bump PRs were opened for GitHub Actions — which is why actions have drifted (several majors behind: `checkout` v4→v7, `github-script` v7→v9, `upload-artifact` v4→v7, `setup-uv` v4→v8, `setup-node` v4→v6, `setup-go` →v6, `create-github-app-token` v2→v3, plus the `docker/*` set) and workflows emit the Node 20 deprecation warning.

The entry mirrors the existing `gomod`/`cargo` style (`directories: ["**/*"]`, monthly, PR-limit 10) and uses **two groups**:
- `github-actions-minor-patch` — all minor/patch bumps in one PR (safe, easy to merge).
- `github-actions-major` — all major bumps in one PR (kept separate because majors can carry breaking changes, e.g. `github-script@v9` drops `require('@actions/github')`).

So the initial catch-up is **~2 PRs** (one minor/patch, one major) instead of ~10+ separate per-major PRs that would blow past `open-pull-requests-limit`. After catch-up it settles to ~0–1 PRs/month.

Part of the fleet-wide github-actions Dependabot enablement — see the tracking issue in malbeclabs/infra.

## Testing Verification
- `dependabot.yml` parses as valid YAML; `updates` lists `gomod`, `cargo`, `github-actions`; the github-actions entry has both `github-actions-minor-patch` and `github-actions-major` groups.
- No workflow files changed.