### PR TITLE
ci: use existing testnet environment for release orchestrator gates

### DIFF
--- a/.github/workflows/release.testnet.yml
+++ b/.github/workflows/release.testnet.yml
@@ -147,7 +147,7 @@ jobs:
   gate-tags:
     runs-on: ubuntu-latest
     needs: open-prs
-    environment: testnet-release-gate
+    environment: testnet
     steps:
       - uses: actions/create-github-app-token@v2
         id: app
@@ -278,7 +278,7 @@ jobs:
             echo "(serviceability is the only program with a settable version account; telemetry has"
             echo "none and geolocation has no CLI setter). Verify with: doublezero --env testnet version"
             echo
-            echo "Then approve the 'testnet-program-deploy' gate on the orchestrator run above."
+            echo "Then approve the waiting 'gate-programs' job (testnet environment) on the orchestrator run above."
           } > staged/DEPLOY.md
       - uses: actions/upload-artifact@v4
         with:
@@ -314,7 +314,7 @@ jobs:
           {
             echo "## Program deploy required"
             echo "Artifacts staged on nyc-tn-bm2 at /opt/doublezero/program-releases/v${{ inputs.version }}/ (see DEPLOY.md there)."
-            echo "Deploy the three programs with the local keypair, set the onchain version, then approve the testnet-program-deploy gate."
+            echo "Deploy the three programs with the local keypair, set the onchain version, then approve the waiting 'gate-programs' job (testnet environment)."
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Ping dev team
         uses: malbeclabs/action-slack-notify@v2
@@ -322,7 +322,7 @@ jobs:
           SLACK_COLOR: warning
           SLACK_USERNAME: Doublezero Releaser
           SLACK_TITLE: "Testnet release v${{ inputs.version }}: program deploy needed"
-          SLACK_MESSAGE: "Artifacts staged on nyc-tn-bm2:/opt/doublezero/program-releases/v${{ inputs.version }}/. Deploy programs, then approve the testnet-program-deploy gate."
+          SLACK_MESSAGE: "Artifacts staged on nyc-tn-bm2:/opt/doublezero/program-releases/v${{ inputs.version }}/. Deploy programs, then approve the waiting gate-programs job (testnet environment) on the orchestrator run."
           MSG_MINIMAL: actions url
           SLACK_WEBHOOK: ${{ secrets.SLACK_TESTNET_ALERTS_WEBHOOK }}
 
@@ -330,7 +330,7 @@ jobs:
   gate-programs:
     runs-on: ubuntu-latest
     needs: [stage-programs, verify-cloudsmith]
-    environment: testnet-program-deploy
+    environment: testnet
     steps:
       - name: Gate passed
         run: echo "Program deploy confirmed by approver; verifying onchain next."

--- a/docs/testnet-release.md
+++ b/docs/testnet-release.md
@@ -32,12 +32,12 @@ gh workflow run release.testnet.yml -R malbeclabs/doublezero -f version=X.Y.Z
 | --- | --- | --- |
 | `preflight` | Validates the version, reads the current workspace version, checks the latest devnet daily release succeeded. | — |
 | `open-prs` | Opens the doublezero version-bump PR (`release/vX.Y.Z`: Cargo.toml, Cargo.lock, CHANGELOG promotion) and the infra pinned-versions PR (`release/testnet-vX.Y.Z`). PR links appear in the run summary. | Review and **merge both PRs**. |
-| `gate-tags` | Waits on the `testnet-release-gate` environment, then verifies both PRs are merged (the gate fails if you approve early). | **Approve gate 1** after both PRs are merged. |
+| `gate-tags` | Waits on the `testnet` environment, then verifies both PRs are merged (the gate fails if you approve early). | **Approve gate 1** after both PRs are merged. |
 | `push-tags` | Pushes the 9 component tags (`controller`, `internet-latency-collector`, `agent`, `device-telemetry-agent`, `geoprobe-agent`, `geoprobe-target`, `funder`, `monitor`, `client`) via the reusable tag workflow, which runs in the protected `testnet` environment. | **Approve the `testnet` environment prompt** on the tag jobs. |
 | `verify-cloudsmith` | Polls CloudSmith (up to ~60 min) until all 9 packages exist at the new version. | — |
 | `build-programs` | Builds the three Solana programs (`serviceability` default features; `telemetry` and `geolocation` with `--features testnet`) from main and uploads them with checksums and a `DEPLOY.md` manifest. | — |
 | `stage-programs` | Dispatches the infra `stage-programs.testnet.yml` workflow, which copies the artifacts to `nyc-tn-bm2:/opt/doublezero/program-releases/vX.Y.Z/`, then pings Slack. | **Approve infra's `testnet` environment** on the dispatched run (link posted to `#int-tech`). Then **deploy the programs** on nyc-tn-bm2 from that directory per the Notion runbook ("Build and deploy DoubleZero solana programs - testnet"), and set the onchain version. |
-| `gate-programs` | Waits on the `testnet-program-deploy` environment. | **Approve gate 2** once the programs are deployed and the onchain version is set. |
+| `gate-programs` | Waits on the `testnet` environment. | **Approve gate 2** once the programs are deployed and the onchain version is set. |
 | `verify-onchain` | Installs the released client from CloudSmith and checks `doublezero --env testnet version` reports the new program version. | — |
 | `deploy-core` | Dispatches infra `deploy-core.testnet.yml` and waits for it. | **Approve infra's `testnet` environment** on the dispatched run (link posted to `#int-tech`). |
 | `deploy-clients` | Dispatches infra `deploy-clients.testnet.yml` and waits for it. | **Approve infra's `testnet` environment** on the dispatched run (link posted to `#int-tech`). |
@@ -45,6 +45,12 @@ gh workflow run release.testnet.yml -R malbeclabs/doublezero -f version=X.Y.Z
 | `announce` | Posts success to Slack with the dashboard link. | **Watch the system dashboard for ~30 min** (https://doublezero.grafana.net/d/bf3dece9-51ac-4087-b6b1-579b3859ce14/). The foundation posts the community announcement. |
 
 Any failed job triggers a Slack alert via `notify-failure`.
+
+All doublezero-side approvals (gate 1, the tag jobs, gate 2) use the single `testnet`
+environment, so the approval prompts look alike — the review dialog lists which job(s)
+are waiting; check the job name to know which gate you are approving. Each gate is
+followed by a verification step, so approving the wrong thing fails fast rather than
+advancing the release.
 
 ## Dry-run mode
 


### PR DESCRIPTION
## Summary of Changes

- Point both orchestrator gates (`gate-tags`, `gate-programs`) in `release.testnet.yml` at the existing `testnet` environment instead of the dedicated `testnet-release-gate` / `testnet-program-deploy` environments, per team decision ([Slack thread](https://doublezerofoundation.slack.com/archives/C07GHK0MU5C/p1783630917085969)): one reviewer list to maintain, no per-gate environment sprawl. The two dedicated environments will be deleted after this merges, and the `testnet` environment will be switched to allow self-review so a release manager can approve their own gates.
- Update the human-facing strings that named the old environments (DEPLOY.md manifest, step summary, Slack ping) to say "approve the waiting `gate-programs` job (`testnet` environment)" instead.
- Runbook: gate rows now reference the `testnet` environment, plus a note that all doublezero-side approvals share one environment — the review dialog's job names tell you which gate you're approving, and each gate's post-approval verification fails fast if the wrong thing is approved.

## Diff Breakdown
| Category          | Files | Lines (+/-)     | Net    |
|-------------------|-------|-----------------|--------|
| Config/build      |     1 | +5     / -5     |     +0 |
| Docs              |     1 | +8     / -2     |     +6 |
| **Total**         |     2 | +13    / -7     |     +6 |

Two-file rename-level change: gate environment consolidation plus matching doc/string updates.

<details>
<summary>Key files (click to expand)</summary>

- `.github/workflows/release.testnet.yml` — both gate jobs now use `environment: testnet`; approval-instruction strings updated
- `docs/testnet-release.md` — gate rows updated; note on shared-environment approvals

</details>

## Testing Verification

- actionlint on the workflow: no new findings (one pre-existing info-level SC2086 in the agave install step, present on main).
- `grep -rn "testnet-release-gate\|testnet-program-deploy"` across `.github/` and `docs/` returns nothing — no stale references.
- No workflows dispatched.

**Merge sequencing:** merge this before deleting the two old environments; a run of the pre-change workflow referencing a deleted environment would auto-recreate it unprotected. The in-flight dry run pinned the old workflow snapshot — cancel it and re-dispatch after this merges (the bot reuses the existing draft PRs).
