### PR TITLE
ci: build testnet release programs with agave v3.0.4 and platform-tools v1.54

### DIFF
--- a/.github/workflows/release.testnet.yml
+++ b/.github/workflows/release.testnet.yml
@@ -283,16 +283,19 @@ jobs:
           ref: main   # the merged version-bump commit
       - uses: dtolnay/rust-toolchain@1.90.0
       - uses: Swatinem/rust-cache@v2
+      # Keep the agave version and --tools-version in sync with
+      # release.devnet.smartcontract.daily.yml (platform-tools >= v1.54 is
+      # required since the solana 3.0 tree pulls edition2024 crates).
       - name: Install agave solana tools
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.4/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Build programs for testnet
         run: |
           set -euo pipefail
-          (cd smartcontract/programs/doublezero-serviceability && cargo build-sbf)
-          (cd smartcontract/programs/doublezero-telemetry && cargo build-sbf --features testnet)
-          (cd smartcontract/programs/doublezero-geolocation && cargo build-sbf --features testnet)
+          (cd smartcontract/programs/doublezero-serviceability && cargo build-sbf --tools-version v1.54)
+          (cd smartcontract/programs/doublezero-telemetry && cargo build-sbf --tools-version v1.54 --features testnet)
+          (cd smartcontract/programs/doublezero-geolocation && cargo build-sbf --tools-version v1.54 --features testnet)
       - name: Assemble artifact with deploy manifest
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary of Changes

* The testnet release orchestrator's `build-programs` job still installed agave v2.3.13, whose bundled platform-tools ship Cargo 1.84.0 — too old for the `edition2024` crates the solana 3.0 migration (v0.29.0) pulled into the dependency tree. Update to agave v3.0.4 and pin `cargo build-sbf --tools-version v1.54`, matching what `release.devnet.smartcontract.daily.yml` was migrated to.
* Found by the v0.29.2 dry run ([run 29103287800](https://github.com/malbeclabs/doublezero/actions/runs/29103287800)): `build-programs` failed with `feature edition2024 is required ... Cargo (1.84.0)` while devnet daily kept working, because the orchestrator froze a pre-migration copy of the install step.
* Comment added to keep the two workflows' agave/tools versions in sync; extracting a shared reusable build step is a possible follow-up if this drifts again.

## Testing Verification

* Install command and `--tools-version v1.54` flags mirror the currently-green `release.devnet.smartcontract.daily.yml` on main verbatim (which builds the same three programs daily).
* Full validation is the next dry run after merge — a re-run of the failed one won't pick up the fix, since re-runs execute the workflow snapshot from the original dispatch.