### PR TITLE
ci: fire edge-connect rebuild on base publish (release-bot App token + devnet notify)

### DIFF
--- a/.github/workflows/release.docker.client.devnet.yml
+++ b/.github/workflows/release.docker.client.devnet.yml
@@ -89,6 +89,9 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: doublezero-edge-connect
+          # Scope the token down to exactly what repository_dispatch needs, rather
+          # than inheriting every permission the release-bot App holds on the repo.
+          permission-contents: write
 
       # Tell doublezero-edge-connect to rebuild its devnet variant against the base
       # image we just published (event-driven; its daily poll is the fallback). The

--- a/.github/workflows/release.docker.client.devnet.yml
+++ b/.github/workflows/release.docker.client.devnet.yml
@@ -75,3 +75,40 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ steps.v.outputs.tag }}
+
+      # Mint a short-lived, least-privilege token scoped to doublezero-edge-connect
+      # from the release-bot GitHub App, used only to fire the cross-repo dispatch
+      # below. Non-fatal: if the app isn't installed on edge-connect the mint fails,
+      # the dispatch is skipped, and edge-connect's daily poll backstops the rebuild.
+      - name: Mint edge-connect dispatch token (devnet)
+        id: ec_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: doublezero-edge-connect
+
+      # Tell doublezero-edge-connect to rebuild its devnet variant against the base
+      # image we just published (event-driven; its daily poll is the fallback). The
+      # devnet publish always republishes :latest (no digest gate), so this notifies
+      # on every successful push, matching the testnet notify-on-every-publish pattern.
+      - name: Notify edge-connect to rebuild (devnet)
+        # Skip cleanly if the token mint failed (empty token) — the poll backstops it.
+        if: steps.ec_token.outputs.token != ''
+        # A failed cross-repo dispatch must not fail an already-successful publish;
+        # edge-connect's daily poll is the fallback.
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          DZ_VERSION: ${{ steps.v.outputs.version }}
+        with:
+          github-token: ${{ steps.ec_token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'doublezero-edge-connect',
+              event_type: 'doublezero-base-published',
+              client_payload: { env: 'devnet', version: process.env.DZ_VERSION },
+            });

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -113,10 +113,26 @@ jobs:
             ${{ env.IMAGE }}:testnet
             ${{ env.IMAGE }}:testnet-${{ steps.v.outputs.version }}
 
+      # Mint a short-lived, least-privilege token scoped to doublezero-edge-connect
+      # from the release-bot GitHub App, used only to fire the cross-repo dispatch
+      # below. Non-fatal: if the app isn't installed on edge-connect the mint fails,
+      # the dispatch is skipped, and edge-connect's daily poll backstops the rebuild.
+      - name: Mint edge-connect dispatch token (testnet)
+        id: ec_token
+        if: steps.v.outputs.publish == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: doublezero-edge-connect
+
       # Tell doublezero-edge-connect to rebuild its :testnet variant against the
       # base image we just published (event-driven; its daily poll is the fallback).
       - name: Notify edge-connect to rebuild (testnet)
-        if: steps.v.outputs.publish == 'true'
+        # Skip cleanly if the token mint failed (empty token) — the poll backstops it.
+        if: steps.v.outputs.publish == 'true' && steps.ec_token.outputs.token != ''
         # A failed cross-repo dispatch must not fail an already-successful publish;
         # edge-connect's daily poll is the fallback.
         continue-on-error: true
@@ -124,7 +140,7 @@ jobs:
         env:
           DZ_VERSION: ${{ steps.v.outputs.version }}
         with:
-          github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
+          github-token: ${{ steps.ec_token.outputs.token }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
@@ -225,10 +241,26 @@ jobs:
             ${{ env.IMAGE }}:mainnet-beta-${{ steps.v.outputs.tag }}
             ${{ env.IMAGE }}:latest
 
+      # Mint a short-lived, least-privilege token scoped to doublezero-edge-connect
+      # from the release-bot GitHub App, used only to fire the cross-repo dispatch
+      # below. Non-fatal: if the app isn't installed on edge-connect the mint fails,
+      # the dispatch is skipped, and edge-connect's daily poll backstops the rebuild.
+      - name: Mint edge-connect dispatch token (mainnet-beta)
+        id: ec_token
+        if: steps.gate.outputs.changed == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: doublezero-edge-connect
+
       # Tell doublezero-edge-connect to rebuild its :mainnet-beta variant against
       # the base image we just published (event-driven; poll is the fallback).
       - name: Notify edge-connect to rebuild (mainnet-beta)
-        if: steps.gate.outputs.changed == 'true'
+        # Skip cleanly if the token mint failed (empty token) — the poll backstops it.
+        if: steps.gate.outputs.changed == 'true' && steps.ec_token.outputs.token != ''
         # A failed cross-repo dispatch must not fail an already-successful publish;
         # edge-connect's daily poll is the fallback.
         continue-on-error: true
@@ -236,7 +268,7 @@ jobs:
         env:
           DZ_VERSION: ${{ steps.v.outputs.version }}
         with:
-          github-token: ${{ secrets.EDGE_CONNECT_DISPATCH_TOKEN }}
+          github-token: ${{ steps.ec_token.outputs.token }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,

--- a/.github/workflows/release.docker.client.yml
+++ b/.github/workflows/release.docker.client.yml
@@ -127,6 +127,9 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: doublezero-edge-connect
+          # Scope the token down to exactly what repository_dispatch needs, rather
+          # than inheriting every permission the release-bot App holds on the repo.
+          permission-contents: write
 
       # Tell doublezero-edge-connect to rebuild its :testnet variant against the
       # base image we just published (event-driven; its daily poll is the fallback).
@@ -255,6 +258,9 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: doublezero-edge-connect
+          # Scope the token down to exactly what repository_dispatch needs, rather
+          # than inheriting every permission the release-bot App holds on the repo.
+          permission-contents: write
 
       # Tell doublezero-edge-connect to rebuild its :mainnet-beta variant against
       # the base image we just published (event-driven; poll is the fallback).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CI
+  - Fix the event-driven `doublezero-edge-connect` rebuild: the base-image publishers now mint a short-lived, least-privilege token from the release-bot GitHub App (scoped to `doublezero-edge-connect`) to fire the cross-repo `repository_dispatch`, replacing the never-created `EDGE_CONNECT_DISPATCH_TOKEN` secret whose absence silently no-op'd every notify. Also add the missing devnet notify step, so all three variants (testnet, mainnet-beta, devnet) trigger a rebuild on base publish. The mint/notify steps stay non-fatal to the publish and edge-connect's daily poll remains the fallback.
+
 ## [v0.30.0](https://github.com/malbeclabs/doublezero/compare/client/v0.29.0...client/v0.30.0) - 2026-07-10
 
 ### Breaking


### PR DESCRIPTION
## Problem

The event-driven `doublezero-edge-connect` rebuild has **never fired**. On every base-image publish the "Notify edge-connect to rebuild" step failed with:

```
Error: Input required and not supplied: github-token
```

because it referenced `secrets.EDGE_CONNECT_DISPATCH_TOKEN`, a secret that was **never created** in this repo. The steps are `continue-on-error: true`, so the failure was silent and the publishes stayed green.

Confirmed on recent runs:
- testnet — run `29119708072` (2026-07-10)
- mainnet-beta — run `28999867250` (2026-07-09)

On the receiver side, `doublezero-edge-connect` has **zero** `repository_dispatch` events / dispatch-workflow runs. The only thing keeping the images in sync has been edge-connect's daily poll (`05:23 UTC`) — up to ~24h late, and one poll run (2026-07-09, devnet base moved) was lost to a hosted-runner acquisition flake before self-healing the next day.

Separately, **devnet had no notify step at all** (`release.docker.client.devnet.yml`), so devnet was never event-driven even in intent.

## Change

- **Auth via the release-bot GitHub App** instead of the missing secret. Each publisher mints a short-lived, least-privilege token scoped to `doublezero-edge-connect` (`actions/create-github-app-token@v2` with `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`) and uses it for the cross-repo `repository_dispatch`. This mirrors the app-token pattern already used in `release.testnet.yml`.
- **Add the missing devnet notify step.** All three variants — testnet, mainnet-beta, devnet — now trigger an event-driven rebuild on base publish.
- **Non-fatal throughout.** Both the mint and the notify steps are `continue-on-error`, and the notify is skipped cleanly when the token is empty. edge-connect's daily poll remains the fallback (and still backstops digest drift from any cause).

The receiver in edge-connect (`release.docker.edge-connect.dispatch.yml`) already validates and handles `testnet | mainnet-beta | devnet`, so no change is needed there.

## ⚠️ Action required before this works end-to-end

The **release-bot GitHub App must be installed on `doublezero-edge-connect`** with **Contents: write** (the permission `repository_dispatch` requires). If it is not yet installed there, an org admin needs to add the installation / grant the repo. Until then the mint step fails non-fatally and the daily poll continues to backstop — no regression.

## Verification
- `python3 -c "import yaml; ..."` parses both workflows; repo `actionlint` runs on this PR.
- After merge, the next base publish should produce a `doublezero-base-published` `repository_dispatch` in `doublezero-edge-connect` and a `release.docker.edge-connect.dispatch` run within ~1 min.