### PR TITLE
e2e: fix flake gap-filler stale check (never fired) + move cron off :00

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,11 +15,13 @@ on:
         description: GHCR image tag for this trusted run
         required: true
   schedule:
-    # Hourly flake gap-filler. Every tick runs only the lightweight schedule-gate
-    # job; the expensive setup + e2e matrix run only when the gate returns
-    # proceed=true (stale main AND idle e2e AND toggle enabled). See schedule-gate
-    # below and malbeclabs/infra docs/plans/2026-07-02-e2e-flake-gap-filler-*.
-    - cron: '0 * * * *'
+    # Flake gap-filler, every 6h at :23 (off the congested :00/:30 scheduler slots).
+    # Each tick runs only the lightweight schedule-gate; the expensive setup + e2e
+    # matrix run only when the gate returns proceed=true (no merge to main in
+    # STALE_HOURS AND e2e idle AND toggle enabled). The 6h cadence bounds how often
+    # it can fire during a long no-merge lull. See schedule-gate below and
+    # malbeclabs/infra docs/plans/2026-07-02-e2e-flake-gap-filler-*.
+    - cron: '23 */6 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -80,10 +82,14 @@ jobs:
             const selfId = context.runId;
             const { owner, repo } = context.repo;
 
-            // Stale check: newest e2e run against main HEAD (push or schedule),
-            // excluding this run. Missing => Infinity => stale.
+            // Stale check: newest *merge* (push) e2e run on main. Only push events
+            // count — the gap-filler's own scheduled ticks are also branch=main e2e
+            // runs, so counting them would make main never look stale (each tick
+            // sees the prior tick ~one cron-interval ago and declines forever). We
+            // want "no real e2e ran on main in STALE_HOURS", i.e. no merge.
+            // Missing => Infinity => stale.
             const mainRuns = await github.rest.actions.listWorkflowRuns({
-              owner, repo, workflow_id: 'e2e.yml', branch: 'main', per_page: 30,
+              owner, repo, workflow_id: 'e2e.yml', branch: 'main', event: 'push', per_page: 30,
             });
             const newestMain = mainRuns.data.workflow_runs
               .filter(r => r.id !== selfId)
@@ -106,12 +112,12 @@ jobs:
 
             const proceed = enabled && stale && idle;
             const ageStr = Number.isFinite(ageHours) ? ageHours.toFixed(1) + 'h' : 'none';
-            core.info(`enabled=${enabled} stale=${stale} (newest main age=${ageStr}, threshold=${STALE_HOURS}h) idle=${idle} (active=${active.length}) => proceed=${proceed}`);
+            core.info(`enabled=${enabled} stale=${stale} (newest merge age=${ageStr}, threshold=${STALE_HOURS}h) idle=${idle} (active=${active.length}) => proceed=${proceed}`);
             core.setOutput('proceed', String(proceed));
             await core.summary.addRaw(
               `### e2e flake gap-filler gate\n` +
               `- enabled: **${enabled}**\n` +
-              `- stale: **${stale}** (newest main run age ${ageStr} / ${STALE_HOURS}h)\n` +
+              `- stale: **${stale}** (newest merge (push) run age ${ageStr} / ${STALE_HOURS}h)\n` +
               `- idle: **${idle}** (in-flight e2e runs excluding self: ${active.length})\n` +
               `- **proceed: ${proceed}**\n`
             ).write();


### PR DESCRIPTION
## Summary of Changes
The e2e flake gap-filler (added in #3968, enabled via `E2E_GAP_FILLER_ENABLED`) **has never actually fired** — 0 of 58 scheduled ticks proceeded over ~2.8 days. This fixes the bug and improves the schedule.

**Root cause:** the gate's staleness check listed all e2e runs on `branch=main`, but *a scheduled tick is itself a `branch=main` e2e run*. It only excluded the current run, so every tick saw the *previous* tick (~1 cron-interval ago) as "recent main activity" and concluded main wasn't 6h-stale → `proceed=false`, forever. Verified from gate logs: every tick showed `enabled=true idle=true stale=false (newest main age≈1.0h)`.

**Fix:**
- Staleness now counts only `push` (merge) runs (`event: 'push'` on the API call). The gate's own scheduled ticks no longer poison it; `stale` now means "no merge to main in `STALE_HOURS` (6h)".
- Cron `0 * * * *` → `23 */6 * * *`: off GitHub's congested `:00`/`:30` slots (the old schedule ran ~35 min late and dropped ~21% of ticks), and the 6h cadence bounds firing to at most ~4×/day during a long no-merge lull (idle-gated, so still yields to real e2e load).

No change to the gate's idle check, the toggle, or downstream jobs.

## Testing Verification
- **Confirmed the failure empirically:** 0/58 scheduled ticks since enabling had a non-skipped `setup` job; gate logs consistently showed `stale=false` with `newest main age≈1h`.
- **Backtested the fix against live data** by replaying both the old and new staleness logic at all 58 historical tick times: the old logic is `stale=false` on every tick (matching 0/58), while the new merge-only logic is `stale=true` on 42/58 — and its age climbs correctly through the weekend no-merge lull (11h → 16h → 24h → 35h) yet correctly reads `false` right after real merges. So the fix flips the wrongly-suppressed ticks to eligible without over-firing during active periods. (Idle isn't backtested, so actual proceeds = stale ∩ idle; the 6h cron further bounds it to ≤4/day.)
- Post-merge: confirm a scheduled tick's gate log shows `stale` tracking *merge* recency, and catch the first proceeded run (setup + expanded matrix) during a real 6h+ lull.