### PR TITLE
serviceability-instruction: link domain builders (RFC-26 R2)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/link.rs
+++ b/crates/doublezero-serviceability-instruction/src/link.rs
@@ -7,7 +7,10 @@ use doublezero_serviceability::{
         get_globalstate_pda, get_link_pda, get_resource_extension_pda, get_topology_pda,
         UNICAST_DEFAULT_TOPOLOGY_NAME,
     },
-    processors::link::create::LinkCreateArgs,
+    processors::link::{
+        accept::LinkAcceptArgs, create::LinkCreateArgs, delete::LinkDeleteArgs,
+        sethealth::LinkSetHealthArgs, update::LinkUpdateArgs,
+    },
     resource::ResourceType,
 };
 use solana_program::{
@@ -65,6 +68,224 @@ pub fn create_link(
     )
 }
 
+/// `AcceptLink` (variant 66).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link                  (writable)
+/// contributor           (writable)  — device_z.contributor_pk
+/// side_z                (writable)  — link.side_z_pk
+/// globalstate           (writable)
+/// side_a                (writable)  — link.side_a_pk
+/// device_tunnel_block   (writable)  — ResourceType::DeviceTunnelBlock
+/// link_ids              (writable)  — ResourceType::LinkIds
+/// ```
+pub fn accept_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    contributor: &Pubkey,
+    side_z: &Pubkey,
+    side_a: &Pubkey,
+    mut args: LinkAcceptArgs,
+) -> Instruction {
+    // The processor rejects `use_onchain_allocation == false` as its first
+    // statement (accept.rs), and `false` is the struct default — a caller-supplied
+    // value here can only ever fail. This builder owns onchain allocation, so it
+    // forces the flag (as the SDK command does).
+    args.use_onchain_allocation = true;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (device_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+    let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+    let accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(*contributor, false),
+        AccountMeta::new(*side_z, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(*side_a, false),
+        AccountMeta::new(device_tunnel_block, false),
+        AccountMeta::new(link_ids, false),
+    ];
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::AcceptLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// Which contributor authority is updating a link, selecting the account preamble
+/// `UpdateLink` uses (the processor accepts either the link's own contributor or
+/// side-Z's contributor). The caller resolves this from onchain state.
+pub enum LinkUpdateAuthority<'a> {
+    /// The link's own contributor. Preamble: `[link, contributor, globalstate]`.
+    Contributor { contributor: &'a Pubkey },
+    /// Side-Z's contributor. Preamble: `[link, contributor, side_z, globalstate]`.
+    SideZContributor { contributor: &'a Pubkey },
+}
+
+/// `UpdateLink` (variant 31).
+///
+/// Account layout, before the trailing accounts (all sections after the preamble
+/// are conditional):
+///
+/// ```text
+/// // preamble — see LinkUpdateAuthority:
+/// link, [contributor | contributor, side_z], globalstate   (all writable)
+/// // when args.tunnel_net.is_some():
+/// side_a, side_z                                            (writable)
+/// // when args.tunnel_id.is_some() || args.tunnel_net.is_some():
+/// device_tunnel_block, link_ids                             (writable)
+/// // when args.link_topologies.is_some():
+/// topology_union[i]                                         (writable)
+/// ```
+///
+/// `topology_union` is the union of the link's current `link_topologies` (RPC-read)
+/// and the requested new set; it is appended only when `args.link_topologies` is
+/// `Some`. `args.use_onchain_allocation` is set to whether tunnel resources are
+/// being updated.
+#[allow(clippy::too_many_arguments)]
+pub fn update_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    authority: LinkUpdateAuthority,
+    side_a: &Pubkey,
+    side_z: &Pubkey,
+    topology_union: &[Pubkey],
+    mut args: LinkUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = match authority {
+        LinkUpdateAuthority::SideZContributor { contributor } => vec![
+            AccountMeta::new(*link, false),
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(*side_z, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        LinkUpdateAuthority::Contributor { contributor } => vec![
+            AccountMeta::new(*link, false),
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+    };
+
+    if args.tunnel_net.is_some() {
+        accounts.push(AccountMeta::new(*side_a, false));
+        accounts.push(AccountMeta::new(*side_z, false));
+    }
+
+    let updating_tunnel_resources = args.tunnel_id.is_some() || args.tunnel_net.is_some();
+    if updating_tunnel_resources {
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+        accounts.push(AccountMeta::new(device_tunnel_block, false));
+        accounts.push(AccountMeta::new(link_ids, false));
+    }
+    args.use_onchain_allocation = updating_tunnel_resources;
+
+    if args.link_topologies.is_some() {
+        for topology in topology_union {
+            accounts.push(AccountMeta::new(*topology, false));
+        }
+    }
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `DeleteLink` (variant 34).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link                  (writable)
+/// contributor           (writable)  — link.contributor_pk
+/// globalstate           (writable)
+/// side_a                (writable)  — link.side_a_pk
+/// side_z                (writable)  — link.side_z_pk
+/// device_tunnel_block   (writable)  — ResourceType::DeviceTunnelBlock
+/// link_ids              (writable)  — ResourceType::LinkIds
+/// owner                 (writable)  — link.owner
+/// topology[i]           (writable)  — one per link.link_topologies entry
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub fn delete_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    contributor: &Pubkey,
+    side_a: &Pubkey,
+    side_z: &Pubkey,
+    owner: &Pubkey,
+    link_topologies: &[Pubkey],
+    mut args: LinkDeleteArgs,
+) -> Instruction {
+    // The processor rejects `use_onchain_deallocation == false` as its first
+    // statement (delete.rs), and `false` is the struct default — a caller-supplied
+    // value here can only ever fail. Force it, as the SDK does.
+    args.use_onchain_deallocation = true;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (device_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+    let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+    let mut accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(*contributor, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(*side_a, false),
+        AccountMeta::new(*side_z, false),
+        AccountMeta::new(device_tunnel_block, false),
+        AccountMeta::new(link_ids, false),
+        AccountMeta::new(*owner, false),
+    ];
+    for topology in link_topologies {
+        accounts.push(AccountMeta::new(*topology, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `SetLinkHealth` (variant 84).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link         (writable)
+/// globalstate  (writable)
+/// ```
+pub fn set_link_health(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    args: LinkSetHealthArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(globalstate, false),
+    ];
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetLinkHealth(args),
+        accounts,
+        payer,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,6 +336,215 @@ mod tests {
                 AccountMeta::new(unicast_default, false),
                 AccountMeta::new(device_tunnel_block, false),
                 AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_accept_link_accounts_and_tag() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+
+        let ix = accept_link(
+            &pid,
+            &payer,
+            &link,
+            &contributor,
+            &side_z,
+            &side_a,
+            LinkAcceptArgs::default(),
+        );
+        assert_eq!(ix.data[0], 66);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::AcceptLink(a) => {
+                // The processor rejects use_onchain_allocation == false; the
+                // builder must force it regardless of the caller's default.
+                assert!(a.use_onchain_allocation);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_update_link_side_z_preamble() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+
+        // No tunnel fields, no topologies -> just the 4-account side-Z preamble.
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::SideZContributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[],
+            LinkUpdateArgs::default(),
+        );
+        assert_eq!(ix.data[0], 31);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_update_link_contributor_tunnel_net_and_topologies() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let topo = Pubkey::new_unique();
+
+        let args = LinkUpdateArgs {
+            tunnel_net: Some("10.0.0.0/21".parse().unwrap()),
+            link_topologies: Some(vec![topo]),
+            ..Default::default()
+        };
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::Contributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[topo],
+            args,
+        );
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(topo, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        // use_onchain_allocation is derived from whether tunnel resources are updated.
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_delete_link_with_topologies() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let topo = Pubkey::new_unique();
+
+        let ix = delete_link(
+            &pid,
+            &payer,
+            &link,
+            &contributor,
+            &side_a,
+            &side_z,
+            &owner,
+            &[topo],
+            LinkDeleteArgs::default(),
+        );
+        assert_eq!(ix.data[0], 34);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(topo, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::DeleteLink(a) => {
+                // The processor rejects use_onchain_deallocation == false; the
+                // builder must force it regardless of the caller's default.
+                assert!(a.use_onchain_deallocation);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_set_link_health() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let ix = set_link_health(&pid, &payer, &link, LinkSetHealthArgs::default());
+        assert_eq!(ix.data[0], 84);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(globalstate, false),
                 AccountMeta::new(payer, true),
                 AccountMeta::new(system_program::ID, false),
             ]

--- a/crates/doublezero-serviceability-instruction/src/link.rs
+++ b/crates/doublezero-serviceability-instruction/src/link.rs
@@ -380,11 +380,15 @@ mod tests {
             ]
         );
         match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
-            DoubleZeroInstruction::AcceptLink(a) => {
-                // The processor rejects use_onchain_allocation == false; the
-                // builder must force it regardless of the caller's default.
-                assert!(a.use_onchain_allocation);
-            }
+            // The processor rejects use_onchain_allocation == false; the builder
+            // must force it while leaving every other arg field untouched.
+            DoubleZeroInstruction::AcceptLink(a) => assert_eq!(
+                a,
+                LinkAcceptArgs {
+                    side_z_iface_name: String::new(),
+                    use_onchain_allocation: true,
+                }
+            ),
             other => panic!("unexpected: {other:?}"),
         }
     }
@@ -399,6 +403,8 @@ mod tests {
         let side_z = Pubkey::new_unique();
 
         // No tunnel fields, no topologies -> just the 4-account side-Z preamble.
+        // Pass use_onchain_allocation: true to prove the builder clears it back to
+        // false when no tunnel resources are being updated.
         let ix = update_link(
             &pid,
             &payer,
@@ -409,7 +415,10 @@ mod tests {
             &side_a,
             &side_z,
             &[],
-            LinkUpdateArgs::default(),
+            LinkUpdateArgs {
+                use_onchain_allocation: true,
+                ..Default::default()
+            },
         );
         assert_eq!(ix.data[0], 31);
         let (globalstate, _) = get_globalstate_pda(&pid);
@@ -424,6 +433,10 @@ mod tests {
                 AccountMeta::new(system_program::ID, false),
             ]
         );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(!a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]
@@ -480,6 +493,57 @@ mod tests {
     }
 
     #[test]
+    fn test_update_link_tunnel_id_only() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+
+        // tunnel_id without tunnel_net: appends the resource accounts but NOT the
+        // side_a/side_z pair, and no topology section.
+        let args = LinkUpdateArgs {
+            tunnel_id: Some(42),
+            ..Default::default()
+        };
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::Contributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[],
+            args,
+        );
+        assert_eq!(ix.data[0], 31);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        // Updating tunnel resources forces use_onchain_allocation on.
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_delete_link_with_topologies() {
         let pid = Pubkey::new_unique();
         let payer = Pubkey::new_unique();
@@ -523,11 +587,14 @@ mod tests {
             ]
         );
         match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
-            DoubleZeroInstruction::DeleteLink(a) => {
-                // The processor rejects use_onchain_deallocation == false; the
-                // builder must force it regardless of the caller's default.
-                assert!(a.use_onchain_deallocation);
-            }
+            // The processor rejects use_onchain_deallocation == false; the builder
+            // must force it while leaving every other arg field untouched.
+            DoubleZeroInstruction::DeleteLink(a) => assert_eq!(
+                a,
+                LinkDeleteArgs {
+                    use_onchain_deallocation: true,
+                }
+            ),
             other => panic!("unexpected: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary

RFC-26 **R2** (stacked on the previous phase's branch). accept_link, update_link (LinkUpdateAuthority preamble + conditional tunnel_net / tunnel-resource / topology-union sections), delete_link (topology reference-count accounts), set_link_health.

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4017. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link  ← **this PR**
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
