### PR TITLE
serviceability-instruction: user domain builders (RFC-26 R3)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/link.rs
+++ b/crates/doublezero-serviceability-instruction/src/link.rs
@@ -7,7 +7,10 @@ use doublezero_serviceability::{
         get_globalstate_pda, get_link_pda, get_resource_extension_pda, get_topology_pda,
         UNICAST_DEFAULT_TOPOLOGY_NAME,
     },
-    processors::link::create::LinkCreateArgs,
+    processors::link::{
+        accept::LinkAcceptArgs, create::LinkCreateArgs, delete::LinkDeleteArgs,
+        sethealth::LinkSetHealthArgs, update::LinkUpdateArgs,
+    },
     resource::ResourceType,
 };
 use solana_program::{
@@ -65,6 +68,224 @@ pub fn create_link(
     )
 }
 
+/// `AcceptLink` (variant 66).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link                  (writable)
+/// contributor           (writable)  — device_z.contributor_pk
+/// side_z                (writable)  — link.side_z_pk
+/// globalstate           (writable)
+/// side_a                (writable)  — link.side_a_pk
+/// device_tunnel_block   (writable)  — ResourceType::DeviceTunnelBlock
+/// link_ids              (writable)  — ResourceType::LinkIds
+/// ```
+pub fn accept_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    contributor: &Pubkey,
+    side_z: &Pubkey,
+    side_a: &Pubkey,
+    mut args: LinkAcceptArgs,
+) -> Instruction {
+    // The processor rejects `use_onchain_allocation == false` as its first
+    // statement (accept.rs), and `false` is the struct default — a caller-supplied
+    // value here can only ever fail. This builder owns onchain allocation, so it
+    // forces the flag (as the SDK command does).
+    args.use_onchain_allocation = true;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (device_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+    let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+    let accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(*contributor, false),
+        AccountMeta::new(*side_z, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(*side_a, false),
+        AccountMeta::new(device_tunnel_block, false),
+        AccountMeta::new(link_ids, false),
+    ];
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::AcceptLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// Which contributor authority is updating a link, selecting the account preamble
+/// `UpdateLink` uses (the processor accepts either the link's own contributor or
+/// side-Z's contributor). The caller resolves this from onchain state.
+pub enum LinkUpdateAuthority<'a> {
+    /// The link's own contributor. Preamble: `[link, contributor, globalstate]`.
+    Contributor { contributor: &'a Pubkey },
+    /// Side-Z's contributor. Preamble: `[link, contributor, side_z, globalstate]`.
+    SideZContributor { contributor: &'a Pubkey },
+}
+
+/// `UpdateLink` (variant 31).
+///
+/// Account layout, before the trailing accounts (all sections after the preamble
+/// are conditional):
+///
+/// ```text
+/// // preamble — see LinkUpdateAuthority:
+/// link, [contributor | contributor, side_z], globalstate   (all writable)
+/// // when args.tunnel_net.is_some():
+/// side_a, side_z                                            (writable)
+/// // when args.tunnel_id.is_some() || args.tunnel_net.is_some():
+/// device_tunnel_block, link_ids                             (writable)
+/// // when args.link_topologies.is_some():
+/// topology_union[i]                                         (writable)
+/// ```
+///
+/// `topology_union` is the union of the link's current `link_topologies` (RPC-read)
+/// and the requested new set; it is appended only when `args.link_topologies` is
+/// `Some`. `args.use_onchain_allocation` is set to whether tunnel resources are
+/// being updated.
+#[allow(clippy::too_many_arguments)]
+pub fn update_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    authority: LinkUpdateAuthority,
+    side_a: &Pubkey,
+    side_z: &Pubkey,
+    topology_union: &[Pubkey],
+    mut args: LinkUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = match authority {
+        LinkUpdateAuthority::SideZContributor { contributor } => vec![
+            AccountMeta::new(*link, false),
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(*side_z, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        LinkUpdateAuthority::Contributor { contributor } => vec![
+            AccountMeta::new(*link, false),
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+    };
+
+    if args.tunnel_net.is_some() {
+        accounts.push(AccountMeta::new(*side_a, false));
+        accounts.push(AccountMeta::new(*side_z, false));
+    }
+
+    let updating_tunnel_resources = args.tunnel_id.is_some() || args.tunnel_net.is_some();
+    if updating_tunnel_resources {
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+        accounts.push(AccountMeta::new(device_tunnel_block, false));
+        accounts.push(AccountMeta::new(link_ids, false));
+    }
+    args.use_onchain_allocation = updating_tunnel_resources;
+
+    if args.link_topologies.is_some() {
+        for topology in topology_union {
+            accounts.push(AccountMeta::new(*topology, false));
+        }
+    }
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `DeleteLink` (variant 34).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link                  (writable)
+/// contributor           (writable)  — link.contributor_pk
+/// globalstate           (writable)
+/// side_a                (writable)  — link.side_a_pk
+/// side_z                (writable)  — link.side_z_pk
+/// device_tunnel_block   (writable)  — ResourceType::DeviceTunnelBlock
+/// link_ids              (writable)  — ResourceType::LinkIds
+/// owner                 (writable)  — link.owner
+/// topology[i]           (writable)  — one per link.link_topologies entry
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub fn delete_link(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    contributor: &Pubkey,
+    side_a: &Pubkey,
+    side_z: &Pubkey,
+    owner: &Pubkey,
+    link_topologies: &[Pubkey],
+    mut args: LinkDeleteArgs,
+) -> Instruction {
+    // The processor rejects `use_onchain_deallocation == false` as its first
+    // statement (delete.rs), and `false` is the struct default — a caller-supplied
+    // value here can only ever fail. Force it, as the SDK does.
+    args.use_onchain_deallocation = true;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (device_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+    let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+    let mut accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(*contributor, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(*side_a, false),
+        AccountMeta::new(*side_z, false),
+        AccountMeta::new(device_tunnel_block, false),
+        AccountMeta::new(link_ids, false),
+        AccountMeta::new(*owner, false),
+    ];
+    for topology in link_topologies {
+        accounts.push(AccountMeta::new(*topology, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteLink(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `SetLinkHealth` (variant 84).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// link         (writable)
+/// globalstate  (writable)
+/// ```
+pub fn set_link_health(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    link: &Pubkey,
+    args: LinkSetHealthArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let accounts = vec![
+        AccountMeta::new(*link, false),
+        AccountMeta::new(globalstate, false),
+    ];
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetLinkHealth(args),
+        accounts,
+        payer,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,6 +336,215 @@ mod tests {
                 AccountMeta::new(unicast_default, false),
                 AccountMeta::new(device_tunnel_block, false),
                 AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_accept_link_accounts_and_tag() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+
+        let ix = accept_link(
+            &pid,
+            &payer,
+            &link,
+            &contributor,
+            &side_z,
+            &side_a,
+            LinkAcceptArgs::default(),
+        );
+        assert_eq!(ix.data[0], 66);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::AcceptLink(a) => {
+                // The processor rejects use_onchain_allocation == false; the
+                // builder must force it regardless of the caller's default.
+                assert!(a.use_onchain_allocation);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_update_link_side_z_preamble() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+
+        // No tunnel fields, no topologies -> just the 4-account side-Z preamble.
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::SideZContributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[],
+            LinkUpdateArgs::default(),
+        );
+        assert_eq!(ix.data[0], 31);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_update_link_contributor_tunnel_net_and_topologies() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let topo = Pubkey::new_unique();
+
+        let args = LinkUpdateArgs {
+            tunnel_net: Some("10.0.0.0/21".parse().unwrap()),
+            link_topologies: Some(vec![topo]),
+            ..Default::default()
+        };
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::Contributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[topo],
+            args,
+        );
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(topo, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        // use_onchain_allocation is derived from whether tunnel resources are updated.
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_delete_link_with_topologies() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let topo = Pubkey::new_unique();
+
+        let ix = delete_link(
+            &pid,
+            &payer,
+            &link,
+            &contributor,
+            &side_a,
+            &side_z,
+            &owner,
+            &[topo],
+            LinkDeleteArgs::default(),
+        );
+        assert_eq!(ix.data[0], 34);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(side_a, false),
+                AccountMeta::new(side_z, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(topo, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::DeleteLink(a) => {
+                // The processor rejects use_onchain_deallocation == false; the
+                // builder must force it regardless of the caller's default.
+                assert!(a.use_onchain_deallocation);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_set_link_health() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let ix = set_link_health(&pid, &payer, &link, LinkSetHealthArgs::default());
+        assert_eq!(ix.data[0], 84);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(globalstate, false),
                 AccountMeta::new(payer, true),
                 AccountMeta::new(system_program::ID, false),
             ]

--- a/crates/doublezero-serviceability-instruction/src/link.rs
+++ b/crates/doublezero-serviceability-instruction/src/link.rs
@@ -380,11 +380,15 @@ mod tests {
             ]
         );
         match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
-            DoubleZeroInstruction::AcceptLink(a) => {
-                // The processor rejects use_onchain_allocation == false; the
-                // builder must force it regardless of the caller's default.
-                assert!(a.use_onchain_allocation);
-            }
+            // The processor rejects use_onchain_allocation == false; the builder
+            // must force it while leaving every other arg field untouched.
+            DoubleZeroInstruction::AcceptLink(a) => assert_eq!(
+                a,
+                LinkAcceptArgs {
+                    side_z_iface_name: String::new(),
+                    use_onchain_allocation: true,
+                }
+            ),
             other => panic!("unexpected: {other:?}"),
         }
     }
@@ -399,6 +403,8 @@ mod tests {
         let side_z = Pubkey::new_unique();
 
         // No tunnel fields, no topologies -> just the 4-account side-Z preamble.
+        // Pass use_onchain_allocation: true to prove the builder clears it back to
+        // false when no tunnel resources are being updated.
         let ix = update_link(
             &pid,
             &payer,
@@ -409,7 +415,10 @@ mod tests {
             &side_a,
             &side_z,
             &[],
-            LinkUpdateArgs::default(),
+            LinkUpdateArgs {
+                use_onchain_allocation: true,
+                ..Default::default()
+            },
         );
         assert_eq!(ix.data[0], 31);
         let (globalstate, _) = get_globalstate_pda(&pid);
@@ -424,6 +433,10 @@ mod tests {
                 AccountMeta::new(system_program::ID, false),
             ]
         );
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(!a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]
@@ -480,6 +493,57 @@ mod tests {
     }
 
     #[test]
+    fn test_update_link_tunnel_id_only() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let link = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let side_a = Pubkey::new_unique();
+        let side_z = Pubkey::new_unique();
+
+        // tunnel_id without tunnel_net: appends the resource accounts but NOT the
+        // side_a/side_z pair, and no topology section.
+        let args = LinkUpdateArgs {
+            tunnel_id: Some(42),
+            ..Default::default()
+        };
+        let ix = update_link(
+            &pid,
+            &payer,
+            &link,
+            LinkUpdateAuthority::Contributor {
+                contributor: &contributor,
+            },
+            &side_a,
+            &side_z,
+            &[],
+            args,
+        );
+        assert_eq!(ix.data[0], 31);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (device_tunnel_block, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (link_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(link, false),
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(device_tunnel_block, false),
+                AccountMeta::new(link_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        // Updating tunnel resources forces use_onchain_allocation on.
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateLink(a) => assert!(a.use_onchain_allocation),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_delete_link_with_topologies() {
         let pid = Pubkey::new_unique();
         let payer = Pubkey::new_unique();
@@ -523,11 +587,14 @@ mod tests {
             ]
         );
         match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
-            DoubleZeroInstruction::DeleteLink(a) => {
-                // The processor rejects use_onchain_deallocation == false; the
-                // builder must force it regardless of the caller's default.
-                assert!(a.use_onchain_deallocation);
-            }
+            // The processor rejects use_onchain_deallocation == false; the builder
+            // must force it while leaving every other arg field untouched.
+            DoubleZeroInstruction::DeleteLink(a) => assert_eq!(
+                a,
+                LinkDeleteArgs {
+                    use_onchain_deallocation: true,
+                }
+            ),
             other => panic!("unexpected: {other:?}"),
         }
     }

--- a/crates/doublezero-serviceability-instruction/src/user.rs
+++ b/crates/doublezero-serviceability-instruction/src/user.rs
@@ -54,6 +54,13 @@ pub fn create_subscribe_user(
     feed: Option<&Pubkey>,
     mut args: UserCreateSubscribeArgs,
 ) -> Instruction {
+    // The processor rejects `dz_prefix_count == 0` as its first statement
+    // (create_subscribe.rs) — CreateSubscribeUser requires on-chain allocation — so a
+    // zero here can only ever fail. Catch it cheaply in debug builds.
+    debug_assert!(
+        dz_prefix_count > 0,
+        "dz_prefix_count must be > 0; CreateSubscribeUser requires on-chain allocation"
+    );
     // The write-back overwrites any caller-set `dz_prefix_count`; assert they agree
     // (or the caller left it zero) to catch confusion cheaply in debug builds.
     debug_assert!(
@@ -135,6 +142,13 @@ pub fn create_user(
     tenant: Option<Pubkey>,
     mut args: UserCreateArgs,
 ) -> Instruction {
+    // The processor rejects `dz_prefix_count == 0` as its first statement (create.rs)
+    // — CreateUser requires on-chain allocation — so a zero here can only ever fail.
+    // Catch it cheaply in debug builds.
+    debug_assert!(
+        dz_prefix_count > 0,
+        "dz_prefix_count must be > 0; CreateUser requires on-chain allocation"
+    );
     args.dz_prefix_count = dz_prefix_count;
 
     let (user, _) = get_user_pda(program_id, &args.client_ip, args.user_type);

--- a/crates/doublezero-serviceability-instruction/src/user.rs
+++ b/crates/doublezero-serviceability-instruction/src/user.rs
@@ -691,6 +691,44 @@ mod tests {
     }
 
     #[test]
+    fn test_update_user_with_non_default_old_tenant_is_writable() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let old_tenant = Pubkey::new_unique();
+        let new_tenant = Pubkey::new_unique();
+
+        let args = UserUpdateArgs {
+            tenant_pk: Some(new_tenant),
+            ..Default::default()
+        };
+        // old_tenant non-default -> appended WRITABLE (ref-count decrement) before new_tenant.
+        let ix = update_user(&pid, &payer, &user, &device, 1, &old_tenant, args);
+        assert_eq!(ix.data[0], 39);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new(old_tenant, false),
+                AccountMeta::new(new_tenant, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
     fn test_update_user_no_tenant_change() {
         let pid = Pubkey::new_unique();
         let payer = Pubkey::new_unique();
@@ -760,6 +798,69 @@ mod tests {
                 AccountMeta::new(system_program::ID, false),
             ]
         );
+    }
+
+    #[test]
+    fn test_delete_user_with_non_default_tenant() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let accesspass = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let tenant = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        // Non-default tenant -> a writable tenant account is inserted between the
+        // dz_prefix accounts and owner.
+        let ix = delete_user(
+            &pid,
+            &payer,
+            &user,
+            &accesspass,
+            &device,
+            1,
+            Some(tenant),
+            &owner,
+            UserDeleteArgs::default(),
+        );
+        assert_eq!(ix.data[0], 42);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(device, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new(tenant, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+
+        // A default tenant is never appended (owner directly follows dz_prefix).
+        let ix2 = delete_user(
+            &pid,
+            &payer,
+            &user,
+            &accesspass,
+            &device,
+            1,
+            Some(Pubkey::default()),
+            &owner,
+            UserDeleteArgs::default(),
+        );
+        assert_eq!(ix2.accounts.len(), 11);
+        assert_eq!(ix2.accounts[ix2.accounts.len() - 3].pubkey, owner);
     }
 
     #[test]

--- a/crates/doublezero-serviceability-instruction/src/user.rs
+++ b/crates/doublezero-serviceability-instruction/src/user.rs
@@ -215,6 +215,13 @@ pub fn update_user(
     old_tenant: &Pubkey,
     mut args: UserUpdateArgs,
 ) -> Instruction {
+    // The processor rejects `dz_prefix_count == 0` as its first statement
+    // (update.rs) — UpdateUser requires on-chain allocation — so a zero here can only
+    // ever fail. Catch it cheaply in debug builds.
+    debug_assert!(
+        dz_prefix_count > 0,
+        "dz_prefix_count must be > 0; UpdateUser requires on-chain allocation"
+    );
     args.dz_prefix_count = dz_prefix_count;
     // This builder always emits the `multicast_publisher_block` account, so the
     // declared count MUST be > 0 or the processor (which reads that account only
@@ -294,6 +301,13 @@ pub fn delete_user(
     owner: &Pubkey,
     mut args: UserDeleteArgs,
 ) -> Instruction {
+    // The processor rejects `dz_prefix_count == 0` as its first statement
+    // (delete.rs) — DeleteUser requires on-chain deallocation — so a zero here can
+    // only ever fail. Catch it cheaply in debug builds.
+    debug_assert!(
+        dz_prefix_count > 0,
+        "dz_prefix_count must be > 0; DeleteUser requires on-chain deallocation"
+    );
     args.dz_prefix_count = dz_prefix_count;
     // This builder always emits the `multicast_publisher_block` account, so the
     // declared count MUST be > 0 or the processor (which reads that account only
@@ -359,6 +373,13 @@ pub fn request_ban_user(
     dz_prefix_count: u8,
     mut args: UserRequestBanArgs,
 ) -> Instruction {
+    // The processor rejects `dz_prefix_count == 0` as its first statement
+    // (requestban.rs) — RequestBanUser requires on-chain deallocation — so a zero here
+    // can only ever fail. Catch it cheaply in debug builds.
+    debug_assert!(
+        dz_prefix_count > 0,
+        "dz_prefix_count must be > 0; RequestBanUser requires on-chain deallocation"
+    );
     args.dz_prefix_count = dz_prefix_count;
     // This builder always emits the `multicast_publisher_block` account, so the
     // declared count MUST be > 0 or the processor (which reads that account only

--- a/crates/doublezero-serviceability-instruction/src/user.rs
+++ b/crates/doublezero-serviceability-instruction/src/user.rs
@@ -4,7 +4,12 @@ use crate::common;
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
     pda::{get_globalstate_pda, get_resource_extension_pda, get_user_pda},
-    processors::user::create_subscribe::UserCreateSubscribeArgs,
+    processors::user::{
+        check_access_pass::CheckUserAccessPassArgs, create::UserCreateArgs,
+        create_subscribe::UserCreateSubscribeArgs, delete::UserDeleteArgs,
+        requestban::UserRequestBanArgs, set_bgp_status::SetUserBGPStatusArgs,
+        update::UserUpdateArgs,
+    },
     resource::ResourceType,
 };
 use solana_program::{
@@ -100,10 +105,330 @@ pub fn create_subscribe_user(
     )
 }
 
+/// `CreateUser` (variant 36).
+///
+/// Account layout (processor `next_account_info` order), before the trailing
+/// `[payer, system]` appended by [`common::build`]:
+///
+/// ```text
+/// user                        (writable)  — get_user_pda(client_ip, user_type)
+/// device                      (writable)
+/// accesspass                  (writable)
+/// globalstate                 (writable)
+/// user_tunnel_block           (writable)  — ResourceType::UserTunnelBlock
+/// multicast_publisher_block   (writable)  — ResourceType::MulticastPublisherBlock
+/// device_tunnel_ids           (writable)  — ResourceType::TunnelIds(device, 0)
+/// dz_prefix_block[i]          (writable)  — one per dz_prefix_count
+/// tenant                      (writable)  — OPTIONAL, only when Some and non-default
+/// ```
+///
+/// `CreateUser` is the genuine **length-detected** instruction: its processor
+/// identifies the optional trailing `tenant` account via `accounts.len()` and
+/// never calls `authorize()`. It is therefore assigned to [`common::build`] — a
+/// Permission account must never be appended, or the count is corrupted.
+pub fn create_user(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    device: &Pubkey,
+    accesspass: &Pubkey,
+    dz_prefix_count: u8,
+    tenant: Option<Pubkey>,
+    mut args: UserCreateArgs,
+) -> Instruction {
+    args.dz_prefix_count = dz_prefix_count;
+
+    let (user, _) = get_user_pda(program_id, &args.client_ip, args.user_type);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+    let (device_tunnel_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::TunnelIds(*device, 0));
+
+    let mut accounts = vec![
+        AccountMeta::new(user, false),
+        AccountMeta::new(*device, false),
+        AccountMeta::new(*accesspass, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(user_tunnel_block, false),
+        AccountMeta::new(multicast_publisher_block, false),
+        AccountMeta::new(device_tunnel_ids, false),
+    ];
+    for idx in 0..dz_prefix_count as usize {
+        let (dz_prefix, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DzPrefixBlock(*device, idx));
+        accounts.push(AccountMeta::new(dz_prefix, false));
+    }
+    if let Some(tenant) = tenant {
+        if tenant != Pubkey::default() {
+            accounts.push(AccountMeta::new(tenant, false));
+        }
+    }
+
+    common::build(
+        program_id,
+        DoubleZeroInstruction::CreateUser(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `UpdateUser` (variant 39).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// user                        (writable)
+/// globalstate                 (writable)
+/// user_tunnel_block           (writable)  — ResourceType::UserTunnelBlock
+/// multicast_publisher_block   (writable)  — ResourceType::MulticastPublisherBlock
+/// device_tunnel_ids           (writable)  — ResourceType::TunnelIds(device, 0)
+/// dz_prefix_block[i]          (writable)  — one per dz_prefix_count
+/// // only when args.tenant_pk.is_some():
+/// old_tenant                  (readonly when default, else writable) — user.tenant_pk
+/// new_tenant                  (writable)  — args.tenant_pk
+/// ```
+///
+/// `args.dz_prefix_count` is written from `dz_prefix_count`. Routes through
+/// `authorize()` via `split_trailing_permission` -> [`common::build_with_permission`].
+pub fn update_user(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user: &Pubkey,
+    device: &Pubkey,
+    dz_prefix_count: u8,
+    old_tenant: &Pubkey,
+    mut args: UserUpdateArgs,
+) -> Instruction {
+    args.dz_prefix_count = dz_prefix_count;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+    let (device_tunnel_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::TunnelIds(*device, 0));
+
+    let mut accounts = vec![
+        AccountMeta::new(*user, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(user_tunnel_block, false),
+        AccountMeta::new(multicast_publisher_block, false),
+        AccountMeta::new(device_tunnel_ids, false),
+    ];
+    for idx in 0..dz_prefix_count as usize {
+        let (dz_prefix, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DzPrefixBlock(*device, idx));
+        accounts.push(AccountMeta::new(dz_prefix, false));
+    }
+    // Reference-count adjustment on tenant change: old (readonly when default so the
+    // runtime accepts it; the processor skips a default key) then new.
+    if let Some(new_tenant) = args.tenant_pk {
+        if *old_tenant == Pubkey::default() {
+            accounts.push(AccountMeta::new_readonly(*old_tenant, false));
+        } else {
+            accounts.push(AccountMeta::new(*old_tenant, false));
+        }
+        accounts.push(AccountMeta::new(new_tenant, false));
+    }
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateUser(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `DeleteUser` (variant 42).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// user                        (writable)
+/// accesspass                  (writable)
+/// globalstate                 (writable)
+/// device                      (writable)
+/// user_tunnel_block           (writable)  — ResourceType::UserTunnelBlock
+/// multicast_publisher_block   (writable)  — ResourceType::MulticastPublisherBlock
+/// device_tunnel_ids           (writable)  — ResourceType::TunnelIds(device, 0)
+/// dz_prefix_block[i]          (writable)  — one per dz_prefix_count
+/// tenant                      (writable)  — OPTIONAL, only when non-default
+/// owner                       (writable)  — user.owner
+/// ```
+///
+/// `DeleteUser` detects its optional tenant from onchain state (not `accounts.len()`)
+/// and calls `authorize()` positionally, so it routes to
+/// [`common::build_with_permission`].
+#[allow(clippy::too_many_arguments)]
+pub fn delete_user(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user: &Pubkey,
+    accesspass: &Pubkey,
+    device: &Pubkey,
+    dz_prefix_count: u8,
+    tenant: Option<Pubkey>,
+    owner: &Pubkey,
+    mut args: UserDeleteArgs,
+) -> Instruction {
+    args.dz_prefix_count = dz_prefix_count;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+    let (device_tunnel_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::TunnelIds(*device, 0));
+
+    let mut accounts = vec![
+        AccountMeta::new(*user, false),
+        AccountMeta::new(*accesspass, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(*device, false),
+        AccountMeta::new(user_tunnel_block, false),
+        AccountMeta::new(multicast_publisher_block, false),
+        AccountMeta::new(device_tunnel_ids, false),
+    ];
+    for idx in 0..dz_prefix_count as usize {
+        let (dz_prefix, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DzPrefixBlock(*device, idx));
+        accounts.push(AccountMeta::new(dz_prefix, false));
+    }
+    if let Some(tenant) = tenant {
+        if tenant != Pubkey::default() {
+            accounts.push(AccountMeta::new(tenant, false));
+        }
+    }
+    accounts.push(AccountMeta::new(*owner, false));
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteUser(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `RequestBanUser` (variant 44).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// user                        (writable)
+/// globalstate                 (writable)
+/// user_tunnel_block           (writable)  — ResourceType::UserTunnelBlock
+/// multicast_publisher_block   (writable)  — ResourceType::MulticastPublisherBlock
+/// device_tunnel_ids           (writable)  — ResourceType::TunnelIds(device, 0)
+/// dz_prefix_block[i]          (writable)  — one per dz_prefix_count
+/// ```
+pub fn request_ban_user(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user: &Pubkey,
+    device: &Pubkey,
+    dz_prefix_count: u8,
+    mut args: UserRequestBanArgs,
+) -> Instruction {
+    args.dz_prefix_count = dz_prefix_count;
+
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+    let (device_tunnel_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::TunnelIds(*device, 0));
+
+    let mut accounts = vec![
+        AccountMeta::new(*user, false),
+        AccountMeta::new(globalstate, false),
+        AccountMeta::new(user_tunnel_block, false),
+        AccountMeta::new(multicast_publisher_block, false),
+        AccountMeta::new(device_tunnel_ids, false),
+    ];
+    for idx in 0..dz_prefix_count as usize {
+        let (dz_prefix, _, _) =
+            get_resource_extension_pda(program_id, ResourceType::DzPrefixBlock(*device, idx));
+        accounts.push(AccountMeta::new(dz_prefix, false));
+    }
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::RequestBanUser(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `CheckUserAccessPass` (variant 71).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// user         (writable)
+/// accesspass   (writable)  — get_accesspass_pda(user.client_ip, user.owner)
+/// globalstate  (writable)
+/// ```
+pub fn check_user_access_pass(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user: &Pubkey,
+    accesspass: &Pubkey,
+    args: CheckUserAccessPassArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let accounts = vec![
+        AccountMeta::new(*user, false),
+        AccountMeta::new(*accesspass, false),
+        AccountMeta::new(globalstate, false),
+    ];
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CheckUserAccessPass(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `SetUserBGPStatus` (variant 106).
+///
+/// Account layout, before the trailing accounts:
+///
+/// ```text
+/// user    (writable)
+/// device  (readonly)
+/// ```
+///
+/// The processor authorizes by checking that the payer equals the device's
+/// `metrics_publisher_pk` — it does NOT call `authorize()`, so this is assigned to
+/// [`common::build`] (no Permission account). Note there is no globalstate account.
+pub fn set_user_bgp_status(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user: &Pubkey,
+    device: &Pubkey,
+    args: SetUserBGPStatusArgs,
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*user, false),
+        AccountMeta::new_readonly(*device, false),
+    ];
+    common::build(
+        program_id,
+        DoubleZeroInstruction::SetUserBGPStatus(args),
+        accounts,
+        payer,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use doublezero_serviceability::state::user::{UserCYOA, UserType};
+    use doublezero_serviceability::state::user::{BGPStatus, UserCYOA, UserType};
     use solana_system_interface::program as system_program;
     use std::net::Ipv4Addr;
 
@@ -212,5 +537,282 @@ mod tests {
         // Permission append is deferred (build_with_permission delegates to build
         // today), so the last account is the system program.
         assert_eq!(ix.accounts.last().unwrap().pubkey, system_program::ID);
+    }
+
+    fn create_args(client_ip: Ipv4Addr) -> UserCreateArgs {
+        UserCreateArgs {
+            user_type: UserType::IBRLWithAllocatedIP,
+            cyoa_type: UserCYOA::GREOverDIA,
+            client_ip,
+            tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+            dz_prefix_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_create_user_length_detected_no_permission() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let accesspass = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(192, 168, 1, 10);
+
+        let ix = create_user(
+            &pid,
+            &payer,
+            &device,
+            &accesspass,
+            1,
+            None,
+            create_args(client_ip),
+        );
+        assert_eq!(ix.data[0], 36);
+        let (user, _) = get_user_pda(&pid, &client_ip, UserType::IBRLWithAllocatedIP);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(device, false),
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+        // build() path: no Permission account, ever.
+        assert_eq!(ix.accounts.last().unwrap().pubkey, system_program::ID);
+    }
+
+    #[test]
+    fn test_create_user_appends_non_default_tenant_before_trailing() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let tenant = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(192, 168, 1, 10);
+
+        let ix = create_user(
+            &pid,
+            &payer,
+            &device,
+            &Pubkey::new_unique(),
+            1,
+            Some(tenant),
+            create_args(client_ip),
+        );
+        // 7 fixed + 1 dz_prefix + tenant + payer + system = 11; tenant precedes payer.
+        assert_eq!(ix.accounts.len(), 11);
+        assert_eq!(ix.accounts[ix.accounts.len() - 3].pubkey, tenant);
+        assert!(ix.accounts[ix.accounts.len() - 3].is_writable);
+
+        // A default tenant is never appended.
+        let ix2 = create_user(
+            &pid,
+            &payer,
+            &device,
+            &Pubkey::new_unique(),
+            1,
+            Some(Pubkey::default()),
+            create_args(client_ip),
+        );
+        assert_eq!(ix2.accounts.len(), 10);
+    }
+
+    #[test]
+    fn test_update_user_with_tenant_change() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let new_tenant = Pubkey::new_unique();
+
+        let args = UserUpdateArgs {
+            tenant_pk: Some(new_tenant),
+            ..Default::default()
+        };
+        // old_tenant default -> appended read-only before new_tenant.
+        let ix = update_user(&pid, &payer, &user, &device, 1, &Pubkey::default(), args);
+        assert_eq!(ix.data[0], 39);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new_readonly(Pubkey::default(), false),
+                AccountMeta::new(new_tenant, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_update_user_no_tenant_change() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+
+        let ix = update_user(
+            &pid,
+            &payer,
+            &user,
+            &device,
+            1,
+            &Pubkey::new_unique(),
+            UserUpdateArgs::default(),
+        );
+        // 5 fixed + 1 dz_prefix + payer + system = 8 (no tenant accounts).
+        assert_eq!(ix.accounts.len(), 8);
+    }
+
+    #[test]
+    fn test_delete_user() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let accesspass = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let ix = delete_user(
+            &pid,
+            &payer,
+            &user,
+            &accesspass,
+            &device,
+            1,
+            None,
+            &owner,
+            UserDeleteArgs::default(),
+        );
+        assert_eq!(ix.data[0], 42);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(device, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_request_ban_user() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+
+        let ix = request_ban_user(
+            &pid,
+            &payer,
+            &user,
+            &device,
+            1,
+            UserRequestBanArgs::default(),
+        );
+        assert_eq!(ix.data[0], 44);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
+        let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
+        let (dti, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (dz0, _, _) = get_resource_extension_pda(&pid, ResourceType::DzPrefixBlock(device, 0));
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(utb, false),
+                AccountMeta::new(mpb, false),
+                AccountMeta::new(dti, false),
+                AccountMeta::new(dz0, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_check_user_access_pass() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let accesspass = Pubkey::new_unique();
+
+        let ix = check_user_access_pass(
+            &pid,
+            &payer,
+            &user,
+            &accesspass,
+            CheckUserAccessPassArgs::default(),
+        );
+        assert_eq!(ix.data[0], 71);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_set_user_bgp_status_no_permission() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+
+        let args = SetUserBGPStatusArgs {
+            bgp_status: BGPStatus::Up,
+            bgp_rtt_ns: 12_345,
+        };
+        let ix = set_user_bgp_status(&pid, &payer, &user, &device, args);
+        assert_eq!(ix.data[0], 106);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(user, false),
+                AccountMeta::new_readonly(device, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
     }
 }

--- a/crates/doublezero-serviceability-instruction/src/user.rs
+++ b/crates/doublezero-serviceability-instruction/src/user.rs
@@ -202,6 +202,12 @@ pub fn update_user(
     mut args: UserUpdateArgs,
 ) -> Instruction {
     args.dz_prefix_count = dz_prefix_count;
+    // This builder always emits the `multicast_publisher_block` account, so the
+    // declared count MUST be > 0 or the processor (which reads that account only
+    // when `multicast_publisher_count > 0`) would skip it and misread every
+    // following account. Written back here for the same reason as
+    // `dz_prefix_count`: keep the declared count and the account list in lockstep.
+    args.multicast_publisher_count = 1;
 
     let (globalstate, _) = get_globalstate_pda(program_id);
     let (user_tunnel_block, _, _) =
@@ -275,6 +281,12 @@ pub fn delete_user(
     mut args: UserDeleteArgs,
 ) -> Instruction {
     args.dz_prefix_count = dz_prefix_count;
+    // This builder always emits the `multicast_publisher_block` account, so the
+    // declared count MUST be > 0 or the processor (which reads that account only
+    // when `multicast_publisher_count > 0`) would skip it and misread every
+    // following account. Written back here for the same reason as
+    // `dz_prefix_count`: keep the declared count and the account list in lockstep.
+    args.multicast_publisher_count = 1;
 
     let (globalstate, _) = get_globalstate_pda(program_id);
     let (user_tunnel_block, _, _) =
@@ -334,6 +346,12 @@ pub fn request_ban_user(
     mut args: UserRequestBanArgs,
 ) -> Instruction {
     args.dz_prefix_count = dz_prefix_count;
+    // This builder always emits the `multicast_publisher_block` account, so the
+    // declared count MUST be > 0 or the processor (which reads that account only
+    // when `multicast_publisher_count > 0`) would skip it and misread every
+    // following account. Written back here for the same reason as
+    // `dz_prefix_count`: keep the declared count and the account list in lockstep.
+    args.multicast_publisher_count = 1;
 
     let (globalstate, _) = get_globalstate_pda(program_id);
     let (user_tunnel_block, _, _) =
@@ -642,6 +660,14 @@ mod tests {
         // old_tenant default -> appended read-only before new_tenant.
         let ix = update_user(&pid, &payer, &user, &device, 1, &Pubkey::default(), args);
         assert_eq!(ix.data[0], 39);
+        // The builder always emits the mpb account, so it MUST pin
+        // multicast_publisher_count > 0 to keep the declared count and the
+        // account list in lockstep (else the processor skips the mpb slot and
+        // misreads every following account).
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::UpdateUser(a) => assert_eq!(a.multicast_publisher_count, 1),
+            other => panic!("unexpected variant: {other:?}"),
+        }
         let (globalstate, _) = get_globalstate_pda(&pid);
         let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
         let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
@@ -705,6 +731,14 @@ mod tests {
             UserDeleteArgs::default(),
         );
         assert_eq!(ix.data[0], 42);
+        // The builder always emits the mpb account, so it MUST pin
+        // multicast_publisher_count > 0 to keep the declared count and the
+        // account list in lockstep (else the processor skips the mpb slot and
+        // misreads every following account).
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::DeleteUser(a) => assert_eq!(a.multicast_publisher_count, 1),
+            other => panic!("unexpected variant: {other:?}"),
+        }
         let (globalstate, _) = get_globalstate_pda(&pid);
         let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
         let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);
@@ -744,6 +778,14 @@ mod tests {
             UserRequestBanArgs::default(),
         );
         assert_eq!(ix.data[0], 44);
+        // The builder always emits the mpb account, so it MUST pin
+        // multicast_publisher_count > 0 to keep the declared count and the
+        // account list in lockstep (else the processor skips the mpb slot and
+        // misreads every following account).
+        match DoubleZeroInstruction::unpack(&ix.data).unwrap() {
+            DoubleZeroInstruction::RequestBanUser(a) => assert_eq!(a.multicast_publisher_count, 1),
+            other => panic!("unexpected variant: {other:?}"),
+        }
         let (globalstate, _) = get_globalstate_pda(&pid);
         let (utb, _, _) = get_resource_extension_pda(&pid, ResourceType::UserTunnelBlock);
         let (mpb, _, _) = get_resource_extension_pda(&pid, ResourceType::MulticastPublisherBlock);


### PR DESCRIPTION
## Summary

RFC-26 **R3** (stacked on the previous phase's branch). create_user (length-detected -> build, no permission), update_user, delete_user, request_ban_user, check_user_access_pass, and set_user_bgp_status (metrics-publisher check, no authorize -> build).

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4018. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user  ← **this PR**
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
