### PR TITLE
serviceability-instruction: location/exchange/contributor builders (RFC-26 R4)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/contributor.rs
+++ b/crates/doublezero-serviceability-instruction/src/contributor.rs
@@ -1,0 +1,181 @@
+//! Contributor-domain instruction builders.
+//!
+//! CRUD template like `location`; `create` also takes the contributor `owner`.
+//! All route through `authorize()` -> [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_contributor_pda, get_globalstate_pda},
+    processors::contributor::{
+        create::ContributorCreateArgs, delete::ContributorDeleteArgs,
+        resume::ContributorResumeArgs, suspend::ContributorSuspendArgs,
+        update::ContributorUpdateArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateContributor` (variant 60). Accounts: `[contributor, owner, globalstate]`.
+///
+/// `account_index` is the new contributor's index (`globalstate.account_index + 1`).
+pub fn create_contributor(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    owner: &Pubkey,
+    account_index: u128,
+    args: ContributorCreateArgs,
+) -> Instruction {
+    let (contributor, _) = get_contributor_pda(program_id, account_index);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateContributor(args),
+        vec![
+            AccountMeta::new(contributor, false),
+            AccountMeta::new(*owner, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdateContributor` (variant 61). Accounts: `[contributor, globalstate]`.
+pub fn update_contributor(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    contributor: &Pubkey,
+    args: ContributorUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateContributor(args),
+        vec![
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SuspendContributor` (variant 62). Accounts: `[contributor, globalstate]`.
+pub fn suspend_contributor(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    contributor: &Pubkey,
+    args: ContributorSuspendArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SuspendContributor(args),
+        vec![
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `ResumeContributor` (variant 63). Accounts: `[contributor, globalstate]`.
+pub fn resume_contributor(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    contributor: &Pubkey,
+    args: ContributorResumeArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::ResumeContributor(args),
+        vec![
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteContributor` (variant 64). Accounts: `[contributor, globalstate]`.
+pub fn delete_contributor(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    contributor: &Pubkey,
+    args: ContributorDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteContributor(args),
+        vec![
+            AccountMeta::new(*contributor, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_contributor_includes_owner() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let ix = create_contributor(&pid, &payer, &owner, 1, ContributorCreateArgs::default());
+        assert_eq!(ix.data[0], 60);
+        let (contributor, _) = get_contributor_pda(&pid, 1);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(contributor, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_contributor_pubkey_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(contributor, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (
+                update_contributor(&pid, &payer, &contributor, ContributorUpdateArgs::default()),
+                61,
+            ),
+            (
+                suspend_contributor(&pid, &payer, &contributor, ContributorSuspendArgs {}),
+                62,
+            ),
+            (
+                resume_contributor(&pid, &payer, &contributor, ContributorResumeArgs {}),
+                63,
+            ),
+            (
+                delete_contributor(&pid, &payer, &contributor, ContributorDeleteArgs {}),
+                64,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/exchange.rs
+++ b/crates/doublezero-serviceability-instruction/src/exchange.rs
@@ -122,8 +122,10 @@ pub fn delete_exchange(
 
 /// `SetDeviceExchange` (variant 65). Accounts: `[exchange, device, globalstate]`.
 ///
-/// `device` is the device being set on the exchange (side 1 or 2, selected by
-/// `args.set` / `args.index`).
+/// `device` is on the side selected by `args.index` (1 or 2); `args.set` chooses
+/// set vs remove. On `Remove`, pass the currently-set device (`exchange.deviceN_pk`)
+/// — the processor decrements the passed device's `reference_count` without
+/// checking it matches the exchange's stored key.
 pub fn set_device_exchange(
     program_id: &Pubkey,
     payer: &Pubkey,

--- a/crates/doublezero-serviceability-instruction/src/exchange.rs
+++ b/crates/doublezero-serviceability-instruction/src/exchange.rs
@@ -1,0 +1,255 @@
+//! Exchange-domain instruction builders.
+//!
+//! CRUD template like `location`, with two wrinkles: `create`/`update` also take
+//! the globalconfig account, and `set_device_exchange` takes a device. All route
+//! through `authorize()` -> [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_exchange_pda, get_globalconfig_pda, get_globalstate_pda},
+    processors::exchange::{
+        create::ExchangeCreateArgs, delete::ExchangeDeleteArgs, resume::ExchangeResumeArgs,
+        setdevice::ExchangeSetDeviceArgs, suspend::ExchangeSuspendArgs, update::ExchangeUpdateArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateExchange` (variant 15). Accounts: `[exchange, globalconfig, globalstate]`.
+///
+/// `account_index` is the new exchange's index (`globalstate.account_index + 1`).
+pub fn create_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    account_index: u128,
+    args: ExchangeCreateArgs,
+) -> Instruction {
+    let (exchange, _) = get_exchange_pda(program_id, account_index);
+    let (globalconfig, _) = get_globalconfig_pda(program_id);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateExchange(args),
+        vec![
+            AccountMeta::new(exchange, false),
+            AccountMeta::new(globalconfig, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdateExchange` (variant 16). Accounts: `[exchange, globalconfig, globalstate]`.
+pub fn update_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    exchange: &Pubkey,
+    args: ExchangeUpdateArgs,
+) -> Instruction {
+    let (globalconfig, _) = get_globalconfig_pda(program_id);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateExchange(args),
+        vec![
+            AccountMeta::new(*exchange, false),
+            AccountMeta::new(globalconfig, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SuspendExchange` (variant 17). Accounts: `[exchange, globalstate]`.
+pub fn suspend_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    exchange: &Pubkey,
+    args: ExchangeSuspendArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SuspendExchange(args),
+        vec![
+            AccountMeta::new(*exchange, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `ResumeExchange` (variant 18). Accounts: `[exchange, globalstate]`.
+pub fn resume_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    exchange: &Pubkey,
+    args: ExchangeResumeArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::ResumeExchange(args),
+        vec![
+            AccountMeta::new(*exchange, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteExchange` (variant 19). Accounts: `[exchange, globalstate]`.
+pub fn delete_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    exchange: &Pubkey,
+    args: ExchangeDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteExchange(args),
+        vec![
+            AccountMeta::new(*exchange, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SetDeviceExchange` (variant 65). Accounts: `[exchange, device, globalstate]`.
+///
+/// `device` is the device being set on the exchange (side 1 or 2, selected by
+/// `args.set` / `args.index`).
+pub fn set_device_exchange(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    exchange: &Pubkey,
+    device: &Pubkey,
+    args: ExchangeSetDeviceArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetDeviceExchange(args),
+        vec![
+            AccountMeta::new(*exchange, false),
+            AccountMeta::new(*device, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    fn create_args() -> ExchangeCreateArgs {
+        ExchangeCreateArgs {
+            code: "xch".to_string(),
+            name: "Exchange".to_string(),
+            lat: 1.0,
+            lng: 2.0,
+            reserved: 0,
+        }
+    }
+
+    #[test]
+    fn test_create_and_update_exchange_include_globalconfig() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let exchange = Pubkey::new_unique();
+        let (globalconfig, _) = get_globalconfig_pda(&pid);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+
+        let create = create_exchange(&pid, &payer, 1, create_args());
+        assert_eq!(create.data[0], 15);
+        let (exchange_pda, _) = get_exchange_pda(&pid, 1);
+        assert_eq!(
+            create.accounts,
+            vec![
+                AccountMeta::new(exchange_pda, false),
+                AccountMeta::new(globalconfig, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+
+        let update = update_exchange(&pid, &payer, &exchange, ExchangeUpdateArgs::default());
+        assert_eq!(update.data[0], 16);
+        assert_eq!(
+            update.accounts,
+            vec![
+                AccountMeta::new(exchange, false),
+                AccountMeta::new(globalconfig, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_exchange_lifecycle_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let exchange = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(exchange, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (
+                suspend_exchange(&pid, &payer, &exchange, ExchangeSuspendArgs {}),
+                17,
+            ),
+            (
+                resume_exchange(&pid, &payer, &exchange, ExchangeResumeArgs {}),
+                18,
+            ),
+            (
+                delete_exchange(&pid, &payer, &exchange, ExchangeDeleteArgs {}),
+                19,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+
+    #[test]
+    fn test_set_device_exchange() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let exchange = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let ix = set_device_exchange(
+            &pid,
+            &payer,
+            &exchange,
+            &device,
+            ExchangeSetDeviceArgs::default(),
+        );
+        assert_eq!(ix.data[0], 65);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(exchange, false),
+                AccountMeta::new(device, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/lib.rs
+++ b/crates/doublezero-serviceability-instruction/src/lib.rs
@@ -40,8 +40,11 @@
 
 mod common;
 
+pub mod contributor;
 pub mod device;
+pub mod exchange;
 pub mod link;
+pub mod location;
 pub mod user;
 
 pub use common::{compute_budget_prelude, MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES};

--- a/crates/doublezero-serviceability-instruction/src/location.rs
+++ b/crates/doublezero-serviceability-instruction/src/location.rs
@@ -1,0 +1,190 @@
+//! Location-domain instruction builders.
+//!
+//! The simple `account_index`-seeded CRUD template: every instruction's
+//! account list is `[location, globalstate]` (create derives the location PDA
+//! from the new index; the rest take the location pubkey). All route through
+//! `authorize()` -> [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_location_pda},
+    processors::location::{
+        create::LocationCreateArgs, delete::LocationDeleteArgs, resume::LocationResumeArgs,
+        suspend::LocationSuspendArgs, update::LocationUpdateArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateLocation` (variant 10). Accounts: `[location, globalstate]`.
+///
+/// `account_index` is the new location's index (`globalstate.account_index + 1`).
+pub fn create_location(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    account_index: u128,
+    args: LocationCreateArgs,
+) -> Instruction {
+    let (location, _) = get_location_pda(program_id, account_index);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateLocation(args),
+        vec![
+            AccountMeta::new(location, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdateLocation` (variant 11). Accounts: `[location, globalstate]`.
+pub fn update_location(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    location: &Pubkey,
+    args: LocationUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateLocation(args),
+        vec![
+            AccountMeta::new(*location, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SuspendLocation` (variant 12). Accounts: `[location, globalstate]`.
+pub fn suspend_location(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    location: &Pubkey,
+    args: LocationSuspendArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SuspendLocation(args),
+        vec![
+            AccountMeta::new(*location, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `ResumeLocation` (variant 13). Accounts: `[location, globalstate]`.
+pub fn resume_location(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    location: &Pubkey,
+    args: LocationResumeArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::ResumeLocation(args),
+        vec![
+            AccountMeta::new(*location, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteLocation` (variant 14). Accounts: `[location, globalstate]`.
+pub fn delete_location(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    location: &Pubkey,
+    args: LocationDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteLocation(args),
+        vec![
+            AccountMeta::new(*location, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    fn create_args() -> LocationCreateArgs {
+        LocationCreateArgs {
+            code: "loc".to_string(),
+            name: "Location".to_string(),
+            country: "US".to_string(),
+            lat: 1.0,
+            lng: 2.0,
+            loc_id: 3,
+        }
+    }
+
+    #[test]
+    fn test_create_location() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let ix = create_location(&pid, &payer, 1, create_args());
+        assert_eq!(ix.data[0], 10);
+        let (location, _) = get_location_pda(&pid, 1);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(location, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_location_pubkey_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let location = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(location, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+
+        for (ix, tag) in [
+            (
+                update_location(&pid, &payer, &location, LocationUpdateArgs::default()),
+                11,
+            ),
+            (
+                suspend_location(&pid, &payer, &location, LocationSuspendArgs {}),
+                12,
+            ),
+            (
+                resume_location(&pid, &payer, &location, LocationResumeArgs {}),
+                13,
+            ),
+            (
+                delete_location(&pid, &payer, &location, LocationDeleteArgs {}),
+                14,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

RFC-26 **R4** (stacked on the previous phase's branch). Three account_index-seeded CRUD domains (create/update/suspend/resume/delete). Exchange create/update carry globalconfig; set_device_exchange carries the device; create_contributor carries the owner.

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4019. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor  ← **this PR**
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
