### PR TITLE
serviceability-instruction: tenant + permission builders (RFC-26 R6)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/lib.rs
+++ b/crates/doublezero-serviceability-instruction/src/lib.rs
@@ -46,6 +46,8 @@ pub mod exchange;
 pub mod link;
 pub mod location;
 pub mod multicastgroup;
+pub mod permission;
+pub mod tenant;
 pub mod user;
 
 pub use common::{compute_budget_prelude, MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES};

--- a/crates/doublezero-serviceability-instruction/src/permission.rs
+++ b/crates/doublezero-serviceability-instruction/src/permission.rs
@@ -1,0 +1,182 @@
+//! Permission-domain instruction builders.
+//!
+//! All route through `authorize()` (PERMISSION_ADMIN) -> [`common::build_with_permission`].
+//! The globalstate account is always read-only here. Note the `permission` account
+//! at index 0 is the *target* permission being managed, distinct from the payer's
+//! own Permission PDA that `authorize()` reads (once activated).
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_permission_pda},
+    processors::permission::{
+        create::PermissionCreateArgs, delete::PermissionDeleteArgs, resume::PermissionResumeArgs,
+        suspend::PermissionSuspendArgs, update::PermissionUpdateArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreatePermission` (variant 97). Accounts: `[permission, globalstate(readonly)]`.
+///
+/// The target permission PDA is derived from `args.user_payer`.
+pub fn create_permission(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: PermissionCreateArgs,
+) -> Instruction {
+    let (permission, _) = get_permission_pda(program_id, &args.user_payer);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreatePermission(args),
+        vec![
+            AccountMeta::new(permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdatePermission` (variant 98). Accounts: `[permission, globalstate(readonly)]`.
+pub fn update_permission(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    permission: &Pubkey,
+    args: PermissionUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdatePermission(args),
+        vec![
+            AccountMeta::new(*permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SuspendPermission` (variant 99). Accounts: `[permission, globalstate(readonly)]`.
+pub fn suspend_permission(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    permission: &Pubkey,
+    args: PermissionSuspendArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SuspendPermission(args),
+        vec![
+            AccountMeta::new(*permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `ResumePermission` (variant 100). Accounts: `[permission, globalstate(readonly)]`.
+pub fn resume_permission(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    permission: &Pubkey,
+    args: PermissionResumeArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::ResumePermission(args),
+        vec![
+            AccountMeta::new(*permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeletePermission` (variant 101). Accounts: `[permission, globalstate(readonly)]`.
+pub fn delete_permission(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    permission: &Pubkey,
+    args: PermissionDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeletePermission(args),
+        vec![
+            AccountMeta::new(*permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_permission_derives_target_from_user_payer() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let args = PermissionCreateArgs {
+            user_payer,
+            ..Default::default()
+        };
+        let ix = create_permission(&pid, &payer, args);
+        assert_eq!(ix.data[0], 97);
+        let (permission, _) = get_permission_pda(&pid, &user_payer);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(permission, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_permission_pubkey_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let permission = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(permission, false),
+            AccountMeta::new_readonly(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (
+                update_permission(&pid, &payer, &permission, PermissionUpdateArgs::default()),
+                98,
+            ),
+            (
+                suspend_permission(&pid, &payer, &permission, PermissionSuspendArgs {}),
+                99,
+            ),
+            (
+                resume_permission(&pid, &payer, &permission, PermissionResumeArgs {}),
+                100,
+            ),
+            (
+                delete_permission(&pid, &payer, &permission, PermissionDeleteArgs {}),
+                101,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/tenant.rs
+++ b/crates/doublezero-serviceability-instruction/src/tenant.rs
@@ -1,0 +1,234 @@
+//! Tenant-domain instruction builders.
+//!
+//! All route through `authorize()` -> [`common::build_with_permission`]. Note the
+//! globalstate account is writable on `create` (it seeds the account index) and
+//! read-only on every other verb.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_resource_extension_pda, get_tenant_pda},
+    processors::tenant::{
+        add_administrator::TenantAddAdministratorArgs, create::TenantCreateArgs,
+        delete::TenantDeleteArgs, remove_administrator::TenantRemoveAdministratorArgs,
+        update::TenantUpdateArgs, update_payment_status::UpdatePaymentStatusArgs,
+    },
+    resource::ResourceType,
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateTenant` (variant 88). Accounts: `[tenant, globalstate(w), vrf_ids]`.
+///
+/// The tenant PDA is derived from `args.code`.
+pub fn create_tenant(program_id: &Pubkey, payer: &Pubkey, args: TenantCreateArgs) -> Instruction {
+    let (tenant, _) = get_tenant_pda(program_id, &args.code);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (vrf_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::VrfIds);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateTenant(args),
+        vec![
+            AccountMeta::new(tenant, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(vrf_ids, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdateTenant` (variant 89). Accounts: `[tenant, globalstate(readonly)]`.
+pub fn update_tenant(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    tenant: &Pubkey,
+    args: TenantUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateTenant(args),
+        vec![
+            AccountMeta::new(*tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteTenant` (variant 90). Accounts: `[tenant, globalstate(readonly), vrf_ids]`.
+pub fn delete_tenant(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    tenant: &Pubkey,
+    args: TenantDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (vrf_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::VrfIds);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteTenant(args),
+        vec![
+            AccountMeta::new(*tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+            AccountMeta::new(vrf_ids, false),
+        ],
+        payer,
+    )
+}
+
+/// `TenantAddAdministrator` (variant 91). Accounts: `[tenant, globalstate(readonly)]`.
+pub fn tenant_add_administrator(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    tenant: &Pubkey,
+    args: TenantAddAdministratorArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::TenantAddAdministrator(args),
+        vec![
+            AccountMeta::new(*tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `TenantRemoveAdministrator` (variant 92). Accounts: `[tenant, globalstate(readonly)]`.
+pub fn tenant_remove_administrator(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    tenant: &Pubkey,
+    args: TenantRemoveAdministratorArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::TenantRemoveAdministrator(args),
+        vec![
+            AccountMeta::new(*tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdatePaymentStatus` (variant 93). Accounts: `[tenant, globalstate(readonly)]`.
+pub fn update_payment_status(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    tenant: &Pubkey,
+    args: UpdatePaymentStatusArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdatePaymentStatus(args),
+        vec![
+            AccountMeta::new(*tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_tenant() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let args = TenantCreateArgs {
+            code: "acme".to_string(),
+            ..Default::default()
+        };
+        let ix = create_tenant(&pid, &payer, args);
+        assert_eq!(ix.data[0], 88);
+        let (tenant, _) = get_tenant_pda(&pid, "acme");
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (vrf_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::VrfIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(tenant, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(vrf_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_delete_tenant() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let tenant = Pubkey::new_unique();
+        let ix = delete_tenant(&pid, &payer, &tenant, TenantDeleteArgs {});
+        assert_eq!(ix.data[0], 90);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (vrf_ids, _, _) = get_resource_extension_pda(&pid, ResourceType::VrfIds);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(tenant, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(vrf_ids, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tenant_readonly_globalstate_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let tenant = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(tenant, false),
+            AccountMeta::new_readonly(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (
+                update_tenant(&pid, &payer, &tenant, TenantUpdateArgs::default()),
+                89,
+            ),
+            (
+                tenant_add_administrator(
+                    &pid,
+                    &payer,
+                    &tenant,
+                    TenantAddAdministratorArgs::default(),
+                ),
+                91,
+            ),
+            (
+                tenant_remove_administrator(
+                    &pid,
+                    &payer,
+                    &tenant,
+                    TenantRemoveAdministratorArgs::default(),
+                ),
+                92,
+            ),
+            (
+                update_payment_status(&pid, &payer, &tenant, UpdatePaymentStatusArgs::default()),
+                93,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/tenant.rs
+++ b/crates/doublezero-serviceability-instruction/src/tenant.rs
@@ -1,8 +1,11 @@
 //! Tenant-domain instruction builders.
 //!
 //! All route through `authorize()` -> [`common::build_with_permission`]. Note the
-//! globalstate account is writable on `create` (it seeds the account index) and
-//! read-only on every other verb.
+//! globalstate account is passed writable on `create` and read-only on every
+//! other verb — this mirrors the SDK command byte-for-byte (the golden-fixture
+//! parity target). The create processor itself only *reads* globalstate; the new
+//! tenant's id is allocated from the `VrfIds` resource-extension account, not from
+//! `globalstate.account_index`.
 
 use crate::common;
 use doublezero_serviceability::{

--- a/crates/doublezero-serviceability-instruction/src/tenant.rs
+++ b/crates/doublezero-serviceability-instruction/src/tenant.rs
@@ -23,7 +23,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-/// `CreateTenant` (variant 88). Accounts: `[tenant, globalstate(w), vrf_ids]`.
+/// `CreateTenant` (variant 88). Accounts: `[tenant, globalstate(w), vrf_ids(w)]`.
 ///
 /// The tenant PDA is derived from `args.code`.
 pub fn create_tenant(program_id: &Pubkey, payer: &Pubkey, args: TenantCreateArgs) -> Instruction {
@@ -61,7 +61,7 @@ pub fn update_tenant(
     )
 }
 
-/// `DeleteTenant` (variant 90). Accounts: `[tenant, globalstate(readonly), vrf_ids]`.
+/// `DeleteTenant` (variant 90). Accounts: `[tenant, globalstate(readonly), vrf_ids(w)]`.
 pub fn delete_tenant(
     program_id: &Pubkey,
     payer: &Pubkey,


### PR DESCRIPTION
## Summary

RFC-26 **R6** (stacked on the previous phase's branch). Tenant CRUD + add/remove administrator + update_payment_status (globalstate writable on create, read-only elsewhere), and permission create/update/suspend/resume/delete (target PDA derived from args.user_payer).

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4021. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission  ← **this PR**
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
