### PR TITLE
serviceability-instruction: topology + feed builders (RFC-26 R7)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/feed.rs
+++ b/crates/doublezero-serviceability-instruction/src/feed.rs
@@ -1,0 +1,122 @@
+//! Feed-domain instruction builders.
+//!
+//! All route through `authorize()` -> [`common::build_with_permission`].
+//! Accounts are `[feed, globalstate]`; create derives the feed PDA from
+//! `args.code` and `args.exchange`.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_feed_pda, get_globalstate_pda},
+    processors::feed::{create::FeedCreateArgs, delete::FeedDeleteArgs, update::FeedUpdateArgs},
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateFeed` (variant 112). Accounts: `[feed, globalstate]`.
+///
+/// The feed PDA is derived from `args.code` and `args.exchange`.
+pub fn create_feed(program_id: &Pubkey, payer: &Pubkey, args: FeedCreateArgs) -> Instruction {
+    let (feed, _) = get_feed_pda(program_id, &args.code, &args.exchange);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateFeed(args),
+        vec![
+            AccountMeta::new(feed, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `UpdateFeed` (variant 113). Accounts: `[feed, globalstate]`.
+pub fn update_feed(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    feed: &Pubkey,
+    args: FeedUpdateArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::UpdateFeed(args),
+        vec![
+            AccountMeta::new(*feed, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteFeed` (variant 114). Accounts: `[feed, globalstate]`.
+pub fn delete_feed(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    feed: &Pubkey,
+    args: FeedDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteFeed(args),
+        vec![
+            AccountMeta::new(*feed, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_feed_derives_pda_from_code_and_exchange() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let exchange = Pubkey::new_unique();
+        let args = FeedCreateArgs {
+            code: "feed".to_string(),
+            exchange,
+            ..Default::default()
+        };
+        let ix = create_feed(&pid, &payer, args);
+        assert_eq!(ix.data[0], 112);
+        let (feed, _) = get_feed_pda(&pid, "feed", &exchange);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(feed, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_feed_pubkey_verbs() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let feed = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(feed, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        let update = update_feed(&pid, &payer, &feed, FeedUpdateArgs::default());
+        assert_eq!(update.data[0], 113);
+        assert_eq!(update.accounts, expected);
+        let delete = delete_feed(&pid, &payer, &feed, FeedDeleteArgs {});
+        assert_eq!(delete.data[0], 114);
+        assert_eq!(delete.accounts, expected);
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/feed.rs
+++ b/crates/doublezero-serviceability-instruction/src/feed.rs
@@ -18,7 +18,10 @@
 //! feed must be added there before the deferred permission append is activated
 //! (see [`common::build_with_permission`]) — otherwise feed-authority keys would
 //! not be guaranteed a Permission account at activation. Closing that gap is a
-//! serviceability-program change, out of scope for this crate.
+//! serviceability-program change, out of scope for this crate; it is tracked in
+//! <https://github.com/malbeclabs/doublezero/issues/4079>. The
+//! `feed_authority_gap_is_still_open` canary test below asserts the gap currently
+//! exists, so closing it forces this note to be revisited.
 
 use crate::common;
 use doublezero_serviceability::{
@@ -129,11 +132,38 @@ mod tests {
             AccountMeta::new(payer, true),
             AccountMeta::new(system_program::ID, false),
         ];
-        let update = update_feed(&pid, &payer, &feed, FeedUpdateArgs::default());
+        // Realistic args: an all-`None` (default) update is rejected by the
+        // processor as a no-op (`InvalidArgument`), so the fixture would not execute.
+        let update = update_feed(
+            &pid,
+            &payer,
+            &feed,
+            FeedUpdateArgs {
+                name: Some("Feed".to_string()),
+                groups: None,
+            },
+        );
         assert_eq!(update.data[0], 113);
         assert_eq!(update.accounts, expected);
         let delete = delete_feed(&pid, &payer, &feed, FeedDeleteArgs {});
         assert_eq!(delete.data[0], 114);
         assert_eq!(delete.accounts, expected);
+    }
+
+    /// Tripwire for the module-doc note: `FEED_AUTHORITY` is currently absent from
+    /// `AUTHORIZE_GATED_FLAGS` even though the feed processors gate on it. When the
+    /// program-side gap (https://github.com/malbeclabs/doublezero/issues/4079) is
+    /// closed, this test fails — a signal that the deferred permission append is
+    /// now safe to activate for feed and that this crate's doc note must be updated.
+    #[test]
+    fn feed_authority_gap_is_still_open() {
+        use doublezero_serviceability::{
+            authorize::AUTHORIZE_GATED_FLAGS, state::permission::permission_flags,
+        };
+        assert!(
+            !AUTHORIZE_GATED_FLAGS.contains(&permission_flags::FEED_AUTHORITY),
+            "FEED_AUTHORITY is now gated: close issue #4079 tracking, then update the \
+             feed.rs module doc and remove this canary"
+        );
     }
 }

--- a/crates/doublezero-serviceability-instruction/src/feed.rs
+++ b/crates/doublezero-serviceability-instruction/src/feed.rs
@@ -82,8 +82,9 @@ mod tests {
         let exchange = Pubkey::new_unique();
         let args = FeedCreateArgs {
             code: "feed".to_string(),
+            name: "Feed".to_string(),
             exchange,
-            ..Default::default()
+            groups: vec![Pubkey::new_unique()],
         };
         let ix = create_feed(&pid, &payer, args);
         assert_eq!(ix.data[0], 112);

--- a/crates/doublezero-serviceability-instruction/src/feed.rs
+++ b/crates/doublezero-serviceability-instruction/src/feed.rs
@@ -3,6 +3,22 @@
 //! All route through `authorize()` -> [`common::build_with_permission`].
 //! Accounts are `[feed, globalstate]`; create derives the feed PDA from
 //! `args.code` and `args.exchange`.
+//!
+//! **Why `build_with_permission`.** The feed `create`/`update`/`delete`
+//! processors call `authorize(.., FEED_AUTHORITY | FOUNDATION)`, so feed is a
+//! permission-gated instruction like topology/tenant and belongs on the
+//! permission-appending path. This intentionally diverges from today's Rust SDK
+//! feed commands, which use the plain (no-permission) `execute_transaction`;
+//! among authorize()-gated instructions the SDK feed commands are the odd ones
+//! out, not these builders.
+//!
+//! One pre-existing program-side gap, unrelated to these builders: `FEED_AUTHORITY`
+//! is absent from `authorize.rs::AUTHORIZE_GATED_FLAGS`. That list drives
+//! `doublezero permission audit` and the `RequirePermissionAccounts` rollout, so
+//! feed must be added there before the deferred permission append is activated
+//! (see [`common::build_with_permission`]) — otherwise feed-authority keys would
+//! not be guaranteed a Permission account at activation. Closing that gap is a
+//! serviceability-program change, out of scope for this crate.
 
 use crate::common;
 use doublezero_serviceability::{

--- a/crates/doublezero-serviceability-instruction/src/lib.rs
+++ b/crates/doublezero-serviceability-instruction/src/lib.rs
@@ -43,11 +43,13 @@ mod common;
 pub mod contributor;
 pub mod device;
 pub mod exchange;
+pub mod feed;
 pub mod link;
 pub mod location;
 pub mod multicastgroup;
 pub mod permission;
 pub mod tenant;
+pub mod topology;
 pub mod user;
 
 pub use common::{compute_budget_prelude, MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES};

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -1,0 +1,282 @@
+//! Topology-domain instruction builders.
+//!
+//! All route through `authorize()` -> [`common::build_with_permission`]. The
+//! topology PDA is derived from `args.name`. `clear_topology` and
+//! `assign_topology_node_segments` are batched: a single-chunk builder plus a
+//! `*_batched(...) -> Vec<Instruction>` convenience. The batch-size constants
+//! account for the trailing `[payer, system]` the builder now owns, keeping each
+//! transaction under Solana's 32-account cap.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_resource_extension_pda, get_topology_pda},
+    processors::topology::{
+        assign_node_segments::AssignTopologyNodeSegmentsArgs, clear::TopologyClearArgs,
+        create::TopologyCreateArgs, delete::TopologyDeleteArgs,
+    },
+    resource::ResourceType,
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// Max link accounts per `clear_topology` transaction (2 fixed + 16 links +
+/// payer + system = 20 < 32).
+pub const CLEAR_BATCH_SIZE: usize = 16;
+/// Max device accounts per `assign_topology_node_segments` transaction (3 fixed +
+/// 4 devices + payer + system = 9 < 32).
+pub const BACKFILL_BATCH_SIZE: usize = 4;
+
+/// `CreateTopology` (variant 107).
+/// Accounts: `[topology, admin_group_bits, globalstate(readonly)]`.
+pub fn create_topology(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: TopologyCreateArgs,
+) -> Instruction {
+    let (topology, _) = get_topology_pda(program_id, &args.name);
+    let (admin_group_bits, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::AdminGroupBits);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateTopology(args),
+        vec![
+            AccountMeta::new(topology, false),
+            AccountMeta::new(admin_group_bits, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteTopology` (variant 108). Accounts: `[topology, globalstate(readonly)]`.
+pub fn delete_topology(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: TopologyDeleteArgs,
+) -> Instruction {
+    let (topology, _) = get_topology_pda(program_id, &args.name);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteTopology(args),
+        vec![
+            AccountMeta::new(topology, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `ClearTopology` (variant 109), single chunk.
+/// Accounts: `[topology(readonly), globalstate(readonly), link[i]...]`.
+pub fn clear_topology(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    links: &[Pubkey],
+    args: TopologyClearArgs,
+) -> Instruction {
+    let (topology, _) = get_topology_pda(program_id, &args.name);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = vec![
+        AccountMeta::new_readonly(topology, false),
+        AccountMeta::new_readonly(globalstate, false),
+    ];
+    for link in links {
+        accounts.push(AccountMeta::new(*link, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::ClearTopology(args),
+        accounts,
+        payer,
+    )
+}
+
+/// Batched `clear_topology`: one instruction per [`CLEAR_BATCH_SIZE`] chunk of
+/// `links` (empty `links` yields an empty vec).
+pub fn clear_topology_batched(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    links: &[Pubkey],
+    args: TopologyClearArgs,
+) -> Vec<Instruction> {
+    links
+        .chunks(CLEAR_BATCH_SIZE)
+        .map(|chunk| clear_topology(program_id, payer, chunk, args.clone()))
+        .collect()
+}
+
+/// `AssignTopologyNodeSegments` (variant 110), single chunk.
+/// Accounts: `[topology(readonly), segment_routing_ids, globalstate(readonly), device[i]...]`.
+pub fn assign_topology_node_segments(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    devices: &[Pubkey],
+    args: AssignTopologyNodeSegmentsArgs,
+) -> Instruction {
+    let (topology, _) = get_topology_pda(program_id, &args.name);
+    let (segment_routing_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::SegmentRoutingIds);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = vec![
+        AccountMeta::new_readonly(topology, false),
+        AccountMeta::new(segment_routing_ids, false),
+        AccountMeta::new_readonly(globalstate, false),
+    ];
+    for device in devices {
+        accounts.push(AccountMeta::new(*device, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::AssignTopologyNodeSegments(args),
+        accounts,
+        payer,
+    )
+}
+
+/// Batched `assign_topology_node_segments`: one instruction per
+/// [`BACKFILL_BATCH_SIZE`] chunk of `devices` (empty `devices` yields an empty vec).
+pub fn assign_topology_node_segments_batched(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    devices: &[Pubkey],
+    args: AssignTopologyNodeSegmentsArgs,
+) -> Vec<Instruction> {
+    devices
+        .chunks(BACKFILL_BATCH_SIZE)
+        .map(|chunk| assign_topology_node_segments(program_id, payer, chunk, args.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use doublezero_serviceability::state::topology::TopologyConstraint;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_topology() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let args = TopologyCreateArgs {
+            name: "topo".to_string(),
+            constraint: TopologyConstraint::default(),
+        };
+        let ix = create_topology(&pid, &payer, args);
+        assert_eq!(ix.data[0], 107);
+        let (topology, _) = get_topology_pda(&pid, "topo");
+        let (admin_group_bits, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::AdminGroupBits);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(topology, false),
+                AccountMeta::new(admin_group_bits, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_delete_topology() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let ix = delete_topology(
+            &pid,
+            &payer,
+            TopologyDeleteArgs {
+                name: "topo".to_string(),
+            },
+        );
+        assert_eq!(ix.data[0], 108);
+        let (topology, _) = get_topology_pda(&pid, "topo");
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(topology, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_clear_topology_single_and_batched() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let args = TopologyClearArgs {
+            name: "topo".to_string(),
+        };
+        let links: Vec<Pubkey> = (0..CLEAR_BATCH_SIZE + 3)
+            .map(|_| Pubkey::new_unique())
+            .collect();
+
+        let single = clear_topology(&pid, &payer, &links[..2], args.clone());
+        assert_eq!(single.data[0], 109);
+        let (topology, _) = get_topology_pda(&pid, "topo");
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            single.accounts,
+            vec![
+                AccountMeta::new_readonly(topology, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(links[0], false),
+                AccountMeta::new(links[1], false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+
+        // 19 links -> 2 chunks (16 + 3).
+        let batched = clear_topology_batched(&pid, &payer, &links, args);
+        assert_eq!(batched.len(), 2);
+        // First chunk: 2 fixed + 16 links + payer + system = 20.
+        assert_eq!(batched[0].accounts.len(), 20);
+        assert_eq!(batched[1].accounts.len(), 2 + 3 + 2);
+    }
+
+    #[test]
+    fn test_assign_node_segments_single_and_batched() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let args = AssignTopologyNodeSegmentsArgs {
+            name: "topo".to_string(),
+        };
+        let devices: Vec<Pubkey> = (0..BACKFILL_BATCH_SIZE + 1)
+            .map(|_| Pubkey::new_unique())
+            .collect();
+
+        let single = assign_topology_node_segments(&pid, &payer, &devices[..1], args.clone());
+        assert_eq!(single.data[0], 110);
+        let (topology, _) = get_topology_pda(&pid, "topo");
+        let (segment_routing_ids, _, _) =
+            get_resource_extension_pda(&pid, ResourceType::SegmentRoutingIds);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            single.accounts,
+            vec![
+                AccountMeta::new_readonly(topology, false),
+                AccountMeta::new(segment_routing_ids, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(devices[0], false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+
+        // 5 devices -> 2 chunks (4 + 1).
+        let batched = assign_topology_node_segments_batched(&pid, &payer, &devices, args);
+        assert_eq!(batched.len(), 2);
+        assert_eq!(batched[0].accounts.len(), 3 + 4 + 2);
+        assert_eq!(batched[1].accounts.len(), 3 + 1 + 2);
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -72,7 +72,12 @@ pub fn delete_topology(
 }
 
 /// `ClearTopology` (variant 109), single chunk.
-/// Accounts: `[topology(readonly), globalstate(readonly), link[i]...]`.
+/// Accounts: `[topology(writable), globalstate(readonly), link[i]...]`.
+///
+/// `topology` is writable: when the topology account still exists and at least
+/// one link is cleared, the processor asserts `is_writable` and decrements its
+/// `reference_count`. Passing it read-only fails that path; passing it writable
+/// is harmless on the closed-topology path (the processor skips the write).
 pub fn clear_topology(
     program_id: &Pubkey,
     payer: &Pubkey,
@@ -82,7 +87,7 @@ pub fn clear_topology(
     let (topology, _) = get_topology_pda(program_id, &args.name);
     let (globalstate, _) = get_globalstate_pda(program_id);
     let mut accounts = vec![
-        AccountMeta::new_readonly(topology, false),
+        AccountMeta::new(topology, false),
         AccountMeta::new_readonly(globalstate, false),
     ];
     for link in links {
@@ -227,7 +232,8 @@ mod tests {
         assert_eq!(
             single.accounts,
             vec![
-                AccountMeta::new_readonly(topology, false),
+                // topology is writable: the processor decrements its reference_count.
+                AccountMeta::new(topology, false),
                 AccountMeta::new_readonly(globalstate, false),
                 AccountMeta::new(links[0], false),
                 AccountMeta::new(links[1], false),

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -248,6 +248,17 @@ mod tests {
         // First chunk: 2 fixed + 16 links + payer + system = 20.
         assert_eq!(batched[0].accounts.len(), 20);
         assert_eq!(batched[1].accounts.len(), 2 + 3 + 2);
+
+        // No links -> no instructions (no empty clear is ever emitted).
+        assert!(clear_topology_batched(
+            &pid,
+            &payer,
+            &[],
+            TopologyClearArgs {
+                name: "topo".to_string()
+            }
+        )
+        .is_empty());
     }
 
     #[test]
@@ -284,5 +295,16 @@ mod tests {
         assert_eq!(batched.len(), 2);
         assert_eq!(batched[0].accounts.len(), 3 + 4 + 2);
         assert_eq!(batched[1].accounts.len(), 3 + 1 + 2);
+
+        // No devices -> no instructions.
+        assert!(assign_topology_node_segments_batched(
+            &pid,
+            &payer,
+            &[],
+            AssignTopologyNodeSegmentsArgs {
+                name: "topo".to_string()
+            }
+        )
+        .is_empty());
     }
 }

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -83,7 +83,8 @@ pub fn delete_topology(
 /// `ClearTopologyCommand` passes `topology` read-only, which would trip the
 /// processor's `is_writable` assert on the topology-still-exists path. The
 /// builder follows the processor (writable is a strict superset privilege, so no
-/// execution regresses); the SDK command is the one that needs fixing.
+/// execution regresses); the SDK command is the one that needs fixing (tracked in
+/// <https://github.com/malbeclabs/doublezero/issues/4078>).
 pub fn clear_topology(
     program_id: &Pubkey,
     payer: &Pubkey,

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -78,6 +78,12 @@ pub fn delete_topology(
 /// one link is cleared, the processor asserts `is_writable` and decrements its
 /// `reference_count`. Passing it read-only fails that path; passing it writable
 /// is harmless on the closed-topology path (the processor skips the write).
+///
+/// This is the crate's one deliberate byte-parity break with the SDK: the SDK
+/// `ClearTopologyCommand` passes `topology` read-only, which would trip the
+/// processor's `is_writable` assert on the topology-still-exists path. The
+/// builder follows the processor (writable is a strict superset privilege, so no
+/// execution regresses); the SDK command is the one that needs fixing.
 pub fn clear_topology(
     program_id: &Pubkey,
     payer: &Pubkey,

--- a/crates/doublezero-serviceability-instruction/src/topology.rs
+++ b/crates/doublezero-serviceability-instruction/src/topology.rs
@@ -4,8 +4,10 @@
 //! topology PDA is derived from `args.name`. `clear_topology` and
 //! `assign_topology_node_segments` are batched: a single-chunk builder plus a
 //! `*_batched(...) -> Vec<Instruction>` convenience. The batch-size constants
-//! account for the trailing `[payer, system]` the builder now owns, keeping each
-//! transaction under Solana's 32-account cap.
+//! account for the trailing `[payer, system]` the builder now owns. The chosen
+//! sizes stay well within Solana's real per-transaction limits — the 64-account
+//! lock limit (`MAX_TX_ACCOUNT_LOCKS`) and, the binding constraint as batches
+//! grow, the ~1232-byte packet size.
 
 use crate::common;
 use doublezero_serviceability::{
@@ -23,10 +25,12 @@ use solana_program::{
 };
 
 /// Max link accounts per `clear_topology` transaction (2 fixed + 16 links +
-/// payer + system = 20 < 32).
+/// payer + system = 20 accounts, well under the 64-account lock limit and the
+/// ~1232-byte packet size).
 pub const CLEAR_BATCH_SIZE: usize = 16;
 /// Max device accounts per `assign_topology_node_segments` transaction (3 fixed +
-/// 4 devices + payer + system = 9 < 32).
+/// 4 devices + payer + system = 9 accounts, well under the 64-account lock limit
+/// and the ~1232-byte packet size).
 pub const BACKFILL_BATCH_SIZE: usize = 4;
 
 /// `CreateTopology` (variant 107).


### PR DESCRIPTION
## Summary

RFC-26 **R7** (stacked on the previous phase's branch). Topology create/delete plus batched clear_topology / assign_topology_node_segments (single-chunk + *_batched; CLEAR_BATCH_SIZE=16 / BACKFILL_BATCH_SIZE=4 moved into the crate). Feed create/update/delete.

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4022. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed  ← **this PR**
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
