### PR TITLE
serviceability-instruction: accesspass + resource builders (RFC-26 R8)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/accesspass.rs
+++ b/crates/doublezero-serviceability-instruction/src/accesspass.rs
@@ -176,18 +176,32 @@ mod tests {
         let user_payer = Pubkey::new_unique();
         let new_tenant = Pubkey::new_unique();
         let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let current_tenant = Pubkey::new_unique();
         let ix = set_access_pass(
             &pid,
             &payer,
             &user_payer,
-            &Pubkey::default(),
+            &current_tenant,
             &new_tenant,
             set_args(client_ip),
         );
-        // 3 base + current_tenant(default) + new_tenant + payer + system = 7.
-        assert_eq!(ix.accounts.len(), 7);
-        assert_eq!(ix.accounts[3].pubkey, Pubkey::default());
-        assert_eq!(ix.accounts[4].pubkey, new_tenant);
+        assert_eq!(ix.data[0], 67);
+        let (accesspass, _) = get_accesspass_pda(&pid, &client_ip, &user_payer);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        // 3 base + current_tenant + new_tenant appended (either non-default), then
+        // the trailing payer/system.
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(user_payer, false),
+                AccountMeta::new(current_tenant, false),
+                AccountMeta::new(new_tenant, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
     }
 
     #[test]

--- a/crates/doublezero-serviceability-instruction/src/accesspass.rs
+++ b/crates/doublezero-serviceability-instruction/src/accesspass.rs
@@ -1,0 +1,261 @@
+//! Access-pass-domain instruction builders.
+//!
+//! All route through `authorize()` -> [`common::build_with_permission`]. The
+//! access-pass PDA is derived from `(client_ip, user_payer)`.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_accesspass_pda, get_globalstate_pda},
+    processors::accesspass::{
+        check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs,
+        set::SetAccessPassArgs, set_feeds::SetAccessPassFeedsArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+use std::net::Ipv4Addr;
+
+/// `SetAccessPass` (variant 67).
+/// Accounts: `[accesspass, globalstate(readonly), user_payer]`, plus
+/// `[current_tenant, new_tenant]` when either is non-default.
+///
+/// The access-pass PDA is derived from `args.client_ip` and `user_payer`.
+/// `current_tenant` is the tenant currently on the pass (onchain-read).
+pub fn set_access_pass(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    user_payer: &Pubkey,
+    current_tenant: &Pubkey,
+    new_tenant: &Pubkey,
+    args: SetAccessPassArgs,
+) -> Instruction {
+    let (accesspass, _) = get_accesspass_pda(program_id, &args.client_ip, user_payer);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = vec![
+        AccountMeta::new(accesspass, false),
+        AccountMeta::new_readonly(globalstate, false),
+        AccountMeta::new(*user_payer, false),
+    ];
+    if *current_tenant != Pubkey::default() || *new_tenant != Pubkey::default() {
+        accounts.push(AccountMeta::new(*current_tenant, false));
+        accounts.push(AccountMeta::new(*new_tenant, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(args),
+        accounts,
+        payer,
+    )
+}
+
+/// `CloseAccessPass` (variant 69). Accounts: `[accesspass, globalstate]`.
+pub fn close_access_pass(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    accesspass: &Pubkey,
+    args: CloseAccessPassArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CloseAccessPass(args),
+        vec![
+            AccountMeta::new(*accesspass, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `CheckStatusAccessPass` (variant 70).
+/// Accounts: `[accesspass, globalstate(readonly)]`.
+///
+/// The access-pass PDA is derived from `(client_ip, user_payer)`; the args carry
+/// no fields, so both are explicit parameters.
+pub fn check_status_access_pass(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    client_ip: Ipv4Addr,
+    user_payer: &Pubkey,
+    args: CheckStatusAccessPassArgs,
+) -> Instruction {
+    let (accesspass, _) = get_accesspass_pda(program_id, &client_ip, user_payer);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CheckStatusAccessPass(args),
+        vec![
+            AccountMeta::new(accesspass, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SetAccessPassFeeds` (variant 115).
+/// Accounts: `[accesspass, globalstate(readonly), feed[i]...(readonly)]`.
+///
+/// The access-pass PDA is derived from `args.client_ip` and `args.user_payer`.
+/// `feed_keys` are the feed accounts, in the same order as `args.feeds`.
+pub fn set_access_pass_feeds(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    feed_keys: &[Pubkey],
+    args: SetAccessPassFeedsArgs,
+) -> Instruction {
+    let (accesspass, _) = get_accesspass_pda(program_id, &args.client_ip, &args.user_payer);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let mut accounts = vec![
+        AccountMeta::new(accesspass, false),
+        AccountMeta::new_readonly(globalstate, false),
+    ];
+    for feed in feed_keys {
+        accounts.push(AccountMeta::new_readonly(*feed, false));
+    }
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(args),
+        accounts,
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use doublezero_serviceability::state::accesspass::AccessPassType;
+    use solana_system_interface::program as system_program;
+
+    fn set_args(client_ip: Ipv4Addr) -> SetAccessPassArgs {
+        SetAccessPassArgs {
+            accesspass_type: AccessPassType::default(),
+            client_ip,
+            last_access_epoch: 0,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }
+    }
+
+    #[test]
+    fn test_set_access_pass_no_tenant() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let ix = set_access_pass(
+            &pid,
+            &payer,
+            &user_payer,
+            &Pubkey::default(),
+            &Pubkey::default(),
+            set_args(client_ip),
+        );
+        assert_eq!(ix.data[0], 67);
+        let (accesspass, _) = get_accesspass_pda(&pid, &client_ip, &user_payer);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(user_payer, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_set_access_pass_with_tenant_appends_pair() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let new_tenant = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let ix = set_access_pass(
+            &pid,
+            &payer,
+            &user_payer,
+            &Pubkey::default(),
+            &new_tenant,
+            set_args(client_ip),
+        );
+        // 3 base + current_tenant(default) + new_tenant + payer + system = 7.
+        assert_eq!(ix.accounts.len(), 7);
+        assert_eq!(ix.accounts[3].pubkey, Pubkey::default());
+        assert_eq!(ix.accounts[4].pubkey, new_tenant);
+    }
+
+    #[test]
+    fn test_close_and_check_status() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let accesspass = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+
+        let close = close_access_pass(&pid, &payer, &accesspass, CloseAccessPassArgs {});
+        assert_eq!(close.data[0], 69);
+        assert_eq!(
+            close.accounts,
+            vec![
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+
+        let user_payer = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let check = check_status_access_pass(
+            &pid,
+            &payer,
+            client_ip,
+            &user_payer,
+            CheckStatusAccessPassArgs {},
+        );
+        assert_eq!(check.data[0], 70);
+        let (ap, _) = get_accesspass_pda(&pid, &client_ip, &user_payer);
+        assert_eq!(
+            check.accounts,
+            vec![
+                AccountMeta::new(ap, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_set_access_pass_feeds() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let user_payer = Pubkey::new_unique();
+        let feed = Pubkey::new_unique();
+        let client_ip = Ipv4Addr::new(10, 0, 0, 1);
+        let args = SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![],
+        };
+        let ix = set_access_pass_feeds(&pid, &payer, &[feed], args);
+        assert_eq!(ix.data[0], 115);
+        let (accesspass, _) = get_accesspass_pda(&pid, &client_ip, &user_payer);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(accesspass, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new_readonly(feed, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/accesspass.rs
+++ b/crates/doublezero-serviceability-instruction/src/accesspass.rs
@@ -106,6 +106,16 @@ pub fn set_access_pass_feeds(
     feed_keys: &[Pubkey],
     args: SetAccessPassFeedsArgs,
 ) -> Instruction {
+    // The processor pairs each `args.feeds` entry with a feed account by position
+    // (`value.feeds.iter().zip(feed_accounts)`), so the two must be equal length.
+    // A mismatch shifts the trailing `[payer, system]` and corrupts the layout;
+    // panic here rather than emit a broken instruction (matches the count/args
+    // debug_asserts in `user.rs`/`device.rs`).
+    debug_assert_eq!(
+        feed_keys.len(),
+        args.feeds.len(),
+        "feed_keys must be paired 1:1 with args.feeds"
+    );
     let (accesspass, _) = get_accesspass_pda(program_id, &args.client_ip, &args.user_payer);
     let (globalstate, _) = get_globalstate_pda(program_id);
     let mut accounts = vec![
@@ -126,7 +136,9 @@ pub fn set_access_pass_feeds(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use doublezero_serviceability::state::accesspass::AccessPassType;
+    use doublezero_serviceability::{
+        processors::accesspass::set_feeds::FeedSeatConfig, state::accesspass::AccessPassType,
+    };
     use solana_system_interface::program as system_program;
 
     fn set_args(client_ip: Ipv4Addr) -> SetAccessPassArgs {
@@ -255,7 +267,14 @@ mod tests {
         let args = SetAccessPassFeedsArgs {
             client_ip,
             user_payer,
-            feeds: vec![],
+            // Paired 1:1 with `feed_keys` (one key -> one config).
+            feeds: vec![FeedSeatConfig {
+                max_users: 1,
+                max_future_users: 0,
+                anniversary_day: 1,
+                window_end: 0,
+                terminates_at: 0,
+            }],
         };
         let ix = set_access_pass_feeds(&pid, &payer, &[feed], args);
         assert_eq!(ix.data[0], 115);

--- a/crates/doublezero-serviceability-instruction/src/accesspass.rs
+++ b/crates/doublezero-serviceability-instruction/src/accesspass.rs
@@ -108,9 +108,11 @@ pub fn set_access_pass_feeds(
 ) -> Instruction {
     // The processor pairs each `args.feeds` entry with a feed account by position
     // (`value.feeds.iter().zip(feed_accounts)`), so the two must be equal length.
-    // A mismatch shifts the trailing `[payer, system]` and corrupts the layout;
-    // panic here rather than emit a broken instruction (matches the count/args
-    // debug_asserts in `user.rs`/`device.rs`).
+    // A mismatch shifts the trailing `[payer, system]` and corrupts the layout.
+    // This panics in debug builds to catch the caller bug cheaply; a release build
+    // relies on the on-chain asserts (the displaced payer trips `is_signer`, or the
+    // feed-owner check fails), so a mismatch fails closed rather than landing
+    // corrupt state. Matches the count/args debug_asserts in `user.rs`/`device.rs`.
     debug_assert_eq!(
         feed_keys.len(),
         args.feeds.len(),

--- a/crates/doublezero-serviceability-instruction/src/lib.rs
+++ b/crates/doublezero-serviceability-instruction/src/lib.rs
@@ -40,6 +40,7 @@
 
 mod common;
 
+pub mod accesspass;
 pub mod contributor;
 pub mod device;
 pub mod exchange;
@@ -48,6 +49,7 @@ pub mod link;
 pub mod location;
 pub mod multicastgroup;
 pub mod permission;
+pub mod resource;
 pub mod tenant;
 pub mod topology;
 pub mod user;

--- a/crates/doublezero-serviceability-instruction/src/resource.rs
+++ b/crates/doublezero-serviceability-instruction/src/resource.rs
@@ -1,0 +1,219 @@
+//! Resource-extension-domain instruction builders.
+//!
+//! All route through `authorize()` -> [`common::build_with_permission`]. The
+//! resource-extension PDA and its associated account are derived from
+//! `args.resource_type` (a data-bearing enum).
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalconfig_pda, get_globalstate_pda, get_resource_extension_pda},
+    processors::resource::{
+        allocate::ResourceAllocateArgs, closeaccount::ResourceExtensionCloseAccountArgs,
+        create::ResourceCreateArgs, deallocate::ResourceDeallocateArgs,
+    },
+    resource::ResourceType,
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// The account a resource extension is associated with: the entity pubkey for
+/// per-entity resources (`DzPrefixBlock`, `TunnelIds`), else the system program.
+fn associated_account(resource_type: ResourceType) -> Pubkey {
+    match resource_type {
+        ResourceType::DzPrefixBlock(pk, _) | ResourceType::TunnelIds(pk, _) => pk,
+        _ => Pubkey::default(),
+    }
+}
+
+/// `AllocateResource` (variant 80).
+/// Accounts: `[resource, associated_account, globalstate]`.
+pub fn allocate_resource(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: ResourceAllocateArgs,
+) -> Instruction {
+    let (resource, _, _) = get_resource_extension_pda(program_id, args.resource_type);
+    let associated = associated_account(args.resource_type);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::AllocateResource(args),
+        vec![
+            AccountMeta::new(resource, false),
+            AccountMeta::new(associated, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `CreateResource` (variant 81).
+/// Accounts: `[resource, associated_account, globalstate, globalconfig]`.
+pub fn create_resource(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: ResourceCreateArgs,
+) -> Instruction {
+    let (resource, _, _) = get_resource_extension_pda(program_id, args.resource_type);
+    let associated = associated_account(args.resource_type);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (globalconfig, _) = get_globalconfig_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateResource(args),
+        vec![
+            AccountMeta::new(resource, false),
+            AccountMeta::new(associated, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(globalconfig, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeallocateResource` (variant 82).
+/// Accounts: `[resource, associated_account, globalstate]`.
+pub fn deallocate_resource(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: ResourceDeallocateArgs,
+) -> Instruction {
+    let (resource, _, _) = get_resource_extension_pda(program_id, args.resource_type);
+    let associated = associated_account(args.resource_type);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeallocateResource(args),
+        vec![
+            AccountMeta::new(resource, false),
+            AccountMeta::new(associated, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `CloseResource` (variant 85). Accounts: `[resource, owner, globalstate]`.
+///
+/// Takes the resource pubkey and its owner directly (both onchain-read on the
+/// close path).
+pub fn close_resource(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    resource: &Pubkey,
+    owner: &Pubkey,
+    args: ResourceExtensionCloseAccountArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CloseResource(args),
+        vec![
+            AccountMeta::new(*resource, false),
+            AccountMeta::new(*owner, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use doublezero_serviceability::resource::IdOrIp;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_allocate_resource_no_associated_for_global_pool() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        // A global pool (DeviceTunnelBlock) -> associated account is the default pubkey.
+        let args = ResourceAllocateArgs {
+            resource_type: ResourceType::DeviceTunnelBlock,
+            requested: None,
+        };
+        let ix = allocate_resource(&pid, &payer, args);
+        assert_eq!(ix.data[0], 80);
+        let (resource, _, _) = get_resource_extension_pda(&pid, ResourceType::DeviceTunnelBlock);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(resource, false),
+                AccountMeta::new(Pubkey::default(), false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_create_resource_per_entity_uses_entity_as_associated() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let device = Pubkey::new_unique();
+        let args = ResourceCreateArgs {
+            resource_type: ResourceType::TunnelIds(device, 0),
+        };
+        let ix = create_resource(&pid, &payer, args);
+        assert_eq!(ix.data[0], 81);
+        let (resource, _, _) = get_resource_extension_pda(&pid, ResourceType::TunnelIds(device, 0));
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let (globalconfig, _) = get_globalconfig_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(resource, false),
+                AccountMeta::new(device, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(globalconfig, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_deallocate_resource() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let args = ResourceDeallocateArgs {
+            resource_type: ResourceType::LinkIds,
+            value: IdOrIp::Id(1),
+        };
+        let ix = deallocate_resource(&pid, &payer, args);
+        assert_eq!(ix.data[0], 82);
+        assert_eq!(ix.accounts.len(), 3 + 2);
+    }
+
+    #[test]
+    fn test_close_resource() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let resource = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let ix = close_resource(
+            &pid,
+            &payer,
+            &resource,
+            &owner,
+            ResourceExtensionCloseAccountArgs {},
+        );
+        assert_eq!(ix.data[0], 85);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(resource, false),
+                AccountMeta::new(owner, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/resource.rs
+++ b/crates/doublezero-serviceability-instruction/src/resource.rs
@@ -187,7 +187,19 @@ mod tests {
         };
         let ix = deallocate_resource(&pid, &payer, args);
         assert_eq!(ix.data[0], 82);
-        assert_eq!(ix.accounts.len(), 3 + 2);
+        // LinkIds is a global pool -> associated account is the default pubkey.
+        let (resource, _, _) = get_resource_extension_pda(&pid, ResourceType::LinkIds);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(resource, false),
+                AccountMeta::new(Pubkey::default(), false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

RFC-26 **R8** (stacked on the previous phase's branch). Access-pass set (conditional tenant pair)/close/check-status/set-feeds, and resource-extension allocate/create/deallocate/close (resource PDA + associated account derived from the data-bearing args.resource_type).

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4023. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource  ← **this PR**
10. #4058 — R9 globalstate/config/allowlist/index/migrate

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
