### PR TITLE
serviceability-instruction: globalstate/globalconfig/allowlist/index/migrate builders (RFC-26 R9)

### DIFF
--- a/crates/doublezero-serviceability-instruction/src/allowlist.rs
+++ b/crates/doublezero-serviceability-instruction/src/allowlist.rs
@@ -1,0 +1,123 @@
+//! Allowlist-domain instruction builders (foundation + QA).
+//!
+//! Each toggles a single pubkey on the GlobalState allowlist; the only account is
+//! GlobalState. All route through `authorize()` -> [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::get_globalstate_pda,
+    processors::allowlist::{
+        foundation::{add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs},
+        qa::{add::AddQaAllowlistArgs, remove::RemoveQaAllowlistArgs},
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+fn build_globalstate_only(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    instruction: DoubleZeroInstruction,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        instruction,
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
+/// `AddFoundationAllowlist` (variant 4). Accounts: `[globalstate]`.
+pub fn add_foundation_allowlist(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: AddFoundationAllowlistArgs,
+) -> Instruction {
+    build_globalstate_only(
+        program_id,
+        payer,
+        DoubleZeroInstruction::AddFoundationAllowlist(args),
+    )
+}
+
+/// `RemoveFoundationAllowlist` (variant 5). Accounts: `[globalstate]`.
+pub fn remove_foundation_allowlist(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: RemoveFoundationAllowlistArgs,
+) -> Instruction {
+    build_globalstate_only(
+        program_id,
+        payer,
+        DoubleZeroInstruction::RemoveFoundationAllowlist(args),
+    )
+}
+
+/// `AddQaAllowlist` (variant 86). Accounts: `[globalstate]`.
+pub fn add_qa_allowlist(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: AddQaAllowlistArgs,
+) -> Instruction {
+    build_globalstate_only(
+        program_id,
+        payer,
+        DoubleZeroInstruction::AddQaAllowlist(args),
+    )
+}
+
+/// `RemoveQaAllowlist` (variant 87). Accounts: `[globalstate]`.
+pub fn remove_qa_allowlist(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: RemoveQaAllowlistArgs,
+) -> Instruction {
+    build_globalstate_only(
+        program_id,
+        payer,
+        DoubleZeroInstruction::RemoveQaAllowlist(args),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_allowlist_toggles() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (
+                add_foundation_allowlist(&pid, &payer, AddFoundationAllowlistArgs::default()),
+                4,
+            ),
+            (
+                remove_foundation_allowlist(&pid, &payer, RemoveFoundationAllowlistArgs::default()),
+                5,
+            ),
+            (
+                add_qa_allowlist(&pid, &payer, AddQaAllowlistArgs::default()),
+                86,
+            ),
+            (
+                remove_qa_allowlist(&pid, &payer, RemoveQaAllowlistArgs::default()),
+                87,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/allowlist.rs
+++ b/crates/doublezero-serviceability-instruction/src/allowlist.rs
@@ -6,30 +6,12 @@
 use crate::common;
 use doublezero_serviceability::{
     instructions::DoubleZeroInstruction,
-    pda::get_globalstate_pda,
     processors::allowlist::{
         foundation::{add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs},
         qa::{add::AddQaAllowlistArgs, remove::RemoveQaAllowlistArgs},
     },
 };
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-};
-
-fn build_globalstate_only(
-    program_id: &Pubkey,
-    payer: &Pubkey,
-    instruction: DoubleZeroInstruction,
-) -> Instruction {
-    let (globalstate, _) = get_globalstate_pda(program_id);
-    common::build_with_permission(
-        program_id,
-        instruction,
-        vec![AccountMeta::new(globalstate, false)],
-        payer,
-    )
-}
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
 
 /// `AddFoundationAllowlist` (variant 4). Accounts: `[globalstate]`.
 pub fn add_foundation_allowlist(
@@ -37,7 +19,7 @@ pub fn add_foundation_allowlist(
     payer: &Pubkey,
     args: AddFoundationAllowlistArgs,
 ) -> Instruction {
-    build_globalstate_only(
+    common::build_globalstate_only(
         program_id,
         payer,
         DoubleZeroInstruction::AddFoundationAllowlist(args),
@@ -50,7 +32,7 @@ pub fn remove_foundation_allowlist(
     payer: &Pubkey,
     args: RemoveFoundationAllowlistArgs,
 ) -> Instruction {
-    build_globalstate_only(
+    common::build_globalstate_only(
         program_id,
         payer,
         DoubleZeroInstruction::RemoveFoundationAllowlist(args),
@@ -63,7 +45,7 @@ pub fn add_qa_allowlist(
     payer: &Pubkey,
     args: AddQaAllowlistArgs,
 ) -> Instruction {
-    build_globalstate_only(
+    common::build_globalstate_only(
         program_id,
         payer,
         DoubleZeroInstruction::AddQaAllowlist(args),
@@ -76,7 +58,7 @@ pub fn remove_qa_allowlist(
     payer: &Pubkey,
     args: RemoveQaAllowlistArgs,
 ) -> Instruction {
-    build_globalstate_only(
+    common::build_globalstate_only(
         program_id,
         payer,
         DoubleZeroInstruction::RemoveQaAllowlist(args),
@@ -86,6 +68,8 @@ pub fn remove_qa_allowlist(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use doublezero_serviceability::pda::get_globalstate_pda;
+    use solana_program::instruction::AccountMeta;
     use solana_system_interface::program as system_program;
 
     #[test]

--- a/crates/doublezero-serviceability-instruction/src/common.rs
+++ b/crates/doublezero-serviceability-instruction/src/common.rs
@@ -4,7 +4,7 @@
 //! serviceability instruction shares, so the payer/system convention lives in
 //! exactly one reviewable location instead of being re-encoded per builder.
 
-use doublezero_serviceability::instructions::DoubleZeroInstruction;
+use doublezero_serviceability::{instructions::DoubleZeroInstruction, pda::get_globalstate_pda};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
@@ -91,6 +91,23 @@ pub(crate) fn build_with_permission(
     payer: &Pubkey,
 ) -> Instruction {
     build(program_id, instruction, accounts, payer)
+}
+
+/// Assemble a builder whose only instruction-specific account is GlobalState
+/// (writable). Shared by the single-GlobalState setters and allowlist toggles;
+/// all route through `authorize()` -> [`build_with_permission`].
+pub(crate) fn build_globalstate_only(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    instruction: DoubleZeroInstruction,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    build_with_permission(
+        program_id,
+        instruction,
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
 }
 
 /// The transaction-level compute-budget prelude: set the compute-unit limit and

--- a/crates/doublezero-serviceability-instruction/src/globalconfig.rs
+++ b/crates/doublezero-serviceability-instruction/src/globalconfig.rs
@@ -1,0 +1,95 @@
+//! GlobalConfig-domain instruction builder.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalconfig_pda, get_globalstate_pda, get_resource_extension_pda},
+    processors::globalconfig::set::SetGlobalConfigArgs,
+    resource::ResourceType,
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `SetGlobalConfig` (variant 3).
+///
+/// Accounts: `[globalconfig, globalstate, device_tunnel_block, user_tunnel_block,
+/// multicast_group_block, link_ids, segment_routing_ids, multicast_publisher_block,
+/// vrf_ids, admin_group_bits]` — the config PDA plus every resource-extension pool
+/// (so the program can re-seed pools when blocks change). Routes through
+/// `authorize()` -> [`common::build_with_permission`].
+pub fn set_global_config(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: SetGlobalConfigArgs,
+) -> Instruction {
+    let (globalconfig, _) = get_globalconfig_pda(program_id);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    let (device_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::DeviceTunnelBlock);
+    let (user_tunnel_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::UserTunnelBlock);
+    let (multicast_group_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastGroupBlock);
+    let (link_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::LinkIds);
+    let (segment_routing_ids, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::SegmentRoutingIds);
+    let (multicast_publisher_block, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::MulticastPublisherBlock);
+    let (vrf_ids, _, _) = get_resource_extension_pda(program_id, ResourceType::VrfIds);
+    let (admin_group_bits, _, _) =
+        get_resource_extension_pda(program_id, ResourceType::AdminGroupBits);
+
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetGlobalConfig(args),
+        vec![
+            AccountMeta::new(globalconfig, false),
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(device_tunnel_block, false),
+            AccountMeta::new(user_tunnel_block, false),
+            AccountMeta::new(multicast_group_block, false),
+            AccountMeta::new(link_ids, false),
+            AccountMeta::new(segment_routing_ids, false),
+            AccountMeta::new(multicast_publisher_block, false),
+            AccountMeta::new(vrf_ids, false),
+            AccountMeta::new(admin_group_bits, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_set_global_config_account_order() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let ix = set_global_config(&pid, &payer, SetGlobalConfigArgs::default());
+        assert_eq!(ix.data[0], 3);
+        let (globalconfig, _) = get_globalconfig_pda(&pid);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let ext = |rt| get_resource_extension_pda(&pid, rt).0;
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(globalconfig, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(ext(ResourceType::DeviceTunnelBlock), false),
+                AccountMeta::new(ext(ResourceType::UserTunnelBlock), false),
+                AccountMeta::new(ext(ResourceType::MulticastGroupBlock), false),
+                AccountMeta::new(ext(ResourceType::LinkIds), false),
+                AccountMeta::new(ext(ResourceType::SegmentRoutingIds), false),
+                AccountMeta::new(ext(ResourceType::MulticastPublisherBlock), false),
+                AccountMeta::new(ext(ResourceType::VrfIds), false),
+                AccountMeta::new(ext(ResourceType::AdminGroupBits), false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/globalstate.rs
+++ b/crates/doublezero-serviceability-instruction/src/globalstate.rs
@@ -1,0 +1,141 @@
+//! GlobalState-domain instruction builders.
+//!
+//! `init_global_state` never calls `authorize()` (it bootstraps GlobalState) so it
+//! uses [`common::build`]; the setters route through `authorize()` ->
+//! [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_program_config_pda},
+    processors::globalstate::{
+        setairdrop::SetAirdropArgs, setauthority::SetAuthorityArgs,
+        setfeatureflags::SetFeatureFlagsArgs, setversion::SetVersionArgs,
+    },
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `InitGlobalState` (variant 1). Accounts: `[program_config, globalstate]`.
+pub fn init_global_state(program_id: &Pubkey, payer: &Pubkey) -> Instruction {
+    let (program_config, _) = get_program_config_pda(program_id);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build(
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config, false),
+            AccountMeta::new(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `SetAuthority` (variant 2). Accounts: `[globalstate]`.
+pub fn set_authority(program_id: &Pubkey, payer: &Pubkey, args: SetAuthorityArgs) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetAuthority(args),
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
+/// `SetAirdrop` (variant 68). Accounts: `[globalstate]`.
+pub fn set_airdrop(program_id: &Pubkey, payer: &Pubkey, args: SetAirdropArgs) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetAirdrop(args),
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
+/// `SetMinVersion` (variant 79). Accounts: `[globalstate]`.
+pub fn set_min_version(program_id: &Pubkey, payer: &Pubkey, args: SetVersionArgs) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetMinVersion(args),
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
+/// `SetFeatureFlags` (variant 94). Accounts: `[globalstate]`.
+pub fn set_feature_flags(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    args: SetFeatureFlagsArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(args),
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_init_global_state_uses_build() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let ix = init_global_state(&pid, &payer);
+        assert_eq!(ix.data[0], 1);
+        let (program_config, _) = get_program_config_pda(&pid);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(program_config, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_globalstate_setters() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        let expected = vec![
+            AccountMeta::new(globalstate, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(system_program::ID, false),
+        ];
+        for (ix, tag) in [
+            (set_authority(&pid, &payer, SetAuthorityArgs::default()), 2),
+            (
+                set_airdrop(
+                    &pid,
+                    &payer,
+                    SetAirdropArgs {
+                        contributor_airdrop_lamports: None,
+                        user_airdrop_lamports: None,
+                    },
+                ),
+                68,
+            ),
+            (set_min_version(&pid, &payer, SetVersionArgs::default()), 79),
+            (
+                set_feature_flags(&pid, &payer, SetFeatureFlagsArgs { feature_flags: 0 }),
+                94,
+            ),
+        ] {
+            assert_eq!(ix.data[0], tag);
+            assert_eq!(ix.accounts, expected);
+        }
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/globalstate.rs
+++ b/crates/doublezero-serviceability-instruction/src/globalstate.rs
@@ -55,13 +55,20 @@ pub fn set_airdrop(program_id: &Pubkey, payer: &Pubkey, args: SetAirdropArgs) ->
     )
 }
 
-/// `SetMinVersion` (variant 79). Accounts: `[globalstate]`.
+/// `SetMinVersion` (variant 79). Accounts: `[program_config, globalstate]`.
+///
+/// The processor reads `program_config` FIRST (it writes the updated
+/// `min_compatible_version` there), then `globalstate`. Both are writable.
 pub fn set_min_version(program_id: &Pubkey, payer: &Pubkey, args: SetVersionArgs) -> Instruction {
+    let (program_config, _) = get_program_config_pda(program_id);
     let (globalstate, _) = get_globalstate_pda(program_id);
     common::build_with_permission(
         program_id,
         DoubleZeroInstruction::SetMinVersion(args),
-        vec![AccountMeta::new(globalstate, false)],
+        vec![
+            AccountMeta::new(program_config, false),
+            AccountMeta::new(globalstate, false),
+        ],
         payer,
     )
 }
@@ -128,7 +135,6 @@ mod tests {
                 ),
                 68,
             ),
-            (set_min_version(&pid, &payer, SetVersionArgs::default()), 79),
             (
                 set_feature_flags(&pid, &payer, SetFeatureFlagsArgs { feature_flags: 0 }),
                 94,
@@ -137,5 +143,21 @@ mod tests {
             assert_eq!(ix.data[0], tag);
             assert_eq!(ix.accounts, expected);
         }
+
+        // SetMinVersion additionally takes `program_config` as its FIRST account
+        // (the processor writes the updated min version there), so it does not
+        // share the single-globalstate layout above.
+        let (program_config, _) = get_program_config_pda(&pid);
+        let ix = set_min_version(&pid, &payer, SetVersionArgs::default());
+        assert_eq!(ix.data[0], 79);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(program_config, false),
+                AccountMeta::new(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
     }
 }

--- a/crates/doublezero-serviceability-instruction/src/globalstate.rs
+++ b/crates/doublezero-serviceability-instruction/src/globalstate.rs
@@ -18,6 +18,22 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
+/// Assemble a setter whose only account is GlobalState (writable). Shared by the
+/// single-globalstate setters below; all route through `authorize()`.
+fn build_globalstate_only(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    instruction: DoubleZeroInstruction,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        instruction,
+        vec![AccountMeta::new(globalstate, false)],
+        payer,
+    )
+}
+
 /// `InitGlobalState` (variant 1). Accounts: `[program_config, globalstate]`.
 pub fn init_global_state(program_id: &Pubkey, payer: &Pubkey) -> Instruction {
     let (program_config, _) = get_program_config_pda(program_id);
@@ -35,24 +51,12 @@ pub fn init_global_state(program_id: &Pubkey, payer: &Pubkey) -> Instruction {
 
 /// `SetAuthority` (variant 2). Accounts: `[globalstate]`.
 pub fn set_authority(program_id: &Pubkey, payer: &Pubkey, args: SetAuthorityArgs) -> Instruction {
-    let (globalstate, _) = get_globalstate_pda(program_id);
-    common::build_with_permission(
-        program_id,
-        DoubleZeroInstruction::SetAuthority(args),
-        vec![AccountMeta::new(globalstate, false)],
-        payer,
-    )
+    build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAuthority(args))
 }
 
 /// `SetAirdrop` (variant 68). Accounts: `[globalstate]`.
 pub fn set_airdrop(program_id: &Pubkey, payer: &Pubkey, args: SetAirdropArgs) -> Instruction {
-    let (globalstate, _) = get_globalstate_pda(program_id);
-    common::build_with_permission(
-        program_id,
-        DoubleZeroInstruction::SetAirdrop(args),
-        vec![AccountMeta::new(globalstate, false)],
-        payer,
-    )
+    build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAirdrop(args))
 }
 
 /// `SetMinVersion` (variant 79). Accounts: `[program_config, globalstate]`.
@@ -79,12 +83,10 @@ pub fn set_feature_flags(
     payer: &Pubkey,
     args: SetFeatureFlagsArgs,
 ) -> Instruction {
-    let (globalstate, _) = get_globalstate_pda(program_id);
-    common::build_with_permission(
+    build_globalstate_only(
         program_id,
-        DoubleZeroInstruction::SetFeatureFlags(args),
-        vec![AccountMeta::new(globalstate, false)],
         payer,
+        DoubleZeroInstruction::SetFeatureFlags(args),
     )
 }
 

--- a/crates/doublezero-serviceability-instruction/src/globalstate.rs
+++ b/crates/doublezero-serviceability-instruction/src/globalstate.rs
@@ -18,22 +18,6 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-/// Assemble a setter whose only account is GlobalState (writable). Shared by the
-/// single-globalstate setters below; all route through `authorize()`.
-fn build_globalstate_only(
-    program_id: &Pubkey,
-    payer: &Pubkey,
-    instruction: DoubleZeroInstruction,
-) -> Instruction {
-    let (globalstate, _) = get_globalstate_pda(program_id);
-    common::build_with_permission(
-        program_id,
-        instruction,
-        vec![AccountMeta::new(globalstate, false)],
-        payer,
-    )
-}
-
 /// `InitGlobalState` (variant 1). Accounts: `[program_config, globalstate]`.
 pub fn init_global_state(program_id: &Pubkey, payer: &Pubkey) -> Instruction {
     let (program_config, _) = get_program_config_pda(program_id);
@@ -51,12 +35,12 @@ pub fn init_global_state(program_id: &Pubkey, payer: &Pubkey) -> Instruction {
 
 /// `SetAuthority` (variant 2). Accounts: `[globalstate]`.
 pub fn set_authority(program_id: &Pubkey, payer: &Pubkey, args: SetAuthorityArgs) -> Instruction {
-    build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAuthority(args))
+    common::build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAuthority(args))
 }
 
 /// `SetAirdrop` (variant 68). Accounts: `[globalstate]`.
 pub fn set_airdrop(program_id: &Pubkey, payer: &Pubkey, args: SetAirdropArgs) -> Instruction {
-    build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAirdrop(args))
+    common::build_globalstate_only(program_id, payer, DoubleZeroInstruction::SetAirdrop(args))
 }
 
 /// `SetMinVersion` (variant 79). Accounts: `[program_config, globalstate]`.
@@ -83,7 +67,7 @@ pub fn set_feature_flags(
     payer: &Pubkey,
     args: SetFeatureFlagsArgs,
 ) -> Instruction {
-    build_globalstate_only(
+    common::build_globalstate_only(
         program_id,
         payer,
         DoubleZeroInstruction::SetFeatureFlags(args),

--- a/crates/doublezero-serviceability-instruction/src/index.rs
+++ b/crates/doublezero-serviceability-instruction/src/index.rs
@@ -1,0 +1,106 @@
+//! Index-domain instruction builders.
+//!
+//! Both route through `authorize()` -> [`common::build_with_permission`].
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction,
+    pda::{get_globalstate_pda, get_index_pda},
+    processors::index::{create::IndexCreateArgs, delete::IndexDeleteArgs},
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `CreateIndex` (variant 104). Accounts: `[index, entity(readonly), globalstate(readonly)]`.
+///
+/// The index PDA is derived from `args.entity_seed` and `args.key`.
+pub fn create_index(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    entity: &Pubkey,
+    args: IndexCreateArgs,
+) -> Instruction {
+    let (index, _) = get_index_pda(program_id, args.entity_seed.as_bytes(), &args.key);
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::CreateIndex(args),
+        vec![
+            AccountMeta::new(index, false),
+            AccountMeta::new_readonly(*entity, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+/// `DeleteIndex` (variant 105). Accounts: `[index, globalstate(readonly)]`.
+pub fn delete_index(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    index: &Pubkey,
+    args: IndexDeleteArgs,
+) -> Instruction {
+    let (globalstate, _) = get_globalstate_pda(program_id);
+    common::build_with_permission(
+        program_id,
+        DoubleZeroInstruction::DeleteIndex(args),
+        vec![
+            AccountMeta::new(*index, false),
+            AccountMeta::new_readonly(globalstate, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_create_index() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let entity = Pubkey::new_unique();
+        let args = IndexCreateArgs {
+            entity_seed: "device".to_string(),
+            key: "abc".to_string(),
+        };
+        let ix = create_index(&pid, &payer, &entity, args);
+        assert_eq!(ix.data[0], 104);
+        let (index, _) = get_index_pda(&pid, b"device", "abc");
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(index, false),
+                AccountMeta::new_readonly(entity, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_delete_index() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let index = Pubkey::new_unique();
+        let ix = delete_index(&pid, &payer, &index, IndexDeleteArgs {});
+        assert_eq!(ix.data[0], 105);
+        let (globalstate, _) = get_globalstate_pda(&pid);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(index, false),
+                AccountMeta::new_readonly(globalstate, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/crates/doublezero-serviceability-instruction/src/lib.rs
+++ b/crates/doublezero-serviceability-instruction/src/lib.rs
@@ -41,12 +41,17 @@
 mod common;
 
 pub mod accesspass;
+pub mod allowlist;
 pub mod contributor;
 pub mod device;
 pub mod exchange;
 pub mod feed;
+pub mod globalconfig;
+pub mod globalstate;
+pub mod index;
 pub mod link;
 pub mod location;
+pub mod migrate;
 pub mod multicastgroup;
 pub mod permission;
 pub mod resource;

--- a/crates/doublezero-serviceability-instruction/src/migrate.rs
+++ b/crates/doublezero-serviceability-instruction/src/migrate.rs
@@ -1,0 +1,59 @@
+//! Migrate-domain instruction builder.
+
+use crate::common;
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, processors::migrate::MigrateArgs,
+};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+/// `Migrate` (variant 0) — migrate one user from its old PDA to the new PDA.
+/// Accounts: `[old_user, new_user]`.
+///
+/// The processor does not call `authorize()`, so this uses [`common::build`].
+/// `old_user` is `get_user_old_pda(index)` and `new_user` is
+/// `get_user_pda(client_ip, user_type)`; both are resolved by the caller.
+pub fn migrate(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    old_user: &Pubkey,
+    new_user: &Pubkey,
+    args: MigrateArgs,
+) -> Instruction {
+    common::build(
+        program_id,
+        DoubleZeroInstruction::Migrate(args),
+        vec![
+            AccountMeta::new(*old_user, false),
+            AccountMeta::new(*new_user, false),
+        ],
+        payer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_system_interface::program as system_program;
+
+    #[test]
+    fn test_migrate_uses_build() {
+        let pid = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let old_user = Pubkey::new_unique();
+        let new_user = Pubkey::new_unique();
+        let ix = migrate(&pid, &payer, &old_user, &new_user, MigrateArgs {});
+        assert_eq!(ix.data[0], 0);
+        assert_eq!(
+            ix.accounts,
+            vec![
+                AccountMeta::new(old_user, false),
+                AccountMeta::new(new_user, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new(system_program::ID, false),
+            ]
+        );
+    }
+}

--- a/smartcontract/sdk/rs/src/commands/globalstate/setversion.rs
+++ b/smartcontract/sdk/rs/src/commands/globalstate/setversion.rs
@@ -1,7 +1,7 @@
 use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction, processors::globalstate::setversion::SetVersionArgs,
-    programversion::ProgramVersion,
+    instructions::DoubleZeroInstruction, pda::get_program_config_pda,
+    processors::globalstate::setversion::SetVersionArgs, programversion::ProgramVersion,
 };
 use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
@@ -15,12 +15,18 @@ impl SetVersionCommand {
         let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+        let (program_config_pubkey, _) = get_program_config_pda(&client.get_program_id());
 
+        // The processor reads `program_config` FIRST (it writes the updated
+        // `min_compatible_version` there), then `globalstate`; both writable.
         client.execute_authorized_transaction(
             DoubleZeroInstruction::SetMinVersion(SetVersionArgs {
                 min_compatible_version: self.min_compatible_version.clone(),
             }),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
         )
     }
 }
@@ -32,17 +38,19 @@ mod tests {
         DoubleZeroClient,
     };
     use doublezero_serviceability::{
-        instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_program_config_pda},
         processors::globalstate::setversion::SetVersionArgs,
     };
     use mockall::predicate;
     use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
     #[test]
-    fn test_commands_setauthority_command() {
+    fn test_commands_setversion_command() {
         let mut client = create_test_client();
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
+        let (program_config_pubkey, _) = get_program_config_pda(&client.get_program_id());
 
         client
             .expect_execute_authorized_transaction()
@@ -50,7 +58,10 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::SetMinVersion(SetVersionArgs {
                     min_compatible_version: "1.0.0".parse().unwrap(),
                 })),
-                predicate::eq(vec![AccountMeta::new(globalstate_pubkey, false)]),
+                predicate::eq(vec![
+                    AccountMeta::new(program_config_pubkey, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));
 


### PR DESCRIPTION
## Summary

RFC-26 **R9** (stacked on the previous phase's branch). init_global_state and migrate (no authorize -> build); setters, set_global_config (config PDA + all 8 resource pools), foundation/QA allowlist toggles, index create/delete. After this every buildable variant has a builder.

All builders route through `authorize()` -> `build_with_permission` unless noted; each carries a verbatim account-layout doc-comment copied from its processor.

## Testing Verification

- Unit tests assert the exact `AccountMeta` list (incl. trailing `[payer, system]`) and the borsh tag byte for every builder, covering the conditional/variable-account paths.

Closes #4024. Part of RFC-26 ([rfcs/rfc26-rust-instruction-builder-library.md](rfcs/rfc26-rust-instruction-builder-library.md)).

---

### PR stack (RFC-26 builder library)

Stacked PRs, merge in order (each is based on the previous one's branch):

1. #4049 — R0 scaffold + exemplars
2. #4050 — R1 device
3. #4051 — R2 link
4. #4052 — R3 user
5. #4053 — R4 location/exchange/contributor
6. #4054 — R5 multicastgroup + allowlists
7. #4055 — R6 tenant + permission
8. #4056 — R7 topology + feed
9. #4057 — R8 accesspass + resource
10. #4058 — R9 globalstate/config/allowlist/index/migrate  ← **this PR**

R10 (commands/* migration + program-test) and RF (fixtures) follow as separate PRs.
