### PR TITLE
cli: expose per-feed seat details in access-pass get --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - CLI
   - Documentation only: update `docs/cli-standard.md` to reference the `doublezero-daemon-cli` module crate (final PR of the RFC-20 daemon-cli extraction stack). The transition shims (`client/doublezero/src/servicecontroller.rs`, `client/doublezero/src/command/`) were already removed by the earlier stack PRs; the binary is unchanged. (#4047)
   - The `feed` verbs accept an exchange code for `--exchange` and multicast group codes for `--group`, in addition to pubkeys; pubkey inputs behave exactly as before. (#4027)
+  - `access-pass get --json` includes a `feed_seats` array exposing each EdgeSeat pass's per-feed seat state (user counts and billing windows); the table view is unchanged. (#4063)
 
 ## [v0.30.0](https://github.com/malbeclabs/doublezero/compare/client/v0.29.0...client/v0.30.0) - 2026-07-10
 

--- a/smartcontract/cli/src/accesspass/get.rs
+++ b/smartcontract/cli/src/accesspass/get.rs
@@ -5,7 +5,7 @@ use doublezero_sdk::commands::{
     accesspass::get::GetAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
     tenant::list::ListTenantCommand,
 };
-use doublezero_serviceability::state::accesspass::AccessPassType;
+use doublezero_serviceability::state::accesspass::{AccessPassType, FeedSeat};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr};
@@ -24,20 +24,6 @@ pub struct GetAccessPassCliCommand {
     pub json: bool,
 }
 
-/// Per-feed seat detail for the JSON view of an EdgeSeat pass. The table view and the
-/// `type` summary show only a feed count, so these per-feed user counts and billing
-/// windows are otherwise invisible.
-#[derive(Serialize)]
-struct FeedSeatDisplay {
-    pub feed_key: String,
-    pub max_users: u8,
-    pub max_future_users: u8,
-    pub current_users: u8,
-    pub anniversary_day: u8,
-    pub window_end: i64,
-    pub terminates_at: i64,
-}
-
 #[derive(Tabled, Serialize)]
 struct AccessPassDisplay {
     pub account: String,
@@ -45,7 +31,7 @@ struct AccessPassDisplay {
     #[serde(rename = "type")]
     pub accesspass_type: String,
     #[tabled(skip)]
-    pub feed_seats: Vec<FeedSeatDisplay>,
+    pub feed_seats: Vec<FeedSeat>,
     pub client_ip: String,
     pub user_payer: String,
     pub tenant: String,
@@ -59,26 +45,6 @@ struct AccessPassDisplay {
     pub multicast_users: String,
     pub status: String,
     pub owner: String,
-}
-
-/// The EdgeSeat feed seats as display rows, so `--json` exposes each feed's user
-/// counts and billing windows. Empty for non-EdgeSeat passes.
-fn feed_seat_displays(accesspass_type: &AccessPassType) -> Vec<FeedSeatDisplay> {
-    match accesspass_type {
-        AccessPassType::EdgeSeat(seats) => seats
-            .iter()
-            .map(|seat| FeedSeatDisplay {
-                feed_key: seat.feed_key.to_string(),
-                max_users: seat.max_users,
-                max_future_users: seat.max_future_users,
-                current_users: seat.current_users,
-                anniversary_day: seat.anniversary_day,
-                window_end: seat.window_end,
-                terminates_at: seat.terminates_at,
-            })
-            .collect(),
-        _ => Vec::new(),
-    }
 }
 
 impl GetAccessPassCliCommand {
@@ -137,7 +103,10 @@ impl GetAccessPassCliCommand {
         let display = AccessPassDisplay {
             account: pubkey.to_string(),
             accesspass_type: accesspass.accesspass_type.to_string(),
-            feed_seats: feed_seat_displays(&accesspass.accesspass_type),
+            feed_seats: match &accesspass.accesspass_type {
+                AccessPassType::EdgeSeat(seats) => seats.clone(),
+                _ => Vec::new(),
+            },
             client_ip: accesspass.client_ip.to_string(),
             user_payer: accesspass.user_payer.to_string(),
             tenant: tenant_display.join(", "),
@@ -349,25 +318,81 @@ mod tests {
     }
 
     #[test]
-    fn test_edge_seat_feed_seats_expose_per_seat_users() {
-        let feed_key = Pubkey::new_unique();
-        let seats = vec![FeedSeat {
-            feed_key,
-            max_users: 2,
-            max_future_users: 2,
-            current_users: 1,
-            anniversary_day: 15,
-            window_end: 100,
-            terminates_at: 200,
-        }];
-        let displays = super::feed_seat_displays(&AccessPassType::EdgeSeat(seats));
-        assert_eq!(displays.len(), 1);
-        assert_eq!(displays[0].feed_key, feed_key.to_string());
-        assert_eq!(displays[0].max_users, 2);
-        assert_eq!(displays[0].current_users, 1);
-        assert_eq!(displays[0].terminates_at, 200);
+    fn test_cli_accesspass_get_json_renders_edge_seat_feeds() {
+        let mut client = create_test_client();
 
-        // Non-EdgeSeat passes carry no per-feed seats.
-        assert!(super::feed_seat_displays(&AccessPassType::Prepaid).is_empty());
+        let client_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let user_payer = Pubkey::new_unique();
+        let accesspass_pubkey = Pubkey::new_unique();
+        let feed_key = Pubkey::new_unique();
+
+        let accesspass = AccessPass {
+            account_type: AccountType::AccessPass,
+            bump_seed: 255,
+            accesspass_type: AccessPassType::EdgeSeat(vec![FeedSeat {
+                feed_key,
+                max_users: 2,
+                max_future_users: 2,
+                current_users: 1,
+                anniversary_day: 15,
+                window_end: 100,
+                terminates_at: 200,
+            }]),
+            client_ip,
+            user_payer,
+            last_access_epoch: u64::MAX,
+            connection_count: 0,
+            status: AccessPassStatus::Connected,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            tenant_allowlist: vec![],
+            owner: Pubkey::new_unique(),
+            flags: 0,
+            unicast_user_count: 0,
+            max_unicast_users: 0,
+            multicast_user_count: 1,
+            max_multicast_users: 2,
+        };
+        let accesspass_clone = accesspass.clone();
+
+        client
+            .expect_get_accesspass()
+            .with(predicate::eq(GetAccessPassCommand {
+                client_ip,
+                user_payer,
+            }))
+            .returning(move |_| Ok(Some((accesspass_pubkey, accesspass_clone.clone()))));
+        client
+            .expect_list_multicastgroup()
+            .with(predicate::eq(ListMulticastGroupCommand {}))
+            .returning(|_| Ok(HashMap::new()));
+        client
+            .expect_list_tenant()
+            .with(predicate::eq(ListTenantCommand {}))
+            .returning(|_| Ok(HashMap::new()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            GetAccessPassCliCommand {
+                client_ip,
+                user_payer,
+                json: true,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+
+        // Lock in the JSON shape consumers depend on: an EdgeSeat pass emits a feed_seats
+        // array with each seat's per-feed users and billing windows.
+        let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        let feeds = json["feed_seats"].as_array().unwrap();
+        assert_eq!(feeds.len(), 1);
+        assert_eq!(feeds[0]["feed_key"], feed_key.to_string());
+        assert_eq!(feeds[0]["max_users"], 2);
+        assert_eq!(feeds[0]["max_future_users"], 2);
+        assert_eq!(feeds[0]["current_users"], 1);
+        assert_eq!(feeds[0]["window_end"], 100);
+        assert_eq!(feeds[0]["terminates_at"], 200);
     }
 }

--- a/smartcontract/cli/src/accesspass/get.rs
+++ b/smartcontract/cli/src/accesspass/get.rs
@@ -5,6 +5,7 @@ use doublezero_sdk::commands::{
     accesspass::get::GetAccessPassCommand, multicastgroup::list::ListMulticastGroupCommand,
     tenant::list::ListTenantCommand,
 };
+use doublezero_serviceability::state::accesspass::AccessPassType;
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::{io::Write, net::Ipv4Addr};
@@ -23,12 +24,28 @@ pub struct GetAccessPassCliCommand {
     pub json: bool,
 }
 
+/// Per-feed seat detail for the JSON view of an EdgeSeat pass. The table view and the
+/// `type` summary show only a feed count, so these per-feed user counts and billing
+/// windows are otherwise invisible.
+#[derive(Serialize)]
+struct FeedSeatDisplay {
+    pub feed_key: String,
+    pub max_users: u8,
+    pub max_future_users: u8,
+    pub current_users: u8,
+    pub anniversary_day: u8,
+    pub window_end: i64,
+    pub terminates_at: i64,
+}
+
 #[derive(Tabled, Serialize)]
 struct AccessPassDisplay {
     pub account: String,
     #[tabled(rename = "type")]
     #[serde(rename = "type")]
     pub accesspass_type: String,
+    #[tabled(skip)]
+    pub feed_seats: Vec<FeedSeatDisplay>,
     pub client_ip: String,
     pub user_payer: String,
     pub tenant: String,
@@ -42,6 +59,26 @@ struct AccessPassDisplay {
     pub multicast_users: String,
     pub status: String,
     pub owner: String,
+}
+
+/// The EdgeSeat feed seats as display rows, so `--json` exposes each feed's user
+/// counts and billing windows. Empty for non-EdgeSeat passes.
+fn feed_seat_displays(accesspass_type: &AccessPassType) -> Vec<FeedSeatDisplay> {
+    match accesspass_type {
+        AccessPassType::EdgeSeat(seats) => seats
+            .iter()
+            .map(|seat| FeedSeatDisplay {
+                feed_key: seat.feed_key.to_string(),
+                max_users: seat.max_users,
+                max_future_users: seat.max_future_users,
+                current_users: seat.current_users,
+                anniversary_day: seat.anniversary_day,
+                window_end: seat.window_end,
+                terminates_at: seat.terminates_at,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 impl GetAccessPassCliCommand {
@@ -100,6 +137,7 @@ impl GetAccessPassCliCommand {
         let display = AccessPassDisplay {
             account: pubkey.to_string(),
             accesspass_type: accesspass.accesspass_type.to_string(),
+            feed_seats: feed_seat_displays(&accesspass.accesspass_type),
             client_ip: accesspass.client_ip.to_string(),
             user_payer: accesspass.user_payer.to_string(),
             tenant: tenant_display.join(", "),
@@ -149,7 +187,7 @@ mod tests {
         AccountType, MulticastGroup,
     };
     use doublezero_serviceability::state::{
-        accesspass::{AccessPass, AccessPassStatus, AccessPassType},
+        accesspass::{AccessPass, AccessPassStatus, AccessPassType, FeedSeat},
         tenant::{Tenant, TenantBillingConfig, TenantPaymentStatus},
     };
     use mockall::predicate;
@@ -308,5 +346,28 @@ mod tests {
             has_row("owner", &accesspass.owner.to_string()),
             "owner row should contain value"
         );
+    }
+
+    #[test]
+    fn test_edge_seat_feed_seats_expose_per_seat_users() {
+        let feed_key = Pubkey::new_unique();
+        let seats = vec![FeedSeat {
+            feed_key,
+            max_users: 2,
+            max_future_users: 2,
+            current_users: 1,
+            anniversary_day: 15,
+            window_end: 100,
+            terminates_at: 200,
+        }];
+        let displays = super::feed_seat_displays(&AccessPassType::EdgeSeat(seats));
+        assert_eq!(displays.len(), 1);
+        assert_eq!(displays[0].feed_key, feed_key.to_string());
+        assert_eq!(displays[0].max_users, 2);
+        assert_eq!(displays[0].current_users, 1);
+        assert_eq!(displays[0].terminates_at, 200);
+
+        // Non-EdgeSeat passes carry no per-feed seats.
+        assert!(super::feed_seat_displays(&AccessPassType::Prepaid).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `access-pass get --json` collapses an EdgeSeat pass to `type: "edge_seat: N feed(s)"`, so a pass's per-feed seat details (feed_key, max/future/current users, window_end, terminates_at) aren't exposed anywhere in machine-readable output.
- Adds a `feed_seats` array to the JSON view, populated from `AccessPassType::EdgeSeat`. Empty for other pass types. The table view is unchanged: the field is `#[tabled(skip)]`, matching the existing skipped-field pattern in `access-pass list`, and `type` still shows the feed count.

## Testing

- Added a unit test covering the EdgeSeat -> `feed_seats` mapping (per-seat fields) and the empty non-EdgeSeat case.
- `cargo test -p doublezero-serviceability-cli --lib -- accesspass::get::tests` passes.
