### PR TITLE
serviceability: gate EdgeSeat access-pass writes on min_compatible_version

### DIFF
--- a/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
+++ b/sdk/serviceability/testdata/fixtures/generate-fixtures/src/main.rs
@@ -183,6 +183,7 @@ fn generate_global_state(dir: &Path) {
         qa_allowlist: vec![qa_pk],
         feature_flags: 1,
         feed_authority_pk: feed_authority_pk,
+        min_compatible_version: Default::default(),
     };
 
     let data = borsh::to_vec(&val).unwrap();

--- a/smartcontract/cli/src/globalconfig/airdrop/get.rs
+++ b/smartcontract/cli/src/globalconfig/airdrop/get.rs
@@ -80,6 +80,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
 
         client

--- a/smartcontract/cli/src/globalconfig/authority/get.rs
+++ b/smartcontract/cli/src/globalconfig/authority/get.rs
@@ -94,6 +94,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: feed_authority,
+            min_compatible_version: Default::default(),
         };
 
         client

--- a/smartcontract/cli/src/globalconfig/featureflags/get.rs
+++ b/smartcontract/cli/src/globalconfig/featureflags/get.rs
@@ -77,6 +77,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 1,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
 
         client
@@ -114,6 +115,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
 
         client
@@ -151,6 +153,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 1,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
 
         client

--- a/smartcontract/cli/src/globalconfig/featureflags/set.rs
+++ b/smartcontract/cli/src/globalconfig/featureflags/set.rs
@@ -99,6 +99,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         }
     }
 

--- a/smartcontract/programs/doublezero-geolocation/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-geolocation/tests/test_helpers.rs
@@ -83,6 +83,7 @@ pub fn create_mock_globalstate_account_shared(
         qa_allowlist: vec![],
         feature_flags: 0,
         feed_authority_pk: Pubkey::new_unique(),
+        min_compatible_version: Default::default(),
     };
 
     let data = borsh::to_vec(&globalstate).unwrap();

--- a/smartcontract/programs/doublezero-serviceability/src/error.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/error.rs
@@ -208,6 +208,8 @@ pub enum DoubleZeroError {
         "Feed billing window is invalid (window_end must be in the future and <= terminates_at)"
     )]
     FeedInvalidBillingWindow, // variant 100
+    #[error("EdgeSeat access passes require min_compatible_version >= 0.30.0 (older clients cannot decode EdgeSeat feed seats)")]
+    EdgeSeatCompatibilityWindowNotMet, // variant 101
 }
 
 impl From<DoubleZeroError> for ProgramError {
@@ -314,6 +316,7 @@ impl From<DoubleZeroError> for ProgramError {
             DoubleZeroError::FeedMaxFutureUsersBelowMaxUsers => ProgramError::Custom(98),
             DoubleZeroError::FeedInvalidAnniversaryDay => ProgramError::Custom(99),
             DoubleZeroError::FeedInvalidBillingWindow => ProgramError::Custom(100),
+            DoubleZeroError::EdgeSeatCompatibilityWindowNotMet => ProgramError::Custom(101),
         }
     }
 }
@@ -421,6 +424,7 @@ impl From<u32> for DoubleZeroError {
             98 => DoubleZeroError::FeedMaxFutureUsersBelowMaxUsers,
             99 => DoubleZeroError::FeedInvalidAnniversaryDay,
             100 => DoubleZeroError::FeedInvalidBillingWindow,
+            101 => DoubleZeroError::EdgeSeatCompatibilityWindowNotMet,
             _ => DoubleZeroError::Custom(e),
         }
     }

--- a/smartcontract/programs/doublezero-serviceability/src/lib.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/lib.rs
@@ -8,7 +8,7 @@ mod helper;
 pub mod id_allocator;
 pub mod instructions;
 pub mod ip_allocator;
-mod min_version;
+pub mod min_version;
 pub mod pda;
 pub mod processors;
 pub mod programversion;

--- a/smartcontract/programs/doublezero-serviceability/src/min_version.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/min_version.rs
@@ -1,1 +1,7 @@
 pub const MIN_COMPATIBLE_VERSION: &str = "0.21.0";
+
+// First client release whose AccessPass decoder understands `EdgeSeat(Vec<FeedSeat>)` (#3954).
+// Older decoders misparse every field after the variant tag and can abort on a bogus allowlist
+// length, so EdgeSeat-typed passes may not be written while min_compatible_version still admits
+// those clients (see `require_edge_seat_compatible_floor`).
+pub const EDGE_SEAT_MIN_COMPATIBLE_VERSION: &str = "0.30.0";

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -3,10 +3,15 @@ pub mod close;
 pub mod set;
 pub mod set_feeds;
 
+use crate::{
+    error::DoubleZeroError, min_version::EDGE_SEAT_MIN_COMPATIBLE_VERSION,
+    programversion::ProgramVersion, state::globalstate::GlobalState,
+};
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed_unchecked,
-    rent::Rent, sysvar::Sysvar,
+    program_error::ProgramError, rent::Rent, sysvar::Sysvar,
 };
+use std::str::FromStr;
 
 // Value to rent exempt three `User` accounts + configurable amount for connect/disconnect txns.
 // `User` account size assumes a single publisher and subscriber pubkey registered (298 bytes each).
@@ -15,6 +20,25 @@ pub const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 298 * 3; // 298 bytes per Us
 /// Default per-user airdrop seeded into `GlobalState.user_airdrop_lamports` at initialization.
 /// Admins can override it via the `SetAirdrop` instruction.
 pub const DEFAULT_USER_AIRDROP_LAMPORTS: u64 = 40_000;
+
+/// EdgeSeat passes serialize as `EdgeSeat(Vec<FeedSeat>)`; clients older than
+/// `EDGE_SEAT_MIN_COMPATIBLE_VERSION` misparse every field after the variant tag and can abort on
+/// a bogus allowlist length. Refuse to write the type until the admitted client floor
+/// (`GlobalState.min_compatible_version`, mirrored from ProgramConfig by SetMinVersion)
+/// guarantees every client can decode it.
+pub fn require_edge_seat_compatible_floor(globalstate: &GlobalState) -> ProgramResult {
+    let required = ProgramVersion::from_str(EDGE_SEAT_MIN_COMPATIBLE_VERSION)
+        .map_err(|_| ProgramError::InvalidArgument)?;
+    if globalstate.min_compatible_version < required {
+        msg!(
+            "EdgeSeat access passes require min_compatible_version >= {}; current {} still admits clients that cannot decode them",
+            required,
+            globalstate.min_compatible_version
+        );
+        return Err(DoubleZeroError::EdgeSeatCompatibilityWindowNotMet.into());
+    }
+    Ok(())
+}
 
 /// Computes the target lamport balance a `user_payer` must hold to cover rent for its `User`
 /// accounts plus the configured per-user airdrop. `multiplier` scales the target for passes that

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -2,7 +2,7 @@ use crate::{
     authorize::authorize,
     error::DoubleZeroError,
     pda::*,
-    processors::accesspass::airdrop_user_credits,
+    processors::accesspass::{airdrop_user_credits, require_edge_seat_compatible_floor},
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
@@ -130,6 +130,11 @@ pub fn process_set_access_pass(
     //     authority, feed authority, or a Permission account granting ACCESS_PASS_ADMIN), or
     //   - they are an administrator of the tenant being added (tenant_add_account).
     let globalstate = GlobalState::try_from(globalstate_account)?;
+
+    // EdgeSeat passes may only be written once the admitted client floor can decode them.
+    if matches!(value.accesspass_type, AccessPassType::EdgeSeat(_)) {
+        require_edge_seat_compatible_floor(&globalstate)?;
+    }
 
     // Pre-deserialize the tenant_add account when present so we can both authorize the caller
     // and later increment its reference_count without double-reading it.

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -2,6 +2,7 @@ use crate::{
     authorize::authorize,
     error::DoubleZeroError,
     pda::get_accesspass_pda,
+    processors::accesspass::require_edge_seat_compatible_floor,
     serializer::try_acc_write,
     state::{
         accesspass::{AccessPass, AccessPassType, FeedSeat},
@@ -107,6 +108,10 @@ pub fn process_set_access_pass_feeds(
 
     // Provisioning actor authorized via ACCESS_PASS_ADMIN (Permission PDA or legacy fallback).
     let globalstate = GlobalState::try_from(globalstate_account)?;
+
+    // Feed seats may only be written once the admitted client floor can decode them.
+    require_edge_seat_compatible_floor(&globalstate)?;
+
     authorize(
         program_id,
         accounts_iter,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/initialize.rs
@@ -108,6 +108,11 @@ pub fn initialize_global_state(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         qa_allowlist: vec![*payer_account.key],
         feature_flags: 0,
         feed_authority_pk: Pubkey::default(),
+        // Mirrors the ProgramConfig default above; SetMinVersion keeps the two in sync.
+        min_compatible_version: ProgramVersion::from_str(
+            crate::min_version::MIN_COMPATIBLE_VERSION,
+        )
+        .unwrap(),
     };
 
     try_acc_create(

--- a/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setversion.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/globalstate/setversion.rs
@@ -77,7 +77,7 @@ pub fn process_set_version(
     );
 
     // Authorization: GLOBALSTATE_ADMIN (Permission account) or foundation (legacy).
-    let globalstate = GlobalState::try_from(globalstate_account)?;
+    let mut globalstate = GlobalState::try_from(globalstate_account)?;
     authorize(
         program_id,
         accounts_iter,
@@ -100,6 +100,11 @@ pub fn process_set_version(
         payer_account,
         accounts,
     )?;
+
+    // Keep the GlobalState mirror in sync so processors that only receive GlobalState can gate
+    // on the admitted client floor (see require_edge_seat_compatible_floor).
+    globalstate.min_compatible_version = value.min_compatible_version.clone();
+    try_acc_write(&globalstate, globalstate_account, payer_account, accounts)?;
 
     #[cfg(test)]
     msg!("Updated: {:?}", globalstate);

--- a/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/globalstate.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{DoubleZeroError, Validate},
     helper::deserialize_vec_with_capacity,
+    programversion::ProgramVersion,
     state::accounttype::AccountType,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -30,6 +31,12 @@ pub struct GlobalState {
     pub qa_allowlist: Vec<Pubkey>,         // 4 + 32 * len
     pub feature_flags: u128,               // 16
     pub feed_authority_pk: Pubkey,         // 32
+    // Mirror of ProgramConfig.min_compatible_version, written by SetMinVersion (single writer)
+    // so processors that already receive GlobalState can gate on the admitted client floor
+    // without a ProgramConfig account (see require_edge_seat_compatible_floor). Defaults to
+    // 0.0.0 on accounts written before this field existed — i.e. the gate stays closed until
+    // SetMinVersion runs.
+    pub min_compatible_version: ProgramVersion, // 12
 }
 
 impl Default for GlobalState {
@@ -49,6 +56,7 @@ impl Default for GlobalState {
             qa_allowlist: Vec::new(),
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: ProgramVersion::default(),
         }
     }
 }
@@ -102,6 +110,7 @@ impl TryFrom<&[u8]> for GlobalState {
             qa_allowlist: deserialize_vec_with_capacity(&mut data).unwrap_or_default(),
             feature_flags: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
             feed_authority_pk: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
+            min_compatible_version: BorshDeserialize::deserialize(&mut data).unwrap_or_default(),
         };
 
         if out.account_type != AccountType::GlobalState {
@@ -195,6 +204,7 @@ mod tests {
             qa_allowlist: vec![Pubkey::new_unique(), Pubkey::new_unique()],
             feature_flags: 1,
             feed_authority_pk: Pubkey::new_unique(),
+            min_compatible_version: "0.30.0".parse().unwrap(),
         };
 
         let data = borsh::to_vec(&val).unwrap();
@@ -244,6 +254,7 @@ mod tests {
             qa_allowlist: vec![Pubkey::new_unique(), Pubkey::new_unique()],
             feature_flags: 0,
             feed_authority_pk: Pubkey::new_unique(),
+            min_compatible_version: ProgramVersion::default(),
         };
         let err = val.validate();
         assert!(err.is_err());

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -1,5 +1,6 @@
 use doublezero_serviceability::{
     instructions::*,
+    min_version::EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     pda::*,
     processors::{
         accesspass::{
@@ -1952,6 +1953,15 @@ async fn test_set_accesspass_refills_depleted_user_payer() {
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,
+    )
+    .await;
+
+    set_min_compatible_version(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        &payer,
+        EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     )
     .await;
 

--- a/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
@@ -1,5 +1,6 @@
 use doublezero_serviceability::{
     instructions::*,
+    min_version::EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     pda::*,
     processors::{
         accesspass::set::SetAccessPassArgs,
@@ -65,6 +66,15 @@ async fn setup_test_env() -> TestEnv {
             AccountMeta::new(globalstate_pubkey, false),
         ],
         &payer,
+    )
+    .await;
+
+    set_min_compatible_version(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        &payer,
+        EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     )
     .await;
 

--- a/smartcontract/programs/doublezero-serviceability/tests/feed_metro_gate_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/feed_metro_gate_test.rs
@@ -9,6 +9,7 @@
 use doublezero_serviceability::{
     entrypoint::process_instruction,
     instructions::DoubleZeroInstruction,
+    min_version::EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     pda::{
         get_accesspass_pda, get_contributor_pda, get_device_pda, get_exchange_pda, get_feed_pda,
         get_globalconfig_pda, get_globalstate_pda, get_location_pda, get_multicastgroup_pda,
@@ -82,6 +83,14 @@ async fn setup_feed_fixture(client_ip: [u8; 4]) -> FeedFixture {
         get_resource_extension_pda(&program_id, ResourceType::MulticastPublisherBlock);
 
     init_globalstate_and_config(&mut banks_client, program_id, &payer, recent_blockhash).await;
+    set_min_compatible_version(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        &payer,
+        EDGE_SEAT_MIN_COMPATIBLE_VERSION,
+    )
+    .await;
 
     let gs = get_globalstate(&mut banks_client, globalstate_pubkey).await;
     let (location_pubkey, _) = get_location_pda(&program_id, gs.account_index + 1);

--- a/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
@@ -2,6 +2,7 @@ use doublezero_serviceability::{
     entrypoint::process_instruction,
     error::DoubleZeroError,
     instructions::DoubleZeroInstruction,
+    min_version::{EDGE_SEAT_MIN_COMPATIBLE_VERSION, MIN_COMPATIBLE_VERSION},
     pda::{get_accesspass_pda, get_feed_pda, get_globalstate_pda, get_program_config_pda},
     processors::{
         accesspass::{
@@ -92,7 +93,8 @@ fn serialized_account(program_id: Pubkey, data: Vec<u8>) -> Account {
 }
 
 /// Initialize global state so the default payer is on the foundation allowlist and thus authorized
-/// (via the ACCESS_PASS_ADMIN legacy fallback) for SetAccessPassFeeds.
+/// (via the ACCESS_PASS_ADMIN legacy fallback) for SetAccessPassFeeds, then raise
+/// `min_compatible_version` to the EdgeSeat floor so EdgeSeat passes may be written.
 async fn init_globalstate(
     banks_client: &mut BanksClient,
     program_id: Pubkey,
@@ -112,6 +114,15 @@ async fn init_globalstate(
             AccountMeta::new(globalstate_pubkey, false),
         ],
         payer,
+    )
+    .await;
+
+    set_min_compatible_version(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        payer,
+        EDGE_SEAT_MIN_COMPATIBLE_VERSION,
     )
     .await;
 
@@ -581,6 +592,8 @@ async fn test_cannot_set_max_users_below_current_users() {
     let globalstate = GlobalState {
         bump_seed: globalstate_bump,
         foundation_allowlist: vec![authority.pubkey()],
+        // The EdgeSeat compatibility gate reads this; seed it at the floor.
+        min_compatible_version: EDGE_SEAT_MIN_COMPATIBLE_VERSION.parse().unwrap(),
         ..GlobalState::default()
     };
     program_test.add_account(
@@ -965,4 +978,148 @@ async fn test_cannot_set_zero_max_users() {
     )
     .await;
     assert_custom_at_ix0(&result, custom_code(DoubleZeroError::FeedMaxUsersZero));
+}
+
+/// While `min_compatible_version` still admits pre-FeedSeat clients, EdgeSeat-typed SetAccessPass
+/// and SetAccessPassFeeds are refused; other pass types are unaffected, and re-raising the floor
+/// re-admits EdgeSeat writes.
+#[tokio::test]
+async fn test_edge_seat_blocked_below_compat_floor() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    let feed_a = create_feed(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        "feda",
+    )
+    .await;
+
+    // Created while the floor is at the EdgeSeat level (raised by init_globalstate).
+    let client_ip = Ipv4Addr::new(100, 0, 0, 11);
+    let user_payer = Pubkey::new_unique();
+    let accesspass_pubkey = create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        client_ip,
+        user_payer,
+        AccessPassType::EdgeSeat(vec![]),
+    )
+    .await;
+
+    // Lower the floor back to the init default: pre-FeedSeat clients are admitted again.
+    set_min_compatible_version(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        &payer,
+        MIN_COMPATIBLE_VERSION,
+    )
+    .await;
+
+    // EdgeSeat-typed SetAccessPass is refused below the floor.
+    let blocked_ip = Ipv4Addr::new(100, 0, 0, 12);
+    let blocked_payer = Pubkey::new_unique();
+    let (blocked_pubkey, _) = get_accesspass_pda(&program_id, &blocked_ip, &blocked_payer);
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::EdgeSeat(vec![]),
+            client_ip: blocked_ip,
+            last_access_epoch: u64::MAX,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 4,
+        }),
+        vec![
+            AccountMeta::new(blocked_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(blocked_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert_custom_at_ix0(
+        &result,
+        custom_code(DoubleZeroError::EdgeSeatCompatibilityWindowNotMet),
+    );
+
+    // SetAccessPassFeeds on the existing pass is refused below the floor.
+    let feeds = vec![FeedSeatConfig {
+        max_users: 5,
+        max_future_users: 5,
+        anniversary_day: 15,
+        window_end: TEST_WINDOW_END,
+        terminates_at: TEST_TERMINATES_AT,
+    }];
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: feeds.clone(),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert_custom_at_ix0(
+        &result,
+        custom_code(DoubleZeroError::EdgeSeatCompatibilityWindowNotMet),
+    );
+
+    // Non-EdgeSeat passes are unaffected by the floor.
+    create_edge_seat_pass(
+        &mut banks_client,
+        program_id,
+        globalstate_pubkey,
+        &payer,
+        recent_blockhash,
+        Ipv4Addr::new(100, 0, 0, 13),
+        Pubkey::new_unique(),
+        AccessPassType::Prepaid,
+    )
+    .await;
+
+    // Raising the floor re-admits EdgeSeat writes.
+    set_min_compatible_version(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        &payer,
+        EDGE_SEAT_MIN_COMPATIBLE_VERSION,
+    )
+    .await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_a, false),
+        ],
+        &payer,
+    )
+    .await;
+    let accesspass = read_accesspass(&mut banks_client, accesspass_pubkey).await;
+    assert_eq!(accesspass.feed_seats().len(), 1);
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/test_helpers.rs
@@ -8,8 +8,8 @@ use doublezero_serviceability::{
     },
     processors::{
         contributor::create::ContributorCreateArgs, exchange::create::ExchangeCreateArgs,
-        globalconfig::set::SetGlobalConfigArgs, location::create::LocationCreateArgs,
-        topology::create::TopologyCreateArgs,
+        globalconfig::set::SetGlobalConfigArgs, globalstate::setversion::SetVersionArgs,
+        location::create::LocationCreateArgs, topology::create::TopologyCreateArgs,
     },
     resource::ResourceType,
     state::{
@@ -156,6 +156,36 @@ pub async fn transfer(
     let mut tx = Transaction::new_with_payer(&[transfer_ix], Some(&source.pubkey()));
     tx.sign(&[&source], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
+}
+
+/// Set `min_compatible_version` (ProgramConfig + its GlobalState mirror) via SetMinVersion.
+/// EdgeSeat-typed access passes may only be written once the floor reaches
+/// `EDGE_SEAT_MIN_COMPATIBLE_VERSION` (see `require_edge_seat_compatible_floor`), so setups raise
+/// it right after InitGlobalState.
+#[allow(dead_code)]
+pub async fn set_min_compatible_version(
+    banks_client: &mut BanksClient,
+    recent_blockhash: solana_program::hash::Hash,
+    program_id: Pubkey,
+    payer: &Keypair,
+    version: &str,
+) {
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+    execute_transaction(
+        banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetMinVersion(SetVersionArgs {
+            min_compatible_version: version.parse().unwrap(),
+        }),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        payer,
+    )
+    .await;
 }
 
 pub async fn execute_transaction(

--- a/smartcontract/sdk/rs/src/commands/device/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/device/delete.rs
@@ -217,6 +217,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
         client
             .expect_get()

--- a/smartcontract/sdk/rs/src/commands/globalstate/setversion.rs
+++ b/smartcontract/sdk/rs/src/commands/globalstate/setversion.rs
@@ -1,7 +1,7 @@
 use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
 use doublezero_serviceability::{
-    instructions::DoubleZeroInstruction, processors::globalstate::setversion::SetVersionArgs,
-    programversion::ProgramVersion,
+    instructions::DoubleZeroInstruction, pda::get_program_config_pda,
+    processors::globalstate::setversion::SetVersionArgs, programversion::ProgramVersion,
 };
 use solana_sdk::{instruction::AccountMeta, signature::Signature};
 
@@ -16,11 +16,17 @@ impl SetVersionCommand {
             .execute(client)
             .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
 
+        // Processor account layout: [program_config, globalstate, payer, system, (permission)];
+        // the trailing accounts are appended by execute_authorized_transaction.
+        let (program_config_pubkey, _) = get_program_config_pda(&client.get_program_id());
         client.execute_authorized_transaction(
             DoubleZeroInstruction::SetMinVersion(SetVersionArgs {
                 min_compatible_version: self.min_compatible_version.clone(),
             }),
-            vec![AccountMeta::new(globalstate_pubkey, false)],
+            vec![
+                AccountMeta::new(program_config_pubkey, false),
+                AccountMeta::new(globalstate_pubkey, false),
+            ],
         )
     }
 }
@@ -32,7 +38,8 @@ mod tests {
         DoubleZeroClient,
     };
     use doublezero_serviceability::{
-        instructions::DoubleZeroInstruction, pda::get_globalstate_pda,
+        instructions::DoubleZeroInstruction,
+        pda::{get_globalstate_pda, get_program_config_pda},
         processors::globalstate::setversion::SetVersionArgs,
     };
     use mockall::predicate;
@@ -43,6 +50,7 @@ mod tests {
         let mut client = create_test_client();
 
         let (globalstate_pubkey, _globalstate) = get_globalstate_pda(&client.get_program_id());
+        let (program_config_pubkey, _) = get_program_config_pda(&client.get_program_id());
 
         client
             .expect_execute_authorized_transaction()
@@ -50,7 +58,10 @@ mod tests {
                 predicate::eq(DoubleZeroInstruction::SetMinVersion(SetVersionArgs {
                     min_compatible_version: "1.0.0".parse().unwrap(),
                 })),
-                predicate::eq(vec![AccountMeta::new(globalstate_pubkey, false)]),
+                predicate::eq(vec![
+                    AccountMeta::new(program_config_pubkey, false),
+                    AccountMeta::new(globalstate_pubkey, false),
+                ]),
             )
             .returning(|_, _| Ok(Signature::new_unique()));
 

--- a/smartcontract/sdk/rs/src/commands/user/delete.rs
+++ b/smartcontract/sdk/rs/src/commands/user/delete.rs
@@ -637,6 +637,7 @@ mod tests {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
         client
             .expect_get()

--- a/smartcontract/sdk/rs/src/tests.rs
+++ b/smartcontract/sdk/rs/src/tests.rs
@@ -40,6 +40,7 @@ pub mod utils {
             qa_allowlist: vec![],
             feature_flags: 0,
             feed_authority_pk: Pubkey::default(),
+            min_compatible_version: Default::default(),
         };
         client
             .expect_get()


### PR DESCRIPTION
## Summary

- Refuse `SetAccessPass` with an EdgeSeat type and `SetAccessPassFeeds` while `min_compatible_version` is below 0.30.0 (`EDGE_SEAT_MIN_COMPATIBLE_VERSION`), with a new error `EdgeSeatCompatibilityWindowNotMet` (Custom 101). EdgeSeat passes serialize as `EdgeSeat(Vec<FeedSeat>)` (#3954); pre-0.30 client decoders misparse every field after the variant tag and can abort on a bogus allowlist preallocation — this is what crash-looped contributor-rewards on testnet (52 GB allocation abort while decoding pass `5x9DTsWCrAQtYKH4W7trEjoaCRHnzywsZp2oFX3sg5Zg`). The gate turns "raise the compat floor before minting EdgeSeat passes" from a runbook step into a program-enforced invariant.
- `min_compatible_version` is mirrored onto `GlobalState` (new trailing field) so the gate reads an account the gated instructions already receive: no new accounts, no SDK or CLI changes, every instruction's account layout untouched, old SDK builders keep working. `SetMinVersion` remains the single writer and updates both the `ProgramConfig` copy and the mirror. GlobalState accounts written before this field decode it as 0.0.0, so the gate fails closed until `SetMinVersion` runs.
- Enablement is per-environment ops with no further deploys: raise the floor to 0.30.0 with `SetMinVersion` and EdgeSeat provisioning resumes there; leave it and the environment stays protected. Once floors are ≥ 0.30.0 everywhere the check is permanently satisfied and dormant.
- Fixes `SetVersionCommand` (SDK): its account list was missing the ProgramConfig account, so SDK/CLI-driven `SetMinVersion` failed with InvalidAccountData before ever updating the floor — consistent with both networks still declaring the 0.21.0 init default. The floor-raise lever this gate depends on now works.

**Deploy note:** both testnet and mainnet currently declare `min_compatible_version = 0.21.0`, so after this program deploys the gate is closed everywhere. Testnet needs `SetMinVersion(0.30.0)` promptly so edge-connect seat provisioning keeps working; mainnet should stay closed until we deliberately raise its floor (which force-upgrades pre-0.30 CLIs via the existing `checkversion` gate).

Context: the incident this hardens against is the do-tn-rewards1 contributor-rewards crash loop. Sibling fixes: doublezerofoundation/doublezero-offchain#402 (merged — rewards SDK pin to client/v0.31.0), #4074 (bounded `deserialize_vec_with_capacity` prealloc), doublezero-offchain#404 (ingest warn+skip). This PR closes the remaining hole: nothing stops a FeedSeat-era program from minting accounts that admitted-but-stale clients cannot decode.

## Testing Verification

- New integration test `test_edge_seat_blocked_below_compat_floor`: EdgeSeat `SetAccessPass` and `SetAccessPassFeeds` rejected with Custom(101) below the floor; Prepaid passes unaffected; `SetMinVersion` re-raising the floor re-admits feed provisioning (exercises the GlobalState mirror sync).
- Existing EdgeSeat/feed suites (`set_access_pass_feeds_test`, `feed_metro_gate_test`, `delete_user_dynamic_accesspass`, accesspass refill) pass with their setups raising the floor — 47/47 program test suites green.
- `make rust-lint`, the workspace test suite (20/20), and the onchain account-compat check (`accounts -ed`: real testnet/devnet accounts decode with the new GlobalState layout) pass; the SBF (`cargo test-sbf`) pass runs in CI.


A minimal hard-kill-switch alternative is up as draft #4076 for comparison — merge exactly one of the two.
