### PR TITLE
serviceability: hard-disable EdgeSeat access-pass writes (kill-switch alternative to #4075)

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -8,6 +8,13 @@ use solana_program::{
     rent::Rent, sysvar::Sysvar,
 };
 
+// Temporary hard switch: EdgeSeat passes serialize as `EdgeSeat(Vec<FeedSeat>)` (#3954), and
+// pre-0.30 client decoders misparse every field after the variant tag, aborting on a bogus
+// allowlist preallocation (the do-tn-rewards1 crash loop). Flip to false — together with the
+// checks in set.rs/set_feeds.rs and the #[ignore]s on the EdgeSeat test suites — in the release
+// after ProgramConfig.min_compatible_version has been raised to >= 0.30.0 everywhere.
+pub const EDGE_SEAT_WRITES_DISABLED: bool = true;
+
 // Value to rent exempt three `User` accounts + configurable amount for connect/disconnect txns.
 // `User` account size assumes a single publisher and subscriber pubkey registered (298 bytes each).
 pub const AIRDROP_USER_RENT_LAMPORTS_BYTES: usize = 298 * 3; // 298 bytes per User account x 3 accounts = 894 bytes

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -2,7 +2,7 @@ use crate::{
     authorize::authorize,
     error::DoubleZeroError,
     pda::*,
-    processors::accesspass::airdrop_user_credits,
+    processors::accesspass::{airdrop_user_credits, EDGE_SEAT_WRITES_DISABLED},
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
@@ -60,6 +60,11 @@ pub fn process_set_access_pass(
     accounts: &[AccountInfo],
     value: &SetAccessPassArgs,
 ) -> ProgramResult {
+    if EDGE_SEAT_WRITES_DISABLED && matches!(value.accesspass_type, AccessPassType::EdgeSeat(_)) {
+        msg!("EdgeSeat access passes are disabled pending the 0.30.0 client compatibility floor");
+        return Err(DoubleZeroError::FeatureNotEnabled.into());
+    }
+
     let accounts_iter = &mut accounts.iter();
 
     let accesspass_account = next_account_info(accounts_iter)?;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_feeds.rs
@@ -60,6 +60,11 @@ pub fn process_set_access_pass_feeds(
     accounts: &[AccountInfo],
     value: &SetAccessPassFeedsArgs,
 ) -> ProgramResult {
+    if crate::processors::accesspass::EDGE_SEAT_WRITES_DISABLED {
+        msg!("SetAccessPassFeeds is disabled pending the 0.30.0 client compatibility floor");
+        return Err(DoubleZeroError::FeatureNotEnabled.into());
+    }
+
     if value.feeds.len() > MAX_ACCESS_PASS_FEEDS {
         msg!(
             "SetAccessPassFeeds accepts at most {} feeds, got {}",

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -1936,6 +1936,7 @@ async fn test_set_accesspass_airdrop_scales_with_allow_multiple_ip() {
 /// drain the `user_payer`, then re-run SetAccessPass with identical params and confirm the
 /// balance is restored to the rent + airdrop target.
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_set_accesspass_refills_depleted_user_payer() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
 

--- a/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/delete_user_dynamic_accesspass.rs
@@ -687,6 +687,7 @@ async fn try_create_user(
 /// pass, a multicast connect is rejected with `FeedAccountRequired`. The pass lives at the UNSPECIFIED PDA
 /// so distinct client IPs all map to the same seat.
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_edge_seat_user_caps_enforced() {
     let mut env = setup_test_env().await;
     let payer_pk = env.payer.pubkey();

--- a/smartcontract/programs/doublezero-serviceability/tests/feed_metro_gate_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/feed_metro_gate_test.rs
@@ -374,6 +374,7 @@ async fn try_subscribe_with_feed(
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_right_metro_joins_group_set() {
     let mut f = setup_feed_fixture([100, 0, 0, 20]).await;
     let (exchange, mgroup) = (f.exchange_pubkey, f.mgroup_pubkey);
@@ -423,6 +424,7 @@ async fn test_right_metro_joins_group_set() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_wrong_metro_device_rejected() {
     let mut f = setup_feed_fixture([100, 0, 0, 21]).await;
     let mgroup = f.mgroup_pubkey;
@@ -453,6 +455,7 @@ async fn test_wrong_metro_device_rejected() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_multi_feed_seat_matching_admits() {
     let mut f = setup_feed_fixture([100, 0, 0, 22]).await;
     let (exchange, mgroup) = (f.exchange_pubkey, f.mgroup_pubkey);
@@ -503,6 +506,7 @@ async fn test_multi_feed_seat_matching_admits() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_group_not_in_feed_rejected() {
     let mut f = setup_feed_fixture([100, 0, 0, 23]).await;
     let exchange = f.exchange_pubkey;

--- a/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/set_access_pass_feeds_test.rs
@@ -192,6 +192,7 @@ async fn read_accesspass(banks_client: &mut BanksClient, pubkey: Pubkey) -> Acce
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_set_access_pass_feeds() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
     let globalstate_pubkey =
@@ -332,6 +333,7 @@ async fn test_set_access_pass_feeds() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_feeds_on_non_edge_seat() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
     let globalstate_pubkey =
@@ -388,6 +390,7 @@ async fn test_cannot_set_feeds_on_non_edge_seat() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_feeds_unauthorized_caller() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
     let globalstate_pubkey =
@@ -447,6 +450,7 @@ async fn test_cannot_set_feeds_unauthorized_caller() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_feeds_exceeds_max() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
     let globalstate_pubkey =
@@ -498,6 +502,7 @@ async fn test_cannot_set_feeds_exceeds_max() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_duplicate_feed_key() {
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
     let globalstate_pubkey =
@@ -565,6 +570,7 @@ async fn test_cannot_set_duplicate_feed_key() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_max_users_below_current_users() {
     // A seat with live users can't be re-provisioned below its current_users. current_users is only
     // ticked by connect-time enforcement (a later PR), so the pass is seeded directly here.
@@ -684,6 +690,7 @@ async fn test_cannot_set_max_users_below_current_users() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_feeds_with_invalid_billing_window() {
     // The per-feed billing fields are validated inside the provisioning loop, each with its own
     // error variant: anniversary_day must be 1..=31, and the window must satisfy
@@ -850,6 +857,7 @@ async fn test_cannot_set_feeds_with_invalid_billing_window() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_max_future_users_below_max_users() {
     // For now the future cap may not drop below the current cap (see set_feeds.rs): shrinking it
     // would force a decision about which live users to drop when the cap flips. Equal or larger is
@@ -912,6 +920,7 @@ async fn test_cannot_set_max_future_users_below_max_users() {
 }
 
 #[tokio::test]
+#[ignore = "EdgeSeat writes hard-disabled pending the 0.30.0 compat floor (EDGE_SEAT_WRITES_DISABLED)"]
 async fn test_cannot_set_zero_max_users() {
     // A zero current cap admits no users, so a seat with max_users == 0 is rejected as nonsensical.
     let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
@@ -965,4 +974,56 @@ async fn test_cannot_set_zero_max_users() {
     )
     .await;
     assert_custom_at_ix0(&result, custom_code(DoubleZeroError::FeedMaxUsersZero));
+}
+
+/// While `EDGE_SEAT_WRITES_DISABLED` is set, both EdgeSeat write paths are refused outright.
+/// Un-ignore the suites above when lifting the switch.
+#[tokio::test]
+async fn test_edge_seat_writes_disabled() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+    let globalstate_pubkey =
+        init_globalstate(&mut banks_client, program_id, &payer, recent_blockhash).await;
+
+    // SetAccessPass with an EdgeSeat type is refused.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 20);
+    let user_payer = Pubkey::new_unique();
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &user_payer);
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::EdgeSeat(vec![]),
+            client_ip,
+            last_access_epoch: u64::MAX,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(user_payer, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::FeatureNotEnabled));
+
+    // SetAccessPassFeeds is refused before any account or argument is inspected.
+    let result = try_execute_and_get_error(
+        &mut banks_client,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFeeds(SetAccessPassFeedsArgs {
+            client_ip,
+            user_payer,
+            feeds: vec![],
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert_custom_at_ix0(&result, custom_code(DoubleZeroError::FeatureNotEnabled));
 }


### PR DESCRIPTION
## Summary

Minimal-stopgap alternative to #4075 — merge exactly one of the two.

- Hard-disables both EdgeSeat write paths behind a `EDGE_SEAT_WRITES_DISABLED = true` const: `SetAccessPass` with an EdgeSeat type and `SetAccessPassFeeds` return `FeatureNotEnabled` unconditionally. Same protection goal as #4075: EdgeSeat passes serialize as `EdgeSeat(Vec<FeedSeat>)` (#3954), pre-0.30 client decoders misparse every field after the variant tag and can abort on a bogus allowlist preallocation (the do-tn-rewards1 crash loop) — so stop minting those bytes while such clients are admitted.
- ~30 source lines across 3 files; no state changes, no new error variant, no SDK/CLI changes, no account-layout changes.

Trade-offs versus #4075 (the dynamic `min_compatible_version` gate):

| | this PR (kill switch) | #4075 (dynamic floor gate) |
|---|---|---|
| source diff | ~30 lines / 3 files | ~70 lines / 8 files (+field-add churn, 24 files total) |
| lift / enable | flip the const → another program release | `SetMinVersion(0.30.0)` transaction, per environment |
| environments | blocks testnet and mainnet equally; testnet edge-connect provisioning paused until the lift release | testnet can open immediately, mainnet stays closed until chosen |
| test coverage | 15 EdgeSeat/feed-seat/metro-gate tests `#[ignore]`d until lift | full suite stays live (setups raise the floor) |
| end state | switch + ignores must be removed | gate goes dormant once floors ≥ 0.30.0, nothing to remove |
| SetVersionCommand account-list bug | untouched (fix needed eventually for any floor raise) | fixed |

**Deploy note:** the switch is active everywhere the moment this program version deploys.

## Testing Verification

- New `test_edge_seat_writes_disabled` asserts both instructions are refused with `FeatureNotEnabled` (Custom 84).
- Remaining program suites pass with the 15 EdgeSeat-dependent tests `#[ignore]`d (they exercise exactly the flows the switch forbids; un-ignore when lifting).
- `make rust-lint` passes.
