### PR TITLE
serviceability: add dzf_locked access-pass flag and set-flags instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Serviceability
   - Bound the preallocation in `deserialize_vec_with_capacity` against the remaining input. A garbage or attacker-controlled u32 length prefix in an account (e.g. a pre-FeedSeat SDK misparsing an EdgeSeat AccessPass) could request tens of GiB via `Vec::with_capacity`, aborting the process through the uncatchable alloc-error handler; the capacity is now capped at the remaining byte count. Decoding of valid accounts is unchanged. (#4072)
+  - `AccessPass` gains a `dzf_locked` flag (bit 0 of `flags`) marking a pass as foundation-managed so automated reconcilers such as the Feed Oracle leave it alone. A new `SetAccessPassFlags` instruction (gated on `ACCESS_PASS_ADMIN`) sets/clears access-pass flags without disturbing the others, and `SetAccessPass` now preserves the flag across unrelated updates. Set it with the `doublezero access-pass dzf-lock` / `dzf-unlock` verbs or `access-pass set --dzf-locked`. (#4083)
 - Device controller
   - Escalate onchain account fetch failures to `ERROR` only when sustained; a transient blip that recovers on the next poll now logs at `WARN`, so a single flaky fetch no longer pages via the generic ERROR-level alert. A weighted score (+1 per failure, -0.5 per success, floored at 0, capped at 6) crosses the threshold on a persistently failing endpoint, so real outages still surface. Each fetch is bounded by a 30s timeout so a hung endpoint fails the tick promptly rather than blocking for minutes. (#4081)
 - Tools

--- a/smartcontract/cli/src/accesspass/dzf_lock.rs
+++ b/smartcontract/cli/src/accesspass/dzf_lock.rs
@@ -1,0 +1,167 @@
+use crate::{
+    doublezerocommand::CliCommand,
+    requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+};
+use clap::Args;
+use doublezero_cli_core::CliContext;
+use doublezero_sdk::commands::accesspass::set_flags::SetAccessPassFlagsCommand;
+use doublezero_serviceability::pda::get_accesspass_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::{io::Write, net::Ipv4Addr, str::FromStr};
+
+/// Mark an access pass as DZF-locked: the DoubleZero Foundation manages the pass out of band, so
+/// automated reconcilers (e.g. the Feed Oracle) must not tear it down. Requires `ACCESS_PASS_ADMIN`.
+#[derive(Args, Debug)]
+pub struct DzfLockAccessPassCliCommand {
+    /// Client IP address in IPv4 format (the pass's `client_ip`; omit for passes keyed on 0.0.0.0)
+    #[arg(long)]
+    pub client_ip: Option<Ipv4Addr>,
+    /// Payer of the access pass ("me" for the current keypair)
+    #[arg(long)]
+    pub user_payer: String,
+}
+
+impl DzfLockAccessPassCliCommand {
+    pub async fn execute<C: CliCommand, W: Write>(
+        self,
+        _ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        set_dzf_locked(client, out, self.client_ip, &self.user_payer, true)
+    }
+}
+
+/// Clear the DZF-locked mark on an access pass, allowing automated reconcilers to manage it again.
+/// Requires `ACCESS_PASS_ADMIN`.
+#[derive(Args, Debug)]
+pub struct DzfUnlockAccessPassCliCommand {
+    /// Client IP address in IPv4 format (the pass's `client_ip`; omit for passes keyed on 0.0.0.0)
+    #[arg(long)]
+    pub client_ip: Option<Ipv4Addr>,
+    /// Payer of the access pass ("me" for the current keypair)
+    #[arg(long)]
+    pub user_payer: String,
+}
+
+impl DzfUnlockAccessPassCliCommand {
+    pub async fn execute<C: CliCommand, W: Write>(
+        self,
+        _ctx: &CliContext,
+        client: &C,
+        out: &mut W,
+    ) -> eyre::Result<()> {
+        set_dzf_locked(client, out, self.client_ip, &self.user_payer, false)
+    }
+}
+
+/// Shared set/clear of the dzf_locked flag. `client_ip` defaults to 0.0.0.0 (matching the
+/// `access-pass set` convention) so passes keyed on the unspecified address can be targeted by
+/// omitting `--client-ip`.
+fn set_dzf_locked<C: CliCommand, W: Write>(
+    client: &C,
+    out: &mut W,
+    client_ip: Option<Ipv4Addr>,
+    user_payer: &str,
+    locked: bool,
+) -> eyre::Result<()> {
+    client.check_requirements(CHECK_ID_JSON | CHECK_BALANCE)?;
+
+    let user_payer = if user_payer.eq_ignore_ascii_case("me") {
+        client.get_payer()
+    } else {
+        Pubkey::from_str(user_payer)?
+    };
+    let client_ip = client_ip.unwrap_or(Ipv4Addr::UNSPECIFIED);
+
+    let (accesspass_pubkey, _) =
+        get_accesspass_pda(&client.get_program_id(), &client_ip, &user_payer);
+    writeln!(out, "AccessPass PDA: {accesspass_pubkey}")?;
+
+    let signature = client.set_accesspass_flags(SetAccessPassFlagsCommand {
+        client_ip,
+        user_payer,
+        allow_multiple_ip: None,
+        dzf_locked: Some(locked),
+    })?;
+    writeln!(out, "Signature: {signature}")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        accesspass::dzf_lock::{DzfLockAccessPassCliCommand, DzfUnlockAccessPassCliCommand},
+        requirements::{CHECK_BALANCE, CHECK_ID_JSON},
+        tests::utils::create_test_client,
+    };
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
+    use doublezero_sdk::commands::accesspass::set_flags::SetAccessPassFlagsCommand;
+    use mockall::predicate;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_cli_accesspass_dzf_lock() {
+        let mut client = create_test_client();
+        let payer = Pubkey::new_unique();
+        let client_ip = [100, 0, 0, 1].into();
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass_flags()
+            .with(predicate::eq(SetAccessPassFlagsCommand {
+                client_ip,
+                user_payer: payer,
+                allow_multiple_ip: None,
+                dzf_locked: Some(true),
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            DzfLockAccessPassCliCommand {
+                client_ip: Some(client_ip),
+                user_payer: payer.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_cli_accesspass_dzf_unlock() {
+        let mut client = create_test_client();
+        let payer = Pubkey::new_unique();
+        let client_ip = [100, 0, 0, 1].into();
+
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass_flags()
+            .with(predicate::eq(SetAccessPassFlagsCommand {
+                client_ip,
+                user_payer: payer,
+                allow_multiple_ip: None,
+                dzf_locked: Some(false),
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            DzfUnlockAccessPassCliCommand {
+                client_ip: Some(client_ip),
+                user_payer: payer.to_string(),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+    }
+}

--- a/smartcontract/cli/src/accesspass/mod.rs
+++ b/smartcontract/cli/src/accesspass/mod.rs
@@ -1,4 +1,5 @@
 pub mod close;
+pub mod dzf_lock;
 pub mod fund;
 pub mod get;
 pub mod list;

--- a/smartcontract/cli/src/accesspass/set.rs
+++ b/smartcontract/cli/src/accesspass/set.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use clap::{Args, ValueEnum};
 use doublezero_cli_core::CliContext;
-use doublezero_sdk::commands::accesspass::set::SetAccessPassCommand;
+use doublezero_sdk::commands::accesspass::{
+    set::SetAccessPassCommand, set_flags::SetAccessPassFlagsCommand,
+};
 use doublezero_serviceability::{
     pda::{get_accesspass_pda, get_tenant_pda},
     state::accesspass::AccessPassType,
@@ -38,9 +40,14 @@ pub struct SetAccessPassCliCommand {
     /// Specifies the solana validator node id for the access pass. Required if accesspass_type is solana-validator
     #[arg(long, required_if_eq("accesspass_type", "solana_validator"))]
     pub solana_validator: Option<Pubkey>, // This will be integrated with identity for all access pass types in future
-    /// Allow multiple IP addresses for this access pass (only for Prepaid type)    
+    /// Allow multiple IP addresses for this access pass (only for Prepaid type)
     #[arg(long, default_value_t = false)]
     pub allow_multiple_ip: bool,
+    /// Mark the access pass as DZF-locked on creation (foundation-managed; ignored by automated
+    /// reconcilers such as the Feed Oracle). Requires `ACCESS_PASS_ADMIN`; applied as a second
+    /// transaction after the pass is created.
+    #[arg(long, default_value_t = false)]
+    pub dzf_locked: bool,
     /// Specifies the name for other access pass types. Required if accesspass_type is others.
     #[arg(long, required_if_eq("accesspass_type", "others"))]
     pub others_name: Option<String>,
@@ -120,9 +127,10 @@ impl SetAccessPassCliCommand {
         );
         writeln!(out, "AccessPass PDA: {accesspass_pubkey}")?;
 
+        let client_ip = self.client_ip.unwrap_or(Ipv4Addr::UNSPECIFIED);
         let signature = client.set_accesspass(SetAccessPassCommand {
             accesspass_type,
-            client_ip: self.client_ip.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            client_ip,
             user_payer,
             last_access_epoch,
             allow_multiple_ip: self.allow_multiple_ip,
@@ -131,6 +139,18 @@ impl SetAccessPassCliCommand {
             max_multicast_users: self.max_multicast_users,
         })?;
         writeln!(out, "Signature: {signature}")?;
+
+        // The dzf_locked flag is owned by the foundation-gated SetAccessPassFlags instruction, so
+        // set it in a second transaction once the pass exists.
+        if self.dzf_locked {
+            let signature = client.set_accesspass_flags(SetAccessPassFlagsCommand {
+                client_ip,
+                user_payer,
+                allow_multiple_ip: None,
+                dzf_locked: Some(true),
+            })?;
+            writeln!(out, "DZF lock signature: {signature}")?;
+        }
 
         Ok(())
     }
@@ -199,6 +219,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -213,6 +234,66 @@ mod tests {
             output_str,
             "AccessPass PDA: 6pw9fvwzjjkkocGuwxhmv1TwHHnYTFjGvV9GKX6nkFMw\nSignature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
         );
+    }
+
+    #[test]
+    fn test_cli_accesspass_set_prepaid_dzf_locked() {
+        let mut client = create_test_client();
+
+        let client_ip = [100, 0, 0, 1].into();
+        let payer = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPB");
+
+        client.expect_get_epoch().returning(|| Ok(10));
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_set_accesspass()
+            .with(predicate::eq(SetAccessPassCommand {
+                accesspass_type: AccessPassType::Prepaid,
+                client_ip,
+                user_payer: payer,
+                last_access_epoch: u64::MAX,
+                allow_multiple_ip: false,
+                tenant: Pubkey::default(),
+                max_unicast_users: 1,
+                max_multicast_users: 1,
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+        // --dzf-locked fires a second transaction to set the flag once the pass exists.
+        client
+            .expect_set_accesspass_flags()
+            .with(predicate::eq(SetAccessPassFlagsCommand {
+                client_ip,
+                user_payer: payer,
+                allow_multiple_ip: None,
+                dzf_locked: Some(true),
+            }))
+            .returning(|_| Ok(Signature::new_unique()));
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            SetAccessPassCliCommand {
+                accesspass_type: CliAccessPassType::Prepaid,
+                client_ip: Some(client_ip),
+                user_payer: payer.to_string(),
+                epochs: "max".into(),
+                solana_validator: None,
+                allow_multiple_ip: false,
+                dzf_locked: true,
+                others_name: None,
+                others_key: None,
+                tenant: None,
+                max_unicast_users: 1,
+                max_multicast_users: 1,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("DZF lock signature: "));
     }
 
     #[test]
@@ -238,6 +319,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -300,6 +382,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: Some(solana_validator),
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -361,6 +444,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -419,6 +503,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: Some(solana_validator),
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -458,6 +543,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -496,6 +582,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: Some("custom-name".to_string()),
                 others_key: None,
                 tenant: None,
@@ -559,6 +646,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: Some("custom-name".to_string()),
                 others_key: Some("custom-key".to_string()),
                 tenant: None,
@@ -595,6 +683,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -627,6 +716,7 @@ mod tests {
                 epochs: "not-a-number".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -660,6 +750,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: Some(too_long.clone()),
@@ -712,6 +803,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: true,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -762,6 +854,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: Some("acme".to_string()),
@@ -809,6 +902,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -857,6 +951,7 @@ mod tests {
                 epochs: "0".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -906,6 +1001,7 @@ mod tests {
                 epochs: "max".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,
@@ -962,6 +1058,7 @@ mod tests {
                 epochs: "1".into(),
                 solana_validator: None,
                 allow_multiple_ip: false,
+                dzf_locked: false,
                 others_name: None,
                 others_key: None,
                 tenant: None,

--- a/smartcontract/cli/src/cli/accesspass.rs
+++ b/smartcontract/cli/src/cli/accesspass.rs
@@ -1,6 +1,10 @@
 use crate::accesspass::{
-    close::CloseAccessPassCliCommand, fund::FundAccessPassCliCommand, get::GetAccessPassCliCommand,
-    list::ListAccessPassCliCommand, set::SetAccessPassCliCommand,
+    close::CloseAccessPassCliCommand,
+    dzf_lock::{DzfLockAccessPassCliCommand, DzfUnlockAccessPassCliCommand},
+    fund::FundAccessPassCliCommand,
+    get::GetAccessPassCliCommand,
+    list::ListAccessPassCliCommand,
+    set::SetAccessPassCliCommand,
     user_balances::UserBalancesAccessPassCliCommand,
 };
 use clap::{Args, Subcommand};
@@ -31,4 +35,10 @@ pub enum AccessPassCommands {
     /// Fund user payers that have insufficient balance
     #[clap()]
     Fund(FundAccessPassCliCommand),
+    /// Mark an access pass as DZF-locked (foundation-managed; ignored by automated reconcilers)
+    #[clap()]
+    DzfLock(DzfLockAccessPassCliCommand),
+    /// Clear the DZF-locked mark on an access pass
+    #[clap()]
+    DzfUnlock(DzfUnlockAccessPassCliCommand),
 }

--- a/smartcontract/cli/src/cli/command.rs
+++ b/smartcontract/cli/src/cli/command.rs
@@ -258,6 +258,8 @@ impl ServiceabilityCommand {
                     args.execute(ctx, client, out, &mut std::io::stdin().lock())
                         .await
                 }
+                AccessPassCommands::DzfLock(args) => args.execute(ctx, client, out).await,
+                AccessPassCommands::DzfUnlock(args) => args.execute(ctx, client, out).await,
             },
             Self::User(cmd) => match cmd.command {
                 UserCommands::Create(args) => args.execute(ctx, client, out).await,

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -3,7 +3,7 @@ use doublezero_sdk::{
     commands::{
         accesspass::{
             close::CloseAccessPassCommand, get::GetAccessPassCommand, list::ListAccessPassCommand,
-            set::SetAccessPassCommand,
+            set::SetAccessPassCommand, set_flags::SetAccessPassFlagsCommand,
         },
         allowlist::{
             foundation::{
@@ -319,6 +319,7 @@ pub trait CliCommand {
         cmd: RemoveMulticastGroupSubAllowlistCommand,
     ) -> eyre::Result<Signature>;
     fn set_accesspass(&self, cmd: SetAccessPassCommand) -> eyre::Result<Signature>;
+    fn set_accesspass_flags(&self, cmd: SetAccessPassFlagsCommand) -> eyre::Result<Signature>;
     fn get_accesspass(
         &self,
         cmd: GetAccessPassCommand,
@@ -773,6 +774,9 @@ impl CliCommand for CliCommandImpl<'_> {
         cmd.execute(self.client)
     }
     fn set_accesspass(&self, cmd: SetAccessPassCommand) -> eyre::Result<Signature> {
+        cmd.execute(self.client)
+    }
+    fn set_accesspass_flags(&self, cmd: SetAccessPassFlagsCommand) -> eyre::Result<Signature> {
         cmd.execute(self.client)
     }
     fn get_accesspass(

--- a/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/entrypoint.rs
@@ -5,6 +5,7 @@ use crate::{
         accesspass::{
             check_status::process_check_status_access_pass, close::process_close_access_pass,
             set::process_set_access_pass, set_feeds::process_set_access_pass_feeds,
+            set_flags::process_set_access_pass_flags,
         },
         allowlist::{
             foundation::{
@@ -422,6 +423,9 @@ pub fn process_instruction(
         }
         DoubleZeroInstruction::SetAccessPassFeeds(value) => {
             process_set_access_pass_feeds(program_id, accounts, &value)?
+        }
+        DoubleZeroInstruction::SetAccessPassFlags(value) => {
+            process_set_access_pass_flags(program_id, accounts, &value)?
         }
     };
     Ok(())

--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -2,6 +2,7 @@ use crate::processors::{
     accesspass::{
         check_status::CheckStatusAccessPassArgs, close::CloseAccessPassArgs,
         set::SetAccessPassArgs, set_feeds::SetAccessPassFeedsArgs,
+        set_flags::SetAccessPassFlagsArgs,
     },
     allowlist::{
         foundation::{add::AddFoundationAllowlistArgs, remove::RemoveFoundationAllowlistArgs},
@@ -251,6 +252,7 @@ pub enum DoubleZeroInstruction {
     UpdateFeed(FeedUpdateArgs),                 // variant 113
     DeleteFeed(FeedDeleteArgs),                 // variant 114
     SetAccessPassFeeds(SetAccessPassFeedsArgs), // variant 115
+    SetAccessPassFlags(SetAccessPassFlagsArgs), // variant 116
 }
 
 impl DoubleZeroInstruction {
@@ -397,6 +399,7 @@ impl DoubleZeroInstruction {
             113 => Ok(Self::UpdateFeed(FeedUpdateArgs::try_from(rest).unwrap())),
             114 => Ok(Self::DeleteFeed(FeedDeleteArgs::try_from(rest).unwrap())),
             115 => Ok(Self::SetAccessPassFeeds(SetAccessPassFeedsArgs::try_from(rest).unwrap())),
+            116 => Ok(Self::SetAccessPassFlags(SetAccessPassFlagsArgs::try_from(rest).unwrap())),
 
             _ => Err(ProgramError::InvalidInstructionData),
         }
@@ -546,6 +549,7 @@ impl DoubleZeroInstruction {
             Self::UpdateFeed(_) => "UpdateFeed".to_string(), // variant 113
             Self::DeleteFeed(_) => "DeleteFeed".to_string(), // variant 114
             Self::SetAccessPassFeeds(_) => "SetAccessPassFeeds".to_string(), // variant 115
+            Self::SetAccessPassFlags(_) => "SetAccessPassFlags".to_string(), // variant 116
         }
     }
 
@@ -687,6 +691,7 @@ impl DoubleZeroInstruction {
             Self::UpdateFeed(args) => format!("{args:?}"), // variant 113
             Self::DeleteFeed(args) => format!("{args:?}"), // variant 114
             Self::SetAccessPassFeeds(args) => format!("{args:?}"), // variant 115
+            Self::SetAccessPassFlags(args) => format!("{args:?}"), // variant 116
         }
     }
 }
@@ -1396,6 +1401,13 @@ mod tests {
                 }],
             }),
             "SetAccessPassFeeds",
+        );
+        test_instruction(
+            DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+                allow_multiple_ip: None,
+                dzf_locked: Some(true),
+            }),
+            "SetAccessPassFlags",
         );
     }
 }

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/mod.rs
@@ -2,6 +2,7 @@ pub mod check_status;
 pub mod close;
 pub mod set;
 pub mod set_feeds;
+pub mod set_flags;
 
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke_signed_unchecked,

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -282,7 +282,7 @@ pub fn process_set_access_pass(
         };
         accesspass.last_access_epoch = value.last_access_epoch;
         // `flags` here only carries ALLOW_MULTIPLE_IP. The DZF_LOCKED bit is managed solely by
-        // the foundation-gated SetAccessPassFlags instruction, so preserve any existing lock
+        // the `ACCESS_PASS_ADMIN`-gated SetAccessPassFlags instruction, so preserve any existing lock
         // rather than clobbering it on an unrelated update.
         accesspass.flags = (accesspass.flags & DZF_LOCKED) | flags;
         accesspass.max_unicast_users = value.max_unicast_users;

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -6,7 +6,7 @@ use crate::{
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
-        accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP},
+        accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP, DZF_LOCKED},
         accounttype::AccountType,
         globalstate::GlobalState,
         permission::permission_flags,
@@ -281,7 +281,10 @@ pub fn process_set_access_pass(
             _ => value.accesspass_type.clone(),
         };
         accesspass.last_access_epoch = value.last_access_epoch;
-        accesspass.flags = flags;
+        // `flags` here only carries ALLOW_MULTIPLE_IP. The DZF_LOCKED bit is managed solely by
+        // the foundation-gated SetAccessPassFlags instruction, so preserve any existing lock
+        // rather than clobbering it on an unrelated update.
+        accesspass.flags = (accesspass.flags & DZF_LOCKED) | flags;
         accesspass.max_unicast_users = value.max_unicast_users;
         accesspass.max_multicast_users = value.max_multicast_users;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -41,8 +41,13 @@ pub fn process_set_access_pass_flags(
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
     let payer_account = next_account_info(accounts_iter)?;
-    let _system_program = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
 
+    assert_eq!(
+        *system_program.unsigned_key(),
+        solana_system_interface::program::ID,
+        "Invalid System Program Account Owner"
+    );
     #[cfg(test)]
     msg!("process_set_access_pass_flags({:?})", value);
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -66,7 +66,7 @@ pub fn process_set_access_pass_flags(
 
     // Reject a no-op call rather than charging for a write that changes nothing.
     if value.allow_multiple_ip.is_none() && value.dzf_locked.is_none() {
-        msg!("SetAccessPassFlags requires at least one flag to set");
+        msg!("SetAccessPassFlags requires at least one flag to update");
         return Err(DoubleZeroError::InvalidArgument.into());
     }
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -1,0 +1,115 @@
+use crate::{
+    authorize::authorize,
+    error::DoubleZeroError,
+    serializer::try_acc_write,
+    state::{
+        accesspass::{AccessPass, ALLOW_MULTIPLE_IP, DZF_LOCKED},
+        globalstate::GlobalState,
+        permission::permission_flags,
+    },
+};
+use borsh::BorshSerialize;
+use borsh_incremental::BorshDeserializeIncremental;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    pubkey::Pubkey,
+};
+
+/// Surgically set or clear individual bits of an existing access pass's `flags` byte. Each field is
+/// tri-state: `None` leaves that flag untouched, `Some(true)` sets it, `Some(false)` clears it. Bits
+/// not named here are always preserved, so this never clobbers unrelated flags. Adding a future flag
+/// is just another `Option<bool>` field.
+///
+/// Gated on `ACCESS_PASS_ADMIN` (like the sibling SetAccessPass path).
+#[derive(BorshSerialize, BorshDeserializeIncremental, Debug, PartialEq, Clone, Default)]
+pub struct SetAccessPassFlagsArgs {
+    pub allow_multiple_ip: Option<bool>,
+    pub dzf_locked: Option<bool>,
+}
+
+pub fn process_set_access_pass_flags(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    value: &SetAccessPassFlagsArgs,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    // Account layout: [accesspass, globalstate, payer, system, (permission)] — matches the sibling
+    // accesspass handlers, with authorize() consuming the trailing Permission account.
+    let accesspass_account = next_account_info(accounts_iter)?;
+    let globalstate_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    #[cfg(test)]
+    msg!("process_set_access_pass_flags({:?})", value);
+
+    assert!(payer_account.is_signer, "Payer must be a signer");
+
+    if accesspass_account.data_is_empty() {
+        return Err(DoubleZeroError::AccessPassNotFound.into());
+    }
+    assert_eq!(
+        accesspass_account.owner, program_id,
+        "Invalid AccessPass Account Owner"
+    );
+    assert_eq!(
+        globalstate_account.owner, program_id,
+        "Invalid GlobalState Account Owner"
+    );
+    assert!(
+        accesspass_account.is_writable,
+        "AccessPass Account is not writable"
+    );
+
+    // Reject a no-op call rather than charging for a write that changes nothing.
+    if value.allow_multiple_ip.is_none() && value.dzf_locked.is_none() {
+        msg!("SetAccessPassFlags requires at least one flag to set");
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
+
+    // All flag changes gate on ACCESS_PASS_ADMIN (Permission PDA or legacy fallback: foundation
+    // allowlist, sentinel, or feed authority), matching the sibling SetAccessPass path.
+    let globalstate = GlobalState::try_from(globalstate_account)?;
+    authorize(
+        program_id,
+        accounts_iter,
+        payer_account.key,
+        &globalstate,
+        permission_flags::ACCESS_PASS_ADMIN,
+    )?;
+
+    let mut accesspass = AccessPass::try_from(accesspass_account)?;
+
+    // Mirror the sibling accesspass handlers: the feed authority may only touch passes it owns.
+    // This is what stops the oracle (which holds ACCESS_PASS_ADMIN) from clearing dzf_locked on a
+    // pass it did not create.
+    if globalstate.feed_authority_pk == *payer_account.key && accesspass.owner != *payer_account.key
+    {
+        msg!("Feed authority can only modify access passes they own");
+        return Err(DoubleZeroError::NotAllowed.into());
+    }
+
+    if let Some(allow_multiple_ip) = value.allow_multiple_ip {
+        if allow_multiple_ip {
+            accesspass.flags |= ALLOW_MULTIPLE_IP;
+        } else {
+            accesspass.flags &= !ALLOW_MULTIPLE_IP;
+        }
+    }
+    if let Some(dzf_locked) = value.dzf_locked {
+        if dzf_locked {
+            accesspass.flags |= DZF_LOCKED;
+        } else {
+            accesspass.flags &= !DZF_LOCKED;
+        }
+    }
+
+    try_acc_write(&accesspass, accesspass_account, payer_account, accounts)?;
+
+    msg!("Set access pass flags: [{}]", accesspass.flags_string());
+
+    Ok(())
+}

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -169,6 +169,10 @@ impl Validate for AccessPassType {
 }
 
 pub const ALLOW_MULTIPLE_IP: u8 = 1 << 1; // 0000_0010
+/// Marks an access pass as "DZF controlled": the DoubleZero Foundation manages this pass (and
+/// any side deal it represents) out of band, so automated reconcilers such as the Feed Oracle
+/// must not tear it down. Set/cleared only by a foundation authority.
+pub const DZF_LOCKED: u8 = 1 << 0; // 0000_0001
 
 #[derive(BorshSerialize, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -293,10 +297,16 @@ impl AccessPass {
     pub fn allow_multiple_ip(&self) -> bool {
         (self.flags & ALLOW_MULTIPLE_IP) != 0
     }
+    pub fn dzf_locked(&self) -> bool {
+        (self.flags & DZF_LOCKED) != 0
+    }
     pub fn flags_string(&self) -> String {
         let mut flags = Vec::new();
         if self.allow_multiple_ip() {
             flags.push("allow_multiple_ip");
+        }
+        if self.dzf_locked() {
+            flags.push("dzf_locked");
         }
         flags.join(", ")
     }
@@ -397,6 +407,45 @@ mod tests {
         "C8imMUBYIJa5WMpf9Luu7UvorH+G/ke723sUhDJktlcU/wQBAAAAX/j7g5ybAvkQvCA7AvgUw0lZDtq7NnPvFq1KHJ6S12sBAQAXgFlhagAAAACAWWFqAAAAAAAAAACeFLryRCj5fplGhNdUu6rPnzO/B37EOrSOFnz2qLrc6v//////////AAAAAAAAAAAAAAACAAAAAAAAAAAAAAEA"];
 
         crate::helper::base_tests::test_parsing::<AccessPass>(&versions).unwrap();
+    }
+
+    #[test]
+    fn test_state_accesspass_flags() {
+        let mut ap = AccessPass {
+            account_type: AccountType::AccessPass,
+            owner: Pubkey::new_unique(),
+            bump_seed: 1,
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: [1, 2, 3, 4].into(),
+            user_payer: Pubkey::new_unique(),
+            last_access_epoch: 0,
+            connection_count: 0,
+            status: AccessPassStatus::Requested,
+            mgroup_pub_allowlist: vec![],
+            mgroup_sub_allowlist: vec![],
+            tenant_allowlist: vec![],
+            flags: 0,
+            unicast_user_count: 0,
+            max_unicast_users: 1,
+            multicast_user_count: 0,
+            max_multicast_users: 1,
+        };
+
+        // No bits set.
+        assert!(!ap.allow_multiple_ip());
+        assert!(!ap.dzf_locked());
+        assert_eq!(ap.flags_string(), "");
+
+        // The two flags are independent bits.
+        ap.flags = DZF_LOCKED;
+        assert!(!ap.allow_multiple_ip());
+        assert!(ap.dzf_locked());
+        assert_eq!(ap.flags_string(), "dzf_locked");
+
+        ap.flags = ALLOW_MULTIPLE_IP | DZF_LOCKED;
+        assert!(ap.allow_multiple_ip());
+        assert!(ap.dzf_locked());
+        assert_eq!(ap.flags_string(), "allow_multiple_ip, dzf_locked");
     }
 
     #[test]

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -169,9 +169,9 @@ impl Validate for AccessPassType {
 }
 
 pub const ALLOW_MULTIPLE_IP: u8 = 1 << 1; // 0000_0010
-/// Marks an access pass as "DZF controlled": the DoubleZero Foundation manages this pass (and
-/// any side deal it represents) out of band, so automated reconcilers such as the Feed Oracle
-/// must not tear it down. Set/cleared only by an `ACCESS_PASS_ADMIN` authority.
+/// Marks an access pass as "DZF controlled": the DoubleZero Foundation manages this pass out of band,
+/// so automated reconcilers such as the Feed Oracle must not tear it down. Set/cleared only by an
+/// `ACCESS_PASS_ADMIN` authority.
 pub const DZF_LOCKED: u8 = 1 << 0; // 0000_0001
 
 #[derive(BorshSerialize, Debug, PartialEq, Clone)]

--- a/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs
@@ -171,7 +171,7 @@ impl Validate for AccessPassType {
 pub const ALLOW_MULTIPLE_IP: u8 = 1 << 1; // 0000_0010
 /// Marks an access pass as "DZF controlled": the DoubleZero Foundation manages this pass (and
 /// any side deal it represents) out of band, so automated reconcilers such as the Feed Oracle
-/// must not tear it down. Set/cleared only by a foundation authority.
+/// must not tear it down. Set/cleared only by an `ACCESS_PASS_ADMIN` authority.
 pub const DZF_LOCKED: u8 = 1 << 0; // 0000_0001
 
 #[derive(BorshSerialize, Debug, PartialEq, Clone)]

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
@@ -1,0 +1,227 @@
+use doublezero_serviceability::{
+    instructions::*,
+    pda::*,
+    processors::accesspass::{set::SetAccessPassArgs, set_flags::SetAccessPassFlagsArgs},
+    state::{
+        accesspass::{AccessPassType, ALLOW_MULTIPLE_IP, DZF_LOCKED},
+        accounttype::AccountType,
+    },
+};
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::{AccountMeta, InstructionError},
+    signature::Keypair,
+    signer::Signer,
+    transaction::TransactionError,
+};
+use std::net::Ipv4Addr;
+
+mod test_helpers;
+use test_helpers::*;
+
+// DoubleZeroError codes (see src/error.rs).
+const CODE_NOT_ALLOWED: u32 = 8;
+const CODE_INVALID_ARGUMENT: u32 = 65;
+
+fn assert_custom_error(result: Result<(), BanksClientError>, expected: u32, context: &str) {
+    match result {
+        Err(BanksClientError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(code),
+        ))) if code == expected => {}
+        _ => panic!("{context}: expected Custom({expected}), got {result:?}"),
+    }
+}
+
+/// Exercises the DZF-locked flag end to end: the generic SetAccessPassFlags instruction sets and
+/// clears the bit, preserves the unrelated ALLOW_MULTIPLE_IP bit, an unrelated SetAccessPass update
+/// preserves the DZF_LOCKED bit, an all-None call is rejected, and a signer without
+/// ACCESS_PASS_ADMIN is rejected.
+#[tokio::test]
+async fn test_accesspass_dzf_locked() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    // Global init: this makes `payer` the sole foundation_allowlist member, which satisfies the
+    // ACCESS_PASS_ADMIN legacy fallback.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create a prepaid access pass with allow_multiple_ip set, so we can prove the two flag bits
+    // are managed independently.
+    let (accesspass_pubkey, _) =
+        get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: Ipv4Addr::UNSPECIFIED,
+            last_access_epoch: 9999,
+            allow_multiple_ip: true,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(ap.account_type, AccountType::AccessPass);
+    assert!(ap.allow_multiple_ip());
+    assert!(!ap.dzf_locked());
+
+    // Set dzf_locked (leaving allow_multiple_ip untouched via None).
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(ap.dzf_locked());
+    assert!(
+        ap.allow_multiple_ip(),
+        "allow_multiple_ip must be preserved"
+    );
+    assert_eq!(ap.flags, ALLOW_MULTIPLE_IP | DZF_LOCKED);
+
+    // An unrelated SetAccessPass update (allow_multiple_ip=false) must clear allow_multiple_ip but
+    // preserve the DZF_LOCKED bit.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: Ipv4Addr::UNSPECIFIED,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(!ap.allow_multiple_ip());
+    assert!(ap.dzf_locked(), "DZF_LOCKED must survive an unrelated set");
+    assert_eq!(ap.flags, DZF_LOCKED);
+
+    // Clear dzf_locked.
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(false),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(!ap.dzf_locked());
+    assert_eq!(ap.flags, 0);
+
+    // An all-None call changes nothing and is rejected.
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: None,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+    assert_custom_error(result, CODE_INVALID_ARGUMENT, "all-None SetAccessPassFlags");
+
+    // A signer without ACCESS_PASS_ADMIN (not foundation/sentinel/feed, no Permission) is rejected.
+    let outsider = Keypair::new();
+    transfer(&mut banks_client, &payer, &outsider.pubkey(), 100_000_000).await;
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &outsider,
+    )
+    .await;
+    assert_custom_error(result, CODE_NOT_ALLOWED, "unauthorized dzf_locked");
+
+    // The rejected attempt left the flag clear.
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(!ap.dzf_locked());
+}

--- a/smartcontract/sdk/rs/src/commands/accesspass/mod.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/mod.rs
@@ -4,3 +4,4 @@ pub mod get;
 pub mod list;
 pub mod set;
 pub mod set_feeds;
+pub mod set_flags;

--- a/smartcontract/sdk/rs/src/commands/accesspass/set_flags.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/set_flags.rs
@@ -1,0 +1,100 @@
+use std::net::Ipv4Addr;
+
+use doublezero_serviceability::{
+    instructions::DoubleZeroInstruction, pda::get_accesspass_pda,
+    processors::accesspass::set_flags::SetAccessPassFlagsArgs,
+};
+use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+use crate::{commands::globalstate::get::GetGlobalStateCommand, DoubleZeroClient};
+
+/// Surgically set or clear individual bits of an existing access pass's flags byte. Each field is
+/// tri-state: `None` leaves the flag unchanged, `Some(v)` sets it to `v`.
+///
+/// On-chain account layout (see `process_set_access_pass_flags`):
+///   `[accesspass, globalstate, payer, system, permission]`
+///
+/// `DoubleZeroClient::execute_authorized_transaction` appends `[payer, system, permission]` after
+/// the base accounts supplied here, so the base list is `[accesspass, globalstate]`. Gated on
+/// `ACCESS_PASS_ADMIN`.
+#[derive(Debug, PartialEq, Clone)]
+pub struct SetAccessPassFlagsCommand {
+    pub client_ip: Ipv4Addr,
+    pub user_payer: Pubkey,
+    pub allow_multiple_ip: Option<bool>,
+    pub dzf_locked: Option<bool>,
+}
+
+impl SetAccessPassFlagsCommand {
+    pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<Signature> {
+        let (globalstate_pubkey, _globalstate) = GetGlobalStateCommand
+            .execute(client)
+            .map_err(|_err| eyre::eyre!("Globalstate not initialized"))?;
+
+        let (accesspass_pubkey, _) =
+            get_accesspass_pda(&client.get_program_id(), &self.client_ip, &self.user_payer);
+
+        client.execute_authorized_transaction(
+            DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+                allow_multiple_ip: self.allow_multiple_ip,
+                dzf_locked: self.dzf_locked,
+            }),
+            vec![
+                AccountMeta::new(accesspass_pubkey, false),
+                AccountMeta::new_readonly(globalstate_pubkey, false),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        commands::accesspass::set_flags::SetAccessPassFlagsCommand,
+        tests::utils::create_test_client, DoubleZeroClient,
+    };
+    use doublezero_serviceability::{
+        instructions::DoubleZeroInstruction,
+        pda::{get_accesspass_pda, get_globalstate_pda},
+        processors::accesspass::set_flags::SetAccessPassFlagsArgs,
+    };
+    use mockall::predicate;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
+
+    #[test]
+    fn test_commands_set_accesspass_flags_command() {
+        let mut client = create_test_client();
+
+        let client_ip = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (globalstate_pubkey, _) = get_globalstate_pda(&client.get_program_id());
+        let (accesspass_pubkey, _) =
+            get_accesspass_pda(&client.get_program_id(), &client_ip, &payer);
+
+        client
+            .expect_execute_authorized_transaction()
+            .with(
+                predicate::eq(DoubleZeroInstruction::SetAccessPassFlags(
+                    SetAccessPassFlagsArgs {
+                        allow_multiple_ip: None,
+                        dzf_locked: Some(true),
+                    },
+                )),
+                predicate::eq(vec![
+                    AccountMeta::new(accesspass_pubkey, false),
+                    AccountMeta::new_readonly(globalstate_pubkey, false),
+                ]),
+            )
+            .returning(|_, _| Ok(Signature::new_unique()));
+
+        let res = SetAccessPassFlagsCommand {
+            client_ip,
+            user_payer: payer,
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }
+        .execute(&client);
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary of Changes

- Add a `dzf_locked` flag to `AccessPass` (bit 0 of the `flags` byte) that marks a pass as foundation-managed, so automated reconcilers such as the Feed Oracle leave it alone instead of tearing it down. This gives the oracle an onchain signal to skip side-deal passes whose payment is settled out of band.
- New `SetAccessPassFlags` instruction (variant 116), gated on `ACCESS_PASS_ADMIN`, that sets/clears access-pass flags independently via `Option<bool>` per flag (`None` = leave, `Some(v)` = set/clear) and never clobbers the other bits. An all-`None` call is rejected.
- `SetAccessPass` now preserves the `dzf_locked` bit across unrelated updates (previously it rebuilt the whole `flags` byte from `allow_multiple_ip` on every call, which would silently clear the lock).
- CLI `doublezero access-pass dzf-lock` / `dzf-unlock` verbs and `access-pass set --dzf-locked` (applied as a second transaction on create), plus the SDK `SetAccessPassFlagsCommand`.

The feed authority (oracle) holds `ACCESS_PASS_ADMIN`, so the existing "feed authority may only touch passes it owns" guard is what prevents the oracle from clearing the lock on a pass it did not create.

Note: re-enabling the Feed Oracle's validator-owned teardown to actually honor this flag is a separate follow-up in the `doublezero-shreds` / feeds repo (and needs coordination on which users have side deals before deploying).

## Diff Breakdown

| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     3 | +169 / -2   | +167 |
| Scaffolding  |    11 | +405 / -6   | +399 |
| Tests        |     1 | +227 / -0   | +227 |
| Docs         |     1 | +1 / -0     |   +1 |
| **Total**    |    16 | +802 / -8   | +794 |

Mostly wiring and tests around a small core: one new processor, a flag definition, and a one-line preservation fix.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs` — new `SetAccessPassFlags` processor: per-flag `Option<bool>` read-modify-write, `ACCESS_PASS_ADMIN` gate, feed-authority-owns guard, all-`None` rejection.
- `smartcontract/programs/doublezero-serviceability/src/state/accesspass.rs` — `DZF_LOCKED` constant, `dzf_locked()` accessor, `flags_string()`, and a flags unit test.
- `smartcontract/cli/src/accesspass/dzf_lock.rs` — `dzf-lock` / `dzf-unlock` CLI verbs over a shared helper.
- `smartcontract/cli/src/accesspass/set.rs` — `--dzf-locked` on create, fired as a second transaction after the pass exists.
- `smartcontract/sdk/rs/src/commands/accesspass/set_flags.rs` — `SetAccessPassFlagsCommand` instruction builder.
- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs` — preserve the `DZF_LOCKED` bit across unrelated `SetAccessPass` updates.
- `smartcontract/programs/doublezero-serviceability/src/instructions.rs` — `SetAccessPassFlags` enum variant, unpack, name, and pack/unpack round-trip test.

</details>

## Testing Verification

- New processor integration test (`accesspass_dzf_locked.rs`): sets then clears `dzf_locked`; verifies the unrelated `ALLOW_MULTIPLE_IP` bit is preserved when only `dzf_locked` changes; verifies an unrelated `SetAccessPass` update preserves `DZF_LOCKED`; rejects an all-`None` call with `InvalidArgument`; rejects a signer without `ACCESS_PASS_ADMIN` with `NotAllowed`.
- Unit tests for `dzf_locked()` / `flags_string()`, the instruction pack/unpack round-trip, the SDK command's account layout, and the CLI `dzf-lock` / `dzf-unlock` verbs and the `--dzf-locked` create path (asserts the second transaction fires).
- `make rust-fmt`, `make rust-lint`, and the full serviceability + SDK + CLI test suites pass.
