### PR TITLE
e2e/qa: verify the shred seat price against chain before paying

### DIFF
--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -616,35 +616,50 @@ func (c *Client) GetEffectiveSeatPrice(ctx context.Context, devicePubkey string,
 	return price, nil
 }
 
-// InstantSeatPriceDollars returns the whole-dollar seat price that
-// request_instant_seat_allocation will charge on the given device, together
-// with the epoch that price was read from.
+// SeatPrices are the whole-dollar seat prices the shred-subscription program
+// computes for a device, at the two epochs a settlement probe has to tell
+// apart. Prices are unprorated: proration only ever reduces the charge, so
+// funding the full price is always sufficient, and a prorated figure is a
+// function of the slot it was read at and would race the payment. The per-seat
+// price override is not applied — GetEffectiveSeatPrice owns that, mirroring
+// the program's checked_override_usdc_price_dollars().
+type SeatPrices struct {
+	// InstantAllocationDollars is what request_instant_seat_allocation charges,
+	// read at LastSettledEpoch.
+	InstantAllocationDollars uint64
+	LastSettledEpoch         uint64
+
+	// CurrentEpochDollars is what a recurring subscriber pays for
+	// CurrentSubscriptionEpoch — the figure `shreds price` reports as
+	// epoch_price. Valid only when HasCurrentEpoch is set: during the
+	// UpdatingPrices phase the ring entry for the current epoch may not have
+	// been written yet for this metro or device.
+	CurrentEpochDollars      uint64
+	HasCurrentEpoch          bool
+	CurrentSubscriptionEpoch uint64
+}
+
+// SeatPrices reads the chain and computes both seat prices for the given
+// device.
 //
-// The program charges the metro price recorded at last_settled_epoch (prorated
-// over the remainder of the epoch when prorating is on), while
-// `doublezero-solana shreds price` quotes the entry one epoch newer, at
-// current_subscription_epoch. Computing the charge from chain state here gives
-// QA an oracle independent of the CLI under test, which is the only way the
-// probe can catch that divergence — and it needs no CLI release to reach the
-// version-pinned QA hosts.
-//
-// The unprorated price is returned deliberately: proration only ever reduces
-// the charge, so funding the full price is always sufficient, and a prorated
-// figure is a function of the slot it was read at and would race the payment.
-// The per-seat price override is not applied here — GetEffectiveSeatPrice owns
-// that, mirroring the program's checked_override_usdc_price_dollars().
-func (c *Client) InstantSeatPriceDollars(ctx context.Context, devicePubkey string) (uint64, uint64, error) {
+// The program charges the price recorded at last_settled_epoch, while
+// `doublezero-solana shreds price` reports the entry one epoch newer as
+// epoch_price. Computing both from chain state gives QA an oracle independent
+// of the CLI under test, which is the only way the probe can check that the
+// CLI's two figures point at the ring entries they claim to — and it needs no
+// CLI release to reach the version-pinned QA hosts.
+func (c *Client) SeatPrices(ctx context.Context, devicePubkey string) (*SeatPrices, error) {
 	deviceKey, err := solana.PublicKeyFromBase58(devicePubkey)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to parse device pubkey %q: %w", devicePubkey, err)
+		return nil, fmt.Errorf("failed to parse device pubkey %q: %w", devicePubkey, err)
 	}
 	programID, err := solana.PublicKeyFromBase58(c.ShredSubscriptionProgramID)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
+		return nil, fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
 	}
 	shredsClient := c.shredsClient(programID)
 
-	var lastSettledEpoch uint64
+	var prices SeatPrices
 	var deviceHistory *shreds.DeviceHistory
 	var metroHistory *shreds.MetroHistory
 
@@ -683,35 +698,57 @@ func (c *Client) InstantSeatPriceDollars(ctx context.Context, devicePubkey strin
 			return false, fmt.Errorf("failed to fetch metro history for exchange %s: %s", device.MetroExchangeKey, c.scrubRPCErr(fetchErr))
 		}
 
-		lastSettledEpoch = controller.LastSettledEpoch
+		prices.LastSettledEpoch = controller.LastSettledEpoch
+		prices.CurrentSubscriptionEpoch = controller.CurrentSubscriptionEpoch
 		deviceHistory = device
 		metroHistory = metro
 		return true, nil
 	}, seatReadTimeout, seatReadInterval); err != nil {
-		return 0, 0, fmt.Errorf("failed to read shred pricing state on host %s: %w", c.Host, err)
+		return nil, fmt.Errorf("failed to read shred pricing state on host %s: %w", c.Host, err)
 	}
 
-	// Both ring entries must exist for the settled epoch: this is the same lookup
-	// the program performs, and it rejects the payment when either misses. Never
-	// fall back to the current entry — that is exactly the divergence under test.
-	metroEntry, ok := metroHistory.Prices.Find(lastSettledEpoch)
-	if !ok {
-		return 0, 0, fmt.Errorf("metro exchange %s has no price entry for last settled epoch %d (host %s)",
-			deviceHistory.MetroExchangeKey, lastSettledEpoch, c.Host)
-	}
-	deviceEntry, ok := deviceHistory.Subscriptions.Find(lastSettledEpoch)
-	if !ok {
-		return 0, 0, fmt.Errorf("device %s has no subscription entry for last settled epoch %d (host %s)",
-			devicePubkey, lastSettledEpoch, c.Host)
+	// Combine the metro price with the device's signed premium at a specific
+	// epoch, exactly as the program does. Never fall back to the ring's current
+	// entry on a miss — reading a different entry than the one asked for is
+	// precisely the divergence this probe exists to catch.
+	priceAt := func(epoch uint64) (uint64, error) {
+		metroEntry, ok := metroHistory.Prices.Find(epoch)
+		if !ok {
+			return 0, fmt.Errorf("metro exchange %s has no price entry for epoch %d", deviceHistory.MetroExchangeKey, epoch)
+		}
+		deviceEntry, ok := deviceHistory.Subscriptions.Find(epoch)
+		if !ok {
+			return 0, fmt.Errorf("device %s has no subscription entry for epoch %d", devicePubkey, epoch)
+		}
+		return uint64(deviceEntry.Subscription.USDCPriceDollars(&metroEntry.Price)), nil
 	}
 
-	price := deviceEntry.Subscription.USDCPriceDollars(&metroEntry.Price)
-	c.log.Debug("Onchain instant seat price",
-		"host", c.Host, "device", devicePubkey, "last_settled_epoch", lastSettledEpoch,
-		"metro_price_dollars", metroEntry.Price.USDCPriceDollars,
-		"device_premium_dollars", deviceEntry.Subscription.USDCMetroPremiumDollars,
-		"price_dollars", price)
-	return uint64(price), lastSettledEpoch, nil
+	// The settled-epoch lookup is the same one the program performs, and the
+	// program rejects the allocation when either ring misses, so a miss here is
+	// fatal.
+	prices.InstantAllocationDollars, err = priceAt(prices.LastSettledEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute the instant-allocation seat price on host %s: %w", c.Host, err)
+	}
+
+	// A miss on the current epoch is expected part-way through the UpdatingPrices
+	// phase, when the ring has not yet been advanced for this metro or device, so
+	// report it as unavailable rather than failing the whole read.
+	if current, currentErr := priceAt(prices.CurrentSubscriptionEpoch); currentErr == nil {
+		prices.CurrentEpochDollars = current
+		prices.HasCurrentEpoch = true
+	} else {
+		c.log.Debug("No onchain price for the current subscription epoch",
+			"host", c.Host, "device", devicePubkey, "reason", currentErr)
+	}
+
+	c.log.Debug("Onchain seat prices", "host", c.Host, "device", devicePubkey,
+		"instant_allocation_dollars", prices.InstantAllocationDollars,
+		"last_settled_epoch", prices.LastSettledEpoch,
+		"current_epoch_dollars", prices.CurrentEpochDollars,
+		"has_current_epoch", prices.HasCurrentEpoch,
+		"current_subscription_epoch", prices.CurrentSubscriptionEpoch)
+	return &prices, nil
 }
 
 // IsSeatProratingEnabled returns true if the shred-subscription program config

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -355,13 +355,13 @@ func (c *Client) shredsQuery() (*shreds.Client, uint32, error) {
 	return c.shredsClient(programID), clientIPBits, nil
 }
 
-// isSeatNotFound reports whether a FetchClientSeat error means the seat account
-// does not exist. A missing account surfaces as shreds.ErrAccountNotFound
-// through the shreds nil-result path and as rpc.ErrNotFound through the live RPC
+// isAccountNotFound reports whether a shreds fetch error means the account does
+// not exist. A missing account surfaces as shreds.ErrAccountNotFound through the
+// shreds nil-result path and as rpc.ErrNotFound through the live RPC
 // (GetAccountInfo) path. Note this matches sentinel errors, not error text, so
 // an unrelated "... not found" message (e.g. "Blockhash not found") is not
-// mistaken for a missing seat.
-func isSeatNotFound(err error) bool {
+// mistaken for a missing account.
+func isAccountNotFound(err error) bool {
 	return errors.Is(err, shreds.ErrAccountNotFound) || errors.Is(err, rpc.ErrNotFound)
 }
 
@@ -382,12 +382,12 @@ func isSeatNotFound(err error) bool {
 // agrees.
 func (c *Client) seatIsWithdrawn(ctx context.Context, shredsClient *shreds.Client, deviceKey solana.PublicKey, clientIPBits uint32) (bool, error) {
 	seat, err := shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
-	if isSeatNotFound(err) {
+	if isAccountNotFound(err) {
 		if c.solanaRPC != nil && c.solanaRPC.EndpointCount() > 1 {
 			c.solanaRPC.Failover()
 		}
 		seat, err = shredsClient.FetchClientSeat(ctx, deviceKey, clientIPBits)
-		if isSeatNotFound(err) {
+		if isAccountNotFound(err) {
 			return true, nil
 		}
 	}
@@ -614,6 +614,104 @@ func (c *Client) GetEffectiveSeatPrice(ctx context.Context, devicePubkey string,
 	price := epochPrice * 1_000_000
 	c.log.Debug("Seat using epoch price", "host", c.Host, "epoch_price_dollars", epochPrice, "price_usdc", price)
 	return price, nil
+}
+
+// InstantSeatPriceDollars returns the whole-dollar seat price that
+// request_instant_seat_allocation will charge on the given device, together
+// with the epoch that price was read from.
+//
+// The program charges the metro price recorded at last_settled_epoch (prorated
+// over the remainder of the epoch when prorating is on), while
+// `doublezero-solana shreds price` quotes the entry one epoch newer, at
+// current_subscription_epoch. Computing the charge from chain state here gives
+// QA an oracle independent of the CLI under test, which is the only way the
+// probe can catch that divergence — and it needs no CLI release to reach the
+// version-pinned QA hosts.
+//
+// The unprorated price is returned deliberately: proration only ever reduces
+// the charge, so funding the full price is always sufficient, and a prorated
+// figure is a function of the slot it was read at and would race the payment.
+// The per-seat price override is not applied here — GetEffectiveSeatPrice owns
+// that, mirroring the program's checked_override_usdc_price_dollars().
+func (c *Client) InstantSeatPriceDollars(ctx context.Context, devicePubkey string) (uint64, uint64, error) {
+	deviceKey, err := solana.PublicKeyFromBase58(devicePubkey)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse device pubkey %q: %w", devicePubkey, err)
+	}
+	programID, err := solana.PublicKeyFromBase58(c.ShredSubscriptionProgramID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
+	}
+	shredsClient := c.shredsClient(programID)
+
+	var lastSettledEpoch uint64
+	var deviceHistory *shreds.DeviceHistory
+	var metroHistory *shreds.MetroHistory
+
+	// All three accounts long predate a QA run, but a lagging RPC node can serve
+	// a view in which one is not yet visible. An account-not-found is a valid
+	// empty read rather than an RPC error, so the failover pool does not retry
+	// it — poll until visible instead of failing on a single stale read.
+	if err := poll.Until(ctx, func() (bool, error) {
+		controller, fetchErr := shredsClient.FetchExecutionController(ctx)
+		if fetchErr != nil {
+			if isAccountNotFound(fetchErr) {
+				c.log.Debug("Execution controller not yet visible, polling", "host", c.Host)
+				return false, nil
+			}
+			// Scrub: a fetch error can embed the (possibly API-keyed) endpoint URL.
+			return false, fmt.Errorf("failed to fetch execution controller: %s", c.scrubRPCErr(fetchErr))
+		}
+
+		device, fetchErr := shredsClient.FetchDeviceHistory(ctx, deviceKey)
+		if fetchErr != nil {
+			if isAccountNotFound(fetchErr) {
+				c.log.Debug("Device history not yet visible, polling", "host", c.Host, "device", devicePubkey)
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to fetch device history for %s: %s", devicePubkey, c.scrubRPCErr(fetchErr))
+		}
+
+		// The device history carries its metro's exchange key, so the metro
+		// history needs no separate exchange lookup.
+		metro, fetchErr := shredsClient.FetchMetroHistory(ctx, device.MetroExchangeKey)
+		if fetchErr != nil {
+			if isAccountNotFound(fetchErr) {
+				c.log.Debug("Metro history not yet visible, polling", "host", c.Host, "exchange", device.MetroExchangeKey)
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to fetch metro history for exchange %s: %s", device.MetroExchangeKey, c.scrubRPCErr(fetchErr))
+		}
+
+		lastSettledEpoch = controller.LastSettledEpoch
+		deviceHistory = device
+		metroHistory = metro
+		return true, nil
+	}, seatReadTimeout, seatReadInterval); err != nil {
+		return 0, 0, fmt.Errorf("failed to read shred pricing state on host %s: %w", c.Host, err)
+	}
+
+	// Both ring entries must exist for the settled epoch: this is the same lookup
+	// the program performs, and it rejects the payment when either misses. Never
+	// fall back to the current entry — that is exactly the divergence under test.
+	metroEntry, ok := metroHistory.Prices.Find(lastSettledEpoch)
+	if !ok {
+		return 0, 0, fmt.Errorf("metro exchange %s has no price entry for last settled epoch %d (host %s)",
+			deviceHistory.MetroExchangeKey, lastSettledEpoch, c.Host)
+	}
+	deviceEntry, ok := deviceHistory.Subscriptions.Find(lastSettledEpoch)
+	if !ok {
+		return 0, 0, fmt.Errorf("device %s has no subscription entry for last settled epoch %d (host %s)",
+			devicePubkey, lastSettledEpoch, c.Host)
+	}
+
+	price := deviceEntry.Subscription.USDCPriceDollars(&metroEntry.Price)
+	c.log.Debug("Onchain instant seat price",
+		"host", c.Host, "device", devicePubkey, "last_settled_epoch", lastSettledEpoch,
+		"metro_price_dollars", metroEntry.Price.USDCPriceDollars,
+		"device_premium_dollars", deviceEntry.Subscription.USDCMetroPremiumDollars,
+		"price_dollars", price)
+	return uint64(price), lastSettledEpoch, nil
 }
 
 // IsSeatProratingEnabled returns true if the shred-subscription program config

--- a/e2e/internal/qa/client_settlement_test.go
+++ b/e2e/internal/qa/client_settlement_test.go
@@ -90,7 +90,7 @@ func TestFilterActiveSeats(t *testing.T) {
 	}
 }
 
-func TestIsSeatNotFound(t *testing.T) {
+func TestIsAccountNotFound(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -104,14 +104,14 @@ func TestIsSeatNotFound(t *testing.T) {
 		// The whole point of matching sentinels rather than error text: a
 		// transient "Blockhash not found" must NOT read as a missing seat, else
 		// a failed withdraw would be silently treated as already-withdrawn.
-		{"blockhash not found is not a missing seat", errors.New("Transaction simulation failed: Blockhash not found"), false},
-		{"jsonrpc method not found is not a missing seat", errors.New("rpc: Method not found"), false},
+		{"blockhash not found is not a missing account", errors.New("Transaction simulation failed: Blockhash not found"), false},
+		{"jsonrpc method not found is not a missing account", errors.New("rpc: Method not found"), false},
 		{"generic error", errors.New("connection timed out"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isSeatNotFound(tt.err); got != tt.want {
-				t.Errorf("isSeatNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			if got := isAccountNotFound(tt.err); got != tt.want {
+				t.Errorf("isAccountNotFound(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/e2e/internal/rpc/agent.go
+++ b/e2e/internal/rpc/agent.go
@@ -383,6 +383,20 @@ func (q *QAAgent) FeedSeatPrice(ctx context.Context, req *pb.FeedSeatPriceReques
 		return nil, fmt.Errorf("failed to get seat prices: %w, output: %s", err, string(out))
 	}
 
+	prices, err := parseDevicePrices(out)
+	if err != nil {
+		q.log.Error("Failed to parse seat prices", "output", string(out), "error", err)
+		return nil, err
+	}
+
+	q.log.Debug("Seat prices retrieved", "count", len(prices))
+	return &pb.FeedSeatPriceResponse{Prices: prices}, nil
+}
+
+// parseDevicePrices converts the JSON emitted by `doublezero-solana shreds
+// price --json` into DevicePrice messages. Split out from FeedSeatPrice so the
+// three-state handling of instant_allocation_price is directly testable.
+func parseDevicePrices(out []byte) ([]*pb.DevicePrice, error) {
 	var rawPrices []struct {
 		DeviceCode     string `json:"device_code"`
 		Device         string `json:"device"`
@@ -394,15 +408,21 @@ func (q *QAAgent) FeedSeatPrice(ctx context.Context, req *pb.FeedSeatPriceReques
 		BasePrice      uint64 `json:"base_price"`
 		Premium        uint64 `json:"premium"`
 		EpochPrice     uint64 `json:"epoch_price"`
+		// Raw, not *uint64: three states have to survive the hop to the test. An
+		// absent key means the installed CLI predates the field (QA hosts pin
+		// doublezero-solana by apt, so that lags a release); an explicit null
+		// means the CLI could not find the settled-epoch ring entry, which is a
+		// real condition rather than a rollout gap; a number is the price, and 0
+		// is a legitimate one. A *uint64 would collapse absent and null into nil.
+		InstantAllocationPrice json.RawMessage `json:"instant_allocation_price"`
 	}
 	if err := json.Unmarshal(out, &rawPrices); err != nil {
-		q.log.Error("Failed to parse seat prices", "output", string(out), "error", err)
 		return nil, fmt.Errorf("failed to parse seat prices: %w", err)
 	}
 
 	prices := make([]*pb.DevicePrice, 0, len(rawPrices))
 	for _, p := range rawPrices {
-		prices = append(prices, &pb.DevicePrice{
+		price := &pb.DevicePrice{
 			DeviceCode:     p.DeviceCode,
 			DevicePubkey:   p.Device,
 			MetroCode:      p.MetroCode,
@@ -413,11 +433,20 @@ func (q *QAAgent) FeedSeatPrice(ctx context.Context, req *pb.FeedSeatPriceReques
 			BasePrice:      p.BasePrice,
 			Premium:        p.Premium,
 			EpochPrice:     p.EpochPrice,
-		})
+		}
+		if raw := strings.TrimSpace(string(p.InstantAllocationPrice)); raw != "" {
+			price.ReportsInstantAllocationPrice = true
+			if raw != "null" {
+				var instant uint64
+				if err := json.Unmarshal(p.InstantAllocationPrice, &instant); err != nil {
+					return nil, fmt.Errorf("failed to parse instant_allocation_price %q: %w", raw, err)
+				}
+				price.InstantAllocationPrice = &instant
+			}
+		}
+		prices = append(prices, price)
 	}
-
-	q.log.Debug("Seat prices retrieved", "count", len(prices))
-	return &pb.FeedSeatPriceResponse{Prices: prices}, nil
+	return prices, nil
 }
 
 // FeedSeatPay implements the FeedSeatPay RPC, which pays for a seat on a device.

--- a/e2e/internal/rpc/agent_test.go
+++ b/e2e/internal/rpc/agent_test.go
@@ -198,3 +198,59 @@ func (d *DummyNetlinker) RouteByProtocol(protocol int) ([]Route, error) {
 		},
 	}, nil
 }
+
+func TestParseDevicePricesInstantAllocationPrice(t *testing.T) {
+	// The three states the QA probe has to tell apart. Absent means the pinned
+	// doublezero-solana predates the field (a rollout gap, so the probe skips its
+	// quote check); null means the CLI could not find the settled-epoch ring
+	// entry (a real condition, so the probe fails); a number is the price, and 0
+	// is a legitimate one that must not read as either.
+	tests := []struct {
+		name         string
+		json         string
+		wantReported bool
+		wantPrice    *uint64
+	}{
+		{
+			name:         "field absent (older CLI)",
+			json:         `[{"device":"dev1","epoch_price":10}]`,
+			wantReported: false,
+		},
+		{
+			name:         "field null (settled-epoch entry missing)",
+			json:         `[{"device":"dev1","epoch_price":10,"instant_allocation_price":null}]`,
+			wantReported: true,
+		},
+		{
+			name:         "field set",
+			json:         `[{"device":"dev1","epoch_price":10,"instant_allocation_price":43}]`,
+			wantReported: true,
+			wantPrice:    ptr(uint64(43)),
+		},
+		{
+			name:         "field set to zero",
+			json:         `[{"device":"dev1","epoch_price":10,"instant_allocation_price":0}]`,
+			wantReported: true,
+			wantPrice:    ptr(uint64(0)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prices, err := parseDevicePrices([]byte(tt.json))
+			require.NoError(t, err)
+			require.Len(t, prices, 1)
+			require.Equal(t, tt.wantReported, prices[0].GetReportsInstantAllocationPrice())
+			require.Equal(t, tt.wantPrice, prices[0].InstantAllocationPrice)
+			// Unrelated fields must still decode.
+			require.Equal(t, uint64(10), prices[0].GetEpochPrice())
+			require.Equal(t, "dev1", prices[0].GetDevicePubkey())
+		})
+	}
+}
+
+func TestParseDevicePricesRejectsMalformedInstantAllocationPrice(t *testing.T) {
+	_, err := parseDevicePrices([]byte(`[{"device":"dev1","instant_allocation_price":"43"}]`))
+	require.Error(t, err)
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/e2e/proto/qa/agent.proto
+++ b/e2e/proto/qa/agent.proto
@@ -252,6 +252,17 @@ message DevicePrice {
   uint64 base_price = 8;
   uint64 premium = 9;
   uint64 epoch_price = 10;
+  // Price an instant seat allocation is charged, read at the settled epoch.
+  // Distinct from epoch_price, which is what a recurring subscriber pays next
+  // epoch. Explicit presence keeps "the CLI reported no price" apart from a
+  // legitimate 0: the CLI declares it Option<u16> and emits null when the
+  // settled-epoch ring entry is missing.
+  optional uint64 instant_allocation_price = 11;
+  // Whether the CLI's JSON carried the instant_allocation_price key at all.
+  // QA hosts pin doublezero-solana by apt, so a CLI predating the field omits
+  // the key entirely; that rollout gap must not read the same as the CLI
+  // reporting the price as unavailable.
+  bool reports_instant_allocation_price = 12;
 }
 
 message FeedSeatPriceResponse {

--- a/e2e/proto/qa/gen/pb-go/agent.pb.go
+++ b/e2e/proto/qa/gen/pb-go/agent.pb.go
@@ -2038,8 +2038,19 @@ type DevicePrice struct {
 	BasePrice      uint64                 `protobuf:"varint,8,opt,name=base_price,json=basePrice,proto3" json:"base_price,omitempty"`
 	Premium        uint64                 `protobuf:"varint,9,opt,name=premium,proto3" json:"premium,omitempty"`
 	EpochPrice     uint64                 `protobuf:"varint,10,opt,name=epoch_price,json=epochPrice,proto3" json:"epoch_price,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Price an instant seat allocation is charged, read at the settled epoch.
+	// Distinct from epoch_price, which is what a recurring subscriber pays next
+	// epoch. Explicit presence keeps "the CLI reported no price" apart from a
+	// legitimate 0: the CLI declares it Option<u16> and emits null when the
+	// settled-epoch ring entry is missing.
+	InstantAllocationPrice *uint64 `protobuf:"varint,11,opt,name=instant_allocation_price,json=instantAllocationPrice,proto3,oneof" json:"instant_allocation_price,omitempty"`
+	// Whether the CLI's JSON carried the instant_allocation_price key at all.
+	// QA hosts pin doublezero-solana by apt, so a CLI predating the field omits
+	// the key entirely; that rollout gap must not read the same as the CLI
+	// reporting the price as unavailable.
+	ReportsInstantAllocationPrice bool `protobuf:"varint,12,opt,name=reports_instant_allocation_price,json=reportsInstantAllocationPrice,proto3" json:"reports_instant_allocation_price,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *DevicePrice) Reset() {
@@ -2140,6 +2151,20 @@ func (x *DevicePrice) GetEpochPrice() uint64 {
 		return x.EpochPrice
 	}
 	return 0
+}
+
+func (x *DevicePrice) GetInstantAllocationPrice() uint64 {
+	if x != nil && x.InstantAllocationPrice != nil {
+		return *x.InstantAllocationPrice
+	}
+	return 0
+}
+
+func (x *DevicePrice) GetReportsInstantAllocationPrice() bool {
+	if x != nil {
+		return x.ReportsInstantAllocationPrice
+	}
+	return false
 }
 
 type FeedSeatPriceResponse struct {
@@ -2431,7 +2456,7 @@ const file_agent_proto_rawDesc = "" +
 	"\tusdc_mint\x18\x03 \x01(\tR\busdcMint\x12\x18\n" +
 	"\akeypair\x18\x04 \x01(\tR\akeypair\x12A\n" +
 	"\x1dshred_subscription_program_id\x18\x05 \x01(\tR\x1ashredSubscriptionProgramId\x12#\n" +
-	"\rdevice_pubkey\x18\x06 \x01(\tR\fdevicePubkey\"\xd1\x02\n" +
+	"\rdevice_pubkey\x18\x06 \x01(\tR\fdevicePubkey\"\xf6\x03\n" +
 	"\vDevicePrice\x12\x1f\n" +
 	"\vdevice_code\x18\x01 \x01(\tR\n" +
 	"deviceCode\x12#\n" +
@@ -2448,7 +2473,10 @@ const file_agent_proto_rawDesc = "" +
 	"\apremium\x18\t \x01(\x04R\apremium\x12\x1f\n" +
 	"\vepoch_price\x18\n" +
 	" \x01(\x04R\n" +
-	"epochPrice\"@\n" +
+	"epochPrice\x12=\n" +
+	"\x18instant_allocation_price\x18\v \x01(\x04H\x00R\x16instantAllocationPrice\x88\x01\x01\x12G\n" +
+	" reports_instant_allocation_price\x18\f \x01(\bR\x1dreportsInstantAllocationPriceB\x1b\n" +
+	"\x19_instant_allocation_price\"@\n" +
 	"\x15FeedSeatPriceResponse\x12'\n" +
 	"\x06prices\x18\x01 \x03(\v2\x0f.qa.DevicePriceR\x06prices\"2\n" +
 	"\x16GetWalletPubkeyRequest\x12\x18\n" +
@@ -2619,6 +2647,7 @@ func file_agent_proto_init() {
 	if File_agent_proto != nil {
 		return
 	}
+	file_agent_proto_msgTypes[29].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/e2e/qa_retransmit_only_settlement_test.go
+++ b/e2e/qa_retransmit_only_settlement_test.go
@@ -48,10 +48,12 @@ func TestQA_RetransmitOnlySettlement(t *testing.T) {
 		selectDevice:      selectRetransmitOnlyDevice,
 
 		priceLogMsg: "Found discounted epoch price",
-		assertPrice: func(t *testing.T, device *qa.Device, epochPrice uint64) {
+		assertPrice: func(t *testing.T, device *qa.Device, price uint64) {
 			// The retransmit-only metro is priced at the discount, so the seat
 			// price must equal the expected retransmit price (default 10 USDC).
-			require.Equal(t, *retransmitPriceFlag, epochPrice,
+			// This is the price the program charges, read from chain, not the CLI
+			// quote — the quote is checked against chain separately.
+			require.Equal(t, *retransmitPriceFlag, price,
 				"retransmit-only device %s should be priced at the discounted retransmit price", device.Code)
 		},
 

--- a/e2e/qa_shred_settlement_test.go
+++ b/e2e/qa_shred_settlement_test.go
@@ -68,10 +68,10 @@ type shredSettlementParams struct {
 // runShredSettlement drives the full shred-pay settlement flow: pick a device,
 // query its seat price from the CLI and cross-check it against the price the
 // program will charge (read from chain), wait for the program's
-// open-for-requests phase, pay, verify the debit and that the multicast tunnel
-// comes up on the right device, (optionally) assert extra invariants, then
-// withdraw and verify the refund accounting. Both settlement QA tests are thin
-// wrappers over this.
+// open-for-requests phase, re-read that price and pay it, verify the debit and
+// that the multicast tunnel comes up on the right device, (optionally) assert
+// extra invariants, then withdraw and verify the refund accounting. Both
+// settlement QA tests are thin wrappers over this.
 func runShredSettlement(t *testing.T, p shredSettlementParams) {
 	if !p.enabled {
 		t.Skip(p.skipReason)
@@ -227,19 +227,15 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 	}
 
 	if !t.Run("query_onchain_seat_price", func(t *testing.T) {
-		// Read the prices the program itself computes straight off the chain. The
-		// escrow is funded from the instant-allocation figure rather than from the
-		// CLI quote, so a quote/charge divergence surfaces as a named assertion
-		// below instead of killing the run at pay time with a raw simulation dump
-		// — and everything downstream (tunnel up, device assignment, withdraw,
-		// prorated refund) still gets exercised.
+		// Read the prices the program itself computes straight off the chain, as
+		// an oracle for the CLI quote. This snapshot is taken next to the quote so
+		// the two comparisons below are as close to simultaneous as possible; the
+		// amount actually funded is re-read just before paying, since the wait for
+		// the open phase can outlive this read.
 		var err error
 		onchain, err = client.SeatPrices(ctx, device.PubKey)
 		require.NoError(t, err, "failed to compute the onchain seat prices")
 		require.NotZero(t, onchain.InstantAllocationDollars, "onchain instant-allocation price is zero for device %s", device.Code)
-
-		amount = strconv.FormatUint(onchain.InstantAllocationDollars, 10)
-		fundedAmount = onchain.InstantAllocationDollars * 1_000_000 // dollars to USDC raw units (6 decimals)
 
 		// The price assertion belongs here, not on the CLI quote: what a caller
 		// means by "this seat costs the discounted price" is what the program
@@ -247,7 +243,8 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 		if p.assertPrice != nil {
 			p.assertPrice(t, device, onchain.InstantAllocationDollars)
 		}
-		log.Info("Onchain seat prices", "device", device.Code, "amount", amount,
+		log.Info("Onchain seat prices", "device", device.Code,
+			"instant_allocation_price", onchain.InstantAllocationDollars,
 			"last_settled_epoch", onchain.LastSettledEpoch,
 			"current_epoch_price", onchain.CurrentEpochDollars,
 			"current_subscription_epoch", onchain.CurrentSubscriptionEpoch)
@@ -349,6 +346,39 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 		// t.Run reports a skipped subtest as success, so skip the parent
 		// explicitly to stop the run here.
 		t.Skipf("expected epoch-tail closed window: %s", epochTailWindow)
+	}
+
+	if !t.Run("refresh_onchain_seat_price", func(t *testing.T) {
+		// wait_for_open_phase blocks for up to two minutes, and a settlement
+		// completing inside that window advances last_settled_epoch — the very
+		// read the charge is derived from. Funding a price captured before the
+		// wait would underfund the escrow and reproduce the opaque pay-time
+		// rejection this test exists to avoid, so the funded amount comes from a
+		// read taken here, immediately before paying. A rollover between this read
+		// and the transaction landing is irreducible (any payer races it), but the
+		// window shrinks from minutes to seconds.
+		refreshed, err := client.SeatPrices(ctx, device.PubKey)
+		require.NoError(t, err, "failed to re-read the onchain seat prices before paying")
+		require.NotZero(t, refreshed.InstantAllocationDollars, "onchain instant-allocation price is zero for device %s", device.Code)
+
+		if refreshed.LastSettledEpoch != onchain.LastSettledEpoch ||
+			refreshed.InstantAllocationDollars != onchain.InstantAllocationDollars {
+			// Warn, not Info: this means the quote comparisons above were made
+			// against a snapshot the payment no longer uses, so a failure up there
+			// should be read in that light.
+			log.Warn("Onchain seat price moved while waiting for the open-for-requests phase; funding the refreshed price",
+				"device", device.Code,
+				"before_price", onchain.InstantAllocationDollars, "before_last_settled_epoch", onchain.LastSettledEpoch,
+				"after_price", refreshed.InstantAllocationDollars, "after_last_settled_epoch", refreshed.LastSettledEpoch)
+		}
+
+		onchain = refreshed
+		amount = strconv.FormatUint(onchain.InstantAllocationDollars, 10)
+		fundedAmount = onchain.InstantAllocationDollars * 1_000_000 // dollars to USDC raw units (6 decimals)
+		log.Info("Funding the seat escrow from the onchain price", "device", device.Code,
+			"amount", amount, "last_settled_epoch", onchain.LastSettledEpoch)
+	}) {
+		return
 	}
 
 	if !t.Run("record_balance_before_pay", func(t *testing.T) {

--- a/e2e/qa_shred_settlement_test.go
+++ b/e2e/qa_shred_settlement_test.go
@@ -64,10 +64,12 @@ type shredSettlementParams struct {
 }
 
 // runShredSettlement drives the full shred-pay settlement flow: pick a device,
-// query its seat price, wait for the program's open-for-requests phase, pay,
-// verify the debit and that the multicast tunnel comes up on the right device,
-// (optionally) assert extra invariants, then withdraw and verify the refund
-// accounting. Both settlement QA tests are thin wrappers over this.
+// query its seat price from the CLI and cross-check it against the price the
+// program will charge (read from chain), wait for the program's
+// open-for-requests phase, pay, verify the debit and that the multicast tunnel
+// comes up on the right device, (optionally) assert extra invariants, then
+// withdraw and verify the refund accounting. Both settlement QA tests are thin
+// wrappers over this.
 func runShredSettlement(t *testing.T, p shredSettlementParams) {
 	if !p.enabled {
 		t.Skip(p.skipReason)
@@ -95,7 +97,9 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 	var device *qa.Device
 	var amount string
 	var epochPrice uint64
-	var parsedAmount uint64
+	var onchainPrice uint64
+	var lastSettledEpoch uint64
+	var fundedAmount uint64
 	var effectivePrice uint64
 	var balanceBeforePay uint64
 	var balanceAfterPay uint64
@@ -218,12 +222,42 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 			p.assertPrice(t, device, price.EpochPrice)
 		}
 		epochPrice = price.EpochPrice
-		amount = strconv.FormatUint(epochPrice, 10)
-		parsedAmount = epochPrice * 1_000_000 // convert dollars to USDC raw units (6 decimals)
-		log.Info(p.priceLogMsg, "device", device.Code, "amount", amount)
+		log.Info(p.priceLogMsg, "device", device.Code, "epoch_price", epochPrice)
 	}) {
 		return
 	}
+
+	if !t.Run("query_onchain_seat_price", func(t *testing.T) {
+		// Read the price the program will actually charge straight off the chain.
+		// The escrow is funded from this rather than from the CLI quote, so a
+		// quote/charge divergence surfaces as the named assertion below instead of
+		// killing the run at pay time with a raw simulation dump — and everything
+		// downstream (tunnel up, device assignment, withdraw, prorated refund)
+		// still gets exercised.
+		var err error
+		onchainPrice, lastSettledEpoch, err = client.InstantSeatPriceDollars(ctx, device.PubKey)
+		require.NoError(t, err, "failed to compute the onchain instant-allocation seat price")
+		require.NotZero(t, onchainPrice, "onchain seat price is zero for device %s", device.Code)
+
+		amount = strconv.FormatUint(onchainPrice, 10)
+		fundedAmount = onchainPrice * 1_000_000 // convert dollars to USDC raw units (6 decimals)
+		log.Info("Onchain instant-allocation seat price",
+			"device", device.Code, "amount", amount, "last_settled_epoch", lastSettledEpoch)
+	}) {
+		return
+	}
+
+	// Deliberately not guarded with `if !t.Run(...) { return }`: a quote/charge
+	// divergence is a real product bug and must fail the run loudly, but the
+	// payment below funds from the onchain price, so the rest of the settlement
+	// flow is still worth running. Whole dollars are compared, not prorated
+	// micro-USDC: proration is a function of the current slot, so any exact
+	// comparison against a separately-timed read is inherently racy.
+	t.Run("validate_quoted_price_matches_chain", func(t *testing.T) {
+		require.Equal(t, onchainPrice, epochPrice,
+			"CLI quoted %d USDC (current_subscription_epoch) but instant allocation charges %d USDC (last_settled_epoch=%d); `shreds price` and `shreds pay` read different ring entries",
+			epochPrice, onchainPrice, lastSettledEpoch)
+	})
 
 	// Set when wait_for_open_phase times out inside the epoch-tail closed
 	// window (verified against live chain state), so the parent can skip the
@@ -302,18 +336,22 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 			}
 			balanceAfterPay = bal
 			lastDebit = balanceBeforePay - bal
-			return lastDebit == parsedAmount
+			return lastDebit == fundedAmount
 		}, balanceSettleTimeout, 5*time.Second, "USDC balance should decrease by the paid amount")
-		log.Info("USDC balance after pay", "balance", balanceAfterPay, "debit", lastDebit, "expected_debit", parsedAmount)
+		log.Info("USDC balance after pay", "balance", balanceAfterPay, "debit", lastDebit, "expected_debit", fundedAmount)
 	}) {
 		return
 	}
 
 	if !t.Run("query_effective_seat_price", func(t *testing.T) {
+		// Built on the onchain price, not the CLI quote: this feeds the
+		// non-prorating balance assertion below, which must predict what the
+		// program actually charged. GetEffectiveSeatPrice applies the seat's price
+		// override on top when one is set.
 		var err error
-		effectivePrice, err = client.GetEffectiveSeatPrice(ctx, device.PubKey, epochPrice)
+		effectivePrice, err = client.GetEffectiveSeatPrice(ctx, device.PubKey, onchainPrice)
 		require.NoError(t, err, "failed to get effective seat price")
-		log.Info("Effective seat price", "effective_usdc", effectivePrice, "epoch_usdc", parsedAmount)
+		log.Info("Effective seat price", "effective_usdc", effectivePrice, "funded_usdc", fundedAmount)
 	}) {
 		return
 	}
@@ -409,10 +447,10 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 		// wallet-delta proration check is not meaningful, so skip it rather than
 		// fail — the settlement path itself is still covered by the pay/ack/
 		// tunnel/withdraw sub-tests above.
-		if refund > parsedAmount {
+		if refund > fundedAmount {
 			log.Warn("skipping wallet-delta proration check: refund exceeds amount paid this run (pre-existing escrow drained)",
 				"refund", refund,
-				"paid_amount", parsedAmount,
+				"paid_amount", fundedAmount,
 				"before_pay", balanceBeforePay,
 				"after_pay", balanceAfterPay,
 				"after_withdraw", balanceAfterWithdraw,
@@ -421,13 +459,13 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 		}
 		// Equivalent to balanceBeforePay - balanceAfterWithdraw, but computed from
 		// the amount paid this run so it cannot underflow given the guard above.
-		retained := parsedAmount - refund
+		retained := fundedAmount - refund
 
 		log.Info("USDC balance after withdraw",
 			"balance", balanceAfterWithdraw,
 			"before_pay", balanceBeforePay,
 			"after_pay", balanceAfterPay,
-			"paid_amount", parsedAmount,
+			"paid_amount", fundedAmount,
 			"effective_price", effectivePrice,
 			"refund", refund,
 			"retained", retained,
@@ -436,10 +474,10 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 
 		// Accounting invariant: regardless of prorating, the sum of what was
 		// refunded to the wallet and what the program retained must equal the
-		// amount debited at pay time. This uses parsedAmount rather than
+		// amount debited at pay time. This uses fundedAmount rather than
 		// effectivePrice because a seat with a zero price override is still
-		// charged parsedAmount at pay and fully refunded on withdraw.
-		require.Equal(t, parsedAmount, refund+retained,
+		// charged fundedAmount at pay and fully refunded on withdraw.
+		require.Equal(t, fundedAmount, refund+retained,
 			"refund + retained must equal the amount paid")
 
 		if !proratingEnabled || effectivePrice == 0 {

--- a/e2e/qa_shred_settlement_test.go
+++ b/e2e/qa_shred_settlement_test.go
@@ -48,12 +48,14 @@ type shredSettlementParams struct {
 	// fail, and is expected to log its own selection detail.
 	selectDevice func(t *testing.T, ctx context.Context, log *slog.Logger, test *qa.Test, client *qa.Client) *qa.Device
 
-	// priceLogMsg is logged after the seat price is queried, e.g. "Found epoch
-	// price" or "Found discounted epoch price".
+	// priceLogMsg is logged after the CLI seat price is queried, e.g. "Found
+	// epoch price" or "Found discounted epoch price".
 	priceLogMsg string
-	// assertPrice, when non-nil, runs an extra assertion on the queried epoch
-	// price (whole USDC dollars) inside the query_seat_price subtest.
-	assertPrice func(t *testing.T, device *qa.Device, epochPrice uint64)
+	// assertPrice, when non-nil, runs an extra assertion on the seat price the
+	// program will charge (whole USDC dollars, read from chain) inside the
+	// query_onchain_seat_price subtest. It deliberately does not see the CLI
+	// quote: what a caller means to pin is what the seat actually costs.
+	assertPrice func(t *testing.T, device *qa.Device, price uint64)
 
 	// extraSubtestName / extraAssertion, when both set, run as a gated subtest
 	// after the tunnel is up and the device assignment is validated, before the
@@ -96,9 +98,8 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 	// Shared state across subtests.
 	var device *qa.Device
 	var amount string
-	var epochPrice uint64
-	var onchainPrice uint64
-	var lastSettledEpoch uint64
+	var quoted *pb.DevicePrice
+	var onchain *qa.SeatPrices
 	var fundedAmount uint64
 	var effectivePrice uint64
 	var balanceBeforePay uint64
@@ -209,54 +210,98 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 
 		// Match by pubkey, not code: querying by --device skips code resolution,
 		// so the returned rows may not carry a device_code.
-		var price *pb.DevicePrice
 		for _, pr := range prices {
 			if pr.DevicePubkey == device.PubKey {
-				price = pr
+				quoted = pr
 				break
 			}
 		}
-		require.NotNil(t, price, "no price found for device %s", device.Code)
-		require.NotZero(t, price.EpochPrice, "epoch price is zero for device %s", device.Code)
-		if p.assertPrice != nil {
-			p.assertPrice(t, device, price.EpochPrice)
-		}
-		epochPrice = price.EpochPrice
-		log.Info(p.priceLogMsg, "device", device.Code, "epoch_price", epochPrice)
+		require.NotNil(t, quoted, "no price found for device %s", device.Code)
+		require.NotZero(t, quoted.EpochPrice, "epoch price is zero for device %s", device.Code)
+		log.Info(p.priceLogMsg, "device", device.Code,
+			"epoch_price", quoted.EpochPrice,
+			"instant_allocation_price", quoted.GetInstantAllocationPrice(),
+			"reports_instant_allocation_price", quoted.GetReportsInstantAllocationPrice())
 	}) {
 		return
 	}
 
 	if !t.Run("query_onchain_seat_price", func(t *testing.T) {
-		// Read the price the program will actually charge straight off the chain.
-		// The escrow is funded from this rather than from the CLI quote, so a
-		// quote/charge divergence surfaces as the named assertion below instead of
-		// killing the run at pay time with a raw simulation dump — and everything
-		// downstream (tunnel up, device assignment, withdraw, prorated refund)
-		// still gets exercised.
+		// Read the prices the program itself computes straight off the chain. The
+		// escrow is funded from the instant-allocation figure rather than from the
+		// CLI quote, so a quote/charge divergence surfaces as a named assertion
+		// below instead of killing the run at pay time with a raw simulation dump
+		// — and everything downstream (tunnel up, device assignment, withdraw,
+		// prorated refund) still gets exercised.
 		var err error
-		onchainPrice, lastSettledEpoch, err = client.InstantSeatPriceDollars(ctx, device.PubKey)
-		require.NoError(t, err, "failed to compute the onchain instant-allocation seat price")
-		require.NotZero(t, onchainPrice, "onchain seat price is zero for device %s", device.Code)
+		onchain, err = client.SeatPrices(ctx, device.PubKey)
+		require.NoError(t, err, "failed to compute the onchain seat prices")
+		require.NotZero(t, onchain.InstantAllocationDollars, "onchain instant-allocation price is zero for device %s", device.Code)
 
-		amount = strconv.FormatUint(onchainPrice, 10)
-		fundedAmount = onchainPrice * 1_000_000 // convert dollars to USDC raw units (6 decimals)
-		log.Info("Onchain instant-allocation seat price",
-			"device", device.Code, "amount", amount, "last_settled_epoch", lastSettledEpoch)
+		amount = strconv.FormatUint(onchain.InstantAllocationDollars, 10)
+		fundedAmount = onchain.InstantAllocationDollars * 1_000_000 // dollars to USDC raw units (6 decimals)
+
+		// The price assertion belongs here, not on the CLI quote: what a caller
+		// means by "this seat costs the discounted price" is what the program
+		// charges, and that is the onchain figure.
+		if p.assertPrice != nil {
+			p.assertPrice(t, device, onchain.InstantAllocationDollars)
+		}
+		log.Info("Onchain seat prices", "device", device.Code, "amount", amount,
+			"last_settled_epoch", onchain.LastSettledEpoch,
+			"current_epoch_price", onchain.CurrentEpochDollars,
+			"current_subscription_epoch", onchain.CurrentSubscriptionEpoch)
 	}) {
 		return
 	}
 
-	// Deliberately not guarded with `if !t.Run(...) { return }`: a quote/charge
-	// divergence is a real product bug and must fail the run loudly, but the
-	// payment below funds from the onchain price, so the rest of the settlement
-	// flow is still worth running. Whole dollars are compared, not prorated
-	// micro-USDC: proration is a function of the current slot, so any exact
-	// comparison against a separately-timed read is inherently racy.
-	t.Run("validate_quoted_price_matches_chain", func(t *testing.T) {
-		require.Equal(t, onchainPrice, epochPrice,
-			"CLI quoted %d USDC (current_subscription_epoch) but instant allocation charges %d USDC (last_settled_epoch=%d); `shreds price` and `shreds pay` read different ring entries",
-			epochPrice, onchainPrice, lastSettledEpoch)
+	// The next two subtests are deliberately not guarded with
+	// `if !t.Run(...) { return }`: a CLI/chain divergence is a real product bug
+	// and must fail the run loudly, but the payment below funds from the onchain
+	// price, so the rest of the settlement flow is still worth running. Both
+	// compare whole dollars, never prorated micro-USDC: proration is a function
+	// of the current slot, so an exact comparison against a separately-timed read
+	// is inherently racy.
+	t.Run("validate_instant_allocation_price_matches_chain", func(t *testing.T) {
+		switch {
+		case !quoted.GetReportsInstantAllocationPrice():
+			// QA hosts install doublezero-solana from a version-pinned apt package
+			// (doublezero_solana_version in malbeclabs/infra
+			// ansible/inventory/*/group_vars/all.yml, 0.5.10-1 at time of writing),
+			// so the field only appears once a release carrying it is published and
+			// the pin bumped. Asserting against an absent field would read 0 and
+			// fail as "quoted 0, chain 43" — a misleading failure that looks like a
+			// new bug rather than a rollout gap.
+			t.Skipf("Skipping: installed doublezero-solana does not report instant_allocation_price (needs a release newer than the pinned 0.5.10-1); chain says %d USDC at last_settled_epoch=%d",
+				onchain.InstantAllocationDollars, onchain.LastSettledEpoch)
+		case quoted.InstantAllocationPrice == nil:
+			// Reported, but null: the CLI could not find the settled-epoch ring
+			// entry. That is a real condition, not a rollout artifact — the program
+			// performs the same lookup and would reject the allocation.
+			t.Fatalf("`shreds price` reported instant_allocation_price as unavailable for device %s, but the chain has a price of %d USDC at last_settled_epoch=%d",
+				device.Code, onchain.InstantAllocationDollars, onchain.LastSettledEpoch)
+		default:
+			require.Equal(t, onchain.InstantAllocationDollars, quoted.GetInstantAllocationPrice(),
+				"CLI quoted %d USDC for an instant allocation but the program charges %d USDC (last_settled_epoch=%d); `shreds price` and `shreds pay` read different ring entries",
+				quoted.GetInstantAllocationPrice(), onchain.InstantAllocationDollars, onchain.LastSettledEpoch)
+		}
+	})
+
+	t.Run("validate_epoch_price_matches_chain", func(t *testing.T) {
+		// The other half of the invariant: epoch_price must keep meaning the
+		// current-epoch price a recurring subscriber pays. Without this, someone
+		// "fixing" the divergence by repointing epoch_price at last_settled_epoch
+		// would go green here while silently breaking recurring subscribers.
+		if !onchain.HasCurrentEpoch {
+			// Part-way through UpdatingPrices the ring has not been advanced to the
+			// current epoch for every metro and device yet, so there is nothing to
+			// compare against. Transient by design, not a regression.
+			t.Skipf("Skipping: no onchain price entry yet for current_subscription_epoch=%d (prices are still being updated)",
+				onchain.CurrentSubscriptionEpoch)
+		}
+		require.Equal(t, onchain.CurrentEpochDollars, quoted.EpochPrice,
+			"CLI quoted epoch_price %d USDC but the chain has %d USDC at current_subscription_epoch=%d; epoch_price must stay the price a recurring subscriber pays next epoch",
+			quoted.EpochPrice, onchain.CurrentEpochDollars, onchain.CurrentSubscriptionEpoch)
 	})
 
 	// Set when wait_for_open_phase times out inside the epoch-tail closed
@@ -349,7 +394,7 @@ func runShredSettlement(t *testing.T, p shredSettlementParams) {
 		// program actually charged. GetEffectiveSeatPrice applies the seat's price
 		// override on top when one is set.
 		var err error
-		effectivePrice, err = client.GetEffectiveSeatPrice(ctx, device.PubKey, onchainPrice)
+		effectivePrice, err = client.GetEffectiveSeatPrice(ctx, device.PubKey, onchain.InstantAllocationDollars)
 		require.NoError(t, err, "failed to get effective seat price")
 		log.Info("Effective seat price", "effective_usdc", effectivePrice, "funded_usdc", fundedAmount)
 	}) {

--- a/sdk/shreds/go/compat_test.go
+++ b/sdk/shreds/go/compat_test.go
@@ -97,14 +97,23 @@ func TestCompatExecutionController(t *testing.T) {
 	assertU16(t, raw, 14, ec.TotalEnabledDevices, "TotalEnabledDevices")
 	assertU32(t, raw, 16, ec.TotalClientSeats, "TotalClientSeats")
 	assertU64(t, raw, 32, ec.CurrentSubscriptionEpoch, "CurrentSubscriptionEpoch")
+	assertU16(t, raw, 46, ec.TotalDevices, "TotalDevices")
+	assertU64(t, raw, 152, ec.LastSettledEpoch, "LastSettledEpoch")
 
 	if ec.CurrentSubscriptionEpoch == 0 {
 		t.Error("CurrentSubscriptionEpoch is 0, expected > 0 on mainnet")
 	}
+	// LastSettledEpoch is the final field of the account body, so a truncated
+	// struct would silently read zero here rather than fail to deserialize.
+	// It normally trails CurrentSubscriptionEpoch by exactly one.
+	if ec.LastSettledEpoch == 0 || ec.LastSettledEpoch > ec.CurrentSubscriptionEpoch {
+		t.Errorf("LastSettledEpoch = %d, expected 0 < epoch <= CurrentSubscriptionEpoch (%d)",
+			ec.LastSettledEpoch, ec.CurrentSubscriptionEpoch)
+	}
 
-	t.Logf("epoch=%d, phase=%s, metros=%d, devices=%d, seats=%d",
-		ec.CurrentSubscriptionEpoch, ec.GetPhase(), ec.TotalMetros,
-		ec.TotalEnabledDevices, ec.TotalClientSeats)
+	t.Logf("epoch=%d, last_settled_epoch=%d, phase=%s, metros=%d, devices=%d (total %d), seats=%d",
+		ec.CurrentSubscriptionEpoch, ec.LastSettledEpoch, ec.GetPhase(), ec.TotalMetros,
+		ec.TotalEnabledDevices, ec.TotalDevices, ec.TotalClientSeats)
 }
 
 func TestCompatMetroHistories(t *testing.T) {

--- a/sdk/shreds/go/ringbuffer_test.go
+++ b/sdk/shreds/go/ringbuffer_test.go
@@ -1,0 +1,186 @@
+package shreds
+
+import "testing"
+
+// writeMetroPrices fills a ring buffer as the onchain program would: epochs are
+// written in ascending order starting at slot 0, wrapping at MaxHistoryCount.
+func writeMetroPrices(epochs ...uint64) MetroPriceRingBuffer {
+	var buf MetroPriceRingBuffer
+	for i, epoch := range epochs {
+		index := i % MaxHistoryCount
+		buf.Entries[index] = MetroPriceEntry{
+			Epoch: epoch,
+			Price: MetroPrice{USDCPriceDollars: uint16(epoch)},
+		}
+		buf.CurrentIndex = uint8(index)
+		if buf.TotalCount < MaxHistoryCount {
+			buf.TotalCount++
+		}
+	}
+	return buf
+}
+
+func TestMetroPriceRingBufferFind(t *testing.T) {
+	t.Run("exact hit on the current entry", func(t *testing.T) {
+		buf := writeMetroPrices(100, 101, 102)
+		entry, ok := buf.Find(102)
+		if !ok {
+			t.Fatal("Find(102) = not found, want found")
+		}
+		if entry.Price.USDCPriceDollars != 102 {
+			t.Errorf("price = %d, want 102", entry.Price.USDCPriceDollars)
+		}
+	})
+
+	t.Run("hit on an older entry", func(t *testing.T) {
+		buf := writeMetroPrices(100, 101, 102)
+		entry, ok := buf.Find(100)
+		if !ok {
+			t.Fatal("Find(100) = not found, want found")
+		}
+		if entry.Price.USDCPriceDollars != 100 {
+			t.Errorf("price = %d, want 100", entry.Price.USDCPriceDollars)
+		}
+	})
+
+	t.Run("wraps past index 0", func(t *testing.T) {
+		// 33 writes: the ring wrapped, so CurrentIndex is 0 and epoch 132 sits at
+		// slot 0 while epoch 131 sits at slot 31. Finding 131 requires the scan to
+		// wrap backwards past index 0.
+		buf := writeMetroPrices(seq(100, 33)...)
+		if buf.CurrentIndex != 0 {
+			t.Fatalf("CurrentIndex = %d, want 0", buf.CurrentIndex)
+		}
+		entry, ok := buf.Find(131)
+		if !ok {
+			t.Fatal("Find(131) = not found, want found")
+		}
+		if entry.Price.USDCPriceDollars != 131 {
+			t.Errorf("price = %d, want 131", entry.Price.USDCPriceDollars)
+		}
+		// Epoch 100 was overwritten by 132 at slot 0.
+		if _, ok := buf.Find(100); ok {
+			t.Error("Find(100) = found, want not found (evicted by wraparound)")
+		}
+	})
+
+	t.Run("does not scan beyond TotalCount", func(t *testing.T) {
+		// Slot 5 holds a stale epoch outside the active window. A scan bounded by
+		// the ring capacity rather than TotalCount would wrongly match it.
+		buf := writeMetroPrices(100, 101)
+		buf.Entries[5] = MetroPriceEntry{Epoch: 99, Price: MetroPrice{USDCPriceDollars: 99}}
+		if _, ok := buf.Find(99); ok {
+			t.Error("Find(99) = found, want not found (slot is beyond TotalCount)")
+		}
+	})
+
+	t.Run("epoch zero misses a zero-initialized buffer", func(t *testing.T) {
+		var buf MetroPriceRingBuffer
+		if _, ok := buf.Find(0); ok {
+			t.Error("Find(0) = found, want not found on an empty buffer")
+		}
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		buf := writeMetroPrices(100, 101, 102)
+		if _, ok := buf.Find(103); ok {
+			t.Error("Find(103) = found, want not found")
+		}
+	})
+}
+
+func TestDeviceSubscriptionRingBufferFind(t *testing.T) {
+	writeSubscriptions := func(epochs ...uint64) DeviceSubscriptionRingBuffer {
+		var buf DeviceSubscriptionRingBuffer
+		for i, epoch := range epochs {
+			index := i % MaxHistoryCount
+			buf.Entries[index] = DeviceSubscriptionEntry{
+				Epoch:        epoch,
+				Subscription: DeviceSubscription{GrantedSeatCount: uint16(epoch)},
+			}
+			buf.CurrentIndex = uint8(index)
+			if buf.TotalCount < MaxHistoryCount {
+				buf.TotalCount++
+			}
+		}
+		return buf
+	}
+
+	t.Run("exact hit", func(t *testing.T) {
+		buf := writeSubscriptions(100, 101, 102)
+		entry, ok := buf.Find(101)
+		if !ok {
+			t.Fatal("Find(101) = not found, want found")
+		}
+		if entry.Subscription.GrantedSeatCount != 101 {
+			t.Errorf("granted seats = %d, want 101", entry.Subscription.GrantedSeatCount)
+		}
+	})
+
+	t.Run("wraps past index 0", func(t *testing.T) {
+		buf := writeSubscriptions(seq(100, 33)...)
+		entry, ok := buf.Find(131)
+		if !ok {
+			t.Fatal("Find(131) = not found, want found")
+		}
+		if entry.Subscription.GrantedSeatCount != 131 {
+			t.Errorf("granted seats = %d, want 131", entry.Subscription.GrantedSeatCount)
+		}
+	})
+
+	t.Run("does not scan beyond TotalCount", func(t *testing.T) {
+		buf := writeSubscriptions(100, 101)
+		buf.Entries[5] = DeviceSubscriptionEntry{Epoch: 99}
+		if _, ok := buf.Find(99); ok {
+			t.Error("Find(99) = found, want not found (slot is beyond TotalCount)")
+		}
+	})
+
+	t.Run("epoch zero misses a zero-initialized buffer", func(t *testing.T) {
+		var buf DeviceSubscriptionRingBuffer
+		if _, ok := buf.Find(0); ok {
+			t.Error("Find(0) = found, want not found on an empty buffer")
+		}
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		buf := writeSubscriptions(100, 101, 102)
+		if _, ok := buf.Find(103); ok {
+			t.Error("Find(103) = found, want not found")
+		}
+	})
+}
+
+func seq(start uint64, count int) []uint64 {
+	epochs := make([]uint64, count)
+	for i := range epochs {
+		epochs[i] = start + uint64(i)
+	}
+	return epochs
+}
+
+func TestDeviceSubscriptionUSDCPriceDollars(t *testing.T) {
+	tests := []struct {
+		name       string
+		metroPrice uint16
+		premium    int16
+		want       uint16
+	}{
+		{"no premium", 43, 0, 43},
+		{"positive premium", 43, 7, 50},
+		{"negative premium is a discount", 43, -13, 30},
+		{"discount saturates at zero", 10, -20, 0},
+		{"most negative premium saturates at zero", 10, -32768, 0},
+		{"premium saturates at u16 max", 65_000, 1_000, 65_535},
+		{"max metro price with max premium saturates", 65_535, 32_767, 65_535},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := DeviceSubscription{USDCMetroPremiumDollars: tt.premium}
+			metro := MetroPrice{USDCPriceDollars: tt.metroPrice}
+			if got := sub.USDCPriceDollars(&metro); got != tt.want {
+				t.Errorf("USDCPriceDollars() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/shreds/go/state.go
+++ b/sdk/shreds/go/state.go
@@ -1,6 +1,10 @@
 package shreds
 
-import "github.com/gagliardetto/solana-go"
+import (
+	"math"
+
+	"github.com/gagliardetto/solana-go"
+)
 
 // MaxHistoryCount is the number of epoch entries in each ring buffer.
 const MaxHistoryCount = 32
@@ -102,7 +106,7 @@ type ExecutionController struct {
 	UpdatedDevicePricesCount  uint16
 	SettledDevicesCount       uint16
 	SettledClientSeatsCount   uint16
-	Padding2                  [2]byte
+	TotalDevices              uint16
 	LastSettledSlot           uint64
 	LastUpdatingPricesSlot    uint64
 	LastOpenForRequestsSlot   uint64
@@ -110,6 +114,7 @@ type ExecutionController struct {
 	EpochRoundCommitment      [32]byte
 	EpochRoundReveal          [32]byte
 	NextSeatFundingIndex      uint64
+	LastSettledEpoch          uint64
 }
 
 // GetPhase returns the execution phase as a typed enum.
@@ -253,6 +258,21 @@ type MetroPriceRingBuffer struct {
 	Entries      [MaxHistoryCount]MetroPriceEntry
 }
 
+// Find returns the entry stamped with epoch, scanning backwards from the
+// current slot. It mirrors the onchain RingBuffer::find: the scan is bounded by
+// TotalCount, not by the ring capacity, so zero-initialized slots never match
+// epoch 0. TotalCount is additionally clamped to the capacity so an
+// out-of-range value read off a corrupt account cannot index out of bounds.
+func (r *MetroPriceRingBuffer) Find(epoch uint64) (*MetroPriceEntry, bool) {
+	for i := 0; i < int(r.TotalCount) && i < MaxHistoryCount; i++ {
+		index := (int(r.CurrentIndex) + MaxHistoryCount - i) % MaxHistoryCount
+		if r.Entries[index].Epoch == epoch {
+			return &r.Entries[index], true
+		}
+	}
+	return nil, false
+}
+
 // MetroHistory tracks pricing history for a metro area.
 type MetroHistory struct {
 	ExchangeKey             solana.PublicKey
@@ -284,6 +304,26 @@ type DeviceSubscription struct {
 	Gap                     [2][32]byte // StorageGap<2>
 }
 
+// USDCPriceDollars returns the whole-dollar seat price for this device
+// subscription: the metro base price adjusted by the signed device premium
+// (negative premiums are discounts). Mirrors the onchain
+// DeviceSubscription::usdc_price_dollars, saturation included.
+func (s *DeviceSubscription) USDCPriceDollars(metroPrice *MetroPrice) uint16 {
+	base := metroPrice.USDCPriceDollars
+	if s.USDCMetroPremiumDollars < 0 {
+		discount := uint16(-int32(s.USDCMetroPremiumDollars))
+		if base < discount {
+			return 0
+		}
+		return base - discount
+	}
+	sum := uint32(base) + uint32(s.USDCMetroPremiumDollars)
+	if sum > math.MaxUint16 {
+		return math.MaxUint16
+	}
+	return uint16(sum)
+}
+
 // DeviceSubscriptionEntry is an epoch-stamped device subscription.
 type DeviceSubscriptionEntry struct {
 	Epoch        uint64
@@ -297,6 +337,18 @@ type DeviceSubscriptionRingBuffer struct {
 	TotalCount   uint8
 	Padding0     [6]byte
 	Entries      [MaxHistoryCount]DeviceSubscriptionEntry
+}
+
+// Find returns the entry stamped with epoch, scanning backwards from the
+// current slot. See MetroPriceRingBuffer.Find for the bounding semantics.
+func (r *DeviceSubscriptionRingBuffer) Find(epoch uint64) (*DeviceSubscriptionEntry, bool) {
+	for i := 0; i < int(r.TotalCount) && i < MaxHistoryCount; i++ {
+		index := (int(r.CurrentIndex) + MaxHistoryCount - i) % MaxHistoryCount
+		if r.Entries[index].Epoch == epoch {
+			return &r.Entries[index], true
+		}
+	}
+	return nil, false
 }
 
 // DeviceHistory tracks subscription history for a device.

--- a/sdk/shreds/go/state_test.go
+++ b/sdk/shreds/go/state_test.go
@@ -14,7 +14,7 @@ func TestStructSizes(t *testing.T) {
 		expected uintptr
 	}{
 		{"ProgramConfig", unsafe.Sizeof(ProgramConfig{}), 248},
-		{"ExecutionController", unsafe.Sizeof(ExecutionController{}), 144},
+		{"ExecutionController", unsafe.Sizeof(ExecutionController{}), 152},
 		{"ClientSeat", unsafe.Sizeof(ClientSeat{}), 232},
 		{"PaymentEscrow", unsafe.Sizeof(PaymentEscrow{}), 136},
 		{"ShredDistribution", unsafe.Sizeof(ShredDistribution{}), 392},
@@ -49,7 +49,9 @@ func TestExecutionControllerDeserialization(t *testing.T) {
 	binary.LittleEndian.PutUint16(data[6:], 10)    // TotalEnabledDevices
 	binary.LittleEndian.PutUint32(data[8:], 100)   // TotalClientSeats
 	binary.LittleEndian.PutUint64(data[24:], 42)   // CurrentSubscriptionEpoch
+	binary.LittleEndian.PutUint16(data[38:], 12)   // TotalDevices
 	binary.LittleEndian.PutUint64(data[136:], 999) // NextSeatFundingIndex
+	binary.LittleEndian.PutUint64(data[144:], 41)  // LastSettledEpoch
 
 	var ec ExecutionController
 	if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &ec); err != nil {
@@ -73,8 +75,14 @@ func TestExecutionControllerDeserialization(t *testing.T) {
 	if ec.CurrentSubscriptionEpoch != 42 {
 		t.Errorf("CurrentSubscriptionEpoch = %d, want 42", ec.CurrentSubscriptionEpoch)
 	}
+	if ec.TotalDevices != 12 {
+		t.Errorf("TotalDevices = %d, want 12", ec.TotalDevices)
+	}
 	if ec.NextSeatFundingIndex != 999 {
 		t.Errorf("NextSeatFundingIndex = %d, want 999", ec.NextSeatFundingIndex)
+	}
+	if ec.LastSettledEpoch != 41 {
+		t.Errorf("LastSettledEpoch = %d, want 41", ec.LastSettledEpoch)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestQA_MulticastSettlement/pay_for_seat` funded the escrow from the CLI's `shreds price` quote, so whenever that quote diverged from what the program charges the run died at the first payment with an opaque `invalid account data for instruction` and every downstream assertion (tunnel up, device assignment, withdraw, prorated refund) never executed. The probe now computes the charge from chain state and funds from that, so the lifecycle runs regardless of what the CLI quotes.
- The divergence is a real product bug: `shreds price` reported the metro price at `current_subscription_epoch` while `request_instant_seat_allocation` charges the price at `last_settled_epoch` (one ring entry back). Testnet `lax-dz001` was repriced 43 -> 10, so after the epoch rolled the quote read 10 and the program charged 43 prorated.
- Quote verification points at `instant_allocation_price`, the new field from doublezerofoundation/doublezero-offchain#405, **not** at `epoch_price`. 405 deliberately keeps `epoch_price` meaning what a recurring subscriber pays next epoch, so asserting the settled-epoch charge against it would fail at every future reprice forever and look like the fix never landed. The plumbing for the new field (proto, QA agent) is in this PR.
- A second assertion pins `epoch_price` against the chain's current-epoch price. That closes the other half of the invariant: repointing `epoch_price` at `last_settled_epoch` to "fix" the divergence would otherwise go green here while silently breaking recurring subscribers.
- Verification goes through the in-repo Go SDK rather than trusting the CLI. QA hosts install `doublezero-solana` from a version-pinned apt package (`doublezero_solana_version` in `malbeclabs/infra` `ansible/inventory/*/group_vars/all.yml`, `0.5.10-1` on both testnet and mainnet-beta), so a CLI-side field reaches QA only after a release is published and the pin bumped. Reading chain state also gives QA an oracle independent of the CLI under test, which is the only reason a probe can catch a quote/charge divergence at all.
- Standalone SDK correctness fix, worth having on its own: `sdk/shreds/go`'s `ExecutionController` was 144 bytes against a 152-byte onchain body — `total_devices` was decoded as padding and `last_settled_epoch` was missing entirely. `deserializeAccount` tolerates trailing bytes for forward compatibility, so the truncation was silent.

### Rollout behavior

The quote check is gated on field presence, three ways:

| CLI reports | Probe |
| --- | --- |
| key absent (pinned 0.5.10-1 today) | skip, naming the version gap |
| explicit `null` | fail — the CLI could not find the settled-epoch ring entry, which means the program would reject the allocation too |
| a number | assert against chain |

So the subtest is green (skipped) until the CLI rolls out, then starts asserting. That is the right shape: this PR's real job — funding from chain so the lifecycle runs — works the moment it merges, and the quote check activates once there is a quote worth checking.

Carrying all three states end to end needs one bit more than a `*uint64`, which collapses absent and null into `nil`. The agent decodes the key as `json.RawMessage` and sets a companion `reports_instant_allocation_price` bool on the wire.

## Testing Verification

- Ring-buffer `Find` unit tests cover an exact hit, wraparound past index 0, the `TotalCount` bound (an epoch parked in a slot beyond `TotalCount` must not match), `epoch == 0` against a zero-initialized buffer, and a miss. The `TotalCount` bound is the one that matters: scanning all 32 slots would spuriously match `epoch == 0` on unwritten entries.
- Table test for the metro-price + signed-premium combination: positive premium, negative premium (discount), and saturation at both ends including `premium == -32768`.
- `parseDevicePrices` table test pins all three presence states plus `instant_allocation_price: 0`, which must read as a real price rather than as absent or null.
- Decoded the new `ExecutionController` layout against live mainnet-beta account data via the opt-in compat test (`SHREDS_COMPAT_TEST=1`): `last_settled_epoch=1007` against `current_subscription_epoch=1008`, `total_devices=97` against `total_enabled_devices=95` — both cross-checked against raw byte reads at their offsets. The compat test now pins those two offsets and asserts `0 < LastSettledEpoch <= CurrentSubscriptionEpoch`, since a re-truncated struct would silently read zero for the trailing field rather than fail to deserialize.
- Checked the override-floor concern against live mainnet-beta state: of 607 client seats, 3 carry a price override and all 3 are set to 0 (comped seats), none above the device's base price at the settled epoch. Funding `base_at_last_settled` therefore sits at or above 405's `seat_price_override.unwrap_or(base_at_last_settled)` floor for every seat that exists, so the QA payment clears the new preflight. Could not run the same scan against the DZ testnet cluster from CI's network, so the evidence is mainnet-only.
- `epoch_price` vs current-epoch chain price is the one assertion not yet observed against a live CLI response — it assumes `shreds price` derives `epoch_price` from the ring entry stamped with `current_subscription_epoch`. If it instead reads the ring's newest entry, the two agree whenever prices have been updated for the epoch (all of `OpenForRequests`), and the probe skips when the current-epoch entry is missing mid-`UpdatingPrices`.
- The e2e suite was not run (it needs live testnet infrastructure and cEOS containers); both QA tests were verified to build under the `qa` tag.