### PR TITLE
cli: add --feed to `user create-subscribe` for EdgeSeat feed passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - `doublezero user create-subscribe` gains a `--feed` flag (a Feed pubkey or an unambiguous feed code) passed as the trailing `Feed` account the EdgeSeat feed metro gate requires. Without it, connecting a Multicast user to a feed pass failed with `FeedAccountRequired`. (#4087)
 - Serviceability
   - `User` accounts can hold EdgeSeat feed seats on multiple feeds: `feed_pks: Vec<Pubkey>` records every feed whose per-feed seat the user consumed at connect, and delete releases all of them. Added to the Go/TypeScript/Python SDK `User` decoders as well. (#4080)
   - Bound the preallocation in `deserialize_vec_with_capacity` against the remaining input. A garbage or attacker-controlled u32 length prefix in an account (e.g. a pre-FeedSeat SDK misparsing an EdgeSeat AccessPass) could request tens of GiB via `Vec::with_capacity`, aborting the process through the uncatchable alloc-error handler; the capacity is now capped at the remaining byte count. Decoding of valid accounts is unchanged. (#4072)

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -113,7 +113,7 @@ impl CreateSubscribeUserCliCommand {
                             pubkey_or_code: feed.clone(),
                             exchange: None,
                         })
-                        .map_err(|_| eyre::eyre!("Feed not found ({})", feed))?;
+                        .map_err(|e| eyre::eyre!("Feed lookup failed ({feed}): {e}"))?;
                     Some(pubkey)
                 }
             },
@@ -536,5 +536,121 @@ mod tests {
             .execute(&ctx, &client, &mut output),
         );
         assert!(res.is_ok(), "{res:?}");
+    }
+
+    // A get_feed failure (e.g. an ambiguous code spanning metros) is surfaced with the
+    // underlying cause, not collapsed into a flat "not found" that hides the remedy.
+    #[test]
+    fn test_cli_user_create_subscribe_surfaces_feed_lookup_error() {
+        let mut client = create_test_client();
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 255,
+            reference_count: 0,
+            code: "device1".to_string(),
+            contributor_pk: Pubkey::default(),
+            location_pk: Pubkey::default(),
+            exchange_pk: Pubkey::default(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [10, 0, 0, 1].into(),
+            dz_prefixes: "10.0.0.1/24".parse().unwrap(),
+            owner: device_pubkey,
+            metrics_publisher_pk: Pubkey::default(),
+            status: DeviceStatus::Activated,
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: 0,
+            max_multicast_publishers: 0,
+            ..Default::default()
+        };
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_device()
+            .with(predicate::eq(GetDeviceCommand {
+                pubkey_or_code: "device1".to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((device_pubkey, device.clone())));
+
+        let mgroup_pubkey = Pubkey::new_unique();
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::default(),
+            index: 1,
+            bump_seed: 1,
+            tenant_pk: Pubkey::default(),
+            code: "mg1".to_string(),
+            multicast_ip: [239, 0, 0, 1].into(),
+            max_bandwidth: 1_000_000_000,
+            status: MulticastGroupStatus::Activated,
+            publisher_count: 0,
+            subscriber_count: 0,
+        };
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((mgroup_pubkey, mgroup.clone())));
+
+        // The SDK rejects an ambiguous code; the CLI must pass that cause through, not
+        // mask it. create_subscribe_user is never reached, so it is not expected.
+        client
+            .expect_get_feed()
+            .with(predicate::eq(GetFeedCommand {
+                pubkey_or_code: "shreds-nyc".to_string(),
+                exchange: None,
+            }))
+            .times(1)
+            .returning(|_| {
+                Err(eyre::eyre!(
+                    "Feed code shreds-nyc is ambiguous: it exists in 2 metros"
+                ))
+            });
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            CreateSubscribeUserCliCommand {
+                device: "device1".to_string(),
+                client_ip: [100, 0, 0, 1].into(),
+                allocate_addr: false,
+                publisher: None,
+                subscriber: Some(mgroup_pubkey.to_string()),
+                wait: false,
+                owner: None,
+                feed: Some("shreds-nyc".to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        let message = format!(
+            "{}",
+            res.expect_err("a feed lookup failure must surface as an error")
+        );
+        assert!(
+            message.contains("shreds-nyc"),
+            "error names the feed: {message}"
+        );
+        assert!(
+            message.contains("ambiguous"),
+            "error preserves the underlying cause: {message}"
+        );
     }
 }

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -156,10 +156,11 @@ mod tests {
     };
     use doublezero_sdk::{
         commands::{
-            device::get::GetDeviceCommand, multicastgroup::get::GetMulticastGroupCommand,
+            device::get::GetDeviceCommand, feed::get::GetFeedCommand,
+            multicastgroup::get::GetMulticastGroupCommand,
             user::create_subscribe::CreateSubscribeUserCommand,
         },
-        AccountType, Device, DeviceStatus, DeviceType, MulticastGroup, MulticastGroupStatus,
+        AccountType, Device, DeviceStatus, DeviceType, Feed, MulticastGroup, MulticastGroupStatus,
         UserCYOA, UserType,
     };
     use doublezero_serviceability::pda::get_user_old_pda;
@@ -399,5 +400,141 @@ mod tests {
             .execute(&ctx, &client, &mut output),
         );
         assert!(res.is_ok());
+    }
+
+    // A bare `--feed` code (not a pubkey) is resolved through `get_feed` with exchange
+    // None, and the resolved pubkey is passed as the trailing Feed account.
+    #[test]
+    fn test_cli_user_create_subscribe_with_feed_code() {
+        let mut client = create_test_client();
+
+        let (pda_pubkey, _bump_seed) = get_user_old_pda(&client.get_program_id(), 1);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 255,
+            reference_count: 0,
+            code: "device1".to_string(),
+            contributor_pk: Pubkey::default(),
+            location_pk: Pubkey::default(),
+            exchange_pk: Pubkey::default(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [10, 0, 0, 1].into(),
+            dz_prefixes: "10.0.0.1/24".parse().unwrap(),
+            owner: device_pubkey,
+            metrics_publisher_pk: Pubkey::default(),
+            status: DeviceStatus::Activated,
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: 0,
+            max_multicast_publishers: 0,
+            ..Default::default()
+        };
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_device()
+            .with(predicate::eq(GetDeviceCommand {
+                pubkey_or_code: "device1".to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((device_pubkey, device.clone())));
+
+        let mgroup_pubkey = Pubkey::new_unique();
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::default(),
+            index: 1,
+            bump_seed: 1,
+            tenant_pk: Pubkey::default(),
+            code: "mg1".to_string(),
+            multicast_ip: [239, 0, 0, 1].into(),
+            max_bandwidth: 1_000_000_000,
+            status: MulticastGroupStatus::Activated,
+            publisher_count: 0,
+            subscriber_count: 0,
+        };
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((mgroup_pubkey, mgroup.clone())));
+
+        // "shreds-nyc" is not a pubkey, so parse_pubkey returns None and the CLI resolves
+        // it through get_feed (exchange None), then passes the returned pubkey through.
+        let resolved_feed_pubkey = Pubkey::new_unique();
+        let feed = Feed {
+            account_type: AccountType::Feed,
+            owner: Pubkey::new_unique(),
+            bump_seed: 255,
+            code: "shreds-nyc".to_string(),
+            name: "Shreds NYC".to_string(),
+            exchange: Pubkey::new_unique(),
+            groups: vec![],
+        };
+        client
+            .expect_get_feed()
+            .with(predicate::eq(GetFeedCommand {
+                pubkey_or_code: "shreds-nyc".to_string(),
+                exchange: None,
+            }))
+            .times(1)
+            .returning(move |_| Ok((resolved_feed_pubkey, feed.clone())));
+
+        client
+            .expect_create_subscribe_user()
+            .with(predicate::eq(CreateSubscribeUserCommand {
+                user_type: UserType::Multicast,
+                device_pk: device_pubkey,
+                cyoa_type: UserCYOA::GREOverDIA,
+                client_ip: [100, 0, 0, 1].into(),
+                publisher: false,
+                subscriber: true,
+                mgroup_pk: mgroup_pubkey,
+                tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+                owner: None,
+                feed_pk: Some(resolved_feed_pubkey),
+            }))
+            .times(1)
+            .returning(move |_| Ok((signature, pda_pubkey)));
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            CreateSubscribeUserCliCommand {
+                device: "device1".to_string(),
+                client_ip: [100, 0, 0, 1].into(),
+                allocate_addr: false,
+                publisher: None,
+                subscriber: Some(mgroup_pubkey.to_string()),
+                wait: false,
+                owner: None,
+                feed: Some("shreds-nyc".to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok(), "{res:?}");
     }
 }

--- a/smartcontract/cli/src/user/create_subscribe.rs
+++ b/smartcontract/cli/src/user/create_subscribe.rs
@@ -9,6 +9,7 @@ use doublezero_cli_core::CliContext;
 use doublezero_sdk::{
     commands::{
         device::get::GetDeviceCommand,
+        feed::get::GetFeedCommand,
         multicastgroup::get::GetMulticastGroupCommand,
         user::{create_subscribe::CreateSubscribeUserCommand, get::GetUserCommand},
     },
@@ -39,6 +40,9 @@ pub struct CreateSubscribeUserCliCommand {
     /// Custom owner pubkey (foundation allowlist only)
     #[arg(long)]
     pub owner: Option<String>,
+    /// Feed pubkey or code for an EdgeSeat feed pass.
+    #[arg(long)]
+    pub feed: Option<String>,
 }
 
 impl CreateSubscribeUserCliCommand {
@@ -99,6 +103,22 @@ impl CreateSubscribeUserCliCommand {
             .map(|s| parse_pubkey(s).ok_or_else(|| eyre::eyre!("Invalid owner pubkey: {}", s)))
             .transpose()?;
 
+        let feed_pk = match self.feed {
+            None => None,
+            Some(feed) => match parse_pubkey(&feed) {
+                Some(pk) => Some(pk),
+                None => {
+                    let (pubkey, _) = client
+                        .get_feed(GetFeedCommand {
+                            pubkey_or_code: feed.clone(),
+                            exchange: None,
+                        })
+                        .map_err(|_| eyre::eyre!("Feed not found ({})", feed))?;
+                    Some(pubkey)
+                }
+            },
+        };
+
         let (signature, pubkey) = client.create_subscribe_user(CreateSubscribeUserCommand {
             user_type: UserType::Multicast,
             device_pk,
@@ -111,7 +131,7 @@ impl CreateSubscribeUserCliCommand {
                 .ok_or(eyre::eyre!("Subscriber is required if publisher is not"))?,
             tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
             owner: owner_pk,
-            feed_pk: None,
+            feed_pk,
         })?;
         writeln!(out, "Signature: {signature}",)?;
 
@@ -252,6 +272,7 @@ mod tests {
                 subscriber: Some(mgroup_pubkey.to_string()),
                 wait: false,
                 owner: None,
+                feed: None,
             }
             .execute(&ctx, &client, &mut output),
         );
@@ -260,5 +281,123 @@ mod tests {
         assert_eq!(
             output_str,"Signature: 3QnHBSdd4doEF6FgpLCejqEw42UQjfvNhQJwoYDSpoBszpCCqVft4cGoneDCnZ6Ez3ujzavzUu85u6F79WtLhcsv\n"
         );
+    }
+
+    // A pubkey `--feed` is passed straight through as the trailing Feed account for an
+    // EdgeSeat feed pass.
+    #[test]
+    fn test_cli_user_create_subscribe_with_feed_pubkey() {
+        let mut client = create_test_client();
+
+        let (pda_pubkey, _bump_seed) = get_user_old_pda(&client.get_program_id(), 1);
+        let signature = Signature::from([
+            120, 138, 162, 185, 59, 209, 241, 157, 71, 157, 74, 131, 4, 87, 54, 28, 38, 180, 222,
+            82, 64, 62, 61, 62, 22, 46, 17, 203, 187, 136, 62, 43, 11, 38, 235, 17, 239, 82, 240,
+            139, 130, 217, 227, 214, 9, 242, 141, 223, 94, 29, 184, 110, 62, 32, 87, 137, 63, 139,
+            100, 221, 20, 137, 4, 5,
+        ]);
+
+        let device_pubkey = Pubkey::new_unique();
+        let device = Device {
+            account_type: AccountType::Device,
+            index: 1,
+            bump_seed: 255,
+            reference_count: 0,
+            code: "device1".to_string(),
+            contributor_pk: Pubkey::default(),
+            location_pk: Pubkey::default(),
+            exchange_pk: Pubkey::default(),
+            device_type: DeviceType::Hybrid,
+            public_ip: [10, 0, 0, 1].into(),
+            dz_prefixes: "10.0.0.1/24".parse().unwrap(),
+            owner: device_pubkey,
+            metrics_publisher_pk: Pubkey::default(),
+            status: DeviceStatus::Activated,
+            mgmt_vrf: "default".to_string(),
+            interfaces: vec![],
+            max_users: 255,
+            users_count: 0,
+            device_health: doublezero_serviceability::state::device::DeviceHealth::ReadyForUsers,
+            desired_status:
+                doublezero_serviceability::state::device::DeviceDesiredStatus::Activated,
+            unicast_users_count: 0,
+            multicast_subscribers_count: 0,
+            max_unicast_users: 0,
+            max_multicast_subscribers: 0,
+            reserved_seats: 0,
+            multicast_publishers_count: 0,
+            max_multicast_publishers: 0,
+            ..Default::default()
+        };
+        client
+            .expect_check_requirements()
+            .with(predicate::eq(CHECK_ID_JSON | CHECK_BALANCE))
+            .returning(|_| Ok(()));
+        client
+            .expect_get_device()
+            .with(predicate::eq(GetDeviceCommand {
+                pubkey_or_code: "device1".to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((device_pubkey, device.clone())));
+
+        let mgroup_pubkey = Pubkey::new_unique();
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            owner: Pubkey::default(),
+            index: 1,
+            bump_seed: 1,
+            tenant_pk: Pubkey::default(),
+            code: "mg1".to_string(),
+            multicast_ip: [239, 0, 0, 1].into(),
+            max_bandwidth: 1_000_000_000,
+            status: MulticastGroupStatus::Activated,
+            publisher_count: 0,
+            subscriber_count: 0,
+        };
+        client
+            .expect_get_multicastgroup()
+            .with(predicate::eq(GetMulticastGroupCommand {
+                pubkey_or_code: mgroup_pubkey.to_string(),
+            }))
+            .times(1)
+            .returning(move |_| Ok((mgroup_pubkey, mgroup.clone())));
+
+        // A full-length pubkey (43-44 chars) so parse_pubkey takes the pubkey path
+        // and passes it straight through, without a get_feed registry lookup.
+        let feed_pubkey = Pubkey::from_str_const("7CTniUa88iJKUHTrCkB4TjAoG6TD7AMivhQeuqN2LPtX");
+        client
+            .expect_create_subscribe_user()
+            .with(predicate::eq(CreateSubscribeUserCommand {
+                user_type: UserType::Multicast,
+                device_pk: device_pubkey,
+                cyoa_type: UserCYOA::GREOverDIA,
+                client_ip: [100, 0, 0, 1].into(),
+                publisher: false,
+                subscriber: true,
+                mgroup_pk: mgroup_pubkey,
+                tunnel_endpoint: Ipv4Addr::UNSPECIFIED,
+                owner: None,
+                feed_pk: Some(feed_pubkey),
+            }))
+            .times(1)
+            .returning(move |_| Ok((signature, pda_pubkey)));
+
+        let mut output = Vec::new();
+        let ctx = cli_context_default_for_tests();
+        let res = block_on(
+            CreateSubscribeUserCliCommand {
+                device: "device1".to_string(),
+                client_ip: [100, 0, 0, 1].into(),
+                allocate_addr: false,
+                publisher: None,
+                subscriber: Some(mgroup_pubkey.to_string()),
+                wait: false,
+                owner: None,
+                feed: Some(feed_pubkey.to_string()),
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- `doublezero user create-subscribe` gains a `--feed` flag (a Feed pubkey, or an unambiguous feed code). It is passed through as the trailing `Feed` account of `CreateSubscribeUser`.
- Without it, connecting a Multicast user to an EdgeSeat *feed* pass fails: the feed metro gate requires the `Feed` account, but the CLI hardcoded `feed_pk = None`, so it returned `FeedAccountRequired` (custom error `0x5c`). The SDK `CreateSubscribeUserCommand` already appends the account when `feed_pk` is set, so this only wires up the CLI flag.

## Testing

- New unit test `test_cli_user_create_subscribe_with_feed_pubkey` asserts a pubkey `--feed` flows straight through to `CreateSubscribeUserCommand.feed_pk` (no registry lookup); the existing `test_cli_user_create_subscribe` is updated for the added field.
- `cargo test -p doublezero-serviceability-cli create_subscribe` passes.