### PR TITLE
serviceability: address review comments on dzf_locked set-flags

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/src/instructions.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/instructions.rs
@@ -1402,10 +1402,25 @@ mod tests {
             }),
             "SetAccessPassFeeds",
         );
+        // Each field is tri-state, so cover a mixed payload, both-Some, and all-None.
         test_instruction(
             DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
                 allow_multiple_ip: None,
                 dzf_locked: Some(true),
+            }),
+            "SetAccessPassFlags",
+        );
+        test_instruction(
+            DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+                allow_multiple_ip: Some(true),
+                dzf_locked: Some(false),
+            }),
+            "SetAccessPassFlags",
+        );
+        test_instruction(
+            DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+                allow_multiple_ip: None,
+                dzf_locked: None,
             }),
             "SetAccessPassFlags",
         );

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs
@@ -6,7 +6,7 @@ use crate::{
     seeds::{SEED_ACCESS_PASS, SEED_PREFIX},
     serializer::{try_acc_create, try_acc_write},
     state::{
-        accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP, DZF_LOCKED},
+        accesspass::{AccessPass, AccessPassStatus, AccessPassType, ALLOW_MULTIPLE_IP},
         accounttype::AccountType,
         globalstate::GlobalState,
         permission::permission_flags,
@@ -281,10 +281,11 @@ pub fn process_set_access_pass(
             _ => value.accesspass_type.clone(),
         };
         accesspass.last_access_epoch = value.last_access_epoch;
-        // `flags` here only carries ALLOW_MULTIPLE_IP. The DZF_LOCKED bit is managed solely by
-        // the `ACCESS_PASS_ADMIN`-gated SetAccessPassFlags instruction, so preserve any existing lock
-        // rather than clobbering it on an unrelated update.
-        accesspass.flags = (accesspass.flags & DZF_LOCKED) | flags;
+        // `flags` here only carries ALLOW_MULTIPLE_IP, the one bit this instruction owns. Clear
+        // just that bit and leave every other flag untouched, so bits managed elsewhere (DZF_LOCKED
+        // via the `ACCESS_PASS_ADMIN`-gated SetAccessPassFlags, and anything added later) survive
+        // an unrelated update automatically.
+        accesspass.flags = (accesspass.flags & !ALLOW_MULTIPLE_IP) | flags;
         accesspass.max_unicast_users = value.max_unicast_users;
         accesspass.max_multicast_users = value.max_multicast_users;
 

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -92,12 +92,15 @@ pub fn process_set_access_pass_flags(
 
     // Reject a no-op call rather than charging for a write that changes nothing. Runs after
     // authorize() so an unauthenticated caller gets NotAllowed rather than a payload diagnostic.
-    // Destructured rather than compared against a Default, so adding a flag field is a compile
-    // error here instead of a silently incomplete check.
+    //
+    // Destructured rather than compared against a Default so a future flag field cannot be
+    // silently omitted here: adding one is a hard error at this pattern (E0027), and forgetting to
+    // fold the new binding into the condition below is an unused-variable warning, which CI fails
+    // on under `-Dwarnings`.
     let SetAccessPassFlagsArgs {
         allow_multiple_ip,
         dzf_locked,
-    } = value;
+    } = *value;
     if allow_multiple_ip.is_none() && dzf_locked.is_none() {
         msg!("SetAccessPassFlags requires at least one flag to update");
         return Err(DoubleZeroError::InvalidArgument.into());
@@ -108,20 +111,29 @@ pub fn process_set_access_pass_flags(
     // Mirror the sibling accesspass handlers: the feed authority may only touch passes it owns.
     // This is what stops the oracle (which holds ACCESS_PASS_ADMIN) from clearing dzf_locked on a
     // pass it did not create.
+    //
+    // DEPENDENCY: this holds only while the oracle's key lives in the legacy
+    // `globalstate.feed_authority_pk`. Once the oracle authorizes purely via a Permission account
+    // granting ACCESS_PASS_ADMIN and this legacy field is cleared or reassigned, the condition is
+    // never true and the guard silently no-ops — losing exactly the property dzf_locked exists to
+    // guarantee. The durable fix is to fence *any* non-foundation/sentinel ACCESS_PASS_ADMIN caller
+    // to passes it owns, which belongs with the feed-authority -> Permission migration because the
+    // same guard is duplicated in accesspass/set.rs and accesspass/close.rs. Revisit all three
+    // together at that point.
     if globalstate.feed_authority_pk == *payer_account.key && accesspass.owner != *payer_account.key
     {
         msg!("Feed authority can only modify access passes they own");
         return Err(DoubleZeroError::NotAllowed.into());
     }
 
-    if let Some(allow_multiple_ip) = *allow_multiple_ip {
+    if let Some(allow_multiple_ip) = allow_multiple_ip {
         if allow_multiple_ip {
             accesspass.flags |= ALLOW_MULTIPLE_IP;
         } else {
             accesspass.flags &= !ALLOW_MULTIPLE_IP;
         }
     }
-    if let Some(dzf_locked) = *dzf_locked {
+    if let Some(dzf_locked) = dzf_locked {
         if dzf_locked {
             accesspass.flags |= DZF_LOCKED;
         } else {

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -119,7 +119,7 @@ pub fn process_set_access_pass_flags(
     // guarantee. The durable fix is to fence *any* non-foundation/sentinel ACCESS_PASS_ADMIN caller
     // to passes it owns, which belongs with the feed-authority -> Permission migration because the
     // same guard is duplicated in accesspass/set.rs and accesspass/close.rs. Revisit all three
-    // together at that point.
+    // together at that point. Tracked in #4092.
     if globalstate.feed_authority_pk == *payer_account.key && accesspass.owner != *payer_account.key
     {
         msg!("Feed authority can only modify access passes they own");

--- a/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
+++ b/smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs
@@ -23,7 +23,11 @@ use solana_program::{
 /// is just another `Option<bool>` field.
 ///
 /// Gated on `ACCESS_PASS_ADMIN` (like the sibling SetAccessPass path).
-#[derive(BorshSerialize, BorshDeserializeIncremental, Debug, PartialEq, Clone, Default)]
+///
+/// Deliberately does not derive `Default`: `default()` would be the all-`None` payload this
+/// instruction rejects, and a `..Default::default()` construction site would silently swallow a
+/// future flag field instead of failing to compile.
+#[derive(BorshSerialize, BorshDeserializeIncremental, Debug, PartialEq, Clone)]
 pub struct SetAccessPassFlagsArgs {
     pub allow_multiple_ip: Option<bool>,
     pub dzf_locked: Option<bool>,
@@ -38,6 +42,12 @@ pub fn process_set_access_pass_flags(
 
     // Account layout: [accesspass, globalstate, payer, system, (permission)] — matches the sibling
     // accesspass handlers, with authorize() consuming the trailing Permission account.
+    //
+    // Unlike set.rs / set_feeds.rs there is intentionally no PDA re-derivation of the accesspass
+    // account: the args deliberately carry no client_ip / user_payer seeds. The account is still
+    // fully validated below (program-owned + AccessPass discriminator via try_from), and an
+    // ACCESS_PASS_ADMIN caller may already target any pass, so threading the seeds back into the
+    // args would only add redundant instruction arguments. Don't "fix" this by re-adding them.
     let accesspass_account = next_account_info(accounts_iter)?;
     let globalstate_account = next_account_info(accounts_iter)?;
     let payer_account = next_account_info(accounts_iter)?;
@@ -69,12 +79,6 @@ pub fn process_set_access_pass_flags(
         "AccessPass Account is not writable"
     );
 
-    // Reject a no-op call rather than charging for a write that changes nothing.
-    if value.allow_multiple_ip.is_none() && value.dzf_locked.is_none() {
-        msg!("SetAccessPassFlags requires at least one flag to update");
-        return Err(DoubleZeroError::InvalidArgument.into());
-    }
-
     // All flag changes gate on ACCESS_PASS_ADMIN (Permission PDA or legacy fallback: foundation
     // allowlist, sentinel, or feed authority), matching the sibling SetAccessPass path.
     let globalstate = GlobalState::try_from(globalstate_account)?;
@@ -85,6 +89,19 @@ pub fn process_set_access_pass_flags(
         &globalstate,
         permission_flags::ACCESS_PASS_ADMIN,
     )?;
+
+    // Reject a no-op call rather than charging for a write that changes nothing. Runs after
+    // authorize() so an unauthenticated caller gets NotAllowed rather than a payload diagnostic.
+    // Destructured rather than compared against a Default, so adding a flag field is a compile
+    // error here instead of a silently incomplete check.
+    let SetAccessPassFlagsArgs {
+        allow_multiple_ip,
+        dzf_locked,
+    } = value;
+    if allow_multiple_ip.is_none() && dzf_locked.is_none() {
+        msg!("SetAccessPassFlags requires at least one flag to update");
+        return Err(DoubleZeroError::InvalidArgument.into());
+    }
 
     let mut accesspass = AccessPass::try_from(accesspass_account)?;
 
@@ -97,14 +114,14 @@ pub fn process_set_access_pass_flags(
         return Err(DoubleZeroError::NotAllowed.into());
     }
 
-    if let Some(allow_multiple_ip) = value.allow_multiple_ip {
+    if let Some(allow_multiple_ip) = *allow_multiple_ip {
         if allow_multiple_ip {
             accesspass.flags |= ALLOW_MULTIPLE_IP;
         } else {
             accesspass.flags &= !ALLOW_MULTIPLE_IP;
         }
     }
-    if let Some(dzf_locked) = value.dzf_locked {
+    if let Some(dzf_locked) = *dzf_locked {
         if dzf_locked {
             accesspass.flags |= DZF_LOCKED;
         } else {
@@ -117,4 +134,73 @@ pub fn process_set_access_pass_flags(
     msg!("Set access pass flags: [{}]", accesspass.flags_string());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each `Option<bool>` is a 1-byte tag plus 1 byte of payload when `Some`, so the tri-state
+    /// encoding is 1 byte per `None` field and 2 per `Some` field.
+    #[test]
+    fn test_set_access_pass_flags_args_wire_format() {
+        let cases: [(SetAccessPassFlagsArgs, &[u8]); 4] = [
+            (
+                SetAccessPassFlagsArgs {
+                    allow_multiple_ip: None,
+                    dzf_locked: None,
+                },
+                &[0, 0],
+            ),
+            (
+                SetAccessPassFlagsArgs {
+                    allow_multiple_ip: None,
+                    dzf_locked: Some(true),
+                },
+                &[0, 1, 1],
+            ),
+            (
+                SetAccessPassFlagsArgs {
+                    allow_multiple_ip: Some(true),
+                    dzf_locked: Some(false),
+                },
+                &[1, 1, 1, 0],
+            ),
+            (
+                SetAccessPassFlagsArgs {
+                    allow_multiple_ip: Some(false),
+                    dzf_locked: Some(true),
+                },
+                &[1, 0, 1, 1],
+            ),
+        ];
+
+        for (args, expected) in cases {
+            let payload = borsh::to_vec(&args).unwrap();
+            assert_eq!(payload, expected, "encoding of {args:?}");
+            assert_eq!(
+                SetAccessPassFlagsArgs::try_from(&payload[..]).unwrap(),
+                args,
+                "round-trip of {args:?}"
+            );
+        }
+    }
+
+    /// `BorshDeserializeIncremental` must accept a payload from a sender that predates a later
+    /// field and default the missing tail to `None`. A truncated payload therefore can never
+    /// accidentally set a flag: at worst it decodes to the all-`None` payload the processor
+    /// rejects with `InvalidArgument`.
+    #[test]
+    fn test_set_access_pass_flags_args_incremental_decode_truncated_payload() {
+        // Only the first field on the wire: allow_multiple_ip = Some(false).
+        let old_payload = [1u8, 0];
+        let args = SetAccessPassFlagsArgs::try_from(&old_payload[..]).unwrap();
+        assert_eq!(args.allow_multiple_ip, Some(false));
+        assert_eq!(args.dzf_locked, None, "missing tail defaults to None");
+
+        // An empty payload defaults every field to None.
+        let args = SetAccessPassFlagsArgs::try_from(&[][..]).unwrap();
+        assert_eq!(args.allow_multiple_ip, None);
+        assert_eq!(args.dzf_locked, None);
+    }
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
@@ -473,6 +473,13 @@ async fn test_accesspass_dzf_locked_requires_permission_account_in_strict_mode()
     .await;
 
     // Grant path: the Permission PDA is appended as the trailing account authorize() reads.
+    //
+    // Note that `pass_admin` is not the feed authority, so the ownership guard in
+    // `process_set_access_pass_flags` never fires and this succeeds against a pass owned by
+    // `payer`. That is correct today — an ACCESS_PASS_ADMIN holder may target any pass — but it is
+    // also the exact shape the oracle takes after the feed-authority -> Permission migration. When
+    // that migration lands, revisit this assertion together with the DEPENDENCY comment on that
+    // guard: what reads as an expected success here would then be the regression.
     execute_transaction_with_extra_accounts(
         &mut banks_client,
         recent_blockhash,

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
@@ -1,15 +1,22 @@
 use doublezero_serviceability::{
     instructions::*,
     pda::*,
-    processors::accesspass::{set::SetAccessPassArgs, set_flags::SetAccessPassFlagsArgs},
+    processors::{
+        accesspass::{set::SetAccessPassArgs, set_flags::SetAccessPassFlagsArgs},
+        globalstate::{setauthority::SetAuthorityArgs, setfeatureflags::SetFeatureFlagsArgs},
+        permission::create::PermissionCreateArgs,
+    },
     state::{
         accesspass::{AccessPassType, ALLOW_MULTIPLE_IP, DZF_LOCKED},
         accounttype::AccountType,
+        feature_flags::FeatureFlag,
+        permission::permission_flags,
     },
 };
 use solana_program_test::*;
 use solana_sdk::{
     instruction::{AccountMeta, InstructionError},
+    pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
     transaction::TransactionError,
@@ -224,4 +231,302 @@ async fn test_accesspass_dzf_locked() {
         .get_accesspass()
         .unwrap();
     assert!(!ap.dzf_locked());
+}
+
+/// Pins the feed-authority ownership guard in `process_set_access_pass_flags`. The feed authority
+/// holds `ACCESS_PASS_ADMIN`, so `authorize()` alone lets it through; only the follow-up
+/// `owner != payer` check stops it from clearing `dzf_locked` on a pass it did not create. The
+/// negative case is paired with a positive control on a pass the feed authority *does* own, so a
+/// regression that broke `authorize()` outright could not masquerade as the guard firing.
+#[tokio::test]
+async fn test_accesspass_dzf_locked_feed_authority_limited_to_own_passes() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Promote a fresh keypair to feed authority. It is deliberately not in foundation_allowlist,
+    // so feed_authority_pk is the only thing granting it ACCESS_PASS_ADMIN.
+    let feed = Keypair::new();
+    transfer(&mut banks_client, &payer, &feed.pubkey(), 10_000_000_000).await;
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAuthority(SetAuthorityArgs {
+            feed_authority_pk: Some(feed.pubkey()),
+            ..Default::default()
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // A pass created by the foundation payer, so `owner == payer` and the feed authority is not
+    // its owner.
+    let foundation_ip = Ipv4Addr::new(100, 0, 0, 10);
+    let (foundation_pass, _) = get_accesspass_pda(&program_id, &foundation_ip, &payer.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: foundation_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(foundation_pass, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // The feed authority passes ACCESS_PASS_ADMIN but does not own this pass, so the ownership
+    // guard rejects it.
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }),
+        vec![
+            AccountMeta::new(foundation_pass, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &feed,
+    )
+    .await;
+    assert_custom_error(
+        result,
+        CODE_NOT_ALLOWED,
+        "feed authority setting dzf_locked on a pass it does not own",
+    );
+
+    let ap = get_account_data(&mut banks_client, foundation_pass)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(ap.owner, payer.pubkey());
+    assert!(
+        !ap.dzf_locked(),
+        "rejected attempt must not have set the bit"
+    );
+
+    // Positive control: the same signer on a pass it does own succeeds, proving the rejection
+    // above came from the ownership guard and not from authorize().
+    let feed_ip = Ipv4Addr::new(100, 0, 0, 11);
+    let feed_user_payer = Pubkey::new_unique();
+    let (feed_pass, _) = get_accesspass_pda(&program_id, &feed_ip, &feed_user_payer);
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip: feed_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(feed_pass, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(feed_user_payer, false),
+        ],
+        &feed,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }),
+        vec![
+            AccountMeta::new(feed_pass, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &feed,
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, feed_pass)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert_eq!(ap.owner, feed.pubkey());
+    assert!(ap.dzf_locked());
+}
+
+/// Proves the Permission grant path for `SetAccessPassFlags` under
+/// `FeatureFlag::RequirePermissionAccounts`: a non-foundation holder of an `ACCESS_PASS_ADMIN`
+/// Permission account may set `dzf_locked`, and the same signer is denied once the trailing
+/// Permission account is omitted (strict mode disables the legacy allowlist fallback).
+#[tokio::test]
+async fn test_accesspass_dzf_locked_requires_permission_account_in_strict_mode() {
+    let (mut banks_client, program_id, payer, recent_blockhash) = init_test().await;
+
+    let (program_config_pubkey, _) = get_program_config_pda(&program_id);
+    let (globalstate_pubkey, _) = get_globalstate_pda(&program_id);
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::InitGlobalState(),
+        vec![
+            AccountMeta::new(program_config_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Create the pass while the legacy path still works; strict mode is enabled afterwards.
+    let client_ip = Ipv4Addr::new(100, 0, 0, 20);
+    let (accesspass_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPass(SetAccessPassArgs {
+            accesspass_type: AccessPassType::Prepaid,
+            client_ip,
+            last_access_epoch: 9999,
+            allow_multiple_ip: false,
+            max_unicast_users: 1,
+            max_multicast_users: 1,
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new(globalstate_pubkey, false),
+            AccountMeta::new(payer.pubkey(), false),
+        ],
+        &payer,
+    )
+    .await;
+
+    // Foundation grants ACCESS_PASS_ADMIN to a keypair that is in no allowlist and is not the
+    // feed/sentinel authority, so the Permission account is its only route to authorization.
+    let pass_admin = Keypair::new();
+    transfer(
+        &mut banks_client,
+        &payer,
+        &pass_admin.pubkey(),
+        10_000_000_000,
+    )
+    .await;
+    let (permission_pda, _) = get_permission_pda(&program_id, &pass_admin.pubkey());
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::CreatePermission(PermissionCreateArgs {
+            user_payer: pass_admin.pubkey(),
+            permissions: permission_flags::ACCESS_PASS_ADMIN,
+        }),
+        vec![
+            AccountMeta::new(permission_pda, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &payer,
+    )
+    .await;
+
+    execute_transaction(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetFeatureFlags(SetFeatureFlagsArgs {
+            feature_flags: FeatureFlag::RequirePermissionAccounts.to_mask(),
+        }),
+        vec![AccountMeta::new(globalstate_pubkey, false)],
+        &payer,
+    )
+    .await;
+
+    // Grant path: the Permission PDA is appended as the trailing account authorize() reads.
+    execute_transaction_with_extra_accounts(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(true),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &pass_admin,
+        &[AccountMeta::new_readonly(permission_pda, false)],
+    )
+    .await;
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(ap.dzf_locked());
+
+    // Same signer, no Permission account: strict mode disables the legacy fallback, so this is
+    // denied even though the grant exists on-chain.
+    let result = execute_transaction_expect_failure(
+        &mut banks_client,
+        recent_blockhash,
+        program_id,
+        DoubleZeroInstruction::SetAccessPassFlags(SetAccessPassFlagsArgs {
+            allow_multiple_ip: None,
+            dzf_locked: Some(false),
+        }),
+        vec![
+            AccountMeta::new(accesspass_pubkey, false),
+            AccountMeta::new_readonly(globalstate_pubkey, false),
+        ],
+        &pass_admin,
+    )
+    .await;
+    assert_custom_error(
+        result,
+        CODE_NOT_ALLOWED,
+        "strict mode without a Permission account",
+    );
+
+    let ap = get_account_data(&mut banks_client, accesspass_pubkey)
+        .await
+        .expect("access pass")
+        .get_accesspass()
+        .unwrap();
+    assert!(
+        ap.dzf_locked(),
+        "denied attempt must not have cleared the bit"
+    );
 }

--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs
@@ -479,7 +479,7 @@ async fn test_accesspass_dzf_locked_requires_permission_account_in_strict_mode()
     // `payer`. That is correct today — an ACCESS_PASS_ADMIN holder may target any pass — but it is
     // also the exact shape the oracle takes after the feed-authority -> Permission migration. When
     // that migration lands, revisit this assertion together with the DEPENDENCY comment on that
-    // guard: what reads as an expected success here would then be the regression.
+    // guard: what reads as an expected success here would then be the regression. Tracked in #4092.
     execute_transaction_with_extra_accounts(
         &mut banks_client,
         recent_blockhash,


### PR DESCRIPTION
## Summary of Changes

- `SetAccessPass` now clears only the bit it owns (`ALLOW_MULTIPLE_IP`) rather than whitelisting `DZF_LOCKED` for preservation, so any flag managed by another instruction survives an unrelated pass update automatically instead of needing the mask extended by hand.
- The feed-authority ownership guard in `SetAccessPassFlags` — the check that stops an `ACCESS_PASS_ADMIN` holder from touching a pass it does not own — is now covered by tests, paired with a positive control on a pass it does own so a broken `authorize()` cannot masquerade as the guard firing.
- `SetAccessPassFlags` rejects an all-`None` payload only after `authorize()`, so an unauthorized caller gets `NotAllowed` rather than a diagnostic about the payload.
- `SetAccessPassFlagsArgs` no longer derives `Default` (its `default()` was exactly the payload the processor rejects), and the no-op check destructures the args so adding a flag field is a compile error instead of a silently incomplete check.
- The tri-state wire format is pinned: both-`Some` and all-`None` round-trips, plus incremental decoding of a truncated payload from a sender predating a later field.
- Records that the absent accesspass PDA re-derivation in `set_flags.rs` is intentional, since the args deliberately carry no `client_ip` / `user_payer` seeds.

Follow-up to #4083, which merged before the review landed. Juan's note on the `feed_authority_pk` guard becoming a no-op after the feed-authority → Permission migration is intentionally **not** addressed here: the same guard is copy-pasted in `accesspass/set.rs` and `accesspass/close.rs`, so it belongs with that migration rather than in this PR. The new test pins the guard's current behavior so the change is visible when it happens.

## Diff Breakdown

| Category    | Files | Lines (+/-)  | Net   |
|-------------|-------|--------------|-------|
| Core logic  |     2 | +32 / -14    |   +18 |
| Tests       |     3 | +390 / -1    |  +389 |
| **Total**   |     4 | +422 / -15   |  +407 |

Almost entirely test coverage over a small behavioral core: one mask change and one reordering. (`set_flags.rs` appears in both rows — its processor changes are core logic, its new `mod tests` is tests.)

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/tests/accesspass_dzf_locked.rs` — two new integration tests: the feed authority denied on a pass it does not own (with a positive control on one it owns), and the Permission grant path under `RequirePermissionAccounts` proving success with the Permission account appended and `NotAllowed` without it.
- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set_flags.rs` — dropped `Default`, destructured no-op check moved below `authorize()`, intentional-no-PDA-check comment, and unit tests for the tri-state encoding and incremental truncation.
- `smartcontract/programs/doublezero-serviceability/src/instructions.rs` — pack/unpack round-trip extended to both-`Some` and all-`None` payloads.
- `smartcontract/programs/doublezero-serviceability/src/processors/accesspass/set.rs` — `flags` mask flipped from whitelist-what-to-keep to clear-only-what-this-instruction-owns.

</details>

## Testing Verification

- Verified the new feed-authority test is a real assertion: temporarily removing the ownership guard makes it fail with `expected Custom(8), got Ok(())`.
- Verified the mask flip is actually future-proof, not just cosmetic: temporarily relocated `DZF_LOCKED` to bit 2 (simulating a third flag) and confirmed it survives an unrelated `SetAccessPass` under the new mask, and is clobbered under the old whitelist mask.
- Confirmed the mask change is behavior-preserving today — the pre-existing "`DZF_LOCKED` must survive an unrelated set" assertion passes unchanged.
- `make rust-lint` and `make rust-test` pass (full serviceability suite, including the 16 existing `accesspass_test` cases).
