### PR TITLE
serviceability: fix two program-test flakes from duplicate transaction signatures

### DIFF
--- a/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs
@@ -2024,6 +2024,14 @@ async fn test_set_accesspass_refills_depleted_user_payer() {
     );
 
     // Second SetAccessPass with identical params: the refill restores the target balance.
+    //
+    // The wait is load-bearing. This call has the same instruction, accounts and payer as the
+    // first one, and `execute_transaction` signs with whatever `get_latest_blockhash` returns
+    // (it ignores the blockhash argument). On an unchanged blockhash the two transactions are
+    // byte-identical, so this one hits the bank's status cache and returns the first one's
+    // cached success without ever executing — no refill happens and the assertion below fails.
+    wait_for_new_blockhash(&mut banks_client).await;
+
     execute_transaction(
         &mut banks_client,
         recent_blockhash,

--- a/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
+++ b/smartcontract/programs/doublezero-serviceability/tests/topology_test.rs
@@ -560,7 +560,12 @@ async fn delete_topology(
     payer: &Keypair,
 ) -> Result<(), BanksClientError> {
     let (topology_pda, _) = get_topology_pda(&program_id, name);
-    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    // Must be a *new* blockhash, not merely the latest. Tests delete the same topology
+    // twice — once expecting `ReferenceCountNotZero`, then again after clearing the
+    // reference — and both transactions carry the same instruction, accounts and payer.
+    // On the same blockhash they are byte-identical, so the second one hits the bank's
+    // status cache and returns the first one's cached failure without ever executing.
+    let recent_blockhash = wait_for_new_blockhash(banks_client).await;
     let base_accounts = vec![
         AccountMeta::new(topology_pda, false),
         AccountMeta::new_readonly(globalstate_pubkey, false),


### PR DESCRIPTION
## Summary of Changes

- Fixes two flaky `solana-program-test` tests that share one root cause. A test that performs the same operation twice builds a byte-identical transaction — same instruction, same accounts, same payer — whenever the blockhash has not rolled over between the two calls. The second submission then hits the bank's status cache and returns the **first** attempt's result without ever executing. Whether that happens is a timing race against program-test's background slot-advance thread, which is where the nondeterminism comes from.
- `test_topology_reference_count_lifecycle` (~25% failure rate) deletes a topology expecting `ReferenceCountNotZero`, then deletes it again after clearing the reference. The cached result is a *failure*, so the second delete reported `Custom(13)` against a topology whose `reference_count` had genuinely reached 0.
- `test_set_accesspass_refills_depleted_user_payer` (47% failure rate) sets an access pass, drains the `user_payer`, then sets the same pass again to refill it. Here the cached result is a *success*: `execute_transaction` unwrapped happily and the refill silently never happened, so only the balance assertion caught it.

Both are test bugs. The program is correct — this is Solana's replay protection behaving as designed.

### Why it was hard to see

`test_topology_reference_count_lifecycle` failed at `.expect("delete should succeed after clear")` immediately after an assertion had read `reference_count == 0`, which reads like a state-visibility problem. It is not: the account reads 0 before *and* after the failed delete at the same root slot, and retrying fails identically because the retry reuses the same blockhash and so reproduces the same signature. That persistence is what ruled out a fork/commitment race and pointed at the status cache.

Confirmed by signature rather than inference. Failing run:

```
delete_topology name=topo-a blockhash=5n9wuAW… sig=2RGaXGkA…   ← 1st, legitimately fails
pre-delete refcount=0
delete_topology name=topo-a blockhash=5n9wuAW… sig=2RGaXGkA…   ← 2nd, identical signature
delete failed: Custom(13)
```

Every passing run produced two different signatures.

## Diff Breakdown

| Category | Files | Lines (+/-) | Net |
|----------|-------|-------------|-----|
| Tests    |     2 | +14 / -1    | +13 |

Test-only. Each site gains a `wait_for_new_blockhash` call and a comment explaining why it is load-bearing, so it does not get optimised away later as a redundant sleep.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/programs/doublezero-serviceability/tests/topology_test.rs` — `delete_topology` waits for a genuinely new blockhash instead of taking whatever `get_latest_blockhash` returns
- `smartcontract/programs/doublezero-serviceability/tests/accesspass_test.rs` — wait before the second `SetAccessPass`; note `execute_transaction` ignores its blockhash argument and signs with `get_latest_blockhash`, so the wait has to happen at the call site

</details>

## Testing Verification

Two independent sweeps, rather than grepping for the pattern and guessing:

- **Failure sweep** — 15 full runs of the serviceability suite (49 binaries, ~490 tests), tallying every test that failed at least once. Exactly the two tests above, nothing else. `test_topology_reference_count_lifecycle` failed 0/15 after its fix; before it, 2/8 on unmodified `main`.
- **Duplicate-detector sweep** — temporarily instrumented all six transaction-submission paths in `test_helpers.rs` to flag any transaction whose signature the bank had already seen, then 6 more full runs: **0 duplicates, 0 failures.** This is the check for the silent case — a duplicate that returns a cached *success* and leaves no failing assertion behind. `execute_transaction_tester` was deliberately excluded; it builds a fresh `Pubkey::new_unique()` payer per call, so its transactions cannot collide.
- Verified each fix individually: `topology_test` 12/12 green (was ~75%), and `test_set_accesspass_refills_depleted_user_payer` green.

Known residual: the detector covered `test_helpers.rs` only. Sixteen direct `banks_client.process_transaction` calls live in eight test files (topology 5, link_onchain_allocation 4, feed_metro_gate 2, and five with one each). Those are covered by the failure sweep for flakiness, but a false-green on one of them would be invisible to both sweeps. Extending the detector there is worthwhile follow-up if we want this airtight.

Cost: `topology_test` goes from ~0.6s to ~0.95s, from the 100ms poll interval inside `wait_for_new_blockhash`.
