### PR TITLE
docs: add geolocation architecture to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,12 @@ DoubleZero is a protocol for building and operating high-performance, permission
 
 **Serialization:** Borsh for onchain accounts, Protobuf for gRPC (controller↔agent), JSON for APIs.
 
+## Geolocation Architecture
+
+- **telemetry-agent** runs on DZDs (Arista devices). It measures geoprobes via TWAMP and sends them location offsets. DZDs are the roots of trust with known coordinates.
+- **geoprobe-agent** runs on geoprobe servers (Ubuntu bare metal or VPS), NOT on DZDs. It receives TWAMP probes from DZDs, caches their location offsets, and measures outbound targets. It currently requires no special privileges (all UDP, unprivileged ports).
+- These are two separate binaries with opposite roles. Never conflate them: DZDs measure geoprobes; geoprobes measure targets.
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
Adds a Geolocation Architecture section to CLAUDE.md documenting the telemetry-agent / geoprobe-agent split, which is easy to get backwards.

- telemetry-agent runs on DZDs (Arista devices) and measures geoprobes via TWAMP; DZDs are the roots of trust with known coordinates.
- geoprobe-agent runs on geoprobe servers (not DZDs), caches DZD location offsets, and measures outbound targets.

The two binaries have opposite roles — DZDs measure geoprobes; geoprobes measure targets — and nothing in the repo's guidance captures that today, so it's a recurring source of confusion when working on geolocation.

Docs only; no code or tests affected.