### PR TITLE
ci: pin the shreds feed-expiry e2e test to its own shard

### DIFF
--- a/.github/workflows/shreds-e2e.yml
+++ b/.github/workflows/shreds-e2e.yml
@@ -55,9 +55,9 @@ jobs:
         uses: actions/github-script@v7
         env:
           CHECK_NAME: shard-e2e
-          # 2 pinned shards + 2 round-robin shards; must match the required
+          # 3 pinned shards + 2 round-robin shards; must match the required
           # status check contexts in the main ruleset.
-          CHECK_SHARDS: "4"
+          CHECK_SHARDS: "5"
         with:
           script: |
             try {
@@ -192,24 +192,28 @@ jobs:
           echo "Discovered $count tests"
           echo "$tests"
 
-          # Pinned heavy tests: each gets its own shard slot to keep the two
+          # Pinned heavy tests: each gets its own shard slot to keep the
           # biggest rocks off the same runner. Update this list if a new test
           # exceeds ~5min, or if a pinned test is renamed/removed upstream
           # (the validation below will fail fast in that case).
           pinned_1="TestE2E_MultiUserInstantAllocationAndWithdrawal"
           pinned_2="TestE2E_DeviceScale"
+          # ~9min, over half of it a single 40-day ledger warp (three validator
+          # restart hops). On a round-robin shard it only passed when Go's
+          # parallel scheduler happened to start it early.
+          pinned_3="TestE2E_FeedSubscriptionOracleExpiryTeardown"
 
           # Fail fast if a pinned test no longer exists in the shreds repo —
           # otherwise its shard would silently run zero tests.
-          for pin in "$pinned_1" "$pinned_2"; do
+          for pin in "$pinned_1" "$pinned_2" "$pinned_3"; do
             if ! echo "$tests" | grep -qxF "$pin"; then
               echo "::error::Pinned test '$pin' not found in doublezero-shreds. Update the pin list in this workflow."
               exit 1
             fi
           done
 
-          # Remaining tests round-robin across shards 3 and 4.
-          remaining=$(echo "$tests" | grep -vE "^(${pinned_1}|${pinned_2})$")
+          # Remaining tests round-robin across shards 4 and 5.
+          remaining=$(echo "$tests" | grep -vE "^(${pinned_1}|${pinned_2}|${pinned_3})$")
 
           ROUND_ROBIN_SHARDS=2
           declare -a shards
@@ -225,11 +229,12 @@ jobs:
             i=$((i + 1))
           done <<< "$remaining"
 
-          # Build JSON matrix: shards 1-2 are pinned, shards 3-4 are round-robin.
+          # Build JSON matrix: shards 1-3 are pinned, shards 4-5 are round-robin.
           matrix="[{\"shard\":1,\"run\":\"^(${pinned_1})$\"}"
           matrix="${matrix},{\"shard\":2,\"run\":\"^(${pinned_2})$\"}"
+          matrix="${matrix},{\"shard\":3,\"run\":\"^(${pinned_3})$\"}"
           for ((i=0; i<ROUND_ROBIN_SHARDS; i++)); do
-            matrix="${matrix},{\"shard\":$((i + 3)),\"run\":\"^(${shards[i]})$\"}"
+            matrix="${matrix},{\"shard\":$((i + 4)),\"run\":\"^(${shards[i]})$\"}"
           done
           matrix="${matrix}]"
 


### PR DESCRIPTION
## Summary of Changes

- `TestE2E_FeedSubscriptionOracleExpiryTeardown` takes ~8m50s, of which 7m13s is a single 40-day ledger warp (three validator restart hops with status-cache soaks between them). On a round-robin shard it shared a 4-way-parallel runner with 16 other tests, so it started only when Go's parallel semaphore got to it — 4m54s and 4m09s into the two attempts of run [30465159406](https://github.com/malbeclabs/doublezero/actions/runs/30465159406), both of which then died with `panic: test timed out after 12m0s` mid-warp. The warp is not the variable part (432.9s pinned vs 434.9s contended); the queue wait was.
- Pin it as `pinned_3`, which is what the pin list's own rule prescribes ("update this list if a new test exceeds ~5min"), and bump the shard count 4 → 5. Round-robin moves to shards 4 and 5; shards 1-3 each run one heavy test.

**Ruleset follow-up:** `shard-e2e (shard 5)` is a new check and needs adding to the main ruleset's required contexts. Shards 1-4 keep their names, so the existing required checks stay satisfied — but until shard 5 is added, a failure there will not block a merge.

## Diff Breakdown

| Category     | Files | Lines (+/-) | Net |
|--------------|-------|-------------|-----|
| Config/build |     1 | +13 / -8    |  +5 |

Workflow-only change; no product code touched.

## Testing Verification

- Run [30543782098](https://github.com/malbeclabs/doublezero/actions/runs/30543782098), all five shards green. Pinned shard 3 ran the test alone in 532.2s against `-timeout=12m` — 3m08s of headroom — with a 10m40s job wall against `timeout-minutes: 15`, so the package timeout is the binding constraint (67s of job overhead precedes `go test`). Shards 4 and 5 came in at 8m42s and 8m01s job wall with 17 and 16 tests.
- Checked the sharding block against `doublezero-shreds` at head before pushing: 36 tests discovered, shards 1-3 pinned one test each, remaining 33 split 17/16, and the pin-existence guard passes for all three pins.
