### PR TITLE
telemetry: keep known peers when a discovery refresh fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - Telemetry
   - A ledger RPC outage no longer stops TWAMP probing on the device telemetry agent: the pinger caches the last known epoch and refreshes it off the probe path, instead of fetching it inline and skipping the tick on failure. Probing stops only when no epoch has ever been fetched or the cached one exceeds the new `-max-epoch-staleness` (default 12h). (#4143)
+- Device telemetry
+  - A peer discovery refresh that fails after reading the ledger no longer wipes the agent's peer list. It cleared the cache before calling `LocalNet.Interfaces()`, so a transient failure there left the pinger iterating zero peers and probing nothing until a later refresh succeeded. The cache is now replaced only once the new list is built, which also shortens the critical section to the assignment. (#4146)
 
 ## [v0.33.0](https://github.com/malbeclabs/doublezero/compare/client/v0.32.0...client/v0.33.0) - 2026-07-31
 

--- a/controlplane/telemetry/internal/telemetry/peers.go
+++ b/controlplane/telemetry/internal/telemetry/peers.go
@@ -121,11 +121,9 @@ func (p *ledgerPeerDiscovery) refresh(ctx context.Context) error {
 		return fmt.Errorf("failed to load program from ledger: %w", err)
 	}
 
-	p.peersMu.Lock()
-	defer p.peersMu.Unlock()
-
-	p.peers = make([]*Peer, 0, len(p.peers))
-
+	// The cache is left in place while the new peer list is built, and replaced only once the build
+	// has succeeded. Nothing below this point may clear it: a refresh that fails partway must leave
+	// the agent probing the peers it already knows about rather than none at all.
 	devices := make(map[string]serviceability.Device)
 	for _, device := range data.Devices {
 		pubkey := solana.PublicKeyFromBytes(device.PubKey[:])
@@ -206,7 +204,10 @@ func (p *ledgerPeerDiscovery) refresh(ctx context.Context) error {
 		})
 	}
 
+	p.peersMu.Lock()
 	p.peers = peers
+	p.peersMu.Unlock()
+
 	p.log.Debug("Refreshed peers", "devices", len(devices), "links", len(links), "peers", len(peers), "tunnelsNotFound", tunnelsNotFound)
 
 	// Record the number of tunnels not found.

--- a/controlplane/telemetry/internal/telemetry/peers_test.go
+++ b/controlplane/telemetry/internal/telemetry/peers_test.go
@@ -2,9 +2,11 @@ package telemetry_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -616,6 +618,83 @@ func TestAgentTelemetry_PeerDiscovery_Ledger(t *testing.T) {
 		cfg = valid
 		cfg.RefreshInterval = 0
 		base(cfg, "zero refresh interval")
+	})
+
+	t.Run("keeps known peers when getting local interfaces fails", func(t *testing.T) {
+		t.Parallel()
+
+		log := log.With("test", t.Name())
+		localDevicePK := stringToPubkey("device1")
+
+		serviceabilityProgram := &mockServiceabilityProgramClient{
+			GetProgramDataFunc: func(ctx context.Context) (*serviceability.ProgramData, error) {
+				return &serviceability.ProgramData{
+					Devices: []serviceability.Device{
+						{PubKey: localDevicePK, PublicIp: [4]uint8{192, 168, 1, 1}},
+						{PubKey: stringToPubkey("device2"), PublicIp: [4]uint8{192, 168, 1, 2}},
+					},
+					Links: []serviceability.Link{
+						{PubKey: stringToPubkey("link_1-2"), Status: serviceability.LinkStatusActivated, SideAPubKey: localDevicePK, SideZPubKey: stringToPubkey("device2"), TunnelNet: [5]uint8{10, 1, 1, 0, 31}},
+					},
+				}, nil
+			},
+		}
+
+		// The first refresh discovers the peer; every refresh after it fails on local interfaces.
+		var interfaceCalls atomic.Int32
+
+		cfg := &telemetry.LedgerPeerDiscoveryConfig{
+			Logger:        log,
+			LocalDevicePK: localDevicePK,
+			ProgramClient: serviceabilityProgram,
+			LocalNet: &netutil.MockLocalNet{
+				InterfacesFunc: func() ([]netutil.Interface, error) {
+					if interfaceCalls.Add(1) > 1 {
+						return nil, errors.New("transient failure getting local interfaces")
+					}
+					return []netutil.Interface{
+						{Name: "tun1-2", Addrs: []net.Addr{&net.IPNet{IP: ipv4([4]uint8{10, 1, 1, 0}), Mask: net.CIDRMask(31, 32)}}},
+					}, nil
+				},
+			},
+			TWAMPPort:       1234,
+			RefreshInterval: 20 * time.Millisecond,
+		}
+
+		peerDiscovery, err := telemetry.NewLedgerPeerDiscovery(cfg)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- peerDiscovery.Run(ctx)
+		}()
+
+		expected := []*telemetry.Peer{
+			{
+				LinkPK:   stringToPubkey("link_1-2"),
+				DevicePK: stringToPubkey("device2"),
+				Tunnel: &netutil.LocalTunnel{
+					Interface: "tun1-2",
+					SourceIP:  ipv4([4]uint8{10, 1, 1, 0}),
+					TargetIP:  ipv4([4]uint8{10, 1, 1, 1}),
+				},
+				TWAMPPort: 1234,
+			},
+		}
+
+		require.Eventually(t, func() bool {
+			return len(peerDiscovery.GetPeers()) == 1
+		}, 2*time.Second, 20*time.Millisecond, "first refresh should discover the peer")
+
+		require.Eventually(t, func() bool {
+			return interfaceCalls.Load() >= 4
+		}, 2*time.Second, 20*time.Millisecond, "later refreshes should keep failing on local interfaces")
+
+		assert.Equal(t, expected, peerDiscovery.GetPeers(), "peers should survive a refresh that fails after the ledger read")
+
+		cancel()
+		assert.NoError(t, <-errCh)
 	})
 }
 


### PR DESCRIPTION
Resolves: #4128

Independent of #4144 and #4145 (different file), so this one branches from `main`.

## Summary of Changes

- `ledgerPeerDiscovery.refresh` no longer empties the peer cache before doing work that can fail. It cleared `p.peers` under the lock and then called `LocalNet.Interfaces()`, so a transient failure there returned with zero peers and `Pinger.Tick` iterated an empty slice, probing nothing until a later refresh succeeded.
- The cache is now replaced only once the new list is built, and the lock covers just that assignment rather than the whole build. The clear was redundant with the existing assignment at the end of the happy path.
- Success path is unchanged.

## Diff Breakdown

| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Tests      |     1 | +79 / -0    |  +79 |
| Core logic |     1 | +6 / -5     |   +1 |
| Docs       |     1 | +3 / -0     |   +3 |
| **Total**  |     3 | +88 / -5    |  +83 |

A one-line behavioral fix plus the regression test that pins it.

<details>
<summary>Key files (click to expand)</summary>

- [`controlplane/telemetry/internal/telemetry/peers.go`](https://github.com/malbeclabs/doublezero/pull/4146/files#diff-9c369dff3cb79259b8bc34d8d952b923103baeef1515402614c23a997a06c286) — drops the `p.peers = make(...)` clear, moves the mutex to wrap only `p.peers = peers`, and leaves a comment that nothing in the build may clear the cache

</details>

## Testing Verification

- New test lets the first refresh discover a peer, then fails every subsequent `LocalNet.Interfaces()` call, and asserts `GetPeers()` still returns the fully populated peer (link, device, tunnel, TWAMP port) after at least three failed refreshes. It fails against the pre-fix code, which returns an empty list.
- Existing peer discovery tests pass unchanged, covering the success path and the skip cases.
- Package passes under `-race`, since the change moves what the mutex covers.
