### PR TITLE
cli: show multicast group codes in feed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - `doublezero feed list` gains a `group_codes` column naming the multicast groups the feed holds, alongside the existing `groups` count. A group the ledger no longer carries renders as its raw pubkey. The JSON output gains the field as well. (malbeclabs/infra#2172, #4150)
+
 ## [v0.33.0](https://github.com/malbeclabs/doublezero/compare/client/v0.32.0...client/v0.33.0) - 2026-07-31
 
 ### Breaking

--- a/smartcontract/cli/src/feed/list.rs
+++ b/smartcontract/cli/src/feed/list.rs
@@ -2,7 +2,9 @@ use crate::doublezerocommand::CliCommand;
 use clap::Args;
 use doublezero_cli_core::{render_collection, CliContext, OutputFormat};
 use doublezero_program_common::serializer;
-use doublezero_sdk::commands::feed::list::ListFeedCommand;
+use doublezero_sdk::commands::{
+    feed::list::ListFeedCommand, multicastgroup::list::ListMulticastGroupCommand,
+};
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::io::Write;
@@ -27,6 +29,8 @@ pub struct FeedDisplay {
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub exchange: Pubkey,
     pub groups: usize,
+    /// Codes of the multicast groups joinable in this feed (pubkey if the group is unknown).
+    pub group_codes: String,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
 }
@@ -39,6 +43,7 @@ impl ListFeedCliCommand {
         out: &mut W,
     ) -> eyre::Result<()> {
         let feeds = client.list_feed(ListFeedCommand)?;
+        let mgroups = client.list_multicastgroup(ListMulticastGroupCommand)?;
 
         let mut displays = feeds
             .into_iter()
@@ -48,6 +53,16 @@ impl ListFeedCliCommand {
                 name: feed.name,
                 exchange: feed.exchange,
                 groups: feed.groups.len(),
+                group_codes: feed
+                    .groups
+                    .iter()
+                    .map(|mg_pk| {
+                        mgroups
+                            .get(mg_pk)
+                            .map_or_else(|| mg_pk.to_string(), |mg| mg.code.clone())
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", "),
                 owner: feed.owner,
             })
             .collect::<Vec<FeedDisplay>>();
@@ -59,5 +74,81 @@ impl ListFeedCliCommand {
             displays,
             OutputFormat::from_flags(self.json, self.json_compact),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{feed::list::ListFeedCliCommand, tests::utils::create_test_client};
+    use doublezero_cli_core::testing::{block_on, cli_context_default_for_tests};
+    use doublezero_sdk::{AccountType, Feed, MulticastGroup, MulticastGroupStatus};
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_cli_feed_list() {
+        let mut client = create_test_client();
+
+        let feed_pk = Pubkey::from_str_const("1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR");
+        let exchange_pk = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3");
+        let owner_pk = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9");
+        let mgroup_pk = Pubkey::from_str_const("1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM");
+        // Deliberately not in the multicast group map, so it renders as a raw pubkey.
+        let unknown_mgroup_pk = Pubkey::from_str_const("11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo4");
+
+        let feed = Feed {
+            account_type: AccountType::Feed,
+            owner: owner_pk,
+            bump_seed: 255,
+            code: "qa-payments".to_string(),
+            name: "QA Payments".to_string(),
+            exchange: exchange_pk,
+            groups: vec![mgroup_pk, unknown_mgroup_pk],
+        };
+        client.expect_list_feed().returning(move |_| {
+            let mut feeds = HashMap::new();
+            feeds.insert(feed_pk, feed.clone());
+            Ok(feeds)
+        });
+
+        let mgroup = MulticastGroup {
+            account_type: AccountType::MulticastGroup,
+            index: 1,
+            bump_seed: 2,
+            tenant_pk: Pubkey::default(),
+            code: "mg01".to_string(),
+            multicast_ip: [1, 2, 3, 4].into(),
+            max_bandwidth: 1234,
+            status: MulticastGroupStatus::Activated,
+            owner: owner_pk,
+            publisher_count: 1,
+            subscriber_count: 2,
+        };
+        client.expect_list_multicastgroup().returning(move |_| {
+            let mut mgroups = HashMap::new();
+            mgroups.insert(mgroup_pk, mgroup.clone());
+            Ok(mgroups)
+        });
+
+        let ctx = cli_context_default_for_tests();
+        let mut output = Vec::new();
+        let res = block_on(
+            ListFeedCliCommand {
+                json: false,
+                json_compact: false,
+            }
+            .execute(&ctx, &client, &mut output),
+        );
+        assert!(res.is_ok(), "{res:?}");
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            output_str.contains("group_codes"),
+            "missing column: {output_str}"
+        );
+        assert!(
+            output_str.contains(&format!("mg01, {unknown_mgroup_pk}")),
+            "unexpected group codes: {output_str}"
+        );
     }
 }

--- a/smartcontract/cli/src/feed/list.rs
+++ b/smartcontract/cli/src/feed/list.rs
@@ -29,7 +29,6 @@ pub struct FeedDisplay {
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub exchange: Pubkey,
     pub groups: usize,
-    /// Codes of the multicast groups joinable in this feed (pubkey if the group is unknown).
     pub group_codes: String,
     #[serde(serialize_with = "serializer::serialize_pubkey_as_string")]
     pub owner: Pubkey,
@@ -142,13 +141,9 @@ mod tests {
         assert!(res.is_ok(), "{res:?}");
 
         let output_str = String::from_utf8(output).unwrap();
-        assert!(
-            output_str.contains("group_codes"),
-            "missing column: {output_str}"
-        );
-        assert!(
-            output_str.contains(&format!("mg01, {unknown_mgroup_pk}")),
-            "unexpected group codes: {output_str}"
+        assert_eq!(
+            output_str,
+            " account                                   | code        | name        | exchange                                  | groups | group_codes                                     | owner                                     \n 1111111FVAiSujNZVgYSc27t6zUTWoKfAGxbRzzPR | qa-payments | QA Payments | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo3 | 2      | mg01, 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo4 | 11111115q4EpJaTXAZWpCg3J2zppWGSZ46KXozzo9 \n"
         );
     }
 }


### PR DESCRIPTION
Resolves: malbeclabs/infra#2172

## Summary of Changes

- `doublezero feed list` gains a `group_codes` column naming the multicast groups the feed holds, so the list answers "what's in this feed?" without a follow-up `feed get` plus manual pubkey lookups.
- Groups are resolved to codes via one `list_multicastgroup` call; a group the ledger no longer carries falls back to its raw pubkey, matching how `accesspass list` renders its allowlists.
- The existing `groups` count column is unchanged, and the JSON output gains the new field (additive — existing consumers that decode a field subset, including the `feed_crud` e2e test, are unaffected).

## Diff Breakdown

| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     1 | +17 / -1    |  +16 |
| Tests        |     1 | +75 / -0    |  +75 |
| Docs         |     1 | +3  / -0    |   +3 |
| **Total**    |     2 | +95 / -1    |  +94 |

A one-column display change; most of the diff is the new list test.

<details>
<summary>Key files (click to expand)</summary>

- `smartcontract/cli/src/feed/list.rs` — adds the `group_codes` field to `FeedDisplay`, resolves group pubkeys to codes with a pubkey fallback, and adds `test_cli_feed_list` covering both the resolved and unknown-group paths
- `CHANGELOG.md` — Unreleased / Changes entry under CLI

</details>

## Testing Verification

- New `test_cli_feed_list` asserts the rendered table carries the column and that a feed holding one known and one unknown group renders `mg01, 11111115q4Ep…` — the code for the resolved group, the raw pubkey for the other.
- Rendered output confirmed by hand: `account | code | name | exchange | groups | group_codes | owner`.
- `cargo test -p doublezero-serviceability-cli feed::` — 34 passing.
