### PR TITLE
e2e/qa: name the gate for instant_allocation_price, not a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- E2E/QA
+  - `TestQA_MulticastSettlement`'s `validate_instant_allocation_price_matches_chain` no longer names a specific `doublezero_solana_version` in its skip path. Both the comment and the skip message said the pin was `0.5.10-1`; testnet has since moved to `0.5.11-1`, so a reader was told the pin was merely behind when in fact `instant_allocation_price` is in no release yet. They now name what actually gates the field — a doublezero-offchain release carrying doublezero-offchain#405 — and where the pin lives, neither of which goes stale as versions move. Comment and message only, no behaviour change.
+
 ## [v0.34.0](https://github.com/malbeclabs/doublezero/compare/client/v0.33.0...client/v0.34.0) - 2026-08-07
 
 ### Breaking

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -418,12 +418,12 @@ func TestQA_MulticastSettlement(t *testing.T) {
 		case !quoted.GetReportsInstantAllocationPrice():
 			// QA hosts install doublezero-solana from a version-pinned apt package
 			// (doublezero_solana_version in malbeclabs/infra
-			// ansible/inventory/*/group_vars/all.yml, 0.5.10-1 at time of writing),
-			// so the field only appears once a release carrying it is published and
-			// the pin bumped. Asserting against an absent field would read 0 and
-			// fail as "quoted 0, chain 43" — a misleading failure that looks like a
-			// new bug rather than a rollout gap.
-			t.Skipf("Skipping: installed doublezero-solana does not report instant_allocation_price (needs a release newer than the pinned 0.5.10-1); chain says %d USDC at last_settled_epoch=%d",
+			// ansible/inventory/<env>/group_vars/all.yml), so the field appears only
+			// once a doublezero-offchain release carrying it is published and that
+			// pin is bumped. The column landed in doublezero-offchain#405. Asserting
+			// against an absent field would read 0 and fail as "quoted 0, chain 43" —
+			// a misleading failure that looks like a new bug rather than a rollout gap.
+			t.Skipf("Skipping: installed doublezero-solana does not report instant_allocation_price (needs a release carrying doublezero-offchain#405); chain says %d USDC at last_settled_epoch=%d",
 				onchain.InstantAllocationDollars, onchain.LastSettledEpoch)
 		case quoted.InstantAllocationPrice == nil:
 			// Reported, but null: the CLI could not find the settled-epoch ring


### PR DESCRIPTION
`TestQA_MulticastSettlement`'s `validate_instant_allocation_price_matches_chain` skip path named a specific pinned version in two places:

```
// ansible/inventory/*/group_vars/all.yml, 0.5.10-1 at time of writing),
t.Skipf("... needs a release newer than the pinned 0.5.10-1 ...")
```

Testnet moved to `0.5.11-1` some time ago, so both read as "the pin is behind, bump it". It isn't. `instant_allocation_price` landed in doublezero-offchain#405 and is still under `## [Unreleased]` there, so no published release carries it and no bump helps yet. That cost real time this week while debugging a `query_onchain_seat_price` failure on testnet.

## Summary

- Name what actually gates the field, a doublezero-offchain release carrying doublezero-offchain#405, instead of a version number that rots.
- Keep the pointer to where the pin lives, with `*` corrected to `<env>`.
- Comment and skip message only. No behaviour change.

## Testing Verification

- `gofmt` clean and `go vet -tags=qa ./e2e/` passes.
- Not exercised against live QA hosts: this subtest only reaches the changed branch when the installed CLI does not report the field, which is the current state on testnet, and the branch it takes is unchanged.