### PR TITLE
ip-proof: add a crate defining the IpOwnershipProof layout and signed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Onchain programs
-  - New `doublezero-ip-proof` crate defines the RFC-27 `IpOwnershipProof` and the exact bytes the verifier signs, in one place the serviceability program, the CLI, and the verification service all share. Nothing consumes it yet. (#4195, #4206)
 - RFCs
   - RFC-27: IP Ownership Verification Service for user connection
+- Utility crates
+  - New `doublezero-ip-proof` crate defines the RFC-27 `IpOwnershipProof` and the exact bytes the verifier signs, in one place the serviceability program, the CLI, and the verification service all share. Nothing consumes it yet. (#4195, #4206)
 
 ## [v0.36.0](https://github.com/malbeclabs/doublezero/compare/client/v0.35.0...client/v0.36.0) - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Onchain programs
+  - New `doublezero-ip-proof` crate defines the RFC-27 `IpOwnershipProof` and the exact bytes the verifier signs, in one place the serviceability program, the CLI, and the verification service all share. Nothing consumes it yet. (#4195, #4206)
 - RFCs
   - RFC-27: IP Ownership Verification Service for user connection
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "doublezero-ip-proof"
+version = "0.36.0"
+dependencies = [
+ "borsh",
+ "hex",
+ "solana-keypair",
+ "solana-program",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "doublezero-program-common"
 version = "0.36.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/doublezero-serviceability-instruction",
     "crates/doublezero-daemon-cli",
     "crates/doublezero-geolocation-cli",
+    "crates/doublezero-ip-proof",
     "crates/sentinel",
 ]
 default-members = []
@@ -59,6 +60,7 @@ env_logger = "0"
 eyre = "0"
 futures = "0"
 futures-util = "0"
+hex = "0.4"
 http = "1"
 http-body-util = "0"
 hyper = "1"
@@ -85,6 +87,7 @@ solana-client = "3.0"
 solana-bincode = "3.0"
 solana-commitment-config = "3.0"
 solana-compute-budget-interface = "3.0"
+solana-keypair = "3.1"
 solana-loader-v3-interface = { version = "6", features = ["serde"] }
 solana-program = "3.0"
 solana-program-test = "=3.0.12"
@@ -92,6 +95,8 @@ solana-pubsub-client = "3.0"
 solana-rpc-client-api = "3.0"
 solana-sdk = "=3.0"
 solana-sdk-ids = "3.0"
+solana-signature = "3.4"
+solana-signer = "3.0"
 solana-system-interface = { version = "3", features = ["bincode"] }
 solana-transaction-status = "3.0"
 bitflags = "2"
@@ -113,6 +118,7 @@ doublezero-cli-core = { path = "crates/doublezero-cli-core" }
 doublezero-config = { path = "config" }
 doublezero-daemon-cli = { path = "crates/doublezero-daemon-cli" }
 doublezero-geolocation-cli = { path = "crates/doublezero-geolocation-cli" }
+doublezero-ip-proof = { path = "crates/doublezero-ip-proof" }
 # default-features = false MUST be set here, not on the consumer edge: an inheriting
 # member's `default-features = false` is ignored unless the workspace dep declares it.
 # This keeps sentinel's server-only deps (Prometheus exporter → rustls/aws-lc-sys) out of

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ rust-build-programs:
 rust-lint: rust-fmt-check
 	@cargo install cargo-hack
 	cargo hack clippy --workspace --all-targets --exclude doublezero-telemetry --exclude doublezero-serviceability --exclude doublezero-program-common --exclude doublezero-record --exclude doublezero-geolocation -- -Dclippy::all -Dclippy::unreadable_literal -Dwarnings
+	# doublezero-ip-proof has an empty default feature set, so the workspace pass above never
+	# reaches signer.rs or test_vectors.rs. --each-feature over the whole tree would be far too
+	# slow; scoping it to this crate is cheap.
+	cargo hack clippy -p doublezero-ip-proof --each-feature --all-targets -- -Dclippy::all -Dclippy::unreadable_literal -Dwarnings
 	cd smartcontract && $(MAKE) lint-programs
 
 .PHONY: rust-fmt

--- a/crates/doublezero-ip-proof/Cargo.toml
+++ b/crates/doublezero-ip-proof/Cargo.toml
@@ -16,23 +16,28 @@ name = "doublezero_ip_proof"
 
 # The RFC-27 IpOwnershipProof layout, shared by three independent consumers that
 # must agree byte for byte: the serviceability program (BPF), the CLI, and the
-# verification service. The default build stays BPF-clean — only borsh,
-# solana-program's Pubkey, and thiserror. Signing/verification lives behind the
-# `signer` feature so no crypto crate reaches the program.
+# verification service. The default build stays BPF-clean — only borsh and
+# solana-program's Pubkey. Signing/verification lives behind the `signer`
+# feature so no crypto crate reaches the program.
 [dependencies]
 borsh.workspace = true
 solana-program.workspace = true
-thiserror.workspace = true
 
 hex = { workspace = true, optional = true }
 solana-keypair = { workspace = true, optional = true }
 solana-signature = { workspace = true, optional = true }
 solana-signer = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 
 [features]
 default = []
 # Off for the BPF build; the program only reconstructs the signed bytes and
 # compares them against what the Ed25519 precompile instruction covers.
-signer = ["dep:solana-keypair", "dep:solana-signature", "dep:solana-signer"]
+signer = [
+  "dep:solana-keypair",
+  "dep:solana-signature",
+  "dep:solana-signer",
+  "dep:thiserror",
+]
 # Committed cross-consumer test vectors. Enabled by consumers in dev-dependencies.
 test-vectors = ["dep:hex"]

--- a/crates/doublezero-ip-proof/Cargo.toml
+++ b/crates/doublezero-ip-proof/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "doublezero-ip-proof"
+
+# clippy ignores rust-version.toml
+rust-version = "1.84.1" # cargo build-sbf --version
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "doublezero_ip_proof"
+
+# The RFC-27 IpOwnershipProof layout, shared by three independent consumers that
+# must agree byte for byte: the serviceability program (BPF), the CLI, and the
+# verification service. The default build stays BPF-clean — only borsh,
+# solana-program's Pubkey, and thiserror. Signing/verification lives behind the
+# `signer` feature so no crypto crate reaches the program.
+[dependencies]
+borsh.workspace = true
+solana-program.workspace = true
+thiserror.workspace = true
+
+hex = { workspace = true, optional = true }
+solana-keypair = { workspace = true, optional = true }
+solana-signature = { workspace = true, optional = true }
+solana-signer = { workspace = true, optional = true }
+
+[features]
+default = []
+# Off for the BPF build; the program only reconstructs the signed bytes and
+# compares them against what the Ed25519 precompile instruction covers.
+signer = ["dep:solana-keypair", "dep:solana-signature", "dep:solana-signer"]
+# Committed cross-consumer test vectors. Enabled by consumers in dev-dependencies.
+test-vectors = ["dep:hex"]

--- a/crates/doublezero-ip-proof/src/lib.rs
+++ b/crates/doublezero-ip-proof/src/lib.rs
@@ -1,6 +1,6 @@
 //! The RFC-27 `IpOwnershipProof`: a signed attestation from the DoubleZero IP verification
 //! service that a given payer originated a request from a given client IP around a given epoch,
-//! for a specific User account.
+//! for a given user type.
 //!
 //! The signed bytes are consumed by three independent places — the serviceability program (BPF),
 //! the CLI, and the verification service — which must agree byte for byte or every proof fails
@@ -16,7 +16,7 @@ use std::net::Ipv4Addr;
 #[cfg(feature = "signer")]
 mod signer;
 #[cfg(feature = "signer")]
-pub use signer::{sign, verify};
+pub use signer::{sign, sign_version, verify};
 
 #[cfg(feature = "test-vectors")]
 pub mod test_vectors;
@@ -25,34 +25,51 @@ pub mod test_vectors;
 /// message a verifier key might ever be asked to sign.
 pub const IP_PROOF_DOMAIN: &[u8; 11] = b"DZ_IP_PROOF";
 
-/// Layout version of the signed message. Bump for any change to the field set or ordering — for
-/// example a v2 that carries an IPv6 client address.
+/// Layout version an issuer writes into [`IpOwnershipProof::version`]. Bump for any change to the
+/// field set or ordering — for example a v2 that carries an IPv6 client address.
 pub const IP_PROOF_VERSION: u8 = 1;
 
-/// Length of the signed message: prefix(11) + version(1) + payer(32) + client_ip(4) + epoch(8) +
-/// user_pubkey(32).
-pub const SIGNED_MESSAGE_LEN: usize = 88;
+/// Versions a verifier accepts. The version travels in the proof, so a new layout can be rolled
+/// out by teaching verifiers to accept both before issuers start writing the new one; drop the old
+/// entry once no outstanding proof can still be inside its freshness window.
+pub const SUPPORTED_IP_PROOF_VERSIONS: &[u8] = &[IP_PROOF_VERSION];
+
+/// Whether a verifier accepts proofs at this layout version.
+pub fn is_supported_version(version: u8) -> bool {
+    SUPPORTED_IP_PROOF_VERSIONS.contains(&version)
+}
 
 const DOMAIN_END: usize = IP_PROOF_DOMAIN.len();
 const VERSION_END: usize = DOMAIN_END + 1;
 const PAYER_END: usize = VERSION_END + 32;
 const CLIENT_IP_END: usize = PAYER_END + 4;
 const EPOCH_END: usize = CLIENT_IP_END + 8;
+const USER_TYPE_END: usize = EPOCH_END + 1;
+
+/// Length of the signed message: prefix(11) + version(1) + payer(32) + client_ip(4) + epoch(8) +
+/// user_type(1). Derived from the field offsets so inserting a field cannot leave the length
+/// behind.
+pub const SIGNED_MESSAGE_LEN: usize = USER_TYPE_END;
 
 /// A signed attestation of IP ownership, carried in instruction data alongside the Ed25519
 /// precompile instruction that actually verifies [`IpOwnershipProof::signature`].
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IpOwnershipProof {
+    /// Layout version of the signed message, written by the issuer. Verifiers reconstruct the
+    /// bytes for *this* version and reject a version they do not support.
+    pub version: u8,
     /// The account paying for / owning the user being created.
     pub payer: Pubkey,
     /// The address the verification service observed the request originate from.
     pub client_ip: Ipv4Addr,
     /// The DoubleZero ledger epoch the proof was issued in.
     pub epoch: u64,
-    /// The User account this proof authorizes. Binding it stops a proof obtained for a routine
-    /// connect from being replayed into another operation on a different account in the same
-    /// epoch.
-    pub user_pubkey: Pubkey,
+    /// Discriminant of the serviceability `UserType` this proof authorizes, kept as a `u8` so this
+    /// crate does not depend on the program it is consumed by. Binding it stops a proof obtained
+    /// for one connection type from being replayed into a different one on the same IP in the same
+    /// epoch — the User PDA is `f(client_ip, user_type)`, so `client_ip` alone does not pin the
+    /// account being created.
+    pub user_type: u8,
     /// Ed25519 signature by the verifier key over [`IpOwnershipProof::signed_message`].
     pub signature: [u8; 64],
 }
@@ -60,7 +77,13 @@ pub struct IpOwnershipProof {
 impl IpOwnershipProof {
     /// The exact bytes the verifier signed. See [`signed_message_for`].
     pub fn signed_message(&self) -> [u8; SIGNED_MESSAGE_LEN] {
-        signed_message_for(&self.payer, &self.client_ip, self.epoch, &self.user_pubkey)
+        signed_message_for(
+            self.version,
+            &self.payer,
+            &self.client_ip,
+            self.epoch,
+            self.user_type,
+        )
     }
 }
 
@@ -73,28 +96,30 @@ impl IpOwnershipProof {
 /// ```text
 /// offset  len  field
 ///      0   11  b"DZ_IP_PROOF"
-///     11    1  version (1)
+///     11    1  version
 ///     12   32  payer
 ///     44    4  client_ip, network order
 ///     48    8  epoch, little-endian
-///     56   32  user_pubkey
+///     56    1  user_type
 /// ```
 pub fn signed_message_for(
+    version: u8,
     payer: &Pubkey,
     client_ip: &Ipv4Addr,
     epoch: u64,
-    user_pubkey: &Pubkey,
+    user_type: u8,
 ) -> [u8; SIGNED_MESSAGE_LEN] {
     let mut message = [0u8; SIGNED_MESSAGE_LEN];
     message[..DOMAIN_END].copy_from_slice(IP_PROOF_DOMAIN);
-    message[DOMAIN_END] = IP_PROOF_VERSION;
+    message[DOMAIN_END] = version;
     message[VERSION_END..PAYER_END].copy_from_slice(payer.as_ref());
     message[PAYER_END..CLIENT_IP_END].copy_from_slice(&client_ip.octets());
     message[CLIENT_IP_END..EPOCH_END].copy_from_slice(&epoch.to_le_bytes());
-    message[EPOCH_END..].copy_from_slice(user_pubkey.as_ref());
+    message[EPOCH_END] = user_type;
     message
 }
 
+#[cfg(feature = "signer")]
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum IpProofError {
     #[error("ip ownership proof signature does not verify against the verifier key")]
@@ -110,10 +135,11 @@ mod tests {
     // derived by the same code it is meant to check.
     fn proof() -> IpOwnershipProof {
         IpOwnershipProof {
+            version: 1,
             payer: Pubkey::new_from_array([1u8; 32]),
             client_ip: Ipv4Addr::new(203, 0, 113, 7),
             epoch: 0x0102_0304_0506_0708,
-            user_pubkey: Pubkey::new_from_array([2u8; 32]),
+            user_type: 3,
             signature: [3u8; 64],
         }
     }
@@ -126,14 +152,14 @@ mod tests {
         expected.extend_from_slice(&[1u8; 32]);
         expected.extend_from_slice(&[203, 0, 113, 7]);
         expected.extend_from_slice(&[0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
-        expected.extend_from_slice(&[2u8; 32]);
+        expected.push(3);
 
         assert_eq!(proof().signed_message().as_slice(), expected.as_slice());
     }
 
     #[test]
     fn signed_message_layout_is_pinned() {
-        assert_eq!(SIGNED_MESSAGE_LEN, 88);
+        assert_eq!(SIGNED_MESSAGE_LEN, 57);
 
         let message = proof().signed_message();
         assert_eq!(&message[..11], b"DZ_IP_PROOF");
@@ -141,12 +167,16 @@ mod tests {
         assert_eq!(&message[12..44], &[1u8; 32]);
         assert_eq!(&message[44..48], &[203, 0, 113, 7]);
         assert_eq!(message[48], 0x08, "epoch is little-endian");
-        assert_eq!(&message[56..88], &[2u8; 32]);
+        assert_eq!(message[56], 3);
     }
 
     #[test]
     fn signed_message_is_sensitive_to_every_field() {
         let base = proof().signed_message();
+
+        let mut other = proof();
+        other.version = 2;
+        assert_ne!(base, other.signed_message());
 
         let mut other = proof();
         other.payer = Pubkey::new_from_array([9u8; 32]);
@@ -161,7 +191,7 @@ mod tests {
         assert_ne!(base, other.signed_message());
 
         let mut other = proof();
-        other.user_pubkey = Pubkey::new_from_array([9u8; 32]);
+        other.user_type = 0;
         assert_ne!(base, other.signed_message());
 
         // The signature is not part of what is signed.
@@ -171,12 +201,31 @@ mod tests {
     }
 
     #[test]
+    fn a_proof_reconstructs_the_version_it_carries_not_the_current_one() {
+        let mut v2 = proof();
+        v2.version = 2;
+
+        assert_eq!(v2.signed_message()[11], 2);
+        assert_eq!(
+            v2.signed_message(),
+            signed_message_for(2, &v2.payer, &v2.client_ip, v2.epoch, v2.user_type),
+        );
+    }
+
+    #[test]
+    fn only_the_declared_versions_are_supported() {
+        assert!(is_supported_version(IP_PROOF_VERSION));
+        assert!(!is_supported_version(0));
+        assert!(!is_supported_version(2));
+    }
+
+    #[test]
     fn borsh_round_trip() {
         let original = proof();
         let bytes = to_vec(&original).unwrap();
 
-        // 32 + 4 + 8 + 32 + 64. Pinned so a field reorder or width change fails loudly.
-        assert_eq!(bytes.len(), 140);
+        // 1 + 32 + 4 + 8 + 1 + 64. Pinned so a field reorder or width change fails loudly.
+        assert_eq!(bytes.len(), 110);
 
         assert_eq!(IpOwnershipProof::try_from_slice(&bytes).unwrap(), original);
     }
@@ -184,6 +233,6 @@ mod tests {
     #[test]
     fn borsh_serializes_client_ip_in_network_order() {
         let bytes = to_vec(&proof()).unwrap();
-        assert_eq!(&bytes[32..36], &[203, 0, 113, 7]);
+        assert_eq!(&bytes[33..37], &[203, 0, 113, 7]);
     }
 }

--- a/crates/doublezero-ip-proof/src/lib.rs
+++ b/crates/doublezero-ip-proof/src/lib.rs
@@ -1,0 +1,189 @@
+//! The RFC-27 `IpOwnershipProof`: a signed attestation from the DoubleZero IP verification
+//! service that a given payer originated a request from a given client IP around a given epoch,
+//! for a specific User account.
+//!
+//! The signed bytes are consumed by three independent places — the serviceability program (BPF),
+//! the CLI, and the verification service — which must agree byte for byte or every proof fails
+//! validation. That layout is defined here once, in [`signed_message_for`].
+//!
+//! The default build is BPF-clean. Signing and verification live behind the `signer` feature so
+//! no crypto crate reaches the program, which verifies through the Ed25519 precompile instead.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+use std::net::Ipv4Addr;
+
+#[cfg(feature = "signer")]
+mod signer;
+#[cfg(feature = "signer")]
+pub use signer::{sign, verify};
+
+#[cfg(feature = "test-vectors")]
+pub mod test_vectors;
+
+/// Domain-separation prefix. Keeps the signed bytes from colliding with any other DoubleZero
+/// message a verifier key might ever be asked to sign.
+pub const IP_PROOF_DOMAIN: &[u8; 11] = b"DZ_IP_PROOF";
+
+/// Layout version of the signed message. Bump for any change to the field set or ordering — for
+/// example a v2 that carries an IPv6 client address.
+pub const IP_PROOF_VERSION: u8 = 1;
+
+/// Length of the signed message: prefix(11) + version(1) + payer(32) + client_ip(4) + epoch(8) +
+/// user_pubkey(32).
+pub const SIGNED_MESSAGE_LEN: usize = 88;
+
+const DOMAIN_END: usize = IP_PROOF_DOMAIN.len();
+const VERSION_END: usize = DOMAIN_END + 1;
+const PAYER_END: usize = VERSION_END + 32;
+const CLIENT_IP_END: usize = PAYER_END + 4;
+const EPOCH_END: usize = CLIENT_IP_END + 8;
+
+/// A signed attestation of IP ownership, carried in instruction data alongside the Ed25519
+/// precompile instruction that actually verifies [`IpOwnershipProof::signature`].
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IpOwnershipProof {
+    /// The account paying for / owning the user being created.
+    pub payer: Pubkey,
+    /// The address the verification service observed the request originate from.
+    pub client_ip: Ipv4Addr,
+    /// The DoubleZero ledger epoch the proof was issued in.
+    pub epoch: u64,
+    /// The User account this proof authorizes. Binding it stops a proof obtained for a routine
+    /// connect from being replayed into another operation on a different account in the same
+    /// epoch.
+    pub user_pubkey: Pubkey,
+    /// Ed25519 signature by the verifier key over [`IpOwnershipProof::signed_message`].
+    pub signature: [u8; 64],
+}
+
+impl IpOwnershipProof {
+    /// The exact bytes the verifier signed. See [`signed_message_for`].
+    pub fn signed_message(&self) -> [u8; SIGNED_MESSAGE_LEN] {
+        signed_message_for(&self.payer, &self.client_ip, self.epoch, &self.user_pubkey)
+    }
+}
+
+/// Builds the signed message from its parts, without needing a proof in hand — the program and
+/// the service both reconstruct it from instruction arguments.
+///
+/// Fixed layout, no length prefixes and no Borsh: every field has a known size, so the bytes are
+/// unambiguous and the program can build them on the stack.
+///
+/// ```text
+/// offset  len  field
+///      0   11  b"DZ_IP_PROOF"
+///     11    1  version (1)
+///     12   32  payer
+///     44    4  client_ip, network order
+///     48    8  epoch, little-endian
+///     56   32  user_pubkey
+/// ```
+pub fn signed_message_for(
+    payer: &Pubkey,
+    client_ip: &Ipv4Addr,
+    epoch: u64,
+    user_pubkey: &Pubkey,
+) -> [u8; SIGNED_MESSAGE_LEN] {
+    let mut message = [0u8; SIGNED_MESSAGE_LEN];
+    message[..DOMAIN_END].copy_from_slice(IP_PROOF_DOMAIN);
+    message[DOMAIN_END] = IP_PROOF_VERSION;
+    message[VERSION_END..PAYER_END].copy_from_slice(payer.as_ref());
+    message[PAYER_END..CLIENT_IP_END].copy_from_slice(&client_ip.octets());
+    message[CLIENT_IP_END..EPOCH_END].copy_from_slice(&epoch.to_le_bytes());
+    message[EPOCH_END..].copy_from_slice(user_pubkey.as_ref());
+    message
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum IpProofError {
+    #[error("ip ownership proof signature does not verify against the verifier key")]
+    InvalidSignature,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use borsh::to_vec;
+
+    // Fixed inputs, so the expected message below is a stable vector rather than something
+    // derived by the same code it is meant to check.
+    fn proof() -> IpOwnershipProof {
+        IpOwnershipProof {
+            payer: Pubkey::new_from_array([1u8; 32]),
+            client_ip: Ipv4Addr::new(203, 0, 113, 7),
+            epoch: 0x0102_0304_0506_0708,
+            user_pubkey: Pubkey::new_from_array([2u8; 32]),
+            signature: [3u8; 64],
+        }
+    }
+
+    #[test]
+    fn signed_message_matches_expected_bytes() {
+        let mut expected = Vec::with_capacity(SIGNED_MESSAGE_LEN);
+        expected.extend_from_slice(b"DZ_IP_PROOF");
+        expected.push(1);
+        expected.extend_from_slice(&[1u8; 32]);
+        expected.extend_from_slice(&[203, 0, 113, 7]);
+        expected.extend_from_slice(&[0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+        expected.extend_from_slice(&[2u8; 32]);
+
+        assert_eq!(proof().signed_message().as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn signed_message_layout_is_pinned() {
+        assert_eq!(SIGNED_MESSAGE_LEN, 88);
+
+        let message = proof().signed_message();
+        assert_eq!(&message[..11], b"DZ_IP_PROOF");
+        assert_eq!(message[11], IP_PROOF_VERSION);
+        assert_eq!(&message[12..44], &[1u8; 32]);
+        assert_eq!(&message[44..48], &[203, 0, 113, 7]);
+        assert_eq!(message[48], 0x08, "epoch is little-endian");
+        assert_eq!(&message[56..88], &[2u8; 32]);
+    }
+
+    #[test]
+    fn signed_message_is_sensitive_to_every_field() {
+        let base = proof().signed_message();
+
+        let mut other = proof();
+        other.payer = Pubkey::new_from_array([9u8; 32]);
+        assert_ne!(base, other.signed_message());
+
+        let mut other = proof();
+        other.client_ip = Ipv4Addr::new(203, 0, 113, 8);
+        assert_ne!(base, other.signed_message());
+
+        let mut other = proof();
+        other.epoch += 1;
+        assert_ne!(base, other.signed_message());
+
+        let mut other = proof();
+        other.user_pubkey = Pubkey::new_from_array([9u8; 32]);
+        assert_ne!(base, other.signed_message());
+
+        // The signature is not part of what is signed.
+        let mut other = proof();
+        other.signature = [4u8; 64];
+        assert_eq!(base, other.signed_message());
+    }
+
+    #[test]
+    fn borsh_round_trip() {
+        let original = proof();
+        let bytes = to_vec(&original).unwrap();
+
+        // 32 + 4 + 8 + 32 + 64. Pinned so a field reorder or width change fails loudly.
+        assert_eq!(bytes.len(), 140);
+
+        assert_eq!(IpOwnershipProof::try_from_slice(&bytes).unwrap(), original);
+    }
+
+    #[test]
+    fn borsh_serializes_client_ip_in_network_order() {
+        let bytes = to_vec(&proof()).unwrap();
+        assert_eq!(&bytes[32..36], &[203, 0, 113, 7]);
+    }
+}

--- a/crates/doublezero-ip-proof/src/signer.rs
+++ b/crates/doublezero-ip-proof/src/signer.rs
@@ -1,0 +1,126 @@
+//! Off-chain signing and verification, behind the `signer` feature.
+//!
+//! The serviceability program does not use this module: onchain, the signature is checked by the
+//! native Ed25519 precompile and the program only reconstructs [`signed_message_for`] and
+//! compares it against what that instruction covers.
+
+use crate::{signed_message_for, IpOwnershipProof, IpProofError};
+use solana_keypair::Keypair;
+use solana_program::pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use std::net::Ipv4Addr;
+
+/// Issues a proof signed by the verifier keypair.
+pub fn sign(
+    verifier: &Keypair,
+    payer: &Pubkey,
+    client_ip: &Ipv4Addr,
+    epoch: u64,
+    user_pubkey: &Pubkey,
+) -> IpOwnershipProof {
+    let signature =
+        verifier.sign_message(&signed_message_for(payer, client_ip, epoch, user_pubkey));
+
+    IpOwnershipProof {
+        payer: *payer,
+        client_ip: *client_ip,
+        epoch,
+        user_pubkey: *user_pubkey,
+        signature: signature.into(),
+    }
+}
+
+/// Checks the proof's signature against the verifier public key.
+///
+/// This says nothing about freshness or about whether the proof matches the operation it is being
+/// presented for — the caller still checks the epoch window, the payer, the client IP, and the
+/// user account.
+pub fn verify(proof: &IpOwnershipProof, verifier_pubkey: &Pubkey) -> Result<(), IpProofError> {
+    let signature = Signature::from(proof.signature);
+
+    if signature.verify(verifier_pubkey.as_ref(), &proof.signed_message()) {
+        Ok(())
+    } else {
+        Err(IpProofError::InvalidSignature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SIGNED_MESSAGE_LEN;
+
+    fn fixture() -> (Keypair, Pubkey, Ipv4Addr, u64, Pubkey) {
+        (
+            Keypair::new(),
+            Pubkey::new_unique(),
+            Ipv4Addr::new(198, 51, 100, 42),
+            931,
+            Pubkey::new_unique(),
+        )
+    }
+
+    #[test]
+    fn sign_verify_round_trip() {
+        let (verifier, payer, ip, epoch, user) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+
+        assert_eq!(proof.payer, payer);
+        assert_eq!(proof.client_ip, ip);
+        assert_eq!(proof.epoch, epoch);
+        assert_eq!(proof.user_pubkey, user);
+        assert_eq!(verify(&proof, &verifier.pubkey()), Ok(()));
+    }
+
+    #[test]
+    fn verify_rejects_a_different_verifier_key() {
+        let (verifier, payer, ip, epoch, user) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+
+        assert_eq!(
+            verify(&proof, &Keypair::new().pubkey()),
+            Err(IpProofError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_tampered_proof() {
+        let (verifier, payer, ip, epoch, user) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+
+        for tampered in [
+            IpOwnershipProof {
+                payer: Pubkey::new_unique(),
+                ..proof
+            },
+            IpOwnershipProof {
+                client_ip: Ipv4Addr::new(198, 51, 100, 43),
+                ..proof
+            },
+            IpOwnershipProof {
+                epoch: epoch + 1,
+                ..proof
+            },
+            IpOwnershipProof {
+                user_pubkey: Pubkey::new_unique(),
+                ..proof
+            },
+        ] {
+            assert_eq!(
+                verify(&tampered, &verifier.pubkey()),
+                Err(IpProofError::InvalidSignature)
+            );
+        }
+    }
+
+    #[test]
+    fn signature_covers_exactly_the_signed_message() {
+        let (verifier, payer, ip, epoch, user) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+
+        let message = signed_message_for(&payer, &ip, epoch, &user);
+        assert_eq!(message.len(), SIGNED_MESSAGE_LEN);
+        assert!(Signature::from(proof.signature).verify(verifier.pubkey().as_ref(), &message));
+    }
+}

--- a/crates/doublezero-ip-proof/src/signer.rs
+++ b/crates/doublezero-ip-proof/src/signer.rs
@@ -4,38 +4,60 @@
 //! native Ed25519 precompile and the program only reconstructs [`signed_message_for`] and
 //! compares it against what that instruction covers.
 
-use crate::{signed_message_for, IpOwnershipProof, IpProofError};
+use crate::{signed_message_for, IpOwnershipProof, IpProofError, IP_PROOF_VERSION};
 use solana_keypair::Keypair;
 use solana_program::pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use std::net::Ipv4Addr;
 
-/// Issues a proof signed by the verifier keypair.
+/// Issues a proof at [`IP_PROOF_VERSION`], signed by the verifier keypair.
 pub fn sign(
     verifier: &Keypair,
     payer: &Pubkey,
     client_ip: &Ipv4Addr,
     epoch: u64,
-    user_pubkey: &Pubkey,
+    user_type: u8,
 ) -> IpOwnershipProof {
-    let signature =
-        verifier.sign_message(&signed_message_for(payer, client_ip, epoch, user_pubkey));
+    sign_version(
+        IP_PROOF_VERSION,
+        verifier,
+        payer,
+        client_ip,
+        epoch,
+        user_type,
+    )
+}
+
+/// Issues a proof at an explicit layout version. Only needed while two versions are in flight; new
+/// issuers want [`sign`].
+pub fn sign_version(
+    version: u8,
+    verifier: &Keypair,
+    payer: &Pubkey,
+    client_ip: &Ipv4Addr,
+    epoch: u64,
+    user_type: u8,
+) -> IpOwnershipProof {
+    let signature = verifier.sign_message(&signed_message_for(
+        version, payer, client_ip, epoch, user_type,
+    ));
 
     IpOwnershipProof {
+        version,
         payer: *payer,
         client_ip: *client_ip,
         epoch,
-        user_pubkey: *user_pubkey,
+        user_type,
         signature: signature.into(),
     }
 }
 
 /// Checks the proof's signature against the verifier public key.
 ///
-/// This says nothing about freshness or about whether the proof matches the operation it is being
-/// presented for — the caller still checks the epoch window, the payer, the client IP, and the
-/// user account.
+/// This says nothing about freshness, about whether the proof's version is supported, or about
+/// whether the proof matches the operation it is being presented for — the caller still checks
+/// [`crate::is_supported_version`], the epoch window, the payer, the client IP, and the user type.
 pub fn verify(proof: &IpOwnershipProof, verifier_pubkey: &Pubkey) -> Result<(), IpProofError> {
     let signature = Signature::from(proof.signature);
 
@@ -51,32 +73,33 @@ mod tests {
     use super::*;
     use crate::SIGNED_MESSAGE_LEN;
 
-    fn fixture() -> (Keypair, Pubkey, Ipv4Addr, u64, Pubkey) {
+    fn fixture() -> (Keypair, Pubkey, Ipv4Addr, u64, u8) {
         (
             Keypair::new(),
             Pubkey::new_unique(),
             Ipv4Addr::new(198, 51, 100, 42),
             931,
-            Pubkey::new_unique(),
+            3,
         )
     }
 
     #[test]
     fn sign_verify_round_trip() {
-        let (verifier, payer, ip, epoch, user) = fixture();
-        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+        let (verifier, payer, ip, epoch, user_type) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, user_type);
 
+        assert_eq!(proof.version, IP_PROOF_VERSION);
         assert_eq!(proof.payer, payer);
         assert_eq!(proof.client_ip, ip);
         assert_eq!(proof.epoch, epoch);
-        assert_eq!(proof.user_pubkey, user);
+        assert_eq!(proof.user_type, user_type);
         assert_eq!(verify(&proof, &verifier.pubkey()), Ok(()));
     }
 
     #[test]
     fn verify_rejects_a_different_verifier_key() {
-        let (verifier, payer, ip, epoch, user) = fixture();
-        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+        let (verifier, payer, ip, epoch, user_type) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, user_type);
 
         assert_eq!(
             verify(&proof, &Keypair::new().pubkey()),
@@ -86,8 +109,8 @@ mod tests {
 
     #[test]
     fn verify_rejects_a_tampered_proof() {
-        let (verifier, payer, ip, epoch, user) = fixture();
-        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+        let (verifier, payer, ip, epoch, user_type) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, user_type);
 
         for tampered in [
             IpOwnershipProof {
@@ -103,7 +126,11 @@ mod tests {
                 ..proof
             },
             IpOwnershipProof {
-                user_pubkey: Pubkey::new_unique(),
+                user_type: user_type + 1,
+                ..proof
+            },
+            IpOwnershipProof {
+                version: proof.version + 1,
                 ..proof
             },
         ] {
@@ -115,11 +142,22 @@ mod tests {
     }
 
     #[test]
-    fn signature_covers_exactly_the_signed_message() {
-        let (verifier, payer, ip, epoch, user) = fixture();
-        let proof = sign(&verifier, &payer, &ip, epoch, &user);
+    fn sign_version_signs_the_requested_version() {
+        let (verifier, payer, ip, epoch, user_type) = fixture();
+        let proof = sign_version(2, &verifier, &payer, &ip, epoch, user_type);
 
-        let message = signed_message_for(&payer, &ip, epoch, &user);
+        assert_eq!(proof.version, 2);
+        assert_eq!(proof.signed_message()[11], 2);
+        assert_eq!(verify(&proof, &verifier.pubkey()), Ok(()));
+        assert!(!crate::is_supported_version(proof.version));
+    }
+
+    #[test]
+    fn signature_covers_exactly_the_signed_message() {
+        let (verifier, payer, ip, epoch, user_type) = fixture();
+        let proof = sign(&verifier, &payer, &ip, epoch, user_type);
+
+        let message = signed_message_for(IP_PROOF_VERSION, &payer, &ip, epoch, user_type);
         assert_eq!(message.len(), SIGNED_MESSAGE_LEN);
         assert!(Signature::from(proof.signature).verify(verifier.pubkey().as_ref(), &message));
     }

--- a/crates/doublezero-ip-proof/src/test_vectors.rs
+++ b/crates/doublezero-ip-proof/src/test_vectors.rs
@@ -3,7 +3,8 @@
 //! The program tests, CLI tests, and verification-service tests all assert against these, so a
 //! change to the signed-message layout that slips past one consumer's own tests still fails
 //! everywhere else. Do not regenerate them to make a test pass: if a vector stops matching, the
-//! wire format changed and [`crate::IP_PROOF_VERSION`] needs a bump.
+//! wire format changed and it needs a new [`crate::IP_PROOF_VERSION`] alongside the old one in
+//! [`crate::SUPPORTED_IP_PROOF_VERSIONS`], not an edited vector.
 
 use crate::{IpOwnershipProof, SIGNED_MESSAGE_LEN};
 use solana_program::pubkey::Pubkey;
@@ -19,12 +20,14 @@ pub const VERIFIER_PUBKEY: &str = "GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB"
 pub struct TestVector {
     /// What this vector stands for, for assertion failure messages.
     pub name: &'static str,
+    /// Layout version the vector was issued at.
+    pub version: u8,
     /// Base58.
     pub payer: &'static str,
     pub client_ip: &'static str,
     pub epoch: u64,
-    /// Base58.
-    pub user_pubkey: &'static str,
+    /// Serviceability `UserType` discriminant.
+    pub user_type: u8,
     /// Hex of the expected [`crate::signed_message_for`] output.
     pub signed_message_hex: &'static str,
     /// Hex of the expected signature by [`VERIFIER_PUBKEY`] over that message.
@@ -34,10 +37,11 @@ pub struct TestVector {
 impl TestVector {
     pub fn proof(&self) -> IpOwnershipProof {
         IpOwnershipProof {
+            version: self.version,
             payer: self.payer(),
             client_ip: self.client_ip(),
             epoch: self.epoch,
-            user_pubkey: self.user_pubkey(),
+            user_type: self.user_type,
             signature: self.signature(),
         }
     }
@@ -48,10 +52,6 @@ impl TestVector {
 
     pub fn client_ip(&self) -> Ipv4Addr {
         Ipv4Addr::from_str(self.client_ip).expect("test vector client_ip is a valid IPv4 address")
-    }
-
-    pub fn user_pubkey(&self) -> Pubkey {
-        Pubkey::from_str(self.user_pubkey).expect("test vector user_pubkey is a valid pubkey")
     }
 
     pub fn signed_message(&self) -> [u8; SIGNED_MESSAGE_LEN] {
@@ -68,27 +68,30 @@ pub fn verifier_pubkey() -> Pubkey {
     Pubkey::from_str(VERIFIER_PUBKEY).expect("test vector verifier pubkey is valid")
 }
 
-/// A proof for a specific, ordinary client IP.
+/// A proof for a specific, ordinary client IP, at the default `UserType` discriminant.
 pub const SPECIFIC_IP: TestVector = TestVector {
     name: "specific client IP",
+    version: 1,
     payer: "29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2",
     client_ip: "203.0.113.7",
     epoch: 931,
-    user_pubkey: "3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3",
-    signed_message_hex: "445a5f49505f50524f4f46011111111111111111111111111111111111111111111111111111111111111111cb007107a3030000000000002222222222222222222222222222222222222222222222222222222222222222",
-    signature_hex: "f6339bb486ce1f0aff5f64f5a4b7dcc83a0ed331a0b407bded77243e0c242d15fb4b08a93dbe02c3757b7c768ee629caa2999df56be88379db346a436779380a",
+    user_type: 0,
+    signed_message_hex: "445a5f49505f50524f4f46011111111111111111111111111111111111111111111111111111111111111111cb007107a30300000000000000",
+    signature_hex: "30890c00d8847a9be171d7c087eef6bd92c62034eb31e568cab1e2465e0bf500ef9540e42b1d0851fcd6668aad4c3b672bf7459c2f1455be8248c8abd8739306",
 };
 
-/// A proof issued against a wildcard AccessPass, where the observed IP is the only per-IP control
-/// and a high epoch exercises the upper bytes of the little-endian encoding.
+/// A proof issued against a wildcard AccessPass, where the observed IP is the only per-IP control.
+/// A high epoch exercises the upper bytes of the little-endian encoding, and a non-zero
+/// `user_type` catches a dropped trailing byte.
 pub const WILDCARD_PASS: TestVector = TestVector {
     name: "wildcard AccessPass connect",
+    version: 1,
     payer: "Bswb3UyeD1pUTaGiE6WvqwFpJZsQSEY1xhJePCDTHdvp",
     client_ip: "198.51.100.42",
     epoch: 72_057_594_037_927_936,
-    user_pubkey: "D2ZcUbtpG5sKq7XLeB4YnpNnTGSptKCxTddoNeydzJQq",
-    signed_message_hex: "445a5f49505f50524f4f4601a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1c633642a0000000000000001b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
-    signature_hex: "b143de0201fabf97050055278656f7c4c9f9c7c84ba09f2401c2e1fd5b55405ca75ba079cc4d63708c3a9bf32524f8917a11e1cf2129dc7a887534fffd772801",
+    user_type: 3,
+    signed_message_hex: "445a5f49505f50524f4f4601a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1c633642a000000000000000103",
+    signature_hex: "205d6b00f2d9ee9ac1ed37e7cc324bcc945f3b351e63d84ec73e272754d43359daec40ee8f1b97eabd711b6cdc971cebd20bf93f9f32e72aee297a5d43f9be00",
 };
 
 pub const ALL: &[TestVector] = &[SPECIFIC_IP, WILDCARD_PASS];
@@ -110,13 +113,14 @@ mod tests {
         for vector in ALL {
             assert_eq!(
                 signed_message_for(
+                    vector.version,
                     &vector.payer(),
                     &vector.client_ip(),
                     vector.epoch,
-                    &vector.user_pubkey(),
+                    vector.user_type,
                 ),
                 vector.signed_message(),
-                "{}: signed message layout changed — bump IP_PROOF_VERSION rather than \
+                "{}: signed message layout changed — add a new IP_PROOF_VERSION rather than \
                  regenerating this vector",
                 vector.name,
             );
@@ -146,12 +150,13 @@ mod tests {
                 vector.name,
             );
             assert_eq!(
-                crate::sign(
+                crate::sign_version(
+                    vector.version,
                     &keypair,
                     &vector.payer(),
                     &vector.client_ip(),
                     vector.epoch,
-                    &vector.user_pubkey(),
+                    vector.user_type,
                 )
                 .signature,
                 vector.signature(),

--- a/crates/doublezero-ip-proof/src/test_vectors.rs
+++ b/crates/doublezero-ip-proof/src/test_vectors.rs
@@ -1,0 +1,163 @@
+//! Committed cross-consumer test vectors, behind the `test-vectors` feature.
+//!
+//! The program tests, CLI tests, and verification-service tests all assert against these, so a
+//! change to the signed-message layout that slips past one consumer's own tests still fails
+//! everywhere else. Do not regenerate them to make a test pass: if a vector stops matching, the
+//! wire format changed and [`crate::IP_PROOF_VERSION`] needs a bump.
+
+use crate::{IpOwnershipProof, SIGNED_MESSAGE_LEN};
+use solana_program::pubkey::Pubkey;
+use std::{net::Ipv4Addr, str::FromStr};
+
+/// Ed25519 keypair (32-byte seed followed by the 32-byte public key) that signed every vector
+/// below. Test-only; it has no role outside this module.
+pub const VERIFIER_KEYPAIR_HEX: &str = "0707070707070707070707070707070707070707070707070707070707070707ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c";
+
+/// Base58 public key of [`VERIFIER_KEYPAIR_HEX`].
+pub const VERIFIER_PUBKEY: &str = "GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB";
+
+pub struct TestVector {
+    /// What this vector stands for, for assertion failure messages.
+    pub name: &'static str,
+    /// Base58.
+    pub payer: &'static str,
+    pub client_ip: &'static str,
+    pub epoch: u64,
+    /// Base58.
+    pub user_pubkey: &'static str,
+    /// Hex of the expected [`crate::signed_message_for`] output.
+    pub signed_message_hex: &'static str,
+    /// Hex of the expected signature by [`VERIFIER_PUBKEY`] over that message.
+    pub signature_hex: &'static str,
+}
+
+impl TestVector {
+    pub fn proof(&self) -> IpOwnershipProof {
+        IpOwnershipProof {
+            payer: self.payer(),
+            client_ip: self.client_ip(),
+            epoch: self.epoch,
+            user_pubkey: self.user_pubkey(),
+            signature: self.signature(),
+        }
+    }
+
+    pub fn payer(&self) -> Pubkey {
+        Pubkey::from_str(self.payer).expect("test vector payer is a valid pubkey")
+    }
+
+    pub fn client_ip(&self) -> Ipv4Addr {
+        Ipv4Addr::from_str(self.client_ip).expect("test vector client_ip is a valid IPv4 address")
+    }
+
+    pub fn user_pubkey(&self) -> Pubkey {
+        Pubkey::from_str(self.user_pubkey).expect("test vector user_pubkey is a valid pubkey")
+    }
+
+    pub fn signed_message(&self) -> [u8; SIGNED_MESSAGE_LEN] {
+        decode_array(self.signed_message_hex)
+    }
+
+    pub fn signature(&self) -> [u8; 64] {
+        decode_array(self.signature_hex)
+    }
+}
+
+/// The public key the vectors' signatures verify against.
+pub fn verifier_pubkey() -> Pubkey {
+    Pubkey::from_str(VERIFIER_PUBKEY).expect("test vector verifier pubkey is valid")
+}
+
+/// A proof for a specific, ordinary client IP.
+pub const SPECIFIC_IP: TestVector = TestVector {
+    name: "specific client IP",
+    payer: "29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2",
+    client_ip: "203.0.113.7",
+    epoch: 931,
+    user_pubkey: "3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3",
+    signed_message_hex: "445a5f49505f50524f4f46011111111111111111111111111111111111111111111111111111111111111111cb007107a3030000000000002222222222222222222222222222222222222222222222222222222222222222",
+    signature_hex: "f6339bb486ce1f0aff5f64f5a4b7dcc83a0ed331a0b407bded77243e0c242d15fb4b08a93dbe02c3757b7c768ee629caa2999df56be88379db346a436779380a",
+};
+
+/// A proof issued against a wildcard AccessPass, where the observed IP is the only per-IP control
+/// and a high epoch exercises the upper bytes of the little-endian encoding.
+pub const WILDCARD_PASS: TestVector = TestVector {
+    name: "wildcard AccessPass connect",
+    payer: "Bswb3UyeD1pUTaGiE6WvqwFpJZsQSEY1xhJePCDTHdvp",
+    client_ip: "198.51.100.42",
+    epoch: 72_057_594_037_927_936,
+    user_pubkey: "D2ZcUbtpG5sKq7XLeB4YnpNnTGSptKCxTddoNeydzJQq",
+    signed_message_hex: "445a5f49505f50524f4f4601a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1c633642a0000000000000001b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+    signature_hex: "b143de0201fabf97050055278656f7c4c9f9c7c84ba09f2401c2e1fd5b55405ca75ba079cc4d63708c3a9bf32524f8917a11e1cf2129dc7a887534fffd772801",
+};
+
+pub const ALL: &[TestVector] = &[SPECIFIC_IP, WILDCARD_PASS];
+
+fn decode_array<const N: usize>(value: &str) -> [u8; N] {
+    let bytes = hex::decode(value).expect("test vector is valid hex");
+    bytes
+        .try_into()
+        .unwrap_or_else(|_| panic!("test vector should decode to {N} bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signed_message_for;
+
+    #[test]
+    fn every_vector_rederives_its_signed_message() {
+        for vector in ALL {
+            assert_eq!(
+                signed_message_for(
+                    &vector.payer(),
+                    &vector.client_ip(),
+                    vector.epoch,
+                    &vector.user_pubkey(),
+                ),
+                vector.signed_message(),
+                "{}: signed message layout changed — bump IP_PROOF_VERSION rather than \
+                 regenerating this vector",
+                vector.name,
+            );
+            assert_eq!(vector.proof().signed_message(), vector.signed_message());
+        }
+    }
+
+    #[cfg(feature = "signer")]
+    #[test]
+    fn every_vector_verifies_against_the_committed_verifier_key() {
+        use solana_keypair::Keypair;
+        use solana_signer::Signer;
+
+        let keypair = Keypair::try_from(
+            hex::decode(VERIFIER_KEYPAIR_HEX)
+                .expect("keypair hex is valid")
+                .as_slice(),
+        )
+        .expect("keypair bytes are a valid ed25519 keypair");
+        assert_eq!(keypair.pubkey(), verifier_pubkey());
+
+        for vector in ALL {
+            assert_eq!(
+                crate::verify(&vector.proof(), &verifier_pubkey()),
+                Ok(()),
+                "{}",
+                vector.name,
+            );
+            assert_eq!(
+                crate::sign(
+                    &keypair,
+                    &vector.payer(),
+                    &vector.client_ip(),
+                    vector.epoch,
+                    &vector.user_pubkey(),
+                )
+                .signature,
+                vector.signature(),
+                "{}: signing is expected to be deterministic",
+                vector.name,
+            );
+        }
+    }
+}

--- a/rfcs/rfc27-ip-verification.md
+++ b/rfcs/rfc27-ip-verification.md
@@ -58,8 +58,9 @@ connect from a non‑preregistered or changing IP.
 
 - **IP Verification Service** — A DoubleZero‑operated HTTP service that observes the source IP of an
   inbound request and returns a signed `IpOwnershipProof`.
-- **`IpOwnershipProof`** — A signed attestation `{ payer, client_ip, epoch, signature }` produced by
-  the verifier keypair.
+- **`IpOwnershipProof`** — A signed attestation
+  `{ version, payer, client_ip, epoch, user_type, signature }` produced by the verifier keypair. Its
+  layout is defined once, normatively, in `crates/doublezero-ip-proof`.
 - **Verifier keypair** — The Ed25519 keypair owned by DoubleZero whose public key is the trust root
   for proof validation; its pubkey is stored in onchain global state.
 - **Wildcard access pass** — An AccessPass stored at the unspecified IP (`0.0.0.0`, `IS_DYNAMIC`)
@@ -96,15 +97,15 @@ sequenceDiagram
     U->>C: doublezero connect ibrl
     Note right of C: client_ip not yet certified
 
-    C->>V: POST https://verify.doublezero.xyz { payer }
+    C->>V: POST https://verify.doublezero.xyz { payer, user_type }
     Note right of V: observes the request's source IP
-    V-->>C: IpOwnershipProof { payer, client_ip, epoch, signature }
+    V-->>C: IpOwnershipProof { version, payer, client_ip, epoch, user_type, signature }
 
     Note over C: client_ip = the IP the service observed
 
     C->>S: CreateUser(client_ip, ...) + Ed25519 verify ix + IpOwnershipProof
     S->>S: Confirm Ed25519 precompile verified (verifier_key, message, signature)
-    S->>S: Check payer, client_ip, epoch freshness
+    S->>S: Check version supported, payer, client_ip, user_type, epoch freshness
 
     alt Proof valid
         S-->>C: User created, IP bound
@@ -116,26 +117,34 @@ sequenceDiagram
 ### Steps
 
 1. The CLI sends a request to the verification service. The service uses the **source IP of the
-   request** as `client_ip`, the `payer` from the body, and the current DoubleZero epoch:
+   request** as `client_ip`, the `payer` and `user_type` from the body, and the current DoubleZero
+   epoch:
 
    ```
    POST https://verify.doublezero.xyz
-   { "payer": "<Pubkey>" }
+   { "payer": "<Pubkey>", "user_type": <u8> }
    ```
+
+   The client does **not** send `client_ip`: the observed source IP is the whole point of the
+   exchange, and a client-supplied IP would defeat it. `user_type` is client-supplied, which is safe
+   — it is not a trust boundary, and the program checks it against the user it is creating.
 
 2. The service returns a signed proof:
 
    ```json
    {
+     "version": <u8>,
      "payer": "<payer_pubkey>",
      "client_ip": "<a.b.c.d>",
      "epoch": <u64>,
+     "user_type": <u8>,
      "signature": "<ed25519_signature>"
    }
    ```
 
-   The signed message is the byte concatenation `payer || client_ip || epoch` (the proof fields in a
-   fixed layout — see below), signed by the verifier keypair.
+   The signed message is a fixed 57-byte layout — a domain-separation prefix and version byte
+   followed by `payer || client_ip || epoch || user_type` — signed by the verifier keypair. See
+   below.
 
 3. The CLI submits the user‑creation transaction carrying both:
    - the `IpOwnershipProof`, and
@@ -146,17 +155,53 @@ sequenceDiagram
 
 ### Proof Specification
 
+`crates/doublezero-ip-proof` is the **normative** definition of both the struct and the signed
+bytes; `signed_message_for()` there is the single source of truth that the program, the CLI, and the
+service all reconstruct from. This section describes it — where the two disagree, the crate wins.
+
 ```rust
 pub struct IpOwnershipProof {
+    pub version: u8,          // 1  layout version, written by the issuer
     pub payer: Pubkey,        // 32
     pub client_ip: Ipv4Addr,  // 4 (IPv4)
     pub epoch: u64,           // 8
+    pub user_type: u8,        // 1  serviceability UserType discriminant
     pub signature: [u8; 64],  // Ed25519
 }
 ```
 
-The signed message is the fixed‑layout serialization of `(payer, client_ip, epoch)`. `Ipv4Addr` is
-used to match the type used throughout the program; it is serialized as its 4 network‑order octets.
+The signed message is 57 bytes, with no length prefixes and no Borsh, so the program can build it on
+the stack and compare it against what the Ed25519 precompile instruction covers:
+
+```text
+offset  len  field
+     0   11  b"DZ_IP_PROOF"       domain separation
+    11    1  version
+    12   32  payer
+    44    4  client_ip, network order
+    48    8  epoch, little-endian
+    56    1  user_type
+```
+
+`Ipv4Addr` is used to match the type used throughout the program; it is serialized as its 4
+network‑order octets.
+
+**Domain separation.** The `DZ_IP_PROOF` prefix keeps these bytes from colliding with any other
+DoubleZero message the verifier key might ever be asked to sign.
+
+**Versioning.** `version` travels *in* the proof rather than being a compile-time constant, so
+verifiers can reconstruct the bytes for any version they accept. A new layout rolls out by teaching
+the program and the service to accept both versions, then switching issuers over, then dropping the
+old version once no outstanding proof can still be inside its freshness window — no atomic cutover
+across program, service, and every deployed CLI.
+
+**`user_type`, and why not the User pubkey.** The User account is a PDA over
+`(client_ip, user_type)`, so `client_ip` alone does not pin the account being created: a proof for an
+IP would otherwise be reusable for a different connection type on that IP. Binding `user_type`
+closes that. Binding the derived User pubkey instead would *not* work: the service is the party that
+discovers `client_ip`, so the client would have to send a pubkey derived from its own autodetected
+IP, and on any NATed or multi-homed host that pubkey disagrees with the IP the service observed —
+producing a validly signed proof that can never verify.
 
 ### Onchain Validation
 
@@ -164,16 +209,19 @@ Solana programs cannot verify an Ed25519 signature directly inside BPF cheaply. 
 the **native Ed25519 precompile**: the CLI includes an `Ed25519SigVerify` instruction in the same
 transaction, and the serviceability program **introspects the Instructions sysvar** to confirm that
 instruction is present and that its public key, message, and signature match the expected verifier
-key and the reconstructed `payer || client_ip || epoch` message.
+key and the reconstructed message.
 
 Required checks:
 
-1. Read `IpOwnershipProof` from instruction data; reconstruct `message = payer || client_ip || epoch`.
+1. Read `IpOwnershipProof` from instruction data; confirm `proof.version` is supported
+   (`doublezero_ip_proof::is_supported_version`) and reconstruct the message with
+   `signed_message_for(proof.version, ...)`.
 2. Load the Ed25519 instruction from the Instructions sysvar and confirm it verifies `signature`
    over `message` with the **verifier public key from global state**.
 3. `proof.payer == user_payer` (the account paying / owning the user).
 4. `proof.client_ip == client_ip` being bound to the user.
-5. `proof.epoch` is within the allowed freshness window relative to `Clock::get()?.epoch`.
+5. `proof.user_type == user_type` being created.
+6. `proof.epoch` is within the allowed freshness window relative to `Clock::get()?.epoch`.
 
 #### Rejection conditions
 
@@ -182,6 +230,8 @@ The program MUST reject when any of the following holds:
 - the Ed25519 verify instruction is absent or does not match (`verifier_key`, `message`, `signature`);
 - `payer` mismatch;
 - `client_ip` mismatch with the value being bound;
+- `user_type` mismatch with the user being created;
+- `proof.version` is not in the supported set;
 - the proof is stale (epoch outside the freshness window);
 - the proof is malformed.
 
@@ -217,6 +267,8 @@ may bind:
   source IP).
 - **Operational:** the service must observe the real client source IP. Behind a proxy/CDN it must use
   a trusted forwarded‑for header; otherwise it would sign the proxy's IP.
+- **Shared format crate:** `crates/doublezero-ip-proof` holds the layout all three consumers build
+  against, so none of them reimplements the signed bytes from prose.
 
 ## Security Considerations
 
@@ -235,9 +287,10 @@ may bind:
 - **Centralized trust root.** The verifier keypair is a DoubleZero‑operated authority. The benefit
   delivered is automated, non‑bypassable per‑IP verification — not decentralization. Key rotation is
   supported via global state.
-- **Replay.** The epoch window bounds proof reuse; because the proof binds `payer` and `client_ip`,
-  reuse only re‑asserts the same binding. A nonce or binding to the specific user account can further
-  constrain reuse if needed (see Open Questions).
+- **Replay.** The epoch window bounds proof reuse; because the proof binds `payer`, `client_ip`, and
+  `user_type`, reuse only re‑asserts the same binding — and since the User PDA is
+  `f(client_ip, user_type)`, that is the same User account. A nonce would further constrain reuse
+  within an epoch if needed (see Open Questions).
 
 ## Backward Compatibility
 
@@ -253,7 +306,7 @@ flow removed) once adoption is sufficient, consistent with RFC‑10 version‑co
 ## Open Questions
 
 - Should proofs be persisted onchain for auditing, or is the bound `client_ip` sufficient?
-- Should the proof bind to the specific user account (or a nonce) to further constrain replay within
+- Is `user_type` binding enough, or should the proof also carry a nonce to constrain replay within
   an epoch?
 - Should IP re‑verification be periodic (re‑prove on a schedule), or only at user creation?
 - Should IPv6 be supported?


### PR DESCRIPTION
Resolves: #4195

Part of [RFC-27](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc27-ip-verification.md) (`rfcs/rfc27-ip-verification.md`), tracker #4194.

## Summary of Changes

- Adds `crates/doublezero-ip-proof`, defining `IpOwnershipProof` and the exact bytes the IP verification service signs. Three independent consumers — the serviceability program (BPF), the CLI, and the verification service — must agree byte for byte or every proof fails validation, so the format is defined once rather than duplicated three times.
- The signed message is a fixed 57-byte layout: a `DZ_IP_PROOF` domain-separation prefix, a version byte, then `payer || client_ip || epoch || user_type`. No length prefixes and no Borsh on the signed portion, so the program can reconstruct it on the stack and compare against what the Ed25519 precompile instruction covers.
- The layout version travels **in** the proof, and `signed_message_for()` takes it as an argument, so a verifier reconstructs the bytes for the version a proof declares rather than for whatever version it was compiled against. `SUPPORTED_IP_PROOF_VERSIONS` gives the program one place to accept a set. A v2 rollout can therefore teach verifiers both versions before switching issuers, instead of needing an atomic cutover across the program, the service, and every deployed CLI inside one freshness window.
- `user_type` is bound rather than the derived User pubkey. The User account is a PDA over `(client_ip, user_type)`, so `client_ip` alone does not pin the account being created — a proof for an IP would otherwise be reusable for a different connection type on that IP. Binding the User pubkey instead would not work: the service is the party that discovers `client_ip`, so the client would have to supply a pubkey derived from its own autodetected IP, and on any NATed or multi-homed host that pubkey disagrees with the IP the service observed, producing a validly signed proof that can never verify.
- Off-chain sign/verify helpers sit behind a non-default `signer` feature. The default build's dependency surface is exactly borsh and `solana-program` — `thiserror` and `IpProofError` are gated with the helpers that need them.
- Committed test vectors behind a `test-vectors` feature, for the program, CLI, and service tests to assert against as those land.
- Updates RFC-27's proof specification to this layout and names the crate as normative, so the verification service (#4198) cannot be written from prose that disagrees with the code. The request body gains `user_type`; onchain validation gains a supported-version check and a `user_type` match.
- Adds a per-crate `cargo hack clippy --each-feature` pass to `rust-lint`. The workspace pass runs with default features only, so a crate whose default feature set is empty would otherwise have most of its code exempt from clippy.

Nothing consumes the crate yet; this is a foundation change with no behavior impact. Onchain validation (#4197), the `GlobalState` verifier key (#4196), the service (#4198), and the client path (#4200/#4201) build on it.

### Note on the issue text

The issue named `ed25519-dalek` for the sign/verify helpers. This uses `solana-keypair` / `solana-signer` / `solana-signature` instead — already resolved in `Cargo.lock`, and the verification service will hold a Solana keypair JSON, so `sign_message()` / `Signature::verify()` are the natural fit with no new crypto dependency. Same intent: the helpers stay behind a non-default feature so nothing extra reaches the program. Test vectors are Rust constants rather than a JSON file, since all three consumers named in the acceptance criteria are Rust.

## Diff Breakdown

| Category     | Files | Lines (+/-) | Net  |
|--------------|-------|-------------|------|
| Core logic   |     2 | +198 / -0   | +198 |
| Tests        |     3 | +372 / -0   | +372 |
| Docs         |     2 | +73 / -18   |  +55 |
| Config/build |     3 | +53 / -0    |  +53 |
| Generated    |     1 | +13 / -0    |  +13 |
| **Total**    |     9 | +709 / -18  | +691 |

Two thirds of the diff is tests and committed vectors; the format itself is ~200 lines. (Core and test counts split within `lib.rs` and `signer.rs`, which carry inline `#[cfg(test)]` modules.)

<details>
<summary>Key files (click to expand)</summary>

- [`crates/doublezero-ip-proof/src/lib.rs`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-d4d650ceadb602f65a20d6dfa0d7bd44f4aee33475970e0c54a3825b28dff3d9) — the `IpOwnershipProof` struct, layout constants derived from the field offsets, version support set, and `signed_message_for()`, plus byte-layout and Borsh round-trip tests
- [`crates/doublezero-ip-proof/src/test_vectors.rs`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-bf9a7fc69db7c8d337777ec98425c31a89ea67d80ef2c14509b257f62efd1ccb) — two committed vectors (specific IP at the default `user_type`, and a wildcard-pass connect with a high epoch and non-zero `user_type`) signed by a fixed test keypair
- [`crates/doublezero-ip-proof/src/signer.rs`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-e66097b68664b56cac53fc76073d633c44f1f205d2a28e544cdc3dce80688788) — `sign()` / `sign_version()` / `verify()` behind the `signer` feature, off-chain only
- [`rfcs/rfc27-ip-verification.md`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-9f9110b47a1525a093f13a2a4644490e1ee50f8284596e1b83f2b25e0b228386) — proof spec updated to the 57-byte layout, with the versioning-rollout and `user_type` rationale
- [`crates/doublezero-ip-proof/Cargo.toml`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-d72436b57edc750568012bc8f948ada8042107f0573109c151de44a526516854) — feature split keeping the default build BPF-clean
- [`Makefile`](https://github.com/malbeclabs/doublezero/pull/4206/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) — per-crate `--each-feature` clippy pass

</details>

## Testing Verification

- Byte-layout test asserts `signed_message()` against a hardcoded expected vector, with offset assertions on the prefix, version byte, little-endian epoch, and trailing `user_type`, so a future field reorder fails loudly rather than silently invalidating every proof.
- A proof carrying `version = 2` reconstructs v2 bytes, not `IP_PROOF_VERSION` bytes — the property that makes a staged version rollout possible.
- Sensitivity test confirms each of `version`, `payer`, `client_ip`, `epoch`, and `user_type` changes the signed message, and that `signature` does not.
- Borsh round trip pins the serialized length at 110 bytes and confirms `client_ip` serializes in network order.
- Sign/verify round trip against a fixed keypair; verify rejects a different verifier key and each individually tampered field, including a bumped version.
- Every committed vector re-derives its own signed message and re-produces its own signature, so the vectors cannot drift from the implementation unnoticed.
- `cargo hack clippy -p doublezero-ip-proof --each-feature --all-targets` is clean across all five feature permutations, which is the pass that keeps `signer.rs` and `test_vectors.rs` linted at all.
- Default-feature dependency surface verified with `cargo tree -e normal`: exactly borsh and `solana-program`.
- BPF buildability: temporarily added the crate as a dependency of `doublezero-serviceability` with a function constructing an `IpOwnershipProof`, calling `signed_message()`, Borsh-serializing it, and calling `is_supported_version()`; `cargo build-sbf --tools-version v1.54` produced `doublezero_serviceability.so` successfully, then reverted. The program does not consume the crate until #4197.
