### PR TITLE
e2e/qa: skip devices without available shred seats

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -255,6 +255,19 @@ current (health-selected) endpoint but deliberately do **not** auto-retry across
 endpoints, since a payment that timed out on submission may have landed onchain
 and a blind retry risks double-submission.
 
+### Multicast settlement device eligibility
+
+When choosing a device automatically, the multicast settlement probe selects
+the lowest-latency reachable device in the required metro class whose enabled
+shred `DeviceHistory` has remaining capacity
+(`ActiveGrantedSeats < ActiveTotalAvailableSeats`). It intentionally does not
+filter on serviceability status or `max_users`, because the QA identity's
+onchain allowlist entry bypasses those checks. That bypass does not apply to the
+independent shred capacity check enforced by `shreds pay`. Devices with no
+remaining shred seats are therefore excluded before the CLI price query; if the
+required metros contain no eligible device, the test fails with an explicit
+eligibility error instead of reporting a misleading missing-price failure.
+
 ### Environment variables
 
 | Variable | Default | Purpose |

--- a/e2e/internal/qa/client_settlement.go
+++ b/e2e/internal/qa/client_settlement.go
@@ -151,10 +151,12 @@ func (c *Client) RetransmitOnlyExchangeKeys(ctx context.Context) (map[string]boo
 // cannot: an empty set means no metro is flagged retransmit-only (the feature
 // is not configured on this network, so the caller may skip), while a non-empty
 // set with a nil device means metros are flagged but none of their devices is
-// reachable — the feature under test cannot be exercised, so the caller should
-// fail rather than silently skip and lose the alert signal. Like ClosestDevice,
-// it does not filter on capacity: the QA user pubkey is on the onchain
-// qa_allowlist, which bypasses capacity limits for QA connections.
+// reachable and eligible for a new shred seat — the feature under test cannot
+// be exercised, so the caller should fail rather than silently skip and lose
+// the alert signal. Serviceability status and capacity are deliberately not
+// considered: the QA user pubkey is on that program's qa_allowlist. Shred seat
+// capacity is independent and must be considered because `shreds pay` does not
+// have the same bypass.
 func (c *Client) ClosestRetransmitOnlyDevice(ctx context.Context) (*Device, map[string]bool, error) {
 	retransmitOnly, err := c.RetransmitOnlyExchangeKeys(ctx)
 	if err != nil {
@@ -183,21 +185,60 @@ func (c *Client) ClosestNonRetransmitOnlyDevice(ctx context.Context) (*Device, e
 }
 
 // closestDeviceInMetros returns the lowest-latency reachable device whose metro
-// membership in exchangeKeys equals want.
+// membership in exchangeKeys equals want and which can accept a new shred seat.
 func (c *Client) closestDeviceInMetros(ctx context.Context, exchangeKeys map[string]bool, want bool) (*Device, error) {
+	programID, err := solana.PublicKeyFromBase58(c.ShredSubscriptionProgramID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse shred subscription program ID %q: %w", c.ShredSubscriptionProgramID, err)
+	}
+	histories, err := c.shredsClient(programID).FetchAllDeviceHistories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch device histories on host %s: %w", c.Host, err)
+	}
+	availableDeviceKeys := availableShredDeviceKeys(histories)
+
 	latencies, err := c.GetLatency(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latency on host %s: %w", c.Host, err)
 	}
 
+	bestDevice, bestAvg := closestAvailableDeviceInMetros(latencies, c.devices, exchangeKeys, availableDeviceKeys, want)
+	if bestDevice != nil {
+		c.log.Debug("Determined closest device", "host", c.Host, "deviceCode", bestDevice.Code,
+			"avgLatencyNs", bestAvg, "retransmitOnly", want)
+	}
+	return bestDevice, nil
+}
+
+// availableShredDeviceKeys returns device pubkeys that the shred price command
+// would report without --all. Use the active header counts rather than the
+// subscription ring: instant allocations and withdrawals update these fields
+// immediately, so they represent the capacity available at selection time.
+func availableShredDeviceKeys(histories []shreds.KeyedDeviceHistory) map[string]bool {
+	available := make(map[string]bool)
+	for _, history := range histories {
+		if history.IsEnabled() && history.ActiveGrantedSeats < history.ActiveTotalAvailableSeats {
+			available[history.DeviceKey.String()] = true
+		}
+	}
+	return available
+}
+
+func closestAvailableDeviceInMetros(
+	latencies []*pb.Latency,
+	devices map[string]*Device,
+	exchangeKeys map[string]bool,
+	availableDeviceKeys map[string]bool,
+	want bool,
+) (*Device, uint64) {
 	var bestDevice *Device
-	var bestAvg uint64 = math.MaxUint64
+	bestAvg := uint64(math.MaxUint64)
 	for _, l := range latencies {
 		if !l.Reachable {
 			continue
 		}
-		device, ok := c.devices[l.DeviceCode]
-		if !ok || exchangeKeys[device.ExchangePubKey] != want {
+		device, ok := devices[l.DeviceCode]
+		if !ok || !availableDeviceKeys[device.PubKey] || exchangeKeys[device.ExchangePubKey] != want {
 			continue
 		}
 		if l.AvgLatencyNs < bestAvg {
@@ -205,11 +246,7 @@ func (c *Client) closestDeviceInMetros(ctx context.Context, exchangeKeys map[str
 			bestDevice = device
 		}
 	}
-	if bestDevice != nil {
-		c.log.Debug("Determined closest device", "host", c.Host, "deviceCode", bestDevice.Code,
-			"avgLatencyNs", bestAvg, "retransmitOnly", want)
-	}
-	return bestDevice, nil
+	return bestDevice, bestAvg
 }
 
 // FeedSeatPrice calls the FeedSeatPrice RPC to query seat pricing for a single

--- a/e2e/internal/qa/client_settlement_test.go
+++ b/e2e/internal/qa/client_settlement_test.go
@@ -7,18 +7,88 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	pb "github.com/malbeclabs/doublezero/e2e/proto/qa/gen/pb-go"
 	shreds "github.com/malbeclabs/doublezero/sdk/shreds/go"
 )
 
-func seat(pubkey byte, ipBits uint32, tenure uint16) shreds.KeyedClientSeat {
+func markedPubkey(marker byte) solana.PublicKey {
 	var pk solana.PublicKey
-	pk[0] = pubkey
+	pk[0] = marker
+	return pk
+}
+
+func seat(pubkey byte, ipBits uint32, tenure uint16) shreds.KeyedClientSeat {
 	return shreds.KeyedClientSeat{
-		Pubkey: pk,
+		Pubkey: markedPubkey(pubkey),
 		ClientSeat: shreds.ClientSeat{
 			ClientIPBits: ipBits,
 			TenureEpochs: tenure,
 		},
+	}
+}
+
+func TestAvailableShredDeviceKeys(t *testing.T) {
+	histories := []shreds.KeyedDeviceHistory{
+		{DeviceHistory: shreds.DeviceHistory{
+			DeviceKey: markedPubkey(1), Flags: 1 << 1,
+			ActiveGrantedSeats: 0, ActiveTotalAvailableSeats: 1,
+		}},
+		{DeviceHistory: shreds.DeviceHistory{
+			DeviceKey: markedPubkey(2), Flags: 1 << 1,
+			ActiveGrantedSeats: 0, ActiveTotalAvailableSeats: 0,
+		}},
+		{DeviceHistory: shreds.DeviceHistory{
+			DeviceKey: markedPubkey(3), Flags: 1 << 1,
+			ActiveGrantedSeats: 2, ActiveTotalAvailableSeats: 2,
+		}},
+		{DeviceHistory: shreds.DeviceHistory{
+			DeviceKey:          markedPubkey(4),
+			ActiveGrantedSeats: 0, ActiveTotalAvailableSeats: 1,
+		}},
+	}
+
+	available := availableShredDeviceKeys(histories)
+	if len(available) != 1 || !available[markedPubkey(1).String()] {
+		t.Fatalf("availableShredDeviceKeys() = %v, want only device 1", available)
+	}
+}
+
+func TestClosestAvailableDeviceInMetros(t *testing.T) {
+	closestUnavailable := &Device{
+		PubKey: markedPubkey(1).String(), Code: "closest-unavailable", ExchangePubKey: "retransmit",
+	}
+	qaBypassDevice := &Device{
+		// Pending with max_users=0: the QA pubkey bypasses these serviceability
+		// checks, so shred capacity is the only capacity filter this selector adds.
+		PubKey: markedPubkey(2).String(), Code: "qa-bypass", ExchangePubKey: "retransmit",
+	}
+	fartherAvailable := &Device{
+		PubKey: markedPubkey(3).String(), Code: "available", ExchangePubKey: "retransmit",
+	}
+	wrongMetro := &Device{
+		PubKey: markedPubkey(4).String(), Code: "wrong-metro", ExchangePubKey: "other",
+	}
+	devices := map[string]*Device{
+		closestUnavailable.Code: closestUnavailable,
+		qaBypassDevice.Code:     qaBypassDevice,
+		fartherAvailable.Code:   fartherAvailable,
+		wrongMetro.Code:         wrongMetro,
+	}
+	latencies := []*pb.Latency{
+		{DeviceCode: closestUnavailable.Code, Reachable: true, AvgLatencyNs: 1},
+		{DeviceCode: qaBypassDevice.Code, Reachable: true, AvgLatencyNs: 2},
+		{DeviceCode: wrongMetro.Code, Reachable: true, AvgLatencyNs: 3},
+		{DeviceCode: fartherAvailable.Code, Reachable: true, AvgLatencyNs: 4},
+	}
+	available := map[string]bool{
+		qaBypassDevice.PubKey:   true,
+		wrongMetro.PubKey:       true,
+		fartherAvailable.PubKey: true,
+	}
+
+	got, avg := closestAvailableDeviceInMetros(latencies, devices, map[string]bool{"retransmit": true}, available, true)
+	if got != qaBypassDevice || avg != 2 {
+		t.Fatalf("closestAvailableDeviceInMetros() = (%v, %d), want (%v, 2)", got, avg, qaBypassDevice)
 	}
 }
 

--- a/e2e/qa_multicast_settlement_test.go
+++ b/e2e/qa_multicast_settlement_test.go
@@ -94,7 +94,7 @@ func selectRetransmitOnlyDevice(t *testing.T, ctx context.Context, log *slog.Log
 			t.Skip("Skipping: no metro is flagged retransmit-only (feature not deployed/configured on this network)")
 		}
 		require.NotNil(t, selected,
-			"retransmit-only metros %v are configured but no reachable device matched; the feature under test cannot be exercised",
+			"retransmit-only metros %v are configured but no reachable device with an available shred seat matched; the feature under test cannot be exercised",
 			flaggedMetroCodes(test, retransmitOnly))
 		device = selected
 	}


### PR DESCRIPTION
## Summary

- Filter automatic multicast settlement device selection using the onchain shred `DeviceHistory`.
- Select only enabled devices where `ActiveGrantedSeats < ActiveTotalAvailableSeats`.
- Preserve the QA allowlist bypass for serviceability status and `max_users`; `Device.Ready()` remains unchanged.
- Report a clear eligibility failure when retransmit-only metros have no reachable device with an available shred seat.
- Add regression tests and document the selection behavior.

## Context

The QA run selected `dz-sea10-sw01`, which was reachable and in a retransmit-only metro but had `0/0` shred seats available. The price command hides devices without remaining seats, resulting in a misleading `no price found` failure. Even if its price were exposed with `--all`, `shreds pay` would reject a new seat because shred capacity does not share the serviceability QA bypass.

Failed run: https://github.com/malbeclabs/infra/actions/runs/32279618092

## Testing

- `go test ./e2e/internal/qa`
- `go test -tags=qa -run '^$' ./e2e --args -env=mainnet-beta`
- `make go-test`
- `make go-lint`