### PR TITLE
monitor: use per-chain slot times in epoch estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Monitor
+  - The serviceability watcher's epoch estimates now use a per-chain slot time instead of 400ms everywhere: 350ms for Solana mainnet, 200ms for Solana testnet (which DoubleZero devnet also dials), and 400ms for the DoubleZero ledger. A 432,000-slot Solana epoch was over-estimated by ~6 hours on mainnet and ~24 hours on testnet in the `previous_epoch_start` / `next_epoch_start` log fields. The mainnet value must move to 200ms once Solana finishes its 200ms slot rollout. (malbeclabs/infra#2319)
 - RFCs
   - RFC-27: IP Ownership Verification Service for user connection
 - Serviceability

--- a/client/doublezerod/internal/runtime/run_test.go
+++ b/client/doublezerod/internal/runtime/run_test.go
@@ -313,10 +313,6 @@ func runIBRLTest(t *testing.T, userType api.UserType, provisioningRequest map[st
 				t.Fatalf("timed out waiting for peer status of pending")
 			}
 			// ensure that 4.4.4.4,3.3.3.3 are added and tagged with bgp (unix.RTPROT_BGP)
-			got, err = nl.RouteListFiltered(nl.FAMILY_V4, &nl.Route{Protocol: unix.RTPROT_BGP}, nl.RT_FILTER_PROTOCOL)
-			if err != nil {
-				t.Fatalf("error fetching routes: %v", err)
-			}
 			tun, err := nl.LinkByName("doublezero0")
 			if err != nil {
 				t.Fatalf("error fetching tunnel info: %v", err)
@@ -348,6 +344,14 @@ func runIBRLTest(t *testing.T, userType api.UserType, provisioningRequest map[st
 					Family:   nl.FAMILY_V4,
 					Type:     syscall.RTN_UNICAST,
 				},
+			}
+			// The session status flips to up before the peer's UPDATE has been parsed
+			// and its prefixes written to the kernel, and the prefixes are installed
+			// one at a time, so poll until the route set converges instead of
+			// sampling it once.
+			got, err = waitForBgpRoutes(want, 10*time.Second)
+			if err != nil {
+				t.Fatalf("error fetching routes: %v", err)
 			}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Fatalf("Route mismatch (-want +got): %s\n", diff)
@@ -1666,6 +1670,25 @@ func waitForPeerStatus(httpClient http.Client, userType api.UserType, status bgp
 		time.Sleep(200 * time.Millisecond)
 	}
 	return false, nil
+}
+
+// waitForBgpRoutes polls the kernel for routes tagged with the BGP protocol until they
+// match want, or until the timeout expires. Route installation is asynchronous with
+// respect to the reported BGP session status and happens one prefix at a time, so a
+// single sample can observe an empty or partial route set. The last observed set is
+// returned so the caller can diff it and report the mismatch.
+func waitForBgpRoutes(want []nl.Route, timeout time.Duration) ([]nl.Route, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		got, err := nl.RouteListFiltered(nl.FAMILY_V4, &nl.Route{Protocol: unix.RTPROT_BGP}, nl.RT_FILTER_PROTOCOL)
+		if err != nil {
+			return nil, err
+		}
+		if cmp.Diff(want, got) == "" || !time.Now().Before(deadline) {
+			return got, nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 func sendClientRequest(httpClient http.Client, endpoint, body string) error {

--- a/controlplane/monitor/internal/serviceability/epoch.go
+++ b/controlplane/monitor/internal/serviceability/epoch.go
@@ -7,13 +7,8 @@ import (
 )
 
 // The slot times below are *observed* rates, not protocol constants: actual slot
-// time varies with network conditions.
-//
-// Solana is mid-rollout to 200ms slots. Testnet is already there; mainnet still
-// produces slots in ~350ms, and solanaMainnetSlotTime must be changed to 200ms
-// once mainnet completes the migration.
-//
-// The DoubleZero ledger targets 400ms and runs slightly ahead of it.
+// time varies with network conditions, and a cluster that changes its slot
+// cadence needs its value here updated.
 const (
 	dzLedgerSlotTime      = 400 * time.Millisecond
 	solanaMainnetSlotTime = 350 * time.Millisecond

--- a/controlplane/monitor/internal/serviceability/epoch.go
+++ b/controlplane/monitor/internal/serviceability/epoch.go
@@ -20,13 +20,11 @@ const (
 	solanaTestnetSlotTime = 200 * time.Millisecond
 )
 
-// slotTimeForChain returns the slot time to use for a chain in a given DoubleZero
-// environment. Anything that is not Solana L1 — and any environment not named
-// below — gets the DoubleZero ledger's slot time.
-func slotTimeForChain(chainName, env string) time.Duration {
-	if chainName != chainSolana {
-		return dzLedgerSlotTime
-	}
+// solanaSlotTime returns the slot time of the Solana cluster a DoubleZero
+// environment dials by default. A SOLANA_RPC_URL override repoints the cluster
+// without changing the environment (see config.NetworkConfigForEnv), so pointing
+// one environment's monitor at another cluster skews the estimate again.
+func solanaSlotTime(env string) time.Duration {
 	switch env {
 	case config.EnvMainnetBeta, config.EnvMainnet:
 		return solanaMainnetSlotTime
@@ -35,12 +33,20 @@ func slotTimeForChain(chainName, env string) time.Duration {
 	case config.EnvTestnet, config.EnvDevnet:
 		return solanaTestnetSlotTime
 	default:
+		// Localnet runs a local test validator, which targets 400ms; so does any
+		// environment we do not recognize, which keeps the previous behavior.
 		return dzLedgerSlotTime
 	}
 }
 
 // CalculateEpochTimes calculates the estimated start time of the previous and next epochs.
 func CalculateEpochTimes(slotIndex, slotsInEpoch uint64, slotTime time.Duration) (currentEpochStartTime, nextEpochTime time.Time) {
+	// A malformed getEpochInfo response would wrap the arithmetic below into a
+	// plausible-looking timestamp; return zero times so the log shows it plainly.
+	if slotsInEpoch == 0 || slotIndex > slotsInEpoch {
+		return time.Time{}, time.Time{}
+	}
+
 	nowUTC := time.Now().UTC()
 
 	// calculate epoch start

--- a/controlplane/monitor/internal/serviceability/epoch.go
+++ b/controlplane/monitor/internal/serviceability/epoch.go
@@ -2,27 +2,54 @@ package serviceability
 
 import (
 	"time"
+
+	"github.com/malbeclabs/doublezero/config"
 )
 
-// slotTimeSeconds is the *approximate* time for a Solana slot (400ms).
-// NOTE: This is a target. The actual slot time varies with network conditions.
-// For more accurate calculations, one would need to use other RPC methods
-// like `getBlockTime` for specific slots, which is beyond the scope of this tool.
-const slotTimeSeconds = 0.4
+// The slot times below are *observed* rates, not protocol constants: actual slot
+// time varies with network conditions.
+//
+// Solana is mid-rollout to 200ms slots. Testnet is already there; mainnet still
+// produces slots in ~350ms, and solanaMainnetSlotTime must be changed to 200ms
+// once mainnet completes the migration.
+//
+// The DoubleZero ledger targets 400ms and runs slightly ahead of it.
+const (
+	dzLedgerSlotTime      = 400 * time.Millisecond
+	solanaMainnetSlotTime = 350 * time.Millisecond
+	solanaTestnetSlotTime = 200 * time.Millisecond
+)
+
+// slotTimeForChain returns the slot time to use for a chain in a given DoubleZero
+// environment. Anything that is not Solana L1 — and any environment not named
+// below — gets the DoubleZero ledger's slot time.
+func slotTimeForChain(chainName, env string) time.Duration {
+	if chainName != chainSolana {
+		return dzLedgerSlotTime
+	}
+	switch env {
+	case config.EnvMainnetBeta, config.EnvMainnet:
+		return solanaMainnetSlotTime
+	// DoubleZero devnet dials Solana *testnet* (config.NetworkConfigForEnv gives it
+	// TestnetSolanaRPC), so Solana devnet's slot rate never applies here.
+	case config.EnvTestnet, config.EnvDevnet:
+		return solanaTestnetSlotTime
+	default:
+		return dzLedgerSlotTime
+	}
+}
 
 // CalculateEpochTimes calculates the estimated start time of the previous and next epochs.
-func CalculateEpochTimes(slotIndex, slotsInEpoch uint64) (currentEpochStartTime, nextEpochTime time.Time) {
+func CalculateEpochTimes(slotIndex, slotsInEpoch uint64, slotTime time.Duration) (currentEpochStartTime, nextEpochTime time.Time) {
 	nowUTC := time.Now().UTC()
 
 	// calculate epoch start
-	secondsSinceEpochStart := float64(slotIndex) * slotTimeSeconds
-	durationSinceEpochStart := time.Duration(secondsSinceEpochStart * float64(time.Second))
+	durationSinceEpochStart := time.Duration(slotIndex) * slotTime
 	currentEpochStartTime = nowUTC.Add(-durationSinceEpochStart)
 
 	// calculate next epoch start
 	slotsUntilNextEpoch := slotsInEpoch - slotIndex
-	secondsUntilNextEpoch := float64(slotsUntilNextEpoch) * slotTimeSeconds
-	durationUntilNextEpoch := time.Duration(secondsUntilNextEpoch * float64(time.Second))
+	durationUntilNextEpoch := time.Duration(slotsUntilNextEpoch) * slotTime
 	nextEpochTime = nowUTC.Add(durationUntilNextEpoch)
 
 	return currentEpochStartTime, nextEpochTime

--- a/controlplane/monitor/internal/serviceability/epoch_test.go
+++ b/controlplane/monitor/internal/serviceability/epoch_test.go
@@ -1,0 +1,71 @@
+package serviceability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceability_SlotTimeForChain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		chain string
+		env   string
+		want  time.Duration
+	}{
+		{"solana mainnet-beta", chainSolana, "mainnet-beta", 350 * time.Millisecond},
+		{"solana mainnet", chainSolana, "mainnet", 350 * time.Millisecond},
+		{"solana testnet", chainSolana, "testnet", 200 * time.Millisecond},
+		// DZ devnet dials Solana testnet.
+		{"solana devnet", chainSolana, "devnet", 200 * time.Millisecond},
+		{"solana localnet", chainSolana, "localnet", 400 * time.Millisecond},
+		{"solana unknown env", chainSolana, "", 400 * time.Millisecond},
+		{"doublezero mainnet-beta", chainDoubleZero, "mainnet-beta", 400 * time.Millisecond},
+		{"doublezero testnet", chainDoubleZero, "testnet", 400 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, slotTimeForChain(tt.chain, tt.env))
+		})
+	}
+}
+
+func TestServiceability_CalculateEpochTimes(t *testing.T) {
+	t.Parallel()
+
+	const slotsInEpoch = 432_000
+	const tolerance = 5 * time.Second
+
+	tests := []struct {
+		name      string
+		slotIndex uint64
+		slotTime  time.Duration
+	}{
+		{"dz ledger mid-epoch", slotsInEpoch / 2, dzLedgerSlotTime},
+		{"solana mainnet mid-epoch", slotsInEpoch / 2, solanaMainnetSlotTime},
+		{"solana testnet mid-epoch", slotsInEpoch / 2, solanaTestnetSlotTime},
+		{"epoch start", 0, solanaMainnetSlotTime},
+		{"epoch end", slotsInEpoch, solanaTestnetSlotTime},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Now().UTC()
+			start, next := CalculateEpochTimes(tt.slotIndex, slotsInEpoch, tt.slotTime)
+
+			// The full epoch spans slotsInEpoch slots, exactly, since both times
+			// derive from a single clock read inside the function.
+			require.Equal(t, time.Duration(slotsInEpoch)*tt.slotTime, next.Sub(start))
+
+			require.WithinDuration(t, now.Add(-time.Duration(tt.slotIndex)*tt.slotTime), start, tolerance)
+			require.WithinDuration(t, now.Add(time.Duration(slotsInEpoch-tt.slotIndex)*tt.slotTime), next, tolerance)
+		})
+	}
+}

--- a/controlplane/monitor/internal/serviceability/epoch_test.go
+++ b/controlplane/monitor/internal/serviceability/epoch_test.go
@@ -7,30 +7,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceability_SlotTimeForChain(t *testing.T) {
+func TestServiceability_SolanaSlotTime(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		chain string
-		env   string
-		want  time.Duration
+		name string
+		env  string
+		want time.Duration
 	}{
-		{"solana mainnet-beta", chainSolana, "mainnet-beta", 350 * time.Millisecond},
-		{"solana mainnet", chainSolana, "mainnet", 350 * time.Millisecond},
-		{"solana testnet", chainSolana, "testnet", 200 * time.Millisecond},
+		{"mainnet-beta", "mainnet-beta", 350 * time.Millisecond},
+		{"mainnet", "mainnet", 350 * time.Millisecond},
+		{"testnet", "testnet", 200 * time.Millisecond},
 		// DZ devnet dials Solana testnet.
-		{"solana devnet", chainSolana, "devnet", 200 * time.Millisecond},
-		{"solana localnet", chainSolana, "localnet", 400 * time.Millisecond},
-		{"solana unknown env", chainSolana, "", 400 * time.Millisecond},
-		{"doublezero mainnet-beta", chainDoubleZero, "mainnet-beta", 400 * time.Millisecond},
-		{"doublezero testnet", chainDoubleZero, "testnet", 400 * time.Millisecond},
+		{"devnet", "devnet", 200 * time.Millisecond},
+		{"localnet", "localnet", 400 * time.Millisecond},
+		{"unknown env", "", 400 * time.Millisecond},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.want, slotTimeForChain(tt.chain, tt.env))
+			require.Equal(t, tt.want, solanaSlotTime(tt.env))
 		})
 	}
 }
@@ -66,6 +63,31 @@ func TestServiceability_CalculateEpochTimes(t *testing.T) {
 
 			require.WithinDuration(t, now.Add(-time.Duration(tt.slotIndex)*tt.slotTime), start, tolerance)
 			require.WithinDuration(t, now.Add(time.Duration(slotsInEpoch-tt.slotIndex)*tt.slotTime), next, tolerance)
+		})
+	}
+}
+
+func TestServiceability_CalculateEpochTimes_MalformedEpochInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		slotIndex    uint64
+		slotsInEpoch uint64
+	}{
+		{"no slots in epoch", 0, 0},
+		{"slot index past end of epoch", 432_001, 432_000},
+		// Would otherwise overflow the duration multiplication.
+		{"absurd slot index", 1 << 62, 432_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			start, next := CalculateEpochTimes(tt.slotIndex, tt.slotsInEpoch, solanaMainnetSlotTime)
+			require.True(t, start.IsZero())
+			require.True(t, next.IsZero())
 		})
 	}
 }

--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -19,11 +19,6 @@ import (
 
 const (
 	watcherName = "serviceability"
-
-	// Chain names. These appear in log fields and select the slot time used for
-	// epoch estimates.
-	chainDoubleZero = "doublezero"
-	chainSolana     = "solana"
 )
 
 var (
@@ -137,12 +132,12 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 	w.cacheUsers = data.Users
 
 	// detect current epoch info
-	w.detectEpochChange(chainDoubleZero, w.cfg.LedgerRPCClient, &w.currDZEpoch)
-	w.detectEpochChange(chainSolana, w.cfg.SolanaRPCClient, &w.currSolanaEpoch)
+	w.detectEpochChange("doublezero", dzLedgerSlotTime, w.cfg.LedgerRPCClient, &w.currDZEpoch)
+	w.detectEpochChange("solana", solanaSlotTime(w.cfg.Env), w.cfg.SolanaRPCClient, &w.currSolanaEpoch)
 	return nil
 }
 
-func (w *ServiceabilityWatcher) detectEpochChange(chainName string, rpcClient LedgerRPCClient, lastEpoch *uint64) {
+func (w *ServiceabilityWatcher) detectEpochChange(chainName string, slotTime time.Duration, rpcClient LedgerRPCClient, lastEpoch *uint64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	epochInfo, err := rpcClient.GetEpochInfo(ctx, solanarpc.CommitmentFinalized)
@@ -152,7 +147,7 @@ func (w *ServiceabilityWatcher) detectEpochChange(chainName string, rpcClient Le
 	}
 
 	currEpoch := epochInfo.Epoch
-	prevEpochStart, nextEpochStart := CalculateEpochTimes(epochInfo.SlotIndex, epochInfo.SlotsInEpoch, slotTimeForChain(chainName, w.cfg.Env))
+	prevEpochStart, nextEpochStart := CalculateEpochTimes(epochInfo.SlotIndex, epochInfo.SlotsInEpoch, slotTime)
 	w.log.Debug("epoch status", "chain", chainName, "current_epoch", currEpoch, "previous_epoch_start", prevEpochStart, "next_epoch_start", nextEpochStart)
 
 	// if epoch is 0, we just restarted

--- a/controlplane/monitor/internal/serviceability/watcher.go
+++ b/controlplane/monitor/internal/serviceability/watcher.go
@@ -19,6 +19,11 @@ import (
 
 const (
 	watcherName = "serviceability"
+
+	// Chain names. These appear in log fields and select the slot time used for
+	// epoch estimates.
+	chainDoubleZero = "doublezero"
+	chainSolana     = "solana"
 )
 
 var (
@@ -132,8 +137,8 @@ func (w *ServiceabilityWatcher) Tick(ctx context.Context) error {
 	w.cacheUsers = data.Users
 
 	// detect current epoch info
-	w.detectEpochChange("doublezero", w.cfg.LedgerRPCClient, &w.currDZEpoch)
-	w.detectEpochChange("solana", w.cfg.SolanaRPCClient, &w.currSolanaEpoch)
+	w.detectEpochChange(chainDoubleZero, w.cfg.LedgerRPCClient, &w.currDZEpoch)
+	w.detectEpochChange(chainSolana, w.cfg.SolanaRPCClient, &w.currSolanaEpoch)
 	return nil
 }
 
@@ -147,7 +152,7 @@ func (w *ServiceabilityWatcher) detectEpochChange(chainName string, rpcClient Le
 	}
 
 	currEpoch := epochInfo.Epoch
-	prevEpochStart, nextEpochStart := CalculateEpochTimes(epochInfo.SlotIndex, epochInfo.SlotsInEpoch)
+	prevEpochStart, nextEpochStart := CalculateEpochTimes(epochInfo.SlotIndex, epochInfo.SlotsInEpoch, slotTimeForChain(chainName, w.cfg.Env))
 	w.log.Debug("epoch status", "chain", chainName, "current_epoch", currEpoch, "previous_epoch_start", prevEpochStart, "next_epoch_start", nextEpochStart)
 
 	// if epoch is 0, we just restarted

--- a/controlplane/telemetry/internal/telemetry/pinger_test.go
+++ b/controlplane/telemetry/internal/telemetry/pinger_test.go
@@ -389,7 +389,11 @@ func TestAgentTelemetry_Pinger(t *testing.T) {
 		}
 
 		handler := newRecordingHandler()
-		buf := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](1024)
+		// Capacity has to outrun this test's worst case, not its expected case: Add applies
+		// backpressure by blocking, and with no submitter draining the partition a full one wedges
+		// Tick for good, so probing would never resume under the fresh epoch. The Eventually
+		// timeouts below allow ~25s of probing at 5ms per sample, so size for ~5k samples.
+		buf := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](1 << 16)
 		pinger := telemetry.NewPinger(slog.New(handler), &telemetry.PingerConfig{
 			LocalDevicePK:        devicePK,
 			Interval:             5 * time.Millisecond,
@@ -927,7 +931,10 @@ func TestAgentTelemetry_PingerEpochMetrics(t *testing.T) {
 
 		handler := newRecordingHandler()
 		devicePK, peerPK, linkPK := newPK(59), newPK(60), newPK(61)
-		buf := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](4096)
+		// Nothing drains this partition and a full one blocks Add for good, so the driver loop below
+		// is paced to the pinger's own interval and the partition sized to hold every sample the
+		// Eventually window allows.
+		buf := buffer.NewMemoryPartitionedBuffer[telemetry.PartitionKey, telemetry.Sample](1 << 16)
 		pinger := telemetry.NewPinger(slog.New(handler), &telemetry.PingerConfig{
 			LocalDevicePK:        devicePK,
 			Interval:             time.Millisecond,
@@ -955,6 +962,7 @@ func TestAgentTelemetry_PingerEpochMetrics(t *testing.T) {
 			defer wg.Done()
 			for ctx.Err() == nil {
 				pinger.Tick(ctx)
+				time.Sleep(time.Millisecond)
 			}
 		}()
 


### PR DESCRIPTION
## Summary of Changes

* The monitor's epoch-time estimate now uses a per-chain slot time: 350ms for Solana mainnet, 200ms for Solana testnet (which DoubleZero devnet also dials), 400ms for the DoubleZero ledger.
* `CalculateEpochTimes` multiplied remaining slots by 400ms for both chains, so the `previous_epoch_start` / `next_epoch_start` log fields put a Solana epoch boundary ~6 hours late on mainnet and ~24 hours late on testnet. The values are hardcoded — no slot-rate estimator, no extra RPC calls.
* Fixes malbeclabs/infra#2319

## Testing Verification

* New `epoch_test.go` pins the env → slot-time mapping (including DZ devnet resolving to Solana testnet's 200ms, and localnet/unrecognized envs keeping 400ms) and asserts the estimated boundaries are exactly `slotsInEpoch × slotTime` apart and correctly signed around `now`.
* For a 432,000-slot epoch the Solana estimate goes from ~48 hours to ~42 hours on mainnet and ~24 hours on testnet; the DoubleZero ledger's estimate is unchanged.
* A `getEpochInfo` response with `slotIndex > slotsInEpoch` or `slotsInEpoch == 0` now yields zero times instead of an underflowed timestamp that reads as a real boundary; covered by a test.
