### PR TITLE
cli: drop the unreachable AccessPass pre-flight copy

### DIFF
--- a/crates/doublezero-daemon-cli/src/connect.rs
+++ b/crates/doublezero-daemon-cli/src/connect.rs
@@ -168,12 +168,16 @@ enum FeedJoinUser {
     },
 }
 
-/// AccessPass pre-flight: `Ok(false)` when no pass exists for
-/// `(client_ip, payer)` so the caller can render its own diagnostic before
-/// bailing. With `enforce_epoch`, the pass must also cover the current epoch.
+/// AccessPass pre-flight: `Ok(false)` when no pass exists for `(client_ip, payer)` so the caller
+/// can render its own diagnostic before bailing. With `enforce_epoch`, the pass must also cover
+/// the current epoch.
 ///
-/// Mirrors `check_accesspass` in `smartcontract/cli/src/requirements.rs` —
-/// keep the two in sync if AccessPass validity semantics change.
+/// [`LedgerClient::get_accesspass`] resolves through `GetAccessPassCommand`, which probes the
+/// dynamic (0.0.0.0) PDA before the exact-IP one, so a wildcard-seat holder — including the
+/// `EdgeSeat` passes the Feed Oracle issues — is found here without a second lookup. That is the
+/// same ordering `CreateUserCommand` uses to pick the PDA it sends, and the program accepts either
+/// (`smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs`), so
+/// this pre-flight accepts exactly what the transaction will.
 fn check_accesspass<L: LedgerClient>(
     ledger: &L,
     client_ip: Ipv4Addr,

--- a/smartcontract/cli/src/requirements.rs
+++ b/smartcontract/cli/src/requirements.rs
@@ -1,12 +1,6 @@
-use std::net::Ipv4Addr;
-
 use crate::doublezerocommand::CliCommand;
 use doublezero_sdk::{
-    commands::{
-        accesspass::get::GetAccessPassCommand,
-        allowlist::foundation::list::ListFoundationAllowlistCommand,
-    },
-    get_doublezero_pubkey,
+    commands::allowlist::foundation::list::ListFoundationAllowlistCommand, get_doublezero_pubkey,
 };
 use indicatif::ProgressBar;
 
@@ -79,32 +73,6 @@ pub fn check_balance(client: &dyn CliCommand, spinner: Option<&ProgressBar>) -> 
         }
         Err(e) => Err(eyre::eyre!("Unable to get balance: {:?}", e)),
     }
-}
-
-/// Mirrors `check_accesspass` in `doublezero-daemon-cli`
-/// (`crates/doublezero-daemon-cli/src/connect.rs`) — keep the two in sync if
-/// AccessPass validity semantics change.
-pub fn check_accesspass(
-    client: &dyn CliCommand,
-    client_ip: Ipv4Addr,
-    enforce_epoch: bool,
-) -> eyre::Result<bool> {
-    // A missing AccessPass returns Ok(false) (not an error) so the caller can
-    // render its own diagnostic (e.g. the client IP and UserPayer) before
-    // bailing, rather than surfacing a generic "not found" message.
-    let Some((_, accesspass)) = client.get_accesspass(GetAccessPassCommand {
-        client_ip,
-        user_payer: client.get_payer(),
-    })?
-    else {
-        return Ok(false);
-    };
-
-    if !enforce_epoch {
-        return Ok(true);
-    }
-    let epoch = client.get_epoch()?;
-    Ok(accesspass.last_access_epoch >= epoch)
 }
 
 pub fn check_allowlist(


### PR DESCRIPTION
Closes #4202. Part of RFC-27 ([`rfcs/rfc27-ip-verification.md`](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc27-ip-verification.md), tracker #4194), though independent of the rest of that work.

## Summary

- Delete `smartcontract/cli/src/requirements.rs::check_accesspass`. It has no callers — `check_requirements` dispatches only `CHECK_ID_JSON`, `CHECK_BALANCE` and `CHECK_FOUNDATION_ALLOWLIST`, and nothing else in the repo references the function. That leaves one live copy of the pre-flight, in `doublezero-daemon-cli`, so the "keep the two in sync" comment each copy carried goes with it.
- No behavior change. `GetAccessPassCommand` has probed the dynamic (`0.0.0.0`) PDA before the exact-IP one since #3860, so the live pre-flight already accepts a wildcard-seat holder — including the `EdgeSeat` passes the Feed Oracle issues — without a fallback of its own. Its doc comment now records where that resolution order lives and that `CreateUserCommand` picks its PDA the same way, so the check accepts exactly what the transaction will send.

## What changed since the first review

The original version of this PR added a `None → lookup(0.0.0.0)` fallback to the pre-flight and hoisted both copies into a new SDK helper. Reviewers were right on both counts:

- The fallback could never fire. Both lookups routed through `GetAccessPassCommand`, which already reads the `0.0.0.0` PDA first, so a miss already proved that account absent; the fallback bought one extra RPC on the no-pass path. (@juan-malbeclabs, @martinsander00)
- There were not two live copies to deduplicate — one was dead code. (@juan-malbeclabs)

So the change is now the deletion, and the CHANGELOG entry is dropped: nothing user-visible moves.

The remaining gap @juan-malbeclabs identified — an epoch-stale `0.0.0.0` pass masking a valid exact-IP pass, which needs `GetAccessPassCommand` to prefer a *usable* pass so `create_user` sends the one the check blessed — is pre-existing on `main` and tracked separately in #4244.

## Testing Verification

- `cargo test -p doublezero_sdk -p doublezero-daemon-cli -p doublezero-serviceability-cli` green (860 tests).
- The pre-flight's body is byte-identical to `main`; only its doc comment changed. The resolution order it depends on is already pinned by the `GetAccessPassCommand` tests in `smartcontract/sdk/rs/src/commands/accesspass/get.rs` (`test_get_accesspass_prefers_dynamic_pass`, `_falls_back_to_exact_ip`, `_returns_none_when_neither_present`, `_unspecified_does_single_lookup`).
- Confirmed the deleted function is unreachable: `grep -rn check_accesspass --include=*.rs` returns only the daemon-cli copy and its call site.
