### PR TITLE
serviceability-cli: prune User test literals to only asserted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - The `user delete`, `user request-ban` and `user update` tests build their expected `User` with `User::default()` instead of a 22-field literal whose non-asserted fields were noise. First slice of #4084. (#4235)
+
 ## [v0.40.0](https://github.com/malbeclabs/doublezero/compare/client/v0.39.0...client/v0.40.0) - 2026-09-11
 
 ### Breaking

--- a/smartcontract/cli/src/user/delete.rs
+++ b/smartcontract/cli/src/user/delete.rs
@@ -57,7 +57,7 @@ mod tests {
     };
     use doublezero_sdk::{
         commands::user::{delete::DeleteUserCommand, get::GetUserCommand},
-        AccountType, User, UserCYOA, UserStatus, UserType,
+        User,
     };
     use doublezero_serviceability::pda::get_user_old_pda;
     use mockall::predicate;
@@ -76,31 +76,9 @@ mod tests {
             100, 221, 20, 137, 4, 5,
         ]);
 
-        let user = User {
-            account_type: AccountType::User,
-            index: 1,
-            bump_seed: 255,
-            user_type: UserType::IBRL,
-            tenant_pk: Pubkey::default(),
-            cyoa_type: UserCYOA::GREOverDIA,
-            device_pk: Pubkey::default(),
-            client_ip: [10, 0, 0, 1].into(),
-            dz_ip: [10, 0, 0, 2].into(),
-            tunnel_id: 0,
-            tunnel_net: "10.2.3.4/24".parse().unwrap(),
-            status: UserStatus::Activated,
-            owner: pda_pubkey,
-            publishers: vec![],
-            subscribers: vec![],
-            validator_pubkey: Pubkey::default(),
-            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
-            tunnel_flags: 0,
-            bgp_status: Default::default(),
-            last_bgp_up_at: 0,
-            last_bgp_reported_at: 0,
-            bgp_rtt_ns: 0,
-            ..Default::default()
-        };
+        // Returned by the mocked get_user; execute() never reads it, so no field is
+        // load-bearing for this test.
+        let user = User::default();
 
         client
             .expect_check_requirements()

--- a/smartcontract/cli/src/user/request_ban.rs
+++ b/smartcontract/cli/src/user/request_ban.rs
@@ -50,11 +50,11 @@ mod tests {
         commands::user::{
             delete::DeleteUserCommand, get::GetUserCommand, requestban::RequestBanUserCommand,
         },
-        AccountType, User, UserCYOA, UserStatus, UserType,
+        User,
     };
     use doublezero_serviceability::pda::get_user_old_pda;
     use mockall::predicate;
-    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use solana_sdk::signature::Signature;
 
     #[test]
     fn test_cli_user_request_ban() {
@@ -69,31 +69,9 @@ mod tests {
             100, 221, 20, 137, 4, 5,
         ]);
 
-        let user = User {
-            account_type: AccountType::User,
-            index: 1,
-            bump_seed: 255,
-            user_type: UserType::IBRL,
-            tenant_pk: Pubkey::default(),
-            cyoa_type: UserCYOA::GREOverDIA,
-            device_pk: Pubkey::default(),
-            client_ip: [10, 0, 0, 1].into(),
-            dz_ip: [10, 0, 0, 2].into(),
-            tunnel_id: 0,
-            tunnel_net: "10.2.3.4/24".parse().unwrap(),
-            status: UserStatus::Activated,
-            owner: pda_pubkey,
-            publishers: vec![],
-            subscribers: vec![],
-            validator_pubkey: Pubkey::default(),
-            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
-            tunnel_flags: 0,
-            bgp_status: Default::default(),
-            last_bgp_up_at: 0,
-            last_bgp_reported_at: 0,
-            bgp_rtt_ns: 0,
-            ..Default::default()
-        };
+        // Returned by the mocked get_user; execute() never reads it, so no field is
+        // load-bearing for this test.
+        let user = User::default();
 
         client
             .expect_check_requirements()

--- a/smartcontract/cli/src/user/update.rs
+++ b/smartcontract/cli/src/user/update.rs
@@ -97,7 +97,7 @@ mod tests {
         commands::user::{
             delete::DeleteUserCommand, get::GetUserCommand, update::UpdateUserCommand,
         },
-        AccountType, User, UserCYOA, UserStatus, UserType,
+        User,
     };
     use doublezero_serviceability::pda::get_user_old_pda;
     use mockall::predicate;
@@ -115,31 +115,9 @@ mod tests {
             100, 221, 20, 137, 4, 5,
         ]);
 
-        let user = User {
-            account_type: AccountType::User,
-            index: 1,
-            bump_seed: 255,
-            user_type: UserType::IBRL,
-            tenant_pk: Pubkey::default(),
-            cyoa_type: UserCYOA::GREOverDIA,
-            device_pk: Pubkey::default(),
-            client_ip: [10, 0, 0, 1].into(),
-            dz_ip: [10, 0, 0, 2].into(),
-            tunnel_id: 0,
-            tunnel_net: "10.2.3.4/24".parse().unwrap(),
-            status: UserStatus::Activated,
-            owner: pda_pubkey,
-            publishers: vec![],
-            subscribers: vec![],
-            validator_pubkey: Pubkey::default(),
-            tunnel_endpoint: std::net::Ipv4Addr::UNSPECIFIED,
-            tunnel_flags: 0,
-            bgp_status: Default::default(),
-            last_bgp_up_at: 0,
-            last_bgp_reported_at: 0,
-            bgp_rtt_ns: 0,
-            ..Default::default()
-        };
+        // Returned by the mocked get_user; execute() never reads it, so no field is
+        // load-bearing for this test.
+        let user = User::default();
 
         client
             .expect_check_requirements()


### PR DESCRIPTION
Progress on #4084

## Summary of Changes
- `test_cli_user_delete`, `test_cli_user_request_ban`, and `test_cli_user_update` each build a full 22-field `User` literal only to hand it back through the mocked `get_user`. None of the three tests assert on any field of that value — `execute()` only cares that `get_user` returns *a* user so the command can proceed to `delete_user`/`update_user`/`request_ban_user`.
- Replaced each with `User::default()` (the manual `impl Default for User` added in #4080), with a comment noting why no field is load-bearing.

This is a first, narrow slice of #4084 — scoped to `smartcontract/cli/src/user/*`. The issue also names `smartcontract/sdk/rs` and `crates/doublezero-daemon-cli`, which have their own `User` literals (some with fields that likely *are* asserted on and need per-test judgment, per the issue's caveat about `User::default()`'s non-neutral values). Left those for follow-up PRs rather than one large mechanical sweep, per the issue's own guidance.

## Diff Breakdown
| Category   | Files | Lines (+/-) | Net  |
|------------|-------|-------------|------|
| Tests      |     3 | +14 / -80   | -66  |
| **Total**  |     3 | +14 / -80   | -66  |

Pure test cleanup — no production code touched.

## Testing Verification
- `cargo test --lib user::` in `smartcontract/cli`: all 29 user-module tests pass, including the 3 changed.
- `cargo clippy --lib -- -Dclippy::all -D warnings`: clean.
- Manually verified each of the 3 tests never reads a field of the `user` value it constructs — only its presence (via `get_user` returning `Ok`) drives the command under test.