### PR TITLE
offchain/scheduler: fail the boot when SOLANA_RPC is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file.
   - `.cursor/BUGBOT.md` and `.github/copilot-instructions.md` now tell Bugbot and Copilot to read the nearest sibling, flag a path that skips a zero or a duplicate, and assert a specific error and the exact log line at the expected index. Onchain checks apply only when the repository has onchain code. The eight path-scoped files under `.github/instructions/` are removed so Copilot reads only the repo-wide file. (#4247)
 - E2E/QA
   - Remove `TestQA_MulticastSettlement`. It funded a seat through `doublezero-solana shreds pay`, which is going away. The agent seat-pay RPC now returns Unimplemented if something still calls it. Unused settlement helpers go with the test. (#4248)
+- Offchain
+  - The scheduler refuses to boot when `SOLANA_RPC` is unset, rather than handing `nil` to the Rust NIF. All three workers read the one config key, so the check sits in `config/runtime.exs` where the single cause was. The test environment is exempt, since the tests set the key themselves. `DZ_LEDGER_RPC` no longer sets a `ledger_rpc` key that nothing in the application read. (#4240 follow-up)
+  - The scheduler README closes its shell code block, so the Installation heading and everything after it stop rendering inside it.
+- Solana programs
+  - Rename `test_lifetime_swept_2z_amount` to match the `lifetime_swapped_2z_amount` field and method it covers, so a search for the swapped-amount tests finds it.
 
 ## [v0.38.0](https://github.com/malbeclabs/doublezero/compare/client/v0.37.0...client/v0.38.0) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - E2E/QA
   - Remove `TestQA_MulticastSettlement`. It funded a seat through `doublezero-solana shreds pay`, which is going away. The agent seat-pay RPC now returns Unimplemented if something still calls it. Unused settlement helpers go with the test. (#4248)
 - Offchain
-  - The scheduler refuses to boot when `SOLANA_RPC` is unset, rather than handing `nil` to the Rust NIF. All three workers read the one config key, so the check sits in `config/runtime.exs` where the single cause was. The test environment is exempt, since the tests set the key themselves. `DZ_LEDGER_RPC` no longer sets a `ledger_rpc` key that nothing in the application read. (#4240 follow-up)
+  - The scheduler refuses to boot when `SOLANA_RPC` is unset or empty, rather than handing `nil` or an empty string to the Rust NIF. All three workers read the one config key, so the check sits in `config/runtime.exs` where the single cause was. The test environment is exempt, since the tests set the key themselves. `DZ_LEDGER_RPC` no longer sets a `ledger_rpc` key that nothing in the application read. (#4240 follow-up)
   - The scheduler README closes its shell code block, so the Installation heading and everything after it stop rendering inside it.
 - Solana programs
   - Rename `test_lifetime_swept_2z_amount` to match the `lifetime_swapped_2z_amount` field and method it covers, so a search for the swapped-amount tests finds it.

--- a/offchain/scheduler/README.md
+++ b/offchain/scheduler/README.md
@@ -16,6 +16,8 @@ To run the scheduler locally:
 
    ```sh
    mix deps.get
+   ```
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed

--- a/offchain/scheduler/config/runtime.exs
+++ b/offchain/scheduler/config/runtime.exs
@@ -2,10 +2,15 @@ import Config
 
 config :scheduler,
   genesis_epoch: 31,
-  ledger_rpc: System.get_env("DZ_LEDGER_RPC"),
-  solana_rpc: System.get_env("SOLANA_RPC"),
   prometheus_endpoint: System.get_env("PROMETHEUS_ENDPOINT", "localhost"),
   plug_router_port: String.to_integer(System.get_env("SCHEDULER_HTTP_PORT", "4001"))
+
+# Every worker hands this value straight to the NIF, which wants a String. An
+# unset variable used to arrive there as nil, so fail the boot instead. Tests
+# set the key themselves and never read this.
+if config_env() != :test do
+  config :scheduler, solana_rpc: System.fetch_env!("SOLANA_RPC")
+end
 
 config :scheduler, Scheduler.PromEx,
   disabled: false,

--- a/offchain/scheduler/config/runtime.exs
+++ b/offchain/scheduler/config/runtime.exs
@@ -5,11 +5,19 @@ config :scheduler,
   prometheus_endpoint: System.get_env("PROMETHEUS_ENDPOINT", "localhost"),
   plug_router_port: String.to_integer(System.get_env("SCHEDULER_HTTP_PORT", "4001"))
 
-# Every worker hands this value straight to the NIF, which wants a String. An
-# unset variable used to arrive there as nil, so fail the boot instead. Tests
-# set the key themselves and never read this.
+# Every worker hands this value straight to the NIF, which wants a usable URL. An
+# unset variable used to arrive there as nil, so fail the boot instead. fetch_env!
+# alone is not enough: it raises only when the variable is missing, so SOLANA_RPC=
+# would pass an empty string through to the same place. Tests set the key
+# themselves and never read this.
 if config_env() != :test do
-  config :scheduler, solana_rpc: System.fetch_env!("SOLANA_RPC")
+  solana_rpc = System.fetch_env!("SOLANA_RPC")
+
+  if String.trim(solana_rpc) == "" do
+    raise "SOLANA_RPC is set but empty. The workers pass it straight to the NIF."
+  end
+
+  config :scheduler, solana_rpc: solana_rpc
 end
 
 config :scheduler, Scheduler.PromEx,

--- a/solana/programs/revenue-distribution/src/state/journal.rs
+++ b/solana/programs/revenue-distribution/src/state/journal.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_lifetime_swept_2z_amount() {
+    fn test_lifetime_swapped_2z_amount() {
         let journal = Journal {
             lifetime_swapped_2z_amount: Uint::from(69_420),
             ..Default::default()


### PR DESCRIPTION
Three findings raised on #4240 that could not be fixed there. That pull request gates on each imported tree staying byte-identical to its filtered source, so any edit to `offchain/` or `solana/` had to wait for a follow-up. **Stacked on #4240** and based on that branch, so the diff shown here is these fixes alone. It retargets to `main` once #4240 merges.

## Summary

- **The scheduler refuses to boot when `SOLANA_RPC` is unset.** All three workers read the one `:solana_rpc` config key and hand it straight to the NIF, which wants a `String`. `config/runtime.exs` read the variable with `System.get_env`, so an unset variable reached Rust as `nil`. `System.fetch_env!` stops the boot instead. One line in the config covers all three workers, which is where the single cause was, rather than a guard in each of them.
- **The test environment is exempt.** CI runs `mix test` with no `SOLANA_RPC`, and the tests set the key themselves through `Application.put_env`. An unguarded `fetch_env!` would break the release workflow's test step.
- **`DZ_LEDGER_RPC` no longer sets a key nothing reads.** It set `:ledger_rpc`, and no worker, module or NIF callback reads that key. It has the same unset-variable gap, so leaving it in place would invite a fix to dead config.
- **The scheduler README closes its shell code block**, so the Installation heading and everything after it stop rendering inside it.
- **The revenue-distribution journal test is renamed** from `test_lifetime_swept_2z_amount` to `test_lifetime_swapped_2z_amount`, matching the `lifetime_swapped_2z_amount` field and method it covers, so a search for the swapped-amount tests finds it.

Reported in the copilot review on #4240 and tracked as malbeclabs/infra#2395.

## Diff Breakdown

| Category | Files | Lines (+/-) | Net |
|---|---|---|---|
| Core logic | 1 | +7 / -2 | +5 |
| Docs | 2 | +7 / -0 | +7 |
| Tests | 1 | +1 / -1 | 0 |

One behaviour change, in a config file. The rest is a heading that rendered in the wrong place and a test name.

## Testing Verification

- `Config.Reader.read!("config/runtime.exs", env: ...)` run against each case: the key is absent in the test environment with the variable unset, the read raises `System.EnvError` in prod with it unset, and it carries the URL in prod with it set.
- `cargo test -p doublezero-revenue-distribution --lib test_lifetime_swapped_2z_amount` passes from inside `solana/`.
- `mix format --check-formatted config/runtime.exs` clean.
