### PR TITLE
device-health-oracle: detect link impairment from monitoring data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Device Health Oracle
+  - Links now move both ways between `ReadyForService` and `Impaired`, driven by the lake `link_rollup_5m` table. Until now the oracle had no link criteria at all, so every link auto-advanced to `ReadyForService` and stayed there with no demotion path. A link is impaired when its latest 5-minute bucket shows the ISIS adjacency down or per-direction loss above `--link-loss-threshold` (default 5%); it recovers only after a fully covered, recent window of clean buckets, reusing the `--drained-slot-count` dwell. Fast to demote, slow to recover, so borderline links do not flap. This is a reporting signal — `link.status` is not gated on `LinkHealth`.
+  - Neither a ClickHouse outage nor missing telemetry moves a link's health in either direction: an unreachable lake would otherwise demote every healthy link on the network in one tick. Query failures are counted under `doublezero_device_health_oracle_errors_total{error_type="link_health_query"}` so an outage is visible without reading as impairment.
+
 ## [v0.39.0](https://github.com/malbeclabs/doublezero/compare/client/v0.38.0...client/v0.39.0) - 2026-09-04
 
 ### Breaking

--- a/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
+++ b/controlplane/device-health-oracle/cmd/device-health-oracle/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -44,6 +45,7 @@ var (
 	slackWebhookURL         = flag.String("slack-webhook-url", "", "The Slack webhook URL to send alerts")
 	provisioningSlotCount   = flag.Uint64("provisioning-slot-count", defaultProvisioningSlotCount, "Burn-in slot count for new devices/links (~20 hours at 200000)")
 	drainedSlotCount        = flag.Uint64("drained-slot-count", defaultDrainedSlotCount, "Burn-in slot count for reactivated devices/links (~30 min at 5000)")
+	linkLossThreshold       = flag.Float64("link-loss-threshold", 5.0, "Per-direction packet loss percentage above which a link is considered impaired (link_rollup_5m a_loss_pct/z_loss_pct)")
 	version                 = "dev"
 	commit                  = "none"
 	date                    = "unknown"
@@ -55,6 +57,14 @@ func main() {
 	if *showVersion {
 		fmt.Printf("version: %s, commit: %s, date: %s\n", version, commit, date)
 		os.Exit(0)
+	}
+
+	// Reject obviously broken thresholds early. A negative or NaN threshold would
+	// silently flag every link as impaired (or never), triggering an onchain
+	// write storm or hiding real failures — better to fail fast at startup.
+	if math.IsNaN(*linkLossThreshold) || math.IsInf(*linkLossThreshold, 0) || *linkLossThreshold < 0 || *linkLossThreshold > 100 {
+		fmt.Fprintf(os.Stderr, "invalid --link-loss-threshold %v: must be in [0, 100]\n", *linkLossThreshold)
+		os.Exit(1)
 	}
 
 	logLevel := slog.LevelInfo
@@ -131,6 +141,8 @@ func main() {
 
 	// Initialize ClickHouse-dependent criteria.
 	var deviceCriteria []worker.DeviceCriterion
+	var linkImpairmentCriteria []worker.LinkCriterion
+	var linkRecoveryCriteria []worker.LinkCriterion
 	if chAddr := os.Getenv("CLICKHOUSE_ADDR"); chAddr != "" {
 		chDB := os.Getenv("CLICKHOUSE_DB")
 		if chDB == "" {
@@ -148,10 +160,14 @@ func main() {
 			log.Warn("ClickHouse connection failed, continuing without ClickHouse-based criteria", "addr", chAddr, "error", err)
 		} else {
 			defer chClient.Close()
-			log.Info("ClickHouse enabled", "addr", chAddr, "db", chDB, "user", chUser, "tls", !chTLSDisabled)
+			log.Info("ClickHouse enabled", "addr", chAddr, "db", chDB, "user", chUser, "tls", !chTLSDisabled, "linkLossThreshold", *linkLossThreshold)
 			controllerSuccess := worker.NewControllerSuccessCriterion(chClient, log)
 			interfaceCounters := worker.NewInterfaceCountersCriterion(chClient, log)
 			deviceCriteria = append(deviceCriteria, controllerSuccess, interfaceCounters)
+			linkImpairmentCriteria = append(linkImpairmentCriteria,
+				worker.NewLinkHealthCriterion(worker.LinkHealthModeImpairment, chClient, *linkLossThreshold, log))
+			linkRecoveryCriteria = append(linkRecoveryCriteria,
+				worker.NewLinkHealthCriterion(worker.LinkHealthModeRecovery, chClient, *linkLossThreshold, log))
 		}
 	} else {
 		log.Error("ClickHouse disabled (CLICKHOUSE_ADDR not set), no ClickHouse-based criteria")
@@ -163,7 +179,14 @@ func main() {
 		Log:                   log,
 	}
 	linkEvaluator := &worker.LinkHealthEvaluator{
-		ReadyForServiceCriteria: nil,
+		// Gate promotion on the same latest-bucket check that drives demotion.
+		// Without it a link already reporting isis_down promotes to RFS and
+		// demotes on the next tick — two onchain writes and a misleading RFS
+		// in between. Safe to reuse: the impairment criterion passes on
+		// no-data, so links with no telemetry promote exactly as before.
+		ReadyForServiceCriteria: linkImpairmentCriteria,
+		ImpairmentCriteria:      linkImpairmentCriteria,
+		RecoveryCriteria:        linkRecoveryCriteria,
 		Log:                     log,
 	}
 

--- a/controlplane/device-health-oracle/internal/worker/clickhouse.go
+++ b/controlplane/device-health-oracle/internal/worker/clickhouse.go
@@ -3,6 +3,8 @@ package worker
 import (
 	"context"
 	"crypto/tls"
+	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -104,6 +106,129 @@ func (c *ClickHouseClient) InterfaceCountersCoverage(ctx context.Context, device
 	}
 
 	return int64(minutesWithRecords), nil
+}
+
+// LinkHealthRecentResult is the most recent rollup bucket's health fields plus
+// the bucket timestamp, returned by LinkHealthChecker.LinkHealthRecent. The
+// bucket timestamp lets callers enforce a recency floor (a stale bucket means
+// the telemetry pipeline is broken — neither demote nor recover on stale data).
+type LinkHealthRecentResult struct {
+	BucketTs time.Time
+	IsisDown bool
+	ALossPct float64
+	ZLossPct float64
+}
+
+// LinkHealthWindowResult summarises a recovery-window check. AllClean is true
+// when every distinct bucket (deduplicated by latest ingested_at) is clean.
+// Bad and Total are exposed for operator diagnostics; MaxBucketTs is the
+// newest bucket in the window, which callers use to reject a window whose
+// data has gone stale.
+type LinkHealthWindowResult struct {
+	Bad         uint64
+	Total       uint64
+	MaxBucketTs time.Time
+	AllClean    bool
+}
+
+// LinkHealthChecker queries ClickHouse for link health rollup records.
+type LinkHealthChecker interface {
+	// LinkHealthRecent returns the most recent link_rollup_5m bucket for the
+	// given link. Multiple rows for the same bucket are disambiguated by
+	// ingested_at (most recently ingested wins). Returns found=false when
+	// there is no data for the link, or when that latest bucket is still
+	// provisioning — a link being brought up should hold its current health
+	// rather than be judged on an older bucket.
+	LinkHealthRecent(ctx context.Context, linkPubkey string) (result LinkHealthRecentResult, found bool, err error)
+
+	// LinkHealthWindowAllClean returns true if every distinct non-provisioning
+	// bucket in [start, end] is clean (isis_down=false AND a_loss_pct <=
+	// threshold AND z_loss_pct <= threshold). Late-arriving rows for the same
+	// bucket are deduplicated by ingested_at so a corrected re-write doesn't
+	// keep a link Impaired even after every distinct bucket reads as clean.
+	// Total and MaxBucketTs let callers additionally require that the window is
+	// covered and recent, so a frozen pipeline cannot recover a link on stale
+	// data. Returns found=false when there are no buckets in the window for
+	// this link.
+	LinkHealthWindowAllClean(ctx context.Context, linkPubkey string, start, end time.Time, lossThreshold float64) (result LinkHealthWindowResult, found bool, err error)
+}
+
+// LinkHealthRecent returns the latest bucket's health fields for the given
+// link, deduplicated by selecting its most recently ingested row, or
+// found=false if that row has provisioning=true.
+func (c *ClickHouseClient) LinkHealthRecent(ctx context.Context, linkPubkey string) (LinkHealthRecentResult, bool, error) {
+	// The inner query resolves the link's newest bucket to its newest row
+	// (ReplacingMergeTree keeps every version until merge, so ordering by
+	// ingested_at is the dedup). The provisioning filter must sit outside it:
+	// in the WHERE clause it would run before the dedup, so a bucket whose
+	// latest row flips provisioning would fall back to a stale version.
+	// A status filter, if one is ever wanted, belongs here too.
+	query := fmt.Sprintf(
+		`SELECT bucket_ts, isis_down, a_loss_pct, z_loss_pct
+		 FROM (
+		   SELECT bucket_ts, isis_down, a_loss_pct, z_loss_pct, provisioning
+		   FROM "%s".link_rollup_5m
+		   WHERE link_pk = ?
+		   ORDER BY bucket_ts DESC, ingested_at DESC
+		   LIMIT 1
+		 )
+		 WHERE provisioning = false`,
+		c.db,
+	)
+
+	var r LinkHealthRecentResult
+	err := c.conn.QueryRow(ctx, query, linkPubkey).Scan(&r.BucketTs, &r.IsisDown, &r.ALossPct, &r.ZLossPct)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return LinkHealthRecentResult{}, false, nil
+		}
+		return LinkHealthRecentResult{}, false, fmt.Errorf("clickhouse query: %w", err)
+	}
+	return r, true, nil
+}
+
+// LinkHealthWindowAllClean returns whether every distinct bucket for the given
+// link in [start, end] is clean. The inner query deduplicates late-arriving
+// rows by selecting the latest ingested_at per bucket; the outer aggregate
+// counts distinct dirty buckets without streaming rows.
+func (c *ClickHouseClient) LinkHealthWindowAllClean(ctx context.Context, linkPubkey string, start, end time.Time, lossThreshold float64) (LinkHealthWindowResult, bool, error) {
+	// provisioning is carried through argMax and filtered after the GROUP BY
+	// for the same reason as in LinkHealthRecent: filtering in the WHERE clause
+	// would drop the current version of a bucket that just flipped
+	// provisioning, leaving the dedup to return a stale one. A status filter,
+	// if one is ever wanted, belongs next to it.
+	query := fmt.Sprintf(
+		`SELECT
+		   countIf(isis_down = true OR a_loss_pct > ? OR z_loss_pct > ?) AS bad_buckets,
+		   count() AS total_buckets,
+		   max(bucket_ts) AS max_bucket_ts
+		 FROM (
+		   SELECT
+		     bucket_ts,
+		     argMax(isis_down, ingested_at)     AS isis_down,
+		     argMax(a_loss_pct, ingested_at)    AS a_loss_pct,
+		     argMax(z_loss_pct, ingested_at)    AS z_loss_pct,
+		     argMax(provisioning, ingested_at)  AS provisioning
+		   FROM "%s".link_rollup_5m
+		   WHERE link_pk = ?
+		     AND bucket_ts >= ?
+		     AND bucket_ts <= ?
+		   GROUP BY bucket_ts
+		 )
+		 WHERE provisioning = false`,
+		c.db,
+	)
+
+	var r LinkHealthWindowResult
+	err := c.conn.QueryRow(ctx, query, lossThreshold, lossThreshold, linkPubkey, start, end).Scan(&r.Bad, &r.Total, &r.MaxBucketTs)
+	if err != nil {
+		return LinkHealthWindowResult{}, false, fmt.Errorf("clickhouse query: %w", err)
+	}
+	if r.Total == 0 {
+		return LinkHealthWindowResult{}, false, nil
+	}
+	r.AllClean = r.Bad == 0
+	return r, true, nil
 }
 
 func (c *ClickHouseClient) Close() error {

--- a/controlplane/device-health-oracle/internal/worker/clickhouse_test.go
+++ b/controlplane/device-health-oracle/internal/worker/clickhouse_test.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,6 +167,204 @@ func TestInterfaceCountersCoverage_QuotesDatabaseName(t *testing.T) {
 	minutes, err := client.InterfaceCountersCoverage(context.Background(), "device123", start, end)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), minutes)
+}
+
+func TestLinkHealthRecent_ReturnsLatestBucket(t *testing.T) {
+	bucketTs := time.Date(2026, 5, 6, 16, 10, 0, 0, time.UTC)
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, query string, args ...any) driver.Row {
+			assert.Contains(t, query, `"testdb".link_rollup_5m`)
+			assert.Contains(t, query, "bucket_ts")
+			assert.Contains(t, query, "ORDER BY bucket_ts DESC, ingested_at DESC")
+			assert.Contains(t, query, "LIMIT 1")
+			// The provisioning filter must sit after the ingested_at dedup, or
+			// a bucket whose newest row flips provisioning gets filtered out
+			// and the dedup falls back to a stale version of it.
+			assert.Greater(t,
+				strings.Index(query, "provisioning = false"),
+				strings.Index(query, "ORDER BY bucket_ts DESC, ingested_at DESC"),
+				"provisioning must be filtered after the dedup, not in the inner WHERE")
+			assert.Len(t, args, 1)
+			assert.Equal(t, "linkABC", args[0])
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					*(dest[0].(*time.Time)) = bucketTs
+					*(dest[1].(*bool)) = true
+					*(dest[2].(*float64)) = 12.5
+					*(dest[3].(*float64)) = 0.0
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	r, found, err := client.LinkHealthRecent(context.Background(), "linkABC")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, bucketTs, r.BucketTs)
+	assert.True(t, r.IsisDown)
+	assert.Equal(t, 12.5, r.ALossPct)
+	assert.Equal(t, 0.0, r.ZLossPct)
+}
+
+func TestLinkHealthRecent_NoData_ReturnsFoundFalse(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(_ ...any) error {
+					return sql.ErrNoRows
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	_, found, err := client.LinkHealthRecent(context.Background(), "linkABC")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestLinkHealthRecent_QueryError(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(_ ...any) error {
+					return errors.New("connection reset")
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	_, _, err := client.LinkHealthRecent(context.Background(), "linkABC")
+	assert.ErrorContains(t, err, "connection reset")
+}
+
+func TestLinkHealthRecent_QuotesDatabaseName(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, query string, _ ...any) driver.Row {
+			assert.Contains(t, query, `"mainnet-beta".link_rollup_5m`)
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					*(dest[0].(*time.Time)) = time.Now()
+					*(dest[1].(*bool)) = false
+					*(dest[2].(*float64)) = 0
+					*(dest[3].(*float64)) = 0
+					return nil
+				},
+			}
+		},
+	}
+	client := &ClickHouseClient{conn: conn, db: "mainnet-beta"}
+	_, found, err := client.LinkHealthRecent(context.Background(), "linkABC")
+	require.NoError(t, err)
+	assert.True(t, found)
+}
+
+func TestLinkHealthWindowAllClean_AllClean(t *testing.T) {
+	maxBucketTs := time.Date(2026, 1, 1, 0, 55, 0, 0, time.UTC)
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, query string, args ...any) driver.Row {
+			assert.Contains(t, query, `"testdb".link_rollup_5m`)
+			assert.Contains(t, query, "countIf")
+			// Inner subquery dedupes ingested_at duplicates per bucket via argMax.
+			assert.Contains(t, query, "argMax")
+			assert.Contains(t, query, "GROUP BY bucket_ts")
+			assert.Contains(t, query, "max(bucket_ts)")
+			// provisioning is deduped alongside the health columns and filtered
+			// afterwards, so a flip on the newest row can't resurrect a stale one.
+			assert.Contains(t, query, "argMax(provisioning, ingested_at)")
+			assert.Greater(t,
+				strings.Index(query, "provisioning = false"),
+				strings.Index(query, "GROUP BY bucket_ts"),
+				"provisioning must be filtered after the GROUP BY dedup")
+			// Args order: lossThreshold, lossThreshold, linkPubkey, start, end
+			assert.Len(t, args, 5)
+			assert.Equal(t, 5.0, args[0])
+			assert.Equal(t, 5.0, args[1])
+			assert.Equal(t, "linkABC", args[2])
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					*(dest[0].(*uint64)) = 0
+					*(dest[1].(*uint64)) = 6
+					*(dest[2].(*time.Time)) = maxBucketTs
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	r, found, err := client.LinkHealthWindowAllClean(context.Background(), "linkABC",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		5.0)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, r.AllClean)
+	assert.Equal(t, uint64(0), r.Bad)
+	assert.Equal(t, uint64(6), r.Total)
+	assert.Equal(t, maxBucketTs, r.MaxBucketTs)
+}
+
+func TestLinkHealthWindowAllClean_HasBadBuckets(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					*(dest[0].(*uint64)) = 2
+					*(dest[1].(*uint64)) = 6
+					*(dest[2].(*time.Time)) = time.Now()
+					return nil
+				},
+			}
+		},
+	}
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	r, found, err := client.LinkHealthWindowAllClean(context.Background(), "linkABC",
+		time.Now().Add(-1*time.Hour), time.Now(), 5.0)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.False(t, r.AllClean)
+	assert.Equal(t, uint64(2), r.Bad)
+	assert.Equal(t, uint64(6), r.Total)
+}
+
+func TestLinkHealthWindowAllClean_NoBucketsInWindow(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(dest ...any) error {
+					*(dest[0].(*uint64)) = 0
+					*(dest[1].(*uint64)) = 0
+					*(dest[2].(*time.Time)) = time.Time{}
+					return nil
+				},
+			}
+		},
+	}
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	_, found, err := client.LinkHealthWindowAllClean(context.Background(), "linkABC",
+		time.Now().Add(-1*time.Hour), time.Now(), 5.0)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestLinkHealthWindowAllClean_QueryError(t *testing.T) {
+	conn := &mockConn{
+		queryRowFunc: func(_ context.Context, _ string, _ ...any) driver.Row {
+			return &mockRow{
+				scanFunc: func(_ ...any) error {
+					return errors.New("connection reset")
+				},
+			}
+		},
+	}
+	client := &ClickHouseClient{conn: conn, db: "testdb"}
+	_, _, err := client.LinkHealthWindowAllClean(context.Background(), "linkABC",
+		time.Now().Add(-1*time.Hour), time.Now(), 5.0)
+	assert.ErrorContains(t, err, "connection reset")
 }
 
 func TestNewClickHouseClient_StripsScheme(t *testing.T) {

--- a/controlplane/device-health-oracle/internal/worker/criteria.go
+++ b/controlplane/device-health-oracle/internal/worker/criteria.go
@@ -41,6 +41,21 @@ func DeviceBurnIn(ctx context.Context, status serviceability.DeviceStatus) (star
 	return start, burnIn.Now, expectedMinutes, true
 }
 
+// LinkBurnIn extracts BurnInTimes from the context and returns the link recovery
+// window — the period over which link health must be continuously clean for a
+// link to recover from Impaired back to ReadyForService. The window is derived
+// from DrainedStart (already resolved from DrainedSlotCount once per tick).
+// Returns ok=false if the context has no BurnInTimes, and expectedMinutes=0
+// when the window has zero length (e.g. a newly created environment).
+func LinkBurnIn(ctx context.Context) (start time.Time, now time.Time, expectedMinutes int64, ok bool) {
+	burnIn, ok := ctx.Value(burnInTimesKey{}).(BurnInTimes)
+	if !ok {
+		return time.Time{}, time.Time{}, 0, false
+	}
+	expectedMinutes = max(int64(burnIn.Now.Sub(burnIn.DrainedStart).Minutes()), 0)
+	return burnIn.DrainedStart, burnIn.Now, expectedMinutes, true
+}
+
 // DeviceCriterion evaluates whether a device meets a specific readiness requirement.
 // Check returns (passed, reason). Reason is a human-readable explanation when passed is false.
 type DeviceCriterion interface {
@@ -111,10 +126,21 @@ func (e *DeviceHealthEvaluator) checkAll(ctx context.Context, device serviceabil
 	return true
 }
 
-// LinkHealthEvaluator evaluates a link's health based on criteria.
-// Links have a single stage: Pending → ReadyForService.
+// LinkHealthEvaluator evaluates a link's health based on criteria, supporting
+// bidirectional transitions between ReadyForService and Impaired:
+//   - Pending/Unknown → ReadyForService when ReadyForServiceCriteria pass.
+//   - ReadyForService → Impaired when any ImpairmentCriteria fail (point-in-time
+//     check on the most recent telemetry bucket — fast demotion).
+//   - Impaired → ReadyForService when RecoveryCriteria pass over the full
+//     recovery window (slow recovery to prevent flapping).
+//
+// The asymmetry — fast demotion via the latest bucket, slow recovery requiring
+// every bucket in the window to be clean — is intentional: it keeps borderline
+// links from flapping while still surfacing real impairment quickly.
 type LinkHealthEvaluator struct {
 	ReadyForServiceCriteria []LinkCriterion
+	ImpairmentCriteria      []LinkCriterion
+	RecoveryCriteria        []LinkCriterion
 	Log                     *slog.Logger
 }
 
@@ -122,12 +148,38 @@ type LinkHealthEvaluator struct {
 func (e *LinkHealthEvaluator) Evaluate(ctx context.Context, link serviceability.Link) serviceability.LinkHealth {
 	current := link.LinkHealth
 
-	if current == serviceability.LinkHealthReadyForService {
+	switch current {
+	case serviceability.LinkHealthReadyForService:
+		// No impairment criteria configured ⇒ no demotion path (preserves
+		// behavior of deployments without ClickHouse wired up).
+		if len(e.ImpairmentCriteria) == 0 {
+			return current
+		}
+		if !e.checkAllLink(ctx, link, e.ImpairmentCriteria) {
+			return serviceability.LinkHealthImpaired
+		}
 		return current
-	}
 
+	case serviceability.LinkHealthImpaired:
+		if len(e.RecoveryCriteria) == 0 {
+			return current
+		}
+		if !e.checkAllLink(ctx, link, e.RecoveryCriteria) {
+			return current
+		}
+		return serviceability.LinkHealthReadyForService
+
+	default:
+		if !e.checkAllLink(ctx, link, e.ReadyForServiceCriteria) {
+			return current
+		}
+		return serviceability.LinkHealthReadyForService
+	}
+}
+
+func (e *LinkHealthEvaluator) checkAllLink(ctx context.Context, link serviceability.Link, criteria []LinkCriterion) bool {
 	linkPubkey := solana.PublicKeyFromBytes(link.PubKey[:]).String()
-	for _, c := range e.ReadyForServiceCriteria {
+	for _, c := range criteria {
 		passed, reason := c.Check(ctx, link)
 		if !passed {
 			e.Log.Info("Link criterion not met",
@@ -135,9 +187,10 @@ func (e *LinkHealthEvaluator) Evaluate(ctx context.Context, link serviceability.
 				"code", link.Code,
 				"criterion", c.Name(),
 				"reason", reason)
-			return current
+			MetricCriterionResults.WithLabelValues(c.Name(), "fail").Inc()
+			return false
 		}
+		MetricCriterionResults.WithLabelValues(c.Name(), "pass").Inc()
 	}
-
-	return serviceability.LinkHealthReadyForService
+	return true
 }

--- a/controlplane/device-health-oracle/internal/worker/criteria_test.go
+++ b/controlplane/device-health-oracle/internal/worker/criteria_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
 	"github.com/stretchr/testify/assert"
@@ -168,4 +169,116 @@ func TestLinkHealthEvaluator_CriterionFails_BlocksAdvancement(t *testing.T) {
 	link := serviceability.Link{LinkHealth: serviceability.LinkHealthPending}
 	result := eval.Evaluate(context.Background(), link)
 	assert.Equal(t, serviceability.LinkHealthPending, result, "should not advance when criterion fails")
+}
+
+func TestLinkHealthEvaluator_ReadyForService_ImpairmentFails_DemotesToImpaired(t *testing.T) {
+	failing := &mockLinkCriterion{name: "impair", result: false, reason: "isis down"}
+	eval := &LinkHealthEvaluator{
+		ImpairmentCriteria: []LinkCriterion{failing},
+		Log:                testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthReadyForService}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthImpaired, result, "RFS link with failing impairment criterion should demote")
+}
+
+func TestLinkHealthEvaluator_ReadyForService_ImpairmentPasses_Stays(t *testing.T) {
+	passing := &mockLinkCriterion{name: "impair", result: true}
+	eval := &LinkHealthEvaluator{
+		ImpairmentCriteria: []LinkCriterion{passing},
+		Log:                testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthReadyForService}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthReadyForService, result)
+}
+
+func TestLinkHealthEvaluator_ReadyForService_NoImpairmentCriteria_Stays(t *testing.T) {
+	// Backwards compat: deployments without ClickHouse have no impairment criteria
+	// and must not see any RFS demotion path.
+	eval := &LinkHealthEvaluator{Log: testLogger()}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthReadyForService}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthReadyForService, result)
+}
+
+func TestLinkHealthEvaluator_Impaired_RecoveryPasses_PromotesToRFS(t *testing.T) {
+	passing := &mockLinkCriterion{name: "recovery", result: true}
+	eval := &LinkHealthEvaluator{
+		RecoveryCriteria: []LinkCriterion{passing},
+		Log:              testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthImpaired}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthReadyForService, result)
+}
+
+func TestLinkHealthEvaluator_Impaired_RecoveryFails_Stays(t *testing.T) {
+	failing := &mockLinkCriterion{name: "recovery", result: false, reason: "still bad"}
+	eval := &LinkHealthEvaluator{
+		RecoveryCriteria: []LinkCriterion{failing},
+		Log:              testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthImpaired}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthImpaired, result)
+}
+
+func TestLinkHealthEvaluator_Impaired_NoRecoveryCriteria_Stays(t *testing.T) {
+	eval := &LinkHealthEvaluator{Log: testLogger()}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthImpaired}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthImpaired, result)
+}
+
+func TestLinkHealthEvaluator_Impaired_MixedRecovery_AnyFailKeepsImpaired(t *testing.T) {
+	passing := &mockLinkCriterion{name: "recovery_pass", result: true}
+	failing := &mockLinkCriterion{name: "recovery_fail", result: false, reason: "nope"}
+	eval := &LinkHealthEvaluator{
+		RecoveryCriteria: []LinkCriterion{passing, failing},
+		Log:              testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthImpaired}
+	result := eval.Evaluate(context.Background(), link)
+	assert.Equal(t, serviceability.LinkHealthImpaired, result)
+}
+
+func TestLinkBurnIn_ExtractsDrainedWindow(t *testing.T) {
+	now := time.Now()
+	drainedStart := now.Add(-30 * time.Minute)
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		ProvisioningStart: now.Add(-20 * time.Hour),
+		DrainedStart:      drainedStart,
+		Now:               now,
+	})
+
+	start, end, expectedMinutes, ok := LinkBurnIn(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, drainedStart, start)
+	assert.Equal(t, now, end)
+	assert.Equal(t, int64(30), expectedMinutes)
+}
+
+func TestLinkBurnIn_NoContextValues(t *testing.T) {
+	_, _, _, ok := LinkBurnIn(context.Background())
+	assert.False(t, ok)
+}
+
+func TestLinkBurnIn_ZeroLengthWindow(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now,
+		Now:          now,
+	})
+
+	_, _, expectedMinutes, ok := LinkBurnIn(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, int64(0), expectedMinutes)
 }

--- a/controlplane/device-health-oracle/internal/worker/link_health.go
+++ b/controlplane/device-health-oracle/internal/worker/link_health.go
@@ -1,0 +1,189 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+)
+
+// LinkHealthMode controls which time window LinkHealthCriterion evaluates.
+type LinkHealthMode int
+
+const (
+	// LinkHealthModeImpairment checks the most recent link_rollup_5m bucket.
+	// Used to detect impairment fast (RFS → Impaired transition).
+	LinkHealthModeImpairment LinkHealthMode = iota
+	// LinkHealthModeRecovery checks every bucket in the recovery window.
+	// Used to gate recovery (Impaired → RFS) — every bucket must be clean.
+	LinkHealthModeRecovery
+)
+
+// linkHealthRecentMaxAge is how recent a rollup bucket must be to be acted on:
+// the latest bucket for the impairment check, the newest bucket in the window
+// for the recovery check. Anything older is stale telemetry, which must
+// neither demote nor recover a link. Sized at 3× the 5-minute rollup cadence
+// to absorb a single missed bucket plus an ingest delay.
+const linkHealthRecentMaxAge = 15 * time.Minute
+
+// LinkHealthCriterion evaluates link impairment from the link_rollup_5m table.
+// In ImpairmentMode it inspects the latest bucket; in RecoveryMode it requires
+// every bucket in the recovery window (resolved via LinkBurnIn) to be clean.
+//
+// "Clean" means: isis_down=false AND a_loss_pct <= LossThreshold AND
+// z_loss_pct <= LossThreshold. Buckets with provisioning=true are excluded
+// to avoid flagging links that are still being brought up.
+//
+// "No data" handling differs by mode: in ImpairmentMode, missing data is
+// treated as a pass (we cannot conclude a link is impaired without telemetry);
+// in RecoveryMode, missing data is treated as a fail (we cannot conclude a
+// link has been continuously clean without telemetry). The net effect is that
+// a link without telemetry stays at its current health. A query error resolves
+// the same way in both modes, and for the same reason — an unreachable
+// ClickHouse must not move any link's health in either direction.
+type LinkHealthCriterion struct {
+	mode          LinkHealthMode
+	checker       LinkHealthChecker
+	lossThreshold float64
+	log           *slog.Logger
+}
+
+func NewLinkHealthCriterion(mode LinkHealthMode, checker LinkHealthChecker, lossThreshold float64, log *slog.Logger) *LinkHealthCriterion {
+	return &LinkHealthCriterion{
+		mode:          mode,
+		checker:       checker,
+		lossThreshold: lossThreshold,
+		log:           log,
+	}
+}
+
+func (c *LinkHealthCriterion) Name() string {
+	if c.mode == LinkHealthModeRecovery {
+		return "link_health_recovery"
+	}
+	return "link_health_impairment"
+}
+
+func (c *LinkHealthCriterion) Check(ctx context.Context, link serviceability.Link) (bool, string) {
+	pubkey := solana.PublicKeyFromBytes(link.PubKey[:]).String()
+
+	if c.mode == LinkHealthModeRecovery {
+		return c.checkRecovery(ctx, link, pubkey)
+	}
+	return c.checkImpairment(ctx, link, pubkey)
+}
+
+func (c *LinkHealthCriterion) checkImpairment(ctx context.Context, link serviceability.Link, pubkey string) (bool, string) {
+	r, found, err := c.checker.LinkHealthRecent(ctx, pubkey)
+	if err != nil {
+		// Hold current health on error, and count it separately so an outage
+		// doesn't read as impairment in MetricCriterionResults{_, "fail"}.
+		//
+		// A failing criterion demotes an RFS link, so returning false here
+		// would turn one transient ClickHouse blip into an Impaired write for
+		// every healthy link on the network, followed by a matching wave of
+		// RFS writes once it recovered. A monitor that calls the network
+		// unhealthy when its own telemetry breaks is worse than one that
+		// reports nothing.
+		c.log.Error("Failed to query link health recent",
+			"link", pubkey, "code", link.Code, "error", err)
+		MetricErrors.WithLabelValues(MetricErrorTypeLinkHealthQuery).Inc()
+		return true, ""
+	}
+	if !found {
+		// No telemetry → cannot conclude impairment. Hold current health.
+		// Distinct from the error path above: no data is a real answer about
+		// the link, a query failure is no answer at all.
+		return true, ""
+	}
+
+	// A stale latest bucket means the rollup pipeline is broken for this link;
+	// treat it like "no data" rather than acting on a frozen snapshot. Without
+	// this floor, a stuck pipeline at the moment of an ISIS flap would keep the
+	// link Impaired indefinitely even after the link recovered.
+	age := time.Since(r.BucketTs)
+	if age > linkHealthRecentMaxAge {
+		c.log.Debug("Link health latest bucket is stale; treating as no data",
+			"link", pubkey, "code", link.Code,
+			"bucketTs", r.BucketTs, "age", age, "maxAge", linkHealthRecentMaxAge)
+		return true, ""
+	}
+
+	c.log.Debug("Link health recent",
+		"link", pubkey, "code", link.Code,
+		"bucketTs", r.BucketTs,
+		"isisDown", r.IsisDown,
+		"aLossPct", r.ALossPct,
+		"zLossPct", r.ZLossPct,
+		"lossThreshold", c.lossThreshold)
+
+	if r.IsisDown {
+		return false, fmt.Sprintf("isis adjacency down (bucket=%s)", r.BucketTs.UTC().Format(time.RFC3339))
+	}
+	if r.ALossPct > c.lossThreshold {
+		return false, fmt.Sprintf("a-side loss %.2f%% > %.2f%% (bucket=%s)", r.ALossPct, c.lossThreshold, r.BucketTs.UTC().Format(time.RFC3339))
+	}
+	if r.ZLossPct > c.lossThreshold {
+		return false, fmt.Sprintf("z-side loss %.2f%% > %.2f%% (bucket=%s)", r.ZLossPct, c.lossThreshold, r.BucketTs.UTC().Format(time.RFC3339))
+	}
+	return true, ""
+}
+
+func (c *LinkHealthCriterion) checkRecovery(ctx context.Context, link serviceability.Link, pubkey string) (bool, string) {
+	start, now, expectedMinutes, ok := LinkBurnIn(ctx)
+	if !ok {
+		return false, "burn-in times not available in context"
+	}
+	// Zero-length window means we can't recover yet — keep at Impaired. (This
+	// is the inverse of the device-side "expectedMinutes==0 ⇒ pass" rule:
+	// here the window is a recovery dwell, not a burn-in.)
+	if expectedMinutes == 0 {
+		return false, "recovery window not yet established"
+	}
+
+	r, found, err := c.checker.LinkHealthWindowAllClean(ctx, pubkey, start, now, c.lossThreshold)
+	if err != nil {
+		c.log.Error("Failed to query link health recovery window",
+			"link", pubkey, "code", link.Code, "error", err)
+		return false, fmt.Sprintf("clickhouse query failed: %v", err)
+	}
+	if !found {
+		return false, "no rollup data in recovery window"
+	}
+
+	c.log.Debug("Link health recovery window",
+		"link", pubkey, "code", link.Code,
+		"allClean", r.AllClean,
+		"badBuckets", r.Bad,
+		"totalBuckets", r.Total,
+		"maxBucketTs", r.MaxBucketTs,
+		"start", start,
+		"end", now,
+		"expectedMinutes", expectedMinutes,
+		"lossThreshold", c.lossThreshold)
+
+	if !r.AllClean {
+		return false, fmt.Sprintf("recovery window has %d/%d impaired buckets", r.Bad, r.Total)
+	}
+
+	// "Every bucket present is clean" is not enough on its own — it is also
+	// satisfied by a window holding one clean bucket, or by one holding only
+	// old clean buckets after a frozen pipeline let the dirty ones age out of
+	// the trailing window. Either would recover a link that is still broken,
+	// and it would then stay RFS because checkImpairment reads the stale
+	// latest bucket as no-data. So require the window to be both covered and
+	// recent; failing either keeps the link Impaired, which is the safe
+	// direction.
+	minBuckets := expectedMinutes/5 - 1
+	if int64(r.Total) < minBuckets {
+		return false, fmt.Sprintf("recovery window has %d/%d expected buckets", r.Total, minBuckets)
+	}
+	if age := time.Since(r.MaxBucketTs); age > linkHealthRecentMaxAge {
+		return false, fmt.Sprintf("recovery window is stale (newest bucket=%s, age=%s)",
+			r.MaxBucketTs.UTC().Format(time.RFC3339), age.Round(time.Second))
+	}
+	return true, ""
+}

--- a/controlplane/device-health-oracle/internal/worker/link_health_test.go
+++ b/controlplane/device-health-oracle/internal/worker/link_health_test.go
@@ -1,0 +1,387 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/smartcontract/sdk/go/serviceability"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLinkHealthChecker struct {
+	recentFunc func(ctx context.Context, linkPubkey string) (LinkHealthRecentResult, bool, error)
+	windowFunc func(ctx context.Context, linkPubkey string, start, end time.Time, lossThreshold float64) (LinkHealthWindowResult, bool, error)
+}
+
+func (m *mockLinkHealthChecker) LinkHealthRecent(ctx context.Context, linkPubkey string) (LinkHealthRecentResult, bool, error) {
+	return m.recentFunc(ctx, linkPubkey)
+}
+
+func (m *mockLinkHealthChecker) LinkHealthWindowAllClean(ctx context.Context, linkPubkey string, start, end time.Time, lossThreshold float64) (LinkHealthWindowResult, bool, error) {
+	return m.windowFunc(ctx, linkPubkey, start, end, lossThreshold)
+}
+
+// freshBucket returns a bucket timestamp that's recent enough to pass the
+// stale-data floor in checkImpairment.
+func freshBucket() time.Time {
+	return time.Now().Add(-1 * time.Minute)
+}
+
+func TestLinkHealthCriterion_Name(t *testing.T) {
+	imp := NewLinkHealthCriterion(LinkHealthModeImpairment, &mockLinkHealthChecker{}, 5.0, testLogger())
+	rec := NewLinkHealthCriterion(LinkHealthModeRecovery, &mockLinkHealthChecker{}, 5.0, testLogger())
+	assert.Equal(t, "link_health_impairment", imp.Name())
+	assert.Equal(t, "link_health_recovery", rec.Name())
+}
+
+func TestLinkHealthCriterion_Impairment_NoData_Passes(t *testing.T) {
+	checker := &mockLinkHealthChecker{
+		recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+			return LinkHealthRecentResult{}, false, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger())
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthReadyForService}
+
+	passed, _ := c.Check(context.Background(), link)
+	assert.True(t, passed, "no data must not flag a link as impaired")
+}
+
+func TestLinkHealthCriterion_Impairment_StaleBucket_Passes(t *testing.T) {
+	// A latest bucket older than the recency floor signals a broken telemetry
+	// pipeline. Don't act on it — neither demote nor recover.
+	checker := &mockLinkHealthChecker{
+		recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+			return LinkHealthRecentResult{
+				BucketTs: time.Now().Add(-1 * time.Hour),
+				IsisDown: true,
+				ALossPct: 100,
+				ZLossPct: 100,
+			}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger())
+
+	passed, _ := c.Check(context.Background(), serviceability.Link{})
+	assert.True(t, passed, "stale bucket should be treated as no data even when it indicates impairment")
+}
+
+func TestLinkHealthCriterion_Impairment_IsisDown_Fails(t *testing.T) {
+	bucket := freshBucket()
+	checker := &mockLinkHealthChecker{
+		recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+			return LinkHealthRecentResult{BucketTs: bucket, IsisDown: true}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(context.Background(), serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "isis")
+	assert.Contains(t, reason, "bucket=")
+}
+
+func TestLinkHealthCriterion_Impairment_LossExceedsThreshold(t *testing.T) {
+	tests := []struct {
+		name     string
+		aLoss    float64
+		zLoss    float64
+		expected bool
+	}{
+		{"both clean", 1.0, 1.0, true},
+		{"a above threshold", 6.0, 1.0, false},
+		{"z above threshold", 1.0, 6.0, false},
+		{"a exactly at threshold", 5.0, 0, true},
+		{"z exactly at threshold", 0, 5.0, true},
+		{"both far above", 80.0, 90.0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &mockLinkHealthChecker{
+				recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+					return LinkHealthRecentResult{
+						BucketTs: freshBucket(),
+						ALossPct: tt.aLoss,
+						ZLossPct: tt.zLoss,
+					}, true, nil
+				},
+			}
+			c := NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger())
+			passed, _ := c.Check(context.Background(), serviceability.Link{})
+			assert.Equal(t, tt.expected, passed)
+		})
+	}
+}
+
+func TestLinkHealthCriterion_Impairment_QueryError_HoldsHealth(t *testing.T) {
+	checker := &mockLinkHealthChecker{
+		recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+			return LinkHealthRecentResult{}, false, errors.New("connection reset")
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger())
+
+	before := testutil.ToFloat64(MetricErrors.WithLabelValues(MetricErrorTypeLinkHealthQuery))
+	passed, reason := c.Check(context.Background(), serviceability.Link{})
+	assert.True(t, passed, "a ClickHouse outage must not demote a healthy link")
+	assert.Empty(t, reason)
+	assert.Equal(t, before+1, testutil.ToFloat64(MetricErrors.WithLabelValues(MetricErrorTypeLinkHealthQuery)),
+		"outages must be counted separately from criterion failures")
+}
+
+// The unit assertion above only proves the criterion passes; this proves the
+// demotion path is actually closed end to end.
+func TestLinkHealthEvaluator_ReadyForService_QueryError_StaysReadyForService(t *testing.T) {
+	checker := &mockLinkHealthChecker{
+		recentFunc: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+			return LinkHealthRecentResult{}, false, errors.New("connection reset")
+		},
+	}
+	eval := &LinkHealthEvaluator{
+		ImpairmentCriteria: []LinkCriterion{
+			NewLinkHealthCriterion(LinkHealthModeImpairment, checker, 5.0, testLogger()),
+		},
+		Log: testLogger(),
+	}
+
+	link := serviceability.Link{LinkHealth: serviceability.LinkHealthReadyForService}
+	assert.Equal(t, serviceability.LinkHealthReadyForService, eval.Evaluate(context.Background(), link))
+}
+
+func TestLinkHealthCriterion_Recovery_NoBurnInContext_Fails(t *testing.T) {
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, &mockLinkHealthChecker{}, 5.0, testLogger())
+	passed, reason := c.Check(context.Background(), serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "burn-in times not available")
+}
+
+func TestLinkHealthCriterion_Recovery_ZeroWindow_Fails(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now,
+		Now:          now,
+	})
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, &mockLinkHealthChecker{}, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "recovery window not yet established")
+}
+
+func TestLinkHealthCriterion_Recovery_AllClean_Passes(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{Bad: 0, Total: 6, MaxBucketTs: freshBucket(), AllClean: true}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.True(t, passed, reason)
+}
+
+func TestLinkHealthCriterion_Recovery_SparseWindow_Fails(t *testing.T) {
+	// One clean bucket satisfies "all buckets clean" but is not the 30 minutes
+	// of clean telemetry the recovery dwell is supposed to require.
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{Bad: 0, Total: 1, MaxBucketTs: freshBucket(), AllClean: true}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "expected buckets")
+}
+
+func TestLinkHealthCriterion_Recovery_WindowCoverageTolerance(t *testing.T) {
+	// One missing bucket at the edge of the window is tolerated; two is not.
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	tests := []struct {
+		name     string
+		total    uint64
+		expected bool
+	}{
+		{"full coverage", 6, true},
+		{"one bucket missing", 5, true},
+		{"two buckets missing", 4, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &mockLinkHealthChecker{
+				windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+					return LinkHealthWindowResult{Total: tt.total, MaxBucketTs: freshBucket(), AllClean: true}, true, nil
+				},
+			}
+			c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+			passed, _ := c.Check(ctx, serviceability.Link{})
+			assert.Equal(t, tt.expected, passed)
+		})
+	}
+}
+
+func TestLinkHealthCriterion_Recovery_StaleWindow_Fails(t *testing.T) {
+	// Frozen pipeline: the dirty buckets aged out of the trailing window and
+	// only old clean ones remain, so "all clean" holds on stale data. Without
+	// the recency floor the link recovers and then stays RFS, because
+	// checkImpairment reads the same stale latest bucket as no-data.
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{
+				Bad:         0,
+				Total:       6,
+				MaxBucketTs: now.Add(-45 * time.Minute),
+				AllClean:    true,
+			}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "stale")
+}
+
+func TestLinkHealthCriterion_Recovery_NotAllClean_Fails(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{Bad: 2, Total: 6, AllClean: false}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "2/6")
+}
+
+func TestLinkHealthCriterion_Recovery_NoData_Fails(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{}, false, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "no rollup data")
+}
+
+func TestLinkHealthCriterion_Recovery_QueryError_Fails(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, _ float64) (LinkHealthWindowResult, bool, error) {
+			return LinkHealthWindowResult{}, false, errors.New("boom")
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, 5.0, testLogger())
+
+	passed, reason := c.Check(ctx, serviceability.Link{})
+	assert.False(t, passed)
+	assert.Contains(t, reason, "clickhouse query failed")
+}
+
+func TestLinkHealthCriterion_Recovery_PassesThresholdToChecker(t *testing.T) {
+	now := time.Now()
+	ctx := ContextWithBurnInTimes(context.Background(), BurnInTimes{
+		DrainedStart: now.Add(-30 * time.Minute),
+		Now:          now,
+	})
+	const threshold = 7.5
+	var observed float64
+	checker := &mockLinkHealthChecker{
+		windowFunc: func(_ context.Context, _ string, _, _ time.Time, lossThreshold float64) (LinkHealthWindowResult, bool, error) {
+			observed = lossThreshold
+			return LinkHealthWindowResult{AllClean: true, Total: 6, MaxBucketTs: freshBucket()}, true, nil
+		},
+	}
+	c := NewLinkHealthCriterion(LinkHealthModeRecovery, checker, threshold, testLogger())
+
+	_, _ = c.Check(ctx, serviceability.Link{})
+	assert.Equal(t, threshold, observed)
+}
+
+// Finding 4: ReadyForServiceCriteria is wired to the impairment criterion, so a
+// link whose latest bucket already reads impaired must not promote to RFS only
+// to be demoted on the next tick. Links with no telemetry still promote.
+func TestLinkHealthEvaluator_Pending_PromotionGatedOnImpairment(t *testing.T) {
+	tests := []struct {
+		name     string
+		recent   func(ctx context.Context, linkPubkey string) (LinkHealthRecentResult, bool, error)
+		expected serviceability.LinkHealth
+	}{
+		{
+			name: "latest bucket impaired blocks promotion",
+			recent: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+				return LinkHealthRecentResult{BucketTs: freshBucket(), IsisDown: true}, true, nil
+			},
+			expected: serviceability.LinkHealthPending,
+		},
+		{
+			name: "no telemetry still promotes",
+			recent: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+				return LinkHealthRecentResult{}, false, nil
+			},
+			expected: serviceability.LinkHealthReadyForService,
+		},
+		{
+			name: "latest bucket clean promotes",
+			recent: func(_ context.Context, _ string) (LinkHealthRecentResult, bool, error) {
+				return LinkHealthRecentResult{BucketTs: freshBucket(), ALossPct: 1, ZLossPct: 1}, true, nil
+			},
+			expected: serviceability.LinkHealthReadyForService,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criterion := NewLinkHealthCriterion(LinkHealthModeImpairment,
+				&mockLinkHealthChecker{recentFunc: tt.recent}, 5.0, testLogger())
+			eval := &LinkHealthEvaluator{
+				ReadyForServiceCriteria: []LinkCriterion{criterion},
+				ImpairmentCriteria:      []LinkCriterion{criterion},
+				Log:                     testLogger(),
+			}
+
+			link := serviceability.Link{LinkHealth: serviceability.LinkHealthPending}
+			assert.Equal(t, tt.expected, eval.Evaluate(context.Background(), link))
+		})
+	}
+}

--- a/controlplane/device-health-oracle/internal/worker/metrics.go
+++ b/controlplane/device-health-oracle/internal/worker/metrics.go
@@ -18,6 +18,11 @@ const (
 	MetricLabelCriterion = "criterion"
 	MetricLabelResult    = "result"
 	MetricLabelKind      = "kind"
+
+	// MetricErrorTypeLinkHealthQuery counts link health rollup queries that
+	// failed. These are held apart from criterion results so a ClickHouse
+	// outage is visible without reading as link impairment.
+	MetricErrorTypeLinkHealthQuery = "link_health_query"
 )
 
 var (


### PR DESCRIPTION
Resolves: #2652
Supersedes: #3678 — rebased onto current main with that review's findings fixed.
RFC: [RFC-12 — network provisioning](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc12-network-provisioning.md)

## Summary of Changes

- Links now transition both ways between `ReadyForService` and `Impaired`, driven by the lake `link_rollup_5m` table. The oracle had **zero** `LinkCriterion`s, so every link auto-advanced to `ReadyForService` and stayed there with no demotion path.
- Impairment is a point-in-time check on the latest 5m bucket (ISIS adjacency down, or per-direction loss above `--link-loss-threshold`). Recovery requires a covered, recent window of clean buckets over the existing `--drained-slot-count` dwell — fast to demote, slow to recover, so borderline links do not flap.
- **Neither a ClickHouse outage nor absent telemetry moves a link in either direction** — separate paths, both holding current health. An unreachable lake would otherwise demote every healthy link in one tick, then re-promote them all on recovery. Failures count under `doublezero_device_health_oracle_errors_total{error_type="link_health_query"}`, so an outage stays visible without reading as impairment.
- Promotion is gated on the same latest-bucket check, so a link already reporting `isis_down` no longer promotes to RFS only to be demoted a tick later.

**A reporting signal, not enforcement.** `check_status_transition()` does not gate `link.status` on `LinkHealth`, and nothing here changes that. The oracle also runs with ClickHouse disabled in devnet and testnet, so this executes nowhere deployed until malbeclabs/infra#1158 lands.

## Two open questions for the reviewer

- **Threshold disagreement.** The default is 5.0, but lake's `link_incidents_v` uses 10% for incidents, so the onchain signal and the lake incident view will disagree in the 5–10% band. Left at 5.0 deliberately; flagging rather than changing it.
- **No `status` filter.** Hard-drained links surface as `isis_down = true`, so the impairment criterion covers them. Consequence: over 14 days of live data, ~**83%** of Impaired writes would be links already `soft-drained` or `hard-drained` (8,225 hard + 5,723 soft vs 2,940 activated impaired buckets). Both queries are written so a `status` predicate drops in as one line beside the existing `provisioning = false` if that ruling changes.

## Diff Breakdown

| Category     | Files | Lines (+/-) | Net   |
|--------------|-------|-------------|-------|
| Tests        |     3 | +700 / -0   | +700  |
| Core logic   |     3 | +374 / -7   | +367  |
| Scaffolding  |     2 | +30 / -2    | +28   |
| Docs         |     1 | +3 / -0     | +3    |
| **Total**    |     9 | +1107 / -9  | +1098 |

Core logic is `link_health.go` (the criterion), `clickhouse.go` (the queries) and `criteria.go` (the evaluator state machine). Two thirds of the diff is tests; it exceeds the ~500-line guideline, but the non-test core is ~370 lines and this is a rebase of reviewed work, so splitting it means reviewing the same code twice.

## Testing Verification

`go test ./controlplane/device-health-oracle/...` passes (90 tests), `golangci-lint` clean. Every fix from the prior review has a test confirmed to fail before it and pass after:

| Fix | Test (`TestLinkHealth…`) |
|-----|------|
| Query error holds health instead of demoting | `Criterion_Impairment_QueryError_HoldsHealth` — asserts the pass **and** the error counter |
| …and the demotion path is really closed | `Evaluator_ReadyForService_QueryError_StaysReadyForService` |
| Recovery needs a covered window | `Criterion_Recovery_SparseWindow_Fails`, `Criterion_Recovery_WindowCoverageTolerance` |
| Recovery needs a recent window (frozen pipeline) | `Criterion_Recovery_StaleWindow_Fails` |
| Promotion gated on impairment | `Evaluator_Pending_PromotionGatedOnImpairment` — blocks on `isis_down`, still promotes with no telemetry |
| `provisioning` filtered after the dedup, not before | `Recent_ReturnsLatestBucket`, `WindowAllClean_AllClean` |

Both failure directions are covered, since a false Impaired is a needless page and a contributor dispute while a missed one is a customer on a broken link: loss exactly at the threshold, either side above it, ISIS down, stale buckets, no data, and sparse windows.
