### PR TITLE
ci: publish a bare vX.Y.Z tag for the root Go module on testnet releases

### DIFF
--- a/.github/workflows/release.testnet.push.tags.components.yml
+++ b/.github/workflows/release.testnet.push.tags.components.yml
@@ -43,3 +43,16 @@ jobs:
     secrets:
       RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+  module-tag:
+    name: "Tag root Go module with version ${{ github.event.inputs.version }}"
+    needs: approve
+    uses: ./.github/workflows/release.testnet.push.tags.yml
+    permissions:
+      contents: write
+    with:
+      version: ${{ github.event.inputs.version }}
+      module_tag: true
+    secrets:
+      RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.testnet.push.tags.yml
+++ b/.github/workflows/release.testnet.push.tags.yml
@@ -8,9 +8,15 @@ on:
         required: true
         type: string
       component:
-        description: 'The component to tag'
-        required: true
+        description: 'The component to tag. Required unless module_tag is true; must be empty when it is.'
+        required: false
         type: string
+        default: ''
+      module_tag:
+        description: 'Tag the root Go module: push a bare vX.Y.Z tag (no component prefix) so `go get github.com/malbeclabs/doublezero@vX.Y.Z` resolves. Mutually exclusive with component.'
+        required: false
+        type: boolean
+        default: false
       ref:
         description: 'Commit to tag. Empty tags the sha the run is pinned to (the manual dispatcher path: main at dispatch).'
         required: false
@@ -41,7 +47,7 @@ on:
 # until it is added here — with its own approval story — in a reviewed change.
 jobs:
   create-and-push-tag:
-    name: Push ${{ inputs.version }} tag for ${{ inputs.component }}
+    name: Push ${{ inputs.version }} tag for ${{ inputs.module_tag && 'root Go module' || inputs.component }}
     runs-on: ubuntu-latest
     steps:
       - name: Require an approval-carrying caller
@@ -81,37 +87,84 @@ jobs:
           # empty ref = the sha this run is pinned to (actions/checkout default)
           ref: ${{ inputs.ref }}
           fetch-tags: true
+          # full history so the module-tag ancestry check below can run merge-base
+          fetch-depth: 0
 
       - name: Validate format and push tag
         run: |
+          set -euo pipefail
           VERSION="${{ inputs.version }}"
           COMPONENT="${{ inputs.component }}"
-          TAG_NAME="$COMPONENT/$VERSION"
+          MODULE_TAG="${{ inputs.module_tag }}"
+          SKIP_EXISTING="${{ inputs.skip_existing }}"
 
           VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
-
           if ! [[ "$VERSION" =~ $VERSION_REGEX ]]; then
-            echo "Error: Version format '$VERSION' is invalid. It must be in the format 'vX.X.X'."
+            echo "::error::Version format '$VERSION' is invalid. It must be in the format 'vX.X.X'."
             exit 1
           fi
           echo "Version format is valid."
+
+          # Exactly one of module_tag / component. module_tag is an explicit
+          # boolean rather than "empty component means bare tag" so a component
+          # typo can never mint a root module version — which, per the
+          # immutability check below, would be unrecoverable.
+          if [ "$MODULE_TAG" = "true" ]; then
+            if [ -n "$COMPONENT" ]; then
+              echo "::error::module_tag=true takes no component (got '$COMPONENT'). A component would make this a component tag, not the root module tag."
+              exit 1
+            fi
+            TAG_NAME="$VERSION"
+          else
+            if [ -z "$COMPONENT" ]; then
+              echo "::error::component is required unless module_tag=true."
+              exit 1
+            fi
+            TAG_NAME="$COMPONENT/$VERSION"
+          fi
+          echo "Target tag: '$TAG_NAME'."
 
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "Dry run — not pushing tag '$TAG_NAME'."
             exit 0
           fi
 
+          HEAD_SHA=$(git rev-parse HEAD)
+
           if EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG_NAME^{commit}"); then
-            if [ "${{ inputs.skip_existing }}" = "true" ]; then
-              HEAD_SHA=$(git rev-parse HEAD)
-              echo "Tag '$TAG_NAME' already exists at $EXISTING; skipping (skip_existing=true)."
-              if [ "$EXISTING" != "$HEAD_SHA" ]; then
-                echo "::warning::existing tag '$TAG_NAME' points at $EXISTING, but this run would have tagged $HEAD_SHA"
-              fi
+            if [ "$EXISTING" = "$HEAD_SHA" ]; then
+              echo "Tag '$TAG_NAME' already exists at $EXISTING (== HEAD); nothing to do."
               exit 0
             fi
-            echo "Error: Tag '$TAG_NAME' already exists in the repository."
+            # A published module tag is immutable: once any consumer resolves it,
+            # proxy.golang.org caches its tree hash permanently, and moving it
+            # gives every consumer a checksum-mismatch security error on their
+            # next build. skip_existing must never downgrade a *mismatched* root
+            # tag to a warning, even on an orchestrator re-run.
+            if [ "$MODULE_TAG" != "true" ] && [ "$SKIP_EXISTING" = "true" ]; then
+              echo "Tag '$TAG_NAME' already exists at $EXISTING; skipping (skip_existing=true)."
+              echo "::warning::existing tag '$TAG_NAME' points at $EXISTING, but this run would have tagged $HEAD_SHA"
+              exit 0
+            fi
+            echo "::error::Tag '$TAG_NAME' already exists at $EXISTING and this run would move it to $HEAD_SHA. Refusing — a moved tag breaks every consumer's checksum."
             exit 1
+          fi
+
+          # The root module tag must descend from the previous one. A Go
+          # pseudo-version sorts by its base tag, not its commit date, so a bare
+          # tag cut off the previous line would let `go get -u` "upgrade" a
+          # consumer backwards onto a build missing commits it is pinned for.
+          if [ "$MODULE_TAG" = "true" ]; then
+            PREV=$(git tag --list --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+            if [ -n "$PREV" ]; then
+              if ! git merge-base --is-ancestor "$PREV" "$HEAD_SHA"; then
+                echo "::error::commit $HEAD_SHA for '$TAG_NAME' does not descend from the previous module tag '$PREV' ($(git rev-parse "$PREV^{commit}")). Refusing to cut a non-linear module version."
+                exit 1
+              fi
+              echo "Ancestry ok: HEAD descends from previous module tag '$PREV'."
+            else
+              echo "No previous bare vX.Y.Z tag found; skipping ancestry check."
+            fi
           fi
           echo "Tag '$TAG_NAME' will be created."
 

--- a/.github/workflows/release.testnet.yml
+++ b/.github/workflows/release.testnet.yml
@@ -334,9 +334,29 @@ jobs:
       RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
+  # Bare vX.Y.Z tag for the root Go module, at the same commit and through the
+  # same approval-gated mechanism as the component tags, so
+  # `go get github.com/malbeclabs/doublezero@vX.Y.Z` resolves instead of every
+  # consumer pinning a pseudo-version. skip_existing does not soften a mismatched
+  # root tag (see release.testnet.push.tags.yml).
+  push-module-tag:
+    needs: gate-tags
+    uses: ./.github/workflows/release.testnet.push.tags.yml
+    permissions:
+      contents: write
+    with:
+      version: v${{ inputs.version }}
+      module_tag: true
+      ref: ${{ needs.gate-tags.outputs.tag_sha }}
+      skip_existing: true
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
   verify-cloudsmith:
     runs-on: ubuntu-latest
-    needs: [preflight, gate-tags, push-tags]
+    needs: [preflight, gate-tags, push-tags, push-module-tag]
     timeout-minutes: 75
     steps:
       - name: Install Cloudsmith CLI
@@ -637,7 +657,7 @@ jobs:
   # a release that actually succeeded.
   pipeline-complete:
     runs-on: ubuntu-latest
-    needs: [preflight, open-prs, gate-tags, push-tags, verify-cloudsmith, build-programs, stage-programs, gate-programs, verify-onchain, deploy-core, deploy-clients, qa]
+    needs: [preflight, open-prs, gate-tags, push-tags, push-module-tag, verify-cloudsmith, build-programs, stage-programs, gate-programs, verify-onchain, deploy-core, deploy-clients, qa]
     if: ${{ !cancelled() }}
     steps:
       - name: Assert every stage succeeded
@@ -658,7 +678,7 @@ jobs:
     # succeeded, and a failed announce means Slack delivery is broken — this
     # notifier posts via the same Slack API and would fail the same way.
     # pipeline-complete IS included so a hollow success also alerts.
-    needs: [preflight, open-prs, gate-tags, push-tags, verify-cloudsmith, build-programs, stage-programs, gate-programs, verify-onchain, deploy-core, deploy-clients, qa, pipeline-complete]
+    needs: [preflight, open-prs, gate-tags, push-tags, push-module-tag, verify-cloudsmith, build-programs, stage-programs, gate-programs, verify-onchain, deploy-core, deploy-clients, qa, pipeline-complete]
     if: failure()
     steps:
       # checkout only to resolve the local composite action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CI
+  - The testnet release path pushes a bare `vX.Y.Z` tag for the root Go module alongside the nine component tags, at the same commit and through the same approval-gated `release.testnet.push.tags.yml` mechanism (new `module_tag` input; a separate `push-module-tag` job in the orchestrator and `module-tag` job in the manual dispatcher). The root module has had no usable version since `v0.8.0` (2025-12-02) — every release since is component-prefixed, which Go's resolver ignores for the root path — so `go get github.com/malbeclabs/doublezero@vX.Y.Z` failed and consumers pinned pseudo-versions. For the root tag `skip_existing` no longer downgrades a mismatched existing tag to a warning (a moved module tag is an unrecoverable checksum error for every consumer once `proxy.golang.org` has cached it), and the tag's commit is asserted to descend from the previous module tag so `go get -u` cannot walk a consumer backwards. (#4162)
+
 ## [v0.40.0](https://github.com/malbeclabs/doublezero/compare/client/v0.39.0...client/v0.40.0) - 2026-09-11
 
 ### Breaking


### PR DESCRIPTION
Addresses #4162, /cc @ben-dz per the issue.

`github.com/malbeclabs/doublezero` has had no usable Go module version since `v0.8.0` (2025-12-02). Every release since is component-prefixed (`agent/v0.33.0`, `client/v0.33.0`, …), and Go's resolver ignores prefixed tags for the root module path, so `go get github.com/malbeclabs/doublezero@vX.Y.Z` fails and every Go consumer pins a pseudo-version instead — `lake` is on `v0.8.1-0.20260728210138-d904a1969083`, and `lake#757` had to hand-enumerate its review surface package by package because there was no tag range to cite.

## What changed

`release.testnet.push.tags.yml` gets a new `module_tag` boolean input, mutually exclusive with `component`: when set, it pushes a bare `vX.Y.Z` tag instead of `component/vX.Y.Z`, through the same caller allowlist and approval gate as the nine component tags (nothing new can call this workflow without an approval story). The orchestrator's `push-tags` job gets a `push-module-tag` sibling — added to the three downstream `needs` lists so a module-tag failure fails the release rather than passing silently — and the manual dispatcher gets a matching `module-tag` job.

Two guards specific to the root tag, called out explicitly in the issue:

- **Immutability.** `skip_existing` no longer downgrades a *mismatched* existing tag to a warning. Once `proxy.golang.org` caches a tag's tree hash, moving it gives every consumer a checksum-mismatch error on their next build — so for the root tag a mismatch is now a hard failure, even on an orchestrator re-run. The existing "tag already exists, same commit → no-op" path is unchanged.
- **Ancestry.** The new tag's commit must descend from the previous bare tag (checkout now takes `fetch-depth: 0` so `merge-base --is-ancestor` has the history to check). A Go pseudo-version sorts by its base tag rather than its commit date, so cutting the tag off a non-descendant commit would let `go get -u` walk a consumer backwards onto a build missing commits its pseudo-version already includes.

## Testing Verification

Can't exercise the reusable workflow directly (needs Actions), so verified statically: both changed workflow files parse as valid YAML, and the inline shell block passes `bash -n`. I walked the new branches by hand against the existing test cases in the issue — module tag with no prior tag (skips ancestry check), module tag descending correctly, module tag off a non-ancestor commit (fails), mismatched existing module tag under `skip_existing: true` (now fails instead of warning), and the untouched component-tag path (`skip_existing` behavior unchanged).