### PR TITLE
fix(api): validate HTTP status code in Solana RPC GetTotalSupply

### DIFF
--- a/api/internal/rpc.go
+++ b/api/internal/rpc.go
@@ -70,6 +70,10 @@ func (c *SolanaClient) GetTotalSupply(ctx context.Context) (float64, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
 	var rpcResp jsonRPCResponse
 	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
 		return 0, fmt.Errorf("failed to decode response body: %w", err)

--- a/api/internal/server_test.go
+++ b/api/internal/server_test.go
@@ -168,5 +168,5 @@ func TestSolanaClient_GetTotalSupply_HTTPError(t *testing.T) {
 
 	_, err := client.GetTotalSupply(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected status code: 429")
+	assert.EqualError(t, err, "unexpected status code: 429")
 }

--- a/api/internal/server_test.go
+++ b/api/internal/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
@@ -154,4 +155,18 @@ func TestApiServer_TotalSupplyEndpoint(t *testing.T) {
 			runEndpointTest(t, serverOpts, "/api/v1/2z/total-supply", tc.expectedStatusCode, expectedBody)
 		})
 	}
+}
+
+func TestSolanaClient_GetTotalSupply_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := NewSolanaClient()
+	client.rpcURL = server.URL
+
+	_, err := client.GetTotalSupply(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code: 429")
 }


### PR DESCRIPTION
In \pi/internal/rpc.go\, \GetTotalSupply\ previously passed non-200 HTTP responses (e.g., HTTP 429 rate limit or 503 gateway error) directly to \json.NewDecoder(resp.Body).Decode(&rpcResp)\. This resulted in obscure JSON decoding error messages ('EOF' or 'invalid character') rather than identifying the upstream RPC HTTP status failure.

This fix:
1. Validates that \esp.StatusCode == http.StatusOK\ before attempting JSON deserialization and returns a clear status error otherwise.
2. Adds unit test coverage (\TestSolanaClient_GetTotalSupply_HTTPError\) in \pi/internal/server_test.go\.
