### PR TITLE
solana-cli: read v1 transactions in shreds payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- CLI
+  - `doublezero-solana shreds payments` asks the Solana node for version 1 and reads the JsonParsed instruction list, so a v1 fund no longer fails the listing with error -32015.
 - CI
   - The Agave toolchain install retries, and a failed one now fails the job. Eight workflow steps across five workflows ran `sh -c "$(curl -sSfL .../install)"` once with no retry, so a transient reset from `release.anza.xyz` killed a job before it ran anything. That form also swallowed a failed fetch: the command substitution comes back empty, `sh -c ""` exits 0, and the step passed having installed nothing. The eight are now one composite action at `.github/actions/solana-toolchain` that fetches and runs as separate steps, checks `solana --version` actually runs, clears partial state between attempts, bounds every wait so a stalled handshake or hung transfer reaches the backoff instead of sitting until the job times out, and backs off. Each caller keeps the version it used before; `solana.yml` and `offchain.local-validator.yml` are on v3.0.12 and the other three on v3.0.4, which is drift worth settling separately.
 - Serviceability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "borsh",
+ "bs58",
  "bytemuck",
  "chrono",
  "clap",

--- a/offchain/crates/solana-cli/CHANGELOG.md
+++ b/offchain/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds payments`: ask the Solana node for version 1 and read JsonParsed instruction lists, so a v1 fund no longer fails the listing with error -32015
 - Remove `revenue-distribution convert-2z` and `harvest-2z` (malbeclabs/doublezero#4275)
 - Validator deposit no longer accepts `--convert-2z-limit-price`
 - `fetch sol-conversion` no longer requests a swap quote

--- a/offchain/crates/solana-cli/Cargo.toml
+++ b/offchain/crates/solana-cli/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 borsh.workspace = true
+bs58.workspace = true
 chrono.workspace = true
 clap.workspace = true
 csv.workspace = true

--- a/offchain/crates/solana-cli/src/command/shreds/payments.rs
+++ b/offchain/crates/solana-cli/src/command/shreds/payments.rs
@@ -94,92 +94,6 @@ fn parse_legacy_fund_payment_escrow_usdc(data: &[u8]) -> Option<u64> {
     Some(u64::from_le_bytes(data[8..16].try_into().ok()?))
 }
 
-fn payment_events(
-    transaction: &EncodedTransaction,
-    escrow_keys: &[Pubkey],
-    block_time: Option<i64>,
-) -> Vec<PaymentEvent> {
-    let EncodedTransaction::Json(ui_transaction) = transaction else {
-        return Vec::new();
-    };
-    let UiMessage::Parsed(message) = &ui_transaction.message else {
-        return Vec::new();
-    };
-
-    let program_id = shred_subscription::ID.to_string();
-    let mut events = Vec::new();
-    for instruction in &message.instructions {
-        let UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(instruction)) = instruction
-        else {
-            continue;
-        };
-        if instruction.program_id != program_id {
-            continue;
-        }
-        let touches_escrow = instruction
-            .accounts
-            .iter()
-            .any(|account| escrow_keys.iter().any(|key| key.to_string() == *account));
-        if !touches_escrow {
-            continue;
-        }
-        let Ok(data) = bs58::decode(&instruction.data).into_vec() else {
-            continue;
-        };
-        if let Some(amount) = parse_legacy_fund_payment_escrow_usdc(&data) {
-            events.push(PaymentEvent {
-                event_type: EventType::Funded,
-                amount_micro: amount as i64,
-                block_time,
-            });
-            continue;
-        }
-
-        match ShredSubscriptionInstructionData::try_from_slice(&data) {
-            // TODO: ClosePaymentEscrow (withdrawal) — the actual
-            // refunded amount is in the tx log message "Withdrew {}
-            // USDC from payment escrow to refund account". Parse that
-            // to get the negative amount. Without it, we can't derive
-            // the correct withdrawal amount from the running balance
-            // alone because oracle debits are not yet tracked.
-            Ok(ShredSubscriptionInstructionData::ClosePaymentEscrow) => {}
-            // These instructions touch the escrow account but don't
-            // move funds — they appear in the same tx as fund/close.
-            //
-            // NOTE: the `InitializeValidatorPublisherRewards` and
-            // `ConfigureValidatorPublisherRewards` variants were
-            // previously listed here, but their account lists do
-            // not reference the escrow PDA so the `touches_escrow`
-            // pre-filter above already excludes them. A sibling
-            // task audits the rest of this listing for the same
-            // reason — the wildcard arm below makes the match
-            // robust to future variants in either direction.
-            Ok(
-                ShredSubscriptionInstructionData::InitializePaymentEscrow
-                | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
-                | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
-                | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
-                | ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal
-                | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
-                    _,
-                )
-                | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
-                | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
-                | ShredSubscriptionInstructionData::CheckCliVersion { .. },
-            ) => {}
-            Ok(_) => {}
-            // TODO: oracle instructions (BatchAllocateSeats,
-            // InstantAllocateSeat) debit the escrow. Their
-            // discriminators are not in the offchain SDK. The debit
-            // amount is in the tx log "Escrow balance: {}" (the
-            // post-debit balance). Parse that and compute the delta
-            // from the running balance to get the negative amount.
-            Err(_) => {}
-        }
-    }
-    events
-}
-
 impl PaymentsCommand {
     pub async fn execute(
         self,
@@ -261,11 +175,85 @@ impl PaymentsCommand {
                     .get_transaction_with_config(&signature, tx_config)
                     .await?;
 
-                events.extend(payment_events(
-                    &tx_response.transaction.transaction,
-                    &escrow_keys,
-                    tx_response.block_time,
-                ));
+                let EncodedTransaction::Json(ui_transaction) = &tx_response.transaction.transaction
+                else {
+                    continue;
+                };
+                let UiMessage::Parsed(message) = &ui_transaction.message else {
+                    continue;
+                };
+
+                let program_id = shred_subscription::ID.to_string();
+                for instruction in &message.instructions {
+                    let UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(instruction)) =
+                        instruction
+                    else {
+                        continue;
+                    };
+                    if instruction.program_id != program_id {
+                        continue;
+                    }
+                    let touches_escrow = instruction
+                        .accounts
+                        .iter()
+                        .any(|account| escrow_keys.iter().any(|key| key.to_string() == *account));
+                    if !touches_escrow {
+                        continue;
+                    }
+                    let Ok(data) = bs58::decode(&instruction.data).into_vec() else {
+                        continue;
+                    };
+                    if let Some(amount) = parse_legacy_fund_payment_escrow_usdc(&data) {
+                        events.push(PaymentEvent {
+                            event_type: EventType::Funded,
+                            amount_micro: amount as i64,
+                            block_time: tx_response.block_time,
+                        });
+                        continue;
+                    }
+
+                    match ShredSubscriptionInstructionData::try_from_slice(&data) {
+                        // TODO: ClosePaymentEscrow (withdrawal) — the actual
+                        // refunded amount is in the tx log message "Withdrew {}
+                        // USDC from payment escrow to refund account". Parse that
+                        // to get the negative amount. Without it, we can't derive
+                        // the correct withdrawal amount from the running balance
+                        // alone because oracle debits are not yet tracked.
+                        Ok(ShredSubscriptionInstructionData::ClosePaymentEscrow) => {}
+                        // These instructions touch the escrow account but don't
+                        // move funds — they appear in the same tx as fund/close.
+                        //
+                        // NOTE: the `InitializeValidatorPublisherRewards` and
+                        // `ConfigureValidatorPublisherRewards` variants were
+                        // previously listed here, but their account lists do
+                        // not reference the escrow PDA so the `touches_escrow`
+                        // pre-filter above already excludes them. A sibling
+                        // task audits the rest of this listing for the same
+                        // reason — the wildcard arm below makes the match
+                        // robust to future variants in either direction.
+                        Ok(
+                            ShredSubscriptionInstructionData::InitializePaymentEscrow
+                            | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
+                            | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
+                            | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
+                            | ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal
+                            | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
+                                _,
+                            )
+                            | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
+                            | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
+                            | ShredSubscriptionInstructionData::CheckCliVersion { .. },
+                        ) => {}
+                        Ok(_) => {}
+                        // TODO: oracle instructions (BatchAllocateSeats,
+                        // InstantAllocateSeat) debit the escrow. Their
+                        // discriminators are not in the offchain SDK. The debit
+                        // amount is in the tx log "Escrow balance: {}" (the
+                        // post-debit balance). Parse that and compute the delta
+                        // from the running balance to get the negative amount.
+                        Err(_) => {}
+                    }
+                }
             }
         }
 
@@ -329,94 +317,5 @@ impl PaymentsCommand {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::{Value, json};
-    use solana_transaction_status_client_types::EncodedTransactionWithStatusMeta;
-
-    use super::*;
-
-    fn fund_data(amount: u64) -> String {
-        let mut data = Vec::from(LEGACY_FUND_PAYMENT_ESCROW_USDC);
-        data.extend_from_slice(&amount.to_le_bytes());
-        bs58::encode(data).into_string()
-    }
-
-    fn response(instructions: Vec<Value>) -> EncodedTransactionWithStatusMeta {
-        serde_json::from_value(json!({
-            "transaction": {
-                "signatures": [Signature::default().to_string()],
-                "message": {
-                    "accountKeys": [],
-                    "recentBlockhash": "11111111111111111111111111111111",
-                    "instructions": instructions,
-                    "addressTableLookups": null,
-                    "transactionConfig": {
-                        "computeUnitLimit": 30_000,
-                        "heapSize": null,
-                        "loadedAccountsDataSizeLimit": 200_000,
-                        "priorityFee": null,
-                    },
-                },
-            },
-            "meta": {
-                "err": null,
-                "status": { "Ok": null },
-                "fee": 5_000,
-                "preBalances": [],
-                "postBalances": [],
-                "innerInstructions": [],
-                "logMessages": [],
-                "preTokenBalances": [],
-                "postTokenBalances": [],
-                "rewards": [],
-            },
-            "version": 1,
-        }))
-        .expect("a getTransaction response must deserialize")
-    }
-
-    fn fund_instruction(escrow: Pubkey, amount: u64) -> Value {
-        json!({
-            "programId": shred_subscription::ID.to_string(),
-            "accounts": [escrow.to_string()],
-            "data": fund_data(amount),
-            "stackHeight": null,
-        })
-    }
-
-    #[test]
-    fn reads_a_v1_fund_for_a_known_escrow() {
-        let escrow = Pubkey::new_unique();
-        let transaction = response(vec![fund_instruction(escrow, 2_000_000)]);
-
-        let events = payment_events(&transaction.transaction, &[escrow], Some(1_700_000_000));
-
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events[0].event_type, EventType::Funded));
-        assert_eq!(events[0].amount_micro, 2_000_000);
-        assert_eq!(events[0].block_time, Some(1_700_000_000));
-    }
-
-    #[test]
-    fn ignores_a_foreign_program_and_a_fund_for_another_escrow() {
-        let escrow = Pubkey::new_unique();
-        let other = Pubkey::new_unique();
-        let transaction = response(vec![
-            json!({
-                "programId": Pubkey::new_unique().to_string(),
-                "accounts": [escrow.to_string()],
-                "data": fund_data(2_000_000),
-                "stackHeight": null,
-            }),
-            fund_instruction(other, 2_000_000),
-        ]);
-
-        let events = payment_events(&transaction.transaction, &[escrow], None);
-
-        assert!(events.is_empty());
     }
 }

--- a/offchain/crates/solana-cli/src/command/shreds/payments.rs
+++ b/offchain/crates/solana-cli/src/command/shreds/payments.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, net::Ipv4Addr};
+use std::{collections::HashSet, io::Write, net::Ipv4Addr};
 
 use anyhow::Result;
 use borsh::BorshDeserialize;
@@ -142,6 +142,7 @@ impl PaymentsCommand {
         }
 
         let escrow_keys: Vec<Pubkey> = escrow_accounts.iter().map(|(key, _)| *key).collect();
+        let escrow_key_set: HashSet<String> = escrow_keys.iter().map(ToString::to_string).collect();
 
         // Fetch transaction history for each escrow.
         let mut events: Vec<PaymentEvent> = Vec::new();
@@ -196,7 +197,7 @@ impl PaymentsCommand {
                     let touches_escrow = instruction
                         .accounts
                         .iter()
-                        .any(|account| escrow_keys.iter().any(|key| key.to_string() == *account));
+                        .any(|account| escrow_key_set.contains(account));
                     if !touches_escrow {
                         continue;
                     }
@@ -204,9 +205,12 @@ impl PaymentsCommand {
                         continue;
                     };
                     if let Some(amount) = parse_legacy_fund_payment_escrow_usdc(&data) {
+                        let Ok(amount_micro) = i64::try_from(amount) else {
+                            continue;
+                        };
                         events.push(PaymentEvent {
                             event_type: EventType::Funded,
-                            amount_micro: amount as i64,
+                            amount_micro,
                             block_time: tx_response.block_time,
                         });
                         continue;

--- a/offchain/crates/solana-cli/src/command/shreds/payments.rs
+++ b/offchain/crates/solana-cli/src/command/shreds/payments.rs
@@ -16,7 +16,9 @@ use solana_client::{
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signature};
-use solana_transaction_status_client_types::UiTransactionEncoding;
+use solana_transaction_status_client_types::{
+    EncodedTransaction, UiInstruction, UiMessage, UiParsedInstruction, UiTransactionEncoding,
+};
 use tabled::{Table, Tabled, settings::Style};
 
 /*
@@ -92,6 +94,92 @@ fn parse_legacy_fund_payment_escrow_usdc(data: &[u8]) -> Option<u64> {
     Some(u64::from_le_bytes(data[8..16].try_into().ok()?))
 }
 
+fn payment_events(
+    transaction: &EncodedTransaction,
+    escrow_keys: &[Pubkey],
+    block_time: Option<i64>,
+) -> Vec<PaymentEvent> {
+    let EncodedTransaction::Json(ui_transaction) = transaction else {
+        return Vec::new();
+    };
+    let UiMessage::Parsed(message) = &ui_transaction.message else {
+        return Vec::new();
+    };
+
+    let program_id = shred_subscription::ID.to_string();
+    let mut events = Vec::new();
+    for instruction in &message.instructions {
+        let UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(instruction)) = instruction
+        else {
+            continue;
+        };
+        if instruction.program_id != program_id {
+            continue;
+        }
+        let touches_escrow = instruction
+            .accounts
+            .iter()
+            .any(|account| escrow_keys.iter().any(|key| key.to_string() == *account));
+        if !touches_escrow {
+            continue;
+        }
+        let Ok(data) = bs58::decode(&instruction.data).into_vec() else {
+            continue;
+        };
+        if let Some(amount) = parse_legacy_fund_payment_escrow_usdc(&data) {
+            events.push(PaymentEvent {
+                event_type: EventType::Funded,
+                amount_micro: amount as i64,
+                block_time,
+            });
+            continue;
+        }
+
+        match ShredSubscriptionInstructionData::try_from_slice(&data) {
+            // TODO: ClosePaymentEscrow (withdrawal) — the actual
+            // refunded amount is in the tx log message "Withdrew {}
+            // USDC from payment escrow to refund account". Parse that
+            // to get the negative amount. Without it, we can't derive
+            // the correct withdrawal amount from the running balance
+            // alone because oracle debits are not yet tracked.
+            Ok(ShredSubscriptionInstructionData::ClosePaymentEscrow) => {}
+            // These instructions touch the escrow account but don't
+            // move funds — they appear in the same tx as fund/close.
+            //
+            // NOTE: the `InitializeValidatorPublisherRewards` and
+            // `ConfigureValidatorPublisherRewards` variants were
+            // previously listed here, but their account lists do
+            // not reference the escrow PDA so the `touches_escrow`
+            // pre-filter above already excludes them. A sibling
+            // task audits the rest of this listing for the same
+            // reason — the wildcard arm below makes the match
+            // robust to future variants in either direction.
+            Ok(
+                ShredSubscriptionInstructionData::InitializePaymentEscrow
+                | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
+                | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
+                | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
+                | ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal
+                | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
+                    _,
+                )
+                | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
+                | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
+                | ShredSubscriptionInstructionData::CheckCliVersion { .. },
+            ) => {}
+            Ok(_) => {}
+            // TODO: oracle instructions (BatchAllocateSeats,
+            // InstantAllocateSeat) debit the escrow. Their
+            // discriminators are not in the offchain SDK. The debit
+            // amount is in the tx log "Escrow balance: {}" (the
+            // post-debit balance). Parse that and compute the delta
+            // from the running balance to get the negative amount.
+            Err(_) => {}
+        }
+    }
+    events
+}
+
 impl PaymentsCommand {
     pub async fn execute(
         self,
@@ -164,96 +252,20 @@ impl PaymentsCommand {
                 let signature: Signature = sig_info.signature.parse()?;
 
                 let tx_config = RpcTransactionConfig {
-                    encoding: Some(UiTransactionEncoding::Base64),
+                    encoding: Some(UiTransactionEncoding::JsonParsed),
                     commitment: Some(CommitmentConfig::confirmed()),
-                    max_supported_transaction_version: Some(0),
+                    max_supported_transaction_version: Some(1),
                 };
 
                 let tx_response = connection
                     .get_transaction_with_config(&signature, tx_config)
                     .await?;
 
-                let versioned_tx = match tx_response.transaction.transaction.decode() {
-                    Some(tx) => tx,
-                    None => continue,
-                };
-
-                let message = versioned_tx.message;
-                let account_keys = message.static_account_keys();
-
-                for ix in message.instructions() {
-                    let program_id = account_keys
-                        .get(ix.program_id_index as usize)
-                        .copied()
-                        .unwrap_or_default();
-
-                    if program_id != *shred_subscription::ID {
-                        continue;
-                    }
-
-                    // Check that this instruction touches our escrow account.
-                    let touches_escrow = ix.accounts.iter().any(|&idx| {
-                        account_keys
-                            .get(idx as usize)
-                            .map(|k| escrow_keys.contains(k))
-                            .unwrap_or(false)
-                    });
-
-                    if !touches_escrow {
-                        continue;
-                    }
-
-                    if let Some(amount) = parse_legacy_fund_payment_escrow_usdc(&ix.data) {
-                        events.push(PaymentEvent {
-                            event_type: EventType::Funded,
-                            amount_micro: amount as i64,
-                            block_time: tx_response.block_time,
-                        });
-                        continue;
-                    }
-
-                    match ShredSubscriptionInstructionData::try_from_slice(&ix.data) {
-                        // TODO: ClosePaymentEscrow (withdrawal) — the actual
-                        // refunded amount is in the tx log message "Withdrew {}
-                        // USDC from payment escrow to refund account". Parse that
-                        // to get the negative amount. Without it, we can't derive
-                        // the correct withdrawal amount from the running balance
-                        // alone because oracle debits are not yet tracked.
-                        Ok(ShredSubscriptionInstructionData::ClosePaymentEscrow) => {}
-                        // These instructions touch the escrow account but don't
-                        // move funds — they appear in the same tx as fund/close.
-                        //
-                        // NOTE: the `InitializeValidatorPublisherRewards` and
-                        // `ConfigureValidatorPublisherRewards` variants were
-                        // previously listed here, but their account lists do
-                        // not reference the escrow PDA so the `touches_escrow`
-                        // pre-filter above already excludes them. A sibling
-                        // task audits the rest of this listing for the same
-                        // reason — the wildcard arm below makes the match
-                        // robust to future variants in either direction.
-                        Ok(
-                            ShredSubscriptionInstructionData::InitializePaymentEscrow
-                            | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
-                            | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
-                            | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
-                            | ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal
-                            | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
-                                _,
-                            )
-                            | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
-                            | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
-                            | ShredSubscriptionInstructionData::CheckCliVersion { .. },
-                        ) => {}
-                        Ok(_) => {}
-                        // TODO: oracle instructions (BatchAllocateSeats,
-                        // InstantAllocateSeat) debit the escrow. Their
-                        // discriminators are not in the offchain SDK. The debit
-                        // amount is in the tx log "Escrow balance: {}" (the
-                        // post-debit balance). Parse that and compute the delta
-                        // from the running balance to get the negative amount.
-                        Err(_) => {}
-                    }
-                }
+                events.extend(payment_events(
+                    &tx_response.transaction.transaction,
+                    &escrow_keys,
+                    tx_response.block_time,
+                ));
             }
         }
 
@@ -317,5 +329,94 @@ impl PaymentsCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+    use solana_transaction_status_client_types::EncodedTransactionWithStatusMeta;
+
+    use super::*;
+
+    fn fund_data(amount: u64) -> String {
+        let mut data = Vec::from(LEGACY_FUND_PAYMENT_ESCROW_USDC);
+        data.extend_from_slice(&amount.to_le_bytes());
+        bs58::encode(data).into_string()
+    }
+
+    fn response(instructions: Vec<Value>) -> EncodedTransactionWithStatusMeta {
+        serde_json::from_value(json!({
+            "transaction": {
+                "signatures": [Signature::default().to_string()],
+                "message": {
+                    "accountKeys": [],
+                    "recentBlockhash": "11111111111111111111111111111111",
+                    "instructions": instructions,
+                    "addressTableLookups": null,
+                    "transactionConfig": {
+                        "computeUnitLimit": 30_000,
+                        "heapSize": null,
+                        "loadedAccountsDataSizeLimit": 200_000,
+                        "priorityFee": null,
+                    },
+                },
+            },
+            "meta": {
+                "err": null,
+                "status": { "Ok": null },
+                "fee": 5_000,
+                "preBalances": [],
+                "postBalances": [],
+                "innerInstructions": [],
+                "logMessages": [],
+                "preTokenBalances": [],
+                "postTokenBalances": [],
+                "rewards": [],
+            },
+            "version": 1,
+        }))
+        .expect("a getTransaction response must deserialize")
+    }
+
+    fn fund_instruction(escrow: Pubkey, amount: u64) -> Value {
+        json!({
+            "programId": shred_subscription::ID.to_string(),
+            "accounts": [escrow.to_string()],
+            "data": fund_data(amount),
+            "stackHeight": null,
+        })
+    }
+
+    #[test]
+    fn reads_a_v1_fund_for_a_known_escrow() {
+        let escrow = Pubkey::new_unique();
+        let transaction = response(vec![fund_instruction(escrow, 2_000_000)]);
+
+        let events = payment_events(&transaction.transaction, &[escrow], Some(1_700_000_000));
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].event_type, EventType::Funded));
+        assert_eq!(events[0].amount_micro, 2_000_000);
+        assert_eq!(events[0].block_time, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn ignores_a_foreign_program_and_a_fund_for_another_escrow() {
+        let escrow = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let transaction = response(vec![
+            json!({
+                "programId": Pubkey::new_unique().to_string(),
+                "accounts": [escrow.to_string()],
+                "data": fund_data(2_000_000),
+                "stackHeight": null,
+            }),
+            fund_instruction(other, 2_000_000),
+        ]);
+
+        let events = payment_events(&transaction.transaction, &[escrow], None);
+
+        assert!(events.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `doublezero-solana shreds payments` asks the Solana node for version 1 when it fetches a landed fund.
- The listing reads the JsonParsed instruction list so a v1 body still yields the funded amount.

## Testing

- Fetch a seat that has a landed fund and run `doublezero-solana shreds payments --device-code <code> --client-ip <ip>`.