### PR TITLE
internet-latency-collector: add cloud node file loader

### DIFF
--- a/controlplane/internet-latency-collector/internal/collector/errors.go
+++ b/controlplane/internet-latency-collector/internal/collector/errors.go
@@ -102,6 +102,7 @@ var (
 	ErrInvalidMeasurement  = NewValidationError("measurement_validation", "invalid measurement data", nil)
 	ErrInvalidInterval     = NewValidationError("interval_validation", "invalid interval configuration", nil)
 	ErrInsufficientSources = NewValidationError("source_validation", "insufficient sources for operation", nil)
+	ErrInvalidNodeFile     = NewValidationError("node_file_validation", "invalid node file", nil)
 
 	ErrRateLimitExceeded   = NewAPIError("api_rate_limit", "rate limit exceeded", nil)
 	ErrUnauthorized        = NewAPIError("api_auth", "unauthorized access", nil)

--- a/controlplane/internet-latency-collector/internal/collector/nodefile.go
+++ b/controlplane/internet-latency-collector/internal/collector/nodefile.go
@@ -1,0 +1,92 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+)
+
+type JSONNode struct {
+	Code          string  `json:"code"`
+	Cloud         string  `json:"cloud"`
+	Latitude      float64 `json:"lat"`
+	Longitude     float64 `json:"lng"`
+	AtlasProbeIDs []int   `json:"atlas_probe_ids"`
+	PingTarget    string  `json:"ping_target"` // Address other nodes ping to reach this node
+}
+
+func LoadNodesFromJSON(logger *slog.Logger, filename string) ([]JSONNode, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open JSON file: %w", err)
+	}
+	defer file.Close()
+
+	var nodes []JSONNode
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&nodes); err != nil {
+		return nil, fmt.Errorf("invalid JSON format: %w", err)
+	}
+
+	if err := validateNodes(nodes); err != nil {
+		return nil, err
+	}
+
+	logger.Info("Loaded nodes from JSON file",
+		slog.Int("node_count", len(nodes)),
+		slog.String("filename", filename))
+
+	return nodes, nil
+}
+
+func validateNodes(nodes []JSONNode) error {
+	if len(nodes) == 0 {
+		return ErrInvalidNodeFile.WithContext("reason", "node file contains empty array")
+	}
+
+	seen := make(map[string]bool, len(nodes))
+	for i, node := range nodes {
+		if node.Code == "" {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("reason", "missing code")
+		}
+		if node.Cloud == "" {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("reason", "missing cloud")
+		}
+		if node.Latitude == 0 && node.Longitude == 0 {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("reason", "invalid coordinates")
+		}
+		if len(node.AtlasProbeIDs) == 0 {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("reason", "no atlas probe ids")
+		}
+		ip := net.ParseIP(node.PingTarget)
+		if ip == nil || ip.To4() == nil {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("ping_target", node.PingTarget).
+				WithContext("reason", "ping target is not an IPv4 address")
+		}
+		if !IsInternetRoutable(node.PingTarget) {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("ping_target", node.PingTarget).
+				WithContext("reason", "ping target is not a routable address")
+		}
+		if seen[node.Code] {
+			return ErrInvalidNodeFile.WithContext("index", i).
+				WithContext("code", node.Code).
+				WithContext("reason", "duplicate code")
+		}
+		seen[node.Code] = true
+	}
+
+	return nil
+}

--- a/controlplane/internet-latency-collector/internal/collector/nodefile_test.go
+++ b/controlplane/internet-latency-collector/internal/collector/nodefile_test.go
@@ -1,0 +1,141 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validNodeFile = `[
+  {"code": "us-east-1", "cloud": "aws", "lat": 39.0438, "lng": -77.4874, "atlas_probe_ids": [1003385], "ping_target": "34.192.0.54"},
+  {"code": "eu-central-1", "cloud": "aws", "lat": 50.1109, "lng": 8.6821, "atlas_probe_ids": [1000566, 1000567], "ping_target": "3.64.0.0"}
+]`
+
+func TestInternetLatency_NodeFile_LoadNodesFromJSON(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	testFile := filepath.Join(t.TempDir(), "nodes.json")
+	require.NoError(t, os.WriteFile(testFile, []byte(validNodeFile), 0644))
+
+	nodes, err := LoadNodesFromJSON(log, testFile)
+	require.NoError(t, err, "LoadNodesFromJSON() failed")
+
+	require.Len(t, nodes, 2)
+
+	require.Equal(t, "us-east-1", nodes[0].Code)
+	require.Equal(t, "aws", nodes[0].Cloud)
+	require.InDelta(t, 39.0438, nodes[0].Latitude, 0.0001)
+	require.InDelta(t, -77.4874, nodes[0].Longitude, 0.0001)
+	require.Equal(t, []int{1003385}, nodes[0].AtlasProbeIDs)
+	require.Equal(t, "34.192.0.54", nodes[0].PingTarget)
+
+	require.Equal(t, "eu-central-1", nodes[1].Code)
+	require.Equal(t, []int{1000566, 1000567}, nodes[1].AtlasProbeIDs)
+	require.Equal(t, "3.64.0.0", nodes[1].PingTarget)
+}
+
+func TestInternetLatency_NodeFile_LoadNodesFromJSON_Invalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		jsonContent string
+		wantReason  string
+	}{
+		{
+			name:        "Empty array",
+			jsonContent: `[]`,
+			wantReason:  "node file contains empty array",
+		},
+		{
+			name:        "Missing code",
+			jsonContent: `[{"cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "1.2.3.4"}]`,
+			wantReason:  "missing code",
+		},
+		{
+			name:        "Missing cloud",
+			jsonContent: `[{"code": "us-east-1", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "1.2.3.4"}]`,
+			wantReason:  "missing cloud",
+		},
+		{
+			name:        "Zero coordinates",
+			jsonContent: `[{"code": "us-east-1", "cloud": "aws", "lat": 0.0, "lng": 0.0, "atlas_probe_ids": [1], "ping_target": "1.2.3.4"}]`,
+			wantReason:  "invalid coordinates",
+		},
+		{
+			name:        "No probe ids",
+			jsonContent: `[{"code": "us-east-1", "cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [], "ping_target": "1.2.3.4"}]`,
+			wantReason:  "no atlas probe ids",
+		},
+		{
+			name:        "Ping target not an address",
+			jsonContent: `[{"code": "us-east-1", "cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "not-an-address"}]`,
+			wantReason:  "ping target is not an IPv4 address",
+		},
+		{
+			name:        "Ping target is IPv6",
+			jsonContent: `[{"code": "us-east-1", "cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "2001:db8::1"}]`,
+			wantReason:  "ping target is not an IPv4 address",
+		},
+		{
+			name:        "Ping target is not routable",
+			jsonContent: `[{"code": "us-east-1", "cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "10.0.0.1"}]`,
+			wantReason:  "ping target is not a routable address",
+		},
+		{
+			name: "Duplicate code",
+			jsonContent: `[
+  {"code": "us-east-1", "cloud": "aws", "lat": 1.0, "lng": 2.0, "atlas_probe_ids": [1], "ping_target": "1.2.3.4"},
+  {"code": "us-east-1", "cloud": "aws", "lat": 3.0, "lng": 4.0, "atlas_probe_ids": [2], "ping_target": "5.6.7.8"}
+]`,
+			wantReason: "duplicate code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			log := logger.With("test", t.Name())
+
+			testFile := filepath.Join(t.TempDir(), "nodes.json")
+			require.NoError(t, os.WriteFile(testFile, []byte(tt.jsonContent), 0644))
+
+			_, err := LoadNodesFromJSON(log, testFile)
+			require.Error(t, err, "expected an error but got none")
+
+			var collectorErr *CollectorError
+			require.True(t, isCollectorErrorLocation(err, &collectorErr),
+				"error should be CollectorError, got %T", err)
+			require.Equal(t, "node_file_validation", collectorErr.Operation)
+			require.Equal(t, tt.wantReason, collectorErr.GetContext("reason"))
+		})
+	}
+}
+
+func TestInternetLatency_NodeFile_LoadNodesFromJSON_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	testFile := filepath.Join(t.TempDir(), "nodes.json")
+	require.NoError(t, os.WriteFile(testFile, []byte(`{"code": "us-east-1"}`), 0644))
+
+	_, err := LoadNodesFromJSON(log, testFile)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid JSON format")
+}
+
+func TestInternetLatency_NodeFile_LoadNodesFromJSON_NonexistentFile(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	_, err := LoadNodesFromJSON(log, "nonexistent_nodes.json")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such file or directory")
+}


### PR DESCRIPTION
Part of measuring latency between AWS regions with the internet latency collector.

Measuring between cloud regions needs more detail per location than the collector's location list
carries: which cloud a region is in, which RIPE Atlas probes may measure from it, and the address
other regions ping to reach it. This adds `LoadNodesFromJSON` in `internal/collector`, which reads
a JSON array of those records and rejects the file when a code, cloud, probe list or coordinate
pair is missing, when a code repeats, or when the ping target is not a routable IPv4 address.

The checks matter because a bad file fails quietly. The collector drops a measurement result that
came back with no reply, so a ping target of `10.0.0.1`, a private address nothing on the internet
can reach, would give you zero rows and no error. Validation turns that into an error when the
file is read.

Nothing calls the loader yet, so nothing changes in production.

Test: `go test ./controlplane/internet-latency-collector/internal/collector/ -run NodeFile`
