### PR TITLE
internet-latency-collector: select one live probe per cloud region

### DIFF
--- a/controlplane/internet-latency-collector/internal/ripeatlas/client.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/collector"
@@ -231,6 +233,46 @@ func (c *Client) GetProbesInRadius(ctx context.Context, latitude, longitude floa
 	}
 
 	return allProbes, nil
+}
+
+// GetConnectedProbeIDs returns which of the given probe IDs RIPE Atlas currently reports as
+// Connected, which is status 1. The call carries no measurement credits.
+func (c *Client) GetConnectedProbeIDs(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+	connected := make(map[int]bool, len(probeIDs))
+	if len(probeIDs) == 0 {
+		return connected, nil
+	}
+
+	ids := make([]string, len(probeIDs))
+	for i, probeID := range probeIDs {
+		ids[i] = strconv.Itoa(probeID)
+	}
+	endpoint := "/probes/?status=1&id__in=" + strings.Join(ids, ",")
+
+	for {
+		resp, err := c.makeRequest(ctx, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get probe status: %w", err)
+		}
+
+		var response ProbesResponse
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode probes response: %w", err)
+		}
+
+		for _, probe := range response.Results {
+			connected[probe.ID] = true
+		}
+
+		if response.Next == "" {
+			break
+		}
+		endpoint = strings.TrimPrefix(response.Next, c.BaseURL)
+	}
+
+	return connected, nil
 }
 
 func (c *Client) GetProbesForLocations(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error) {

--- a/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/client_test.go
@@ -1065,3 +1065,69 @@ func TestInternetLatency_RIPEAtlas_GetCreditBalance(t *testing.T) {
 	require.NoError(t, err, "GetCreditBalance() should not return error")
 	require.Equal(t, 1000.0, balance, "Expected credit balance to be 1000")
 }
+
+func TestInternetLatency_RIPEAtlas_GetConnectedProbeIDs(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var endpoints []string
+	client := &Client{
+		log:     log,
+		BaseURL: "https://atlas.ripe.net/api/v2",
+		HTTPClient: &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				endpoints = append(endpoints, req.URL.String())
+				body, _ := json.Marshal(ProbesResponse{
+					Count:   2,
+					Results: []Probe{{ID: 1000731}, {ID: 1000733}},
+				})
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}, nil
+			},
+		},
+	}
+
+	connected, err := client.GetConnectedProbeIDs(t.Context(), []int{1000731, 1000732, 1000733})
+
+	require.NoError(t, err)
+	require.Equal(t, map[int]bool{1000731: true, 1000733: true}, connected)
+	require.Len(t, endpoints, 1)
+	require.Contains(t, endpoints[0], "id__in=1000731,1000732,1000733")
+	require.Contains(t, endpoints[0], "status=1")
+}
+
+func TestInternetLatency_RIPEAtlas_GetConnectedProbeIDs_Pagination(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	callCount := 0
+	client := &Client{
+		log:     log,
+		BaseURL: "https://atlas.ripe.net/api/v2",
+		HTTPClient: &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				callCount++
+				response := ProbesResponse{Count: 2, Results: []Probe{{ID: 1000733}}}
+				if callCount == 1 {
+					response.Next = "https://atlas.ripe.net/api/v2/probes/?page=2"
+					response.Results = []Probe{{ID: 1000731}}
+				}
+				body, _ := json.Marshal(response)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}, nil
+			},
+		},
+	}
+
+	connected, err := client.GetConnectedProbeIDs(t.Context(), []int{1000731, 1000733})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount)
+	require.Equal(t, map[int]bool{1000731: true, 1000733: true}, connected)
+}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud.go
@@ -3,6 +3,8 @@ package ripeatlas
 import (
 	"context"
 	"log/slog"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/collector"
@@ -100,4 +102,104 @@ func (c *Collector) targetLocationFromDescription(description string) (string, b
 		return "", false
 	}
 	return parts[1][:idx], true
+}
+
+// A nil result means the check failed, which leaves every region on the probe it has enlisted.
+func (c *Collector) cloudLiveProbes(ctx context.Context) map[int]bool {
+	probeIDs := make([]int, 0, len(c.cloudNodes))
+	for _, node := range c.cloudNodes {
+		probeIDs = append(probeIDs, node.AtlasProbeIDs...)
+	}
+	sort.Ints(probeIDs)
+
+	live, err := c.client.GetConnectedProbeIDs(ctx, probeIDs)
+	if err != nil {
+		c.log.Warn("Failed to check cloud probe liveness, keeping the enlisted probes",
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	c.log.Info("Checked cloud probe liveness",
+		slog.Int("configured", len(probeIDs)),
+		slog.Int("connected", len(live)))
+	return live
+}
+
+// Each region gets one probe, taken from its own list in the node file and nowhere else.
+func (c *Collector) selectCloudProbes(locationMatches []LocationProbeMatch, live map[int]bool, measurementState *MeasurementState) []LocationProbeMatch {
+	enlisted := enlistedProbesByLocation(measurementState)
+
+	result := make([]LocationProbeMatch, len(locationMatches))
+	copy(result, locationMatches)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.probeToLocation = make(map[int]string)
+
+	for i, match := range result {
+		result[i].NearbyProbes = nil
+		result[i].ProbeCount = 0
+
+		node, ok := c.cloudNodes[match.LocationCode]
+		if !ok {
+			c.log.Warn("No node file entry for location",
+				slog.String("location", match.LocationCode))
+			continue
+		}
+
+		probeID := cloudSourceProbe(node.AtlasProbeIDs, enlisted[match.LocationCode], live, measurementState)
+		if probeID == 0 {
+			c.log.Warn("No live probe for region, it contributes no samples",
+				slog.String("location", match.LocationCode),
+				slog.Any("configured_probe_ids", node.AtlasProbeIDs))
+			continue
+		}
+
+		result[i].NearbyProbes = []Probe{{ID: probeID, Latitude: node.Latitude, Longitude: node.Longitude}}
+		result[i].ProbeCount = 1
+		c.probeToLocation[probeID] = match.LocationCode
+	}
+
+	return result
+}
+
+// The enlisted probe keeps the seat while it is Connected and not marked unresponsive. A region
+// whose every candidate is gone keeps its dead probe rather than dropping out.
+func cloudSourceProbe(configured []int, enlisted int, live map[int]bool, measurementState *MeasurementState) int {
+	if !slices.Contains(configured, enlisted) {
+		enlisted = 0
+	}
+
+	usable := func(probeID int) bool {
+		return live[probeID] && !measurementState.IsProbeUnresponsive(probeID)
+	}
+
+	if usable(enlisted) {
+		return enlisted
+	}
+	for _, probeID := range configured {
+		if usable(probeID) {
+			return probeID
+		}
+	}
+	return enlisted
+}
+
+// The enlisted probe is the choice earlier cycles made. RIPE measurement IDs rise over time, so
+// the highest ID carries the most recent choice.
+func enlistedProbesByLocation(measurementState *MeasurementState) map[string]int {
+	metadata := measurementState.GetAllMetadata()
+	measurementIDs := make([]int, 0, len(metadata))
+	for measurementID := range metadata {
+		measurementIDs = append(measurementIDs, measurementID)
+	}
+	sort.Ints(measurementIDs)
+
+	enlisted := make(map[string]int)
+	for _, measurementID := range measurementIDs {
+		for _, source := range metadata[measurementID].Sources {
+			enlisted[source.LocationCode] = source.ProbeID
+		}
+	}
+	return enlisted
 }

--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud_blame_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud_blame_test.go
@@ -288,6 +288,71 @@ func cloudFleetMeasurements() []Measurement {
 	}
 }
 
+func TestInternetLatency_RIPEAtlas_CloudBlame_FleetThatExportedNothingIsNotTornDown(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var stoppedMeasurements []int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetAllMeasurementsFunc: func(ctx context.Context, tag string) ([]Measurement, error) {
+			return cloudFleetMeasurements(), nil
+		},
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			measurementID := 9000 + len(createdMeasurements)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{measurementID}}, nil
+		},
+		StopMeasurementFunc: func(ctx context.Context, measurementID int) error {
+			mu.Lock()
+			stoppedMeasurements = append(stoppedMeasurements, measurementID)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudFleetNodes())
+
+	// A first deployment three hours in: every measurement was created in one batch, nothing
+	// has landed yet, so every source still reads zero.
+	threeHoursAgo := time.Now().Unix() - 10800
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	c.measurementState.SetMetadata(8001, MeasurementMeta{
+		TargetLocation: "eu-west-1",
+		TargetAddress:  "3.248.0.0",
+		Sources: []SourceProbeMeta{
+			{LocationCode: "us-east-1", ProbeID: 1000731, LastResponseAt: 0},
+			{LocationCode: "us-west-2", ProbeID: 1000901, LastResponseAt: 0},
+		},
+		CreatedAt: threeHoursAgo,
+	})
+	c.measurementState.SetMetadata(8002, MeasurementMeta{
+		TargetLocation: "us-east-1",
+		TargetAddress:  "34.192.0.54",
+		Sources: []SourceProbeMeta{
+			{LocationCode: "us-west-2", ProbeID: 1000901, LastResponseAt: 0},
+		},
+		CreatedAt: threeHoursAgo,
+	})
+
+	err := c.configureMeasurements(t.Context(), cloudFleetLocations(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	require.Empty(t, c.measurementState.GetUnresponsiveProbes(),
+		"a fleet that has exported nothing names no source probe as the cause")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, stoppedMeasurements, "a fleet that has exported nothing must not be torn down")
+	require.Empty(t, createdMeasurements, "the measurements already running are still the wanted ones")
+}
+
 func TestInternetLatency_RIPEAtlas_CloudBlame_LiveMeasurementBlamesItsDarkSource(t *testing.T) {
 	t.Parallel()
 
@@ -332,4 +397,62 @@ func TestInternetLatency_RIPEAtlas_CloudBlame_LiveMeasurementBlamesItsDarkSource
 		"the one source that has delivered nothing to a measurement that is exporting must be blamed")
 	require.False(t, c.measurementState.IsProbeUnresponsive(1000731),
 		"a source that is delivering must not be blamed")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudBlame_FleetThatStoppedExportingIsNotTornDown(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var stoppedMeasurements []int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetAllMeasurementsFunc: func(ctx context.Context, tag string) ([]Measurement, error) {
+			return cloudFleetMeasurements(), nil
+		},
+		StopMeasurementFunc: func(ctx context.Context, measurementID int) error {
+			mu.Lock()
+			stoppedMeasurements = append(stoppedMeasurements, measurementID)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudFleetNodes())
+
+	// The measurements were recreated three hours ago and delivered for a while, then every
+	// export stopped: the sources enlisted at recreation still read zero.
+	now := time.Now().Unix()
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	c.measurementState.SetMetadata(8001, MeasurementMeta{
+		TargetLocation: "eu-west-1",
+		TargetAddress:  "3.248.0.0",
+		Sources: []SourceProbeMeta{
+			{LocationCode: "us-east-1", ProbeID: 1000731, LastResponseAt: 0},
+			{LocationCode: "us-west-2", ProbeID: 1000901, LastResponseAt: 0},
+		},
+		CreatedAt:    now - 10800,
+		LastExportAt: now - 7200,
+	})
+	c.measurementState.SetMetadata(8002, MeasurementMeta{
+		TargetLocation: "us-east-1",
+		TargetAddress:  "34.192.0.54",
+		Sources: []SourceProbeMeta{
+			{LocationCode: "us-west-2", ProbeID: 1000901, LastResponseAt: 0},
+		},
+		CreatedAt:    now - 10800,
+		LastExportAt: now - 7200,
+	})
+
+	err := c.configureMeasurements(t.Context(), cloudFleetLocations(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	require.Empty(t, c.measurementState.GetUnresponsiveProbes(),
+		"a measurement that has stopped exporting names no source probe as the cause")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, stoppedMeasurements, "a fleet that has stopped exporting must not be torn down")
 }

--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud_probes_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud_probes_test.go
@@ -1,0 +1,457 @@
+package ripeatlas
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/collector"
+	"github.com/stretchr/testify/require"
+)
+
+// cloudProbeTestNodes gives us-east-1 three ordered candidates. eu-west-1 sorts first, so it is
+// the measurement target and us-east-1 is the only source.
+func cloudProbeTestNodes() []CloudNode {
+	nodes := cloudTestNodes()
+	nodes[1].AtlasProbeIDs = []int{1000731, 1000732, 1000733}
+	return nodes
+}
+
+// cloudDelistedProbeNodes drops 1000731 from us-east-1, so an earlier cycle's incumbent is no
+// longer on the list the node file names.
+func cloudDelistedProbeNodes() []CloudNode {
+	nodes := cloudProbeTestNodes()
+	nodes[1].AtlasProbeIDs = []int{1000732, 1000733}
+	return nodes
+}
+
+// cloudProbeLocations returns the two regions with no probes attached, as the measurement cycle
+// hands them to selection.
+func cloudProbeLocations() []LocationProbeMatch {
+	return []LocationProbeMatch{
+		{LocationMatch: collector.LocationMatch{LocationCode: "eu-west-1", Latitude: 53.3498, Longitude: -6.2603}},
+		{LocationMatch: collector.LocationMatch{LocationCode: "us-east-1", Latitude: 39.0438, Longitude: -77.4874}},
+	}
+}
+
+func cloudProbeTestState(t *testing.T) *MeasurementState {
+	t.Helper()
+
+	return NewMeasurementState(filepath.Join(t.TempDir(), CloudTimestampFileName))
+}
+
+// enlist records the source probe an earlier cycle chose, which is where stickiness reads from.
+func enlist(state *MeasurementState, measurementID int, locationCode string, probeID int) {
+	state.SetMetadata(measurementID, MeasurementMeta{
+		TargetLocation: "eu-west-1",
+		TargetAddress:  "3.248.0.0",
+		Sources:        []SourceProbeMeta{{LocationCode: locationCode, ProbeID: probeID, LastResponseAt: time.Now().Unix()}},
+		CreatedAt:      time.Now().Unix() - 60,
+		LastExportAt:   time.Now().Unix(),
+	})
+}
+
+func selectedProbes(matches []LocationProbeMatch) map[string]int {
+	selected := map[string]int{}
+	for _, match := range matches {
+		if len(match.NearbyProbes) > 0 {
+			selected[match.LocationCode] = match.NearbyProbes[0].ID
+		}
+	}
+	return selected
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_FirstLiveCandidateWins(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	live := map[int]bool{1000441: true, 1000731: true, 1000732: true, 1000733: true}
+
+	matches := c.selectCloudProbes(cloudProbeLocations(), live, cloudProbeTestState(t))
+
+	require.Equal(t, map[string]int{"eu-west-1": 1000441, "us-east-1": 1000731}, selectedProbes(matches))
+	for _, match := range matches {
+		require.Len(t, match.NearbyProbes, 1, "a region measures from one probe, however many are live")
+		require.Equal(t, 1, match.ProbeCount)
+	}
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_DeadCandidateFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	live := map[int]bool{1000441: true, 1000732: true, 1000733: true}
+
+	matches := c.selectCloudProbes(cloudProbeLocations(), live, cloudProbeTestState(t))
+
+	require.Equal(t, 1000732, selectedProbes(matches)["us-east-1"],
+		"a disconnected first entry hands the seat to the next one in the list")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_LiveIncumbentIsKept(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	state := cloudProbeTestState(t)
+	enlist(state, 8001, "us-east-1", 1000732)
+
+	live := map[int]bool{1000441: true, 1000731: true, 1000732: true, 1000733: true}
+	matches := c.selectCloudProbes(cloudProbeLocations(), live, state)
+
+	require.Equal(t, 1000732, selectedProbes(matches)["us-east-1"],
+		"an earlier-listed probe reconnecting must not reclaim the seat")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_BlacklistedIncumbentMovesOn(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	state := cloudProbeTestState(t)
+	enlist(state, 8001, "us-east-1", 1000731)
+	state.AddUnresponsiveProbe(1000731)
+
+	live := map[int]bool{1000441: true, 1000731: true, 1000732: true, 1000733: true}
+	matches := c.selectCloudProbes(cloudProbeLocations(), live, state)
+
+	require.Equal(t, 1000732, selectedProbes(matches)["us-east-1"],
+		"an unresponsive incumbent hands the seat on even while RIPE reports it Connected")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_AllCandidatesDeadKeepsIncumbent(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	state := cloudProbeTestState(t)
+	enlist(state, 8001, "us-east-1", 1000732)
+
+	matches := c.selectCloudProbes(cloudProbeLocations(), map[int]bool{}, state)
+
+	require.Equal(t, 1000732, selectedProbes(matches)["us-east-1"],
+		"a region with nothing live keeps its dead probe rather than dropping out")
+	require.NotContains(t, selectedProbes(matches), "eu-west-1",
+		"a region with nothing live and nothing enlisted contributes no probe")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_NewestEnlistmentWins(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudProbeTestNodes())
+	state := cloudProbeTestState(t)
+	enlist(state, 7001, "us-east-1", 1000732)
+	enlist(state, 9001, "us-east-1", 1000733)
+
+	live := map[int]bool{1000441: true, 1000731: true, 1000732: true, 1000733: true}
+	matches := c.selectCloudProbes(cloudProbeLocations(), live, state)
+
+	require.Equal(t, 1000733, selectedProbes(matches)["us-east-1"],
+		"two disagreeing enlistments resolve to the one the later measurement carries")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_DelistedIncumbentLosesTheSeat(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudDelistedProbeNodes())
+	state := cloudProbeTestState(t)
+	enlist(state, 8001, "us-east-1", 1000731)
+
+	matches := c.selectCloudProbes(cloudProbeLocations(), map[int]bool{}, state)
+
+	require.NotContains(t, selectedProbes(matches), "us-east-1",
+		"a probe the node file no longer lists must not keep the seat, even with nothing else live")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_LivenessQueryCoversEveryConfiguredID(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var requested [][]int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetConnectedProbeIDsFunc: func(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+			mu.Lock()
+			requested = append(requested, probeIDs)
+			mu.Unlock()
+			return map[int]bool{1000441: true, 1000731: true}, nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudProbeTestNodes())
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, requested, 1, "liveness costs one call per measurement cycle")
+	require.Equal(t, []int{1000441, 1000731, 1000732, 1000733}, requested[0])
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_NoDiscoveryNoRotation(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var probesInRadiusCalls int
+	var probesForLocationsCalls int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			measurementID := 5000 + len(createdMeasurements)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{measurementID}}, nil
+		},
+		GetProbesInRadiusFunc: func(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error) {
+			mu.Lock()
+			probesInRadiusCalls++
+			mu.Unlock()
+			return []Probe{{ID: 9999, Address: "5.5.5.5", Latitude: latitude, Longitude: longitude}}, nil
+		},
+		GetProbesForLocationsFunc: func(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error) {
+			mu.Lock()
+			probesForLocationsCalls++
+			mu.Unlock()
+			return locations, nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudProbeTestNodes())
+
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	c.measurementState.AddUnresponsiveProbe(1000731)
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, 0, probesForLocationsCalls, "cloud mode must not run probe discovery")
+	require.Equal(t, 0, probesInRadiusCalls, "cloud mode must not look for replacement probes")
+
+	require.Len(t, createdMeasurements, 1)
+	require.Equal(t, "3.248.0.0", createdMeasurements[0].Definitions[0].Target)
+
+	probeIDs := []int{}
+	for _, probe := range createdMeasurements[0].Probes {
+		probeIDs = append(probeIDs, probe.Value)
+	}
+	require.Equal(t, []int{1000732}, probeIDs,
+		"the region measures from one probe out of its own list, with no substitute")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_DeadIncumbentDoesNotRecreateMeasurement(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var stoppedMeasurements []int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetAllMeasurementsFunc: func(ctx context.Context, tag string) ([]Measurement, error) {
+			return []Measurement{cloudMeasurement()}, nil
+		},
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{9001}}, nil
+		},
+		StopMeasurementFunc: func(ctx context.Context, measurementID int) error {
+			mu.Lock()
+			stoppedMeasurements = append(stoppedMeasurements, measurementID)
+			mu.Unlock()
+			return nil
+		},
+		GetConnectedProbeIDsFunc: func(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+			return map[int]bool{}, nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudProbeTestNodes())
+
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	enlist(c.measurementState, 8001, "us-east-1", 1000732)
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Empty(t, stoppedMeasurements, "a region with nothing live must not recreate what it feeds")
+	require.Empty(t, createdMeasurements)
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_LivenessErrorChangesNothing(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var stoppedMeasurements []int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetAllMeasurementsFunc: func(ctx context.Context, tag string) ([]Measurement, error) {
+			return []Measurement{cloudMeasurement()}, nil
+		},
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{9002}}, nil
+		},
+		StopMeasurementFunc: func(ctx context.Context, measurementID int) error {
+			mu.Lock()
+			stoppedMeasurements = append(stoppedMeasurements, measurementID)
+			mu.Unlock()
+			return nil
+		},
+		GetConnectedProbeIDsFunc: func(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+			return nil, errors.New("ripe atlas unavailable")
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudProbeTestNodes())
+
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	enlist(c.measurementState, 8001, "us-east-1", 1000732)
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Empty(t, stoppedMeasurements, "a failed liveness check must not churn probes")
+	require.Empty(t, createdMeasurements)
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_NewlyUnresponsiveProbeRollsOverSameCycle(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var stoppedMeasurements []int
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		GetAllMeasurementsFunc: func(ctx context.Context, tag string) ([]Measurement, error) {
+			return []Measurement{cloudMeasurement()}, nil
+		},
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{9003}}, nil
+		},
+		StopMeasurementFunc: func(ctx context.Context, measurementID int) error {
+			mu.Lock()
+			stoppedMeasurements = append(stoppedMeasurements, measurementID)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudProbeTestNodes())
+
+	// The enlisted probe has delivered nothing since creation, well past the grace period.
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	c.measurementState.SetMetadata(8001, MeasurementMeta{
+		TargetLocation: "eu-west-1",
+		TargetAddress:  "3.248.0.0",
+		Sources:        []SourceProbeMeta{{LocationCode: "us-east-1", ProbeID: 1000731, LastResponseAt: 0}},
+		CreatedAt:      time.Now().Unix() - 10800,
+		LastExportAt:   time.Now().Unix(),
+	})
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Contains(t, stoppedMeasurements, 8001)
+	require.Len(t, createdMeasurements, 1)
+
+	probeIDs := []int{}
+	for _, probe := range createdMeasurements[0].Probes {
+		probeIDs = append(probeIDs, probe.Value)
+	}
+	require.Equal(t, []int{1000732}, probeIDs,
+		"a probe marked unresponsive hands over within the same cycle")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudProbes_DelistedProbeIsNeverEnlisted(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	var createdMeasurements []MeasurementRequest
+	var mu sync.Mutex
+
+	mockClient := &MockClient{
+		CreateMeasurementFunc: func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
+			mu.Lock()
+			createdMeasurements = append(createdMeasurements, request)
+			mu.Unlock()
+			return &MeasurementResponse{Measurements: []int{9004}}, nil
+		},
+		GetConnectedProbeIDsFunc: func(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+			return map[int]bool{}, nil
+		},
+	}
+
+	stateDir := t.TempDir()
+	c := newCloudTestCollector(t, log, mockClient, "mainnet-beta", cloudDelistedProbeNodes())
+
+	c.measurementState = NewMeasurementState(filepath.Join(stateDir, CloudTimestampFileName))
+	enlist(c.measurementState, 8001, "us-east-1", 1000731)
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, stateDir, 10*time.Minute)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, request := range createdMeasurements {
+		for _, probe := range request.Probes {
+			require.NotEqual(t, 1000731, probe.Value,
+				"a measurement must never be created from a probe the node file no longer lists")
+		}
+	}
+	require.Empty(t, createdMeasurements,
+		"a region whose remaining candidates are all dead contributes nothing this cycle")
+}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -47,6 +47,7 @@ const (
 type clientInterface interface {
 	GetProbesInRadius(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error)
 	GetProbesForLocations(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error)
+	GetConnectedProbeIDs(ctx context.Context, probeIDs []int) (map[int]bool, error)
 	CreateMeasurement(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error)
 	GetAllMeasurements(ctx context.Context, tag string) ([]Measurement, error)
 	GetMeasurementResultsIncremental(ctx context.Context, measurementID int, startTimestamp int64) ([]any, error)
@@ -742,46 +743,58 @@ func (c *Collector) RunRipeAtlasMeasurementCreation(ctx context.Context, dryRun 
 		slog.Bool("dry_run", dryRun),
 		slog.Int("location_count", len(locations)))
 
-	// Convert LocationMatch to LocationProbeMatch
-	var locationProbeMatches []LocationProbeMatch
-	for _, loc := range locations {
-		locationProbeMatches = append(locationProbeMatches, LocationProbeMatch{
-			LocationMatch: loc,
-			NearbyProbes:  []Probe{},
-			ProbeCount:    0,
-		})
-	}
-	c.log.Info("Found locations", slog.Int("location_count", len(locations)))
+	// The node file names each cloud region's probes, so cloud mode runs no probe discovery and
+	// matches no probe by proximity. Selection happens in configureMeasurements.
+	var locationMatches []LocationProbeMatch
+	if c.cloudMode {
+		for _, loc := range locations {
+			locationMatches = append(locationMatches, LocationProbeMatch{LocationMatch: loc})
+		}
+	} else {
+		// Convert LocationMatch to LocationProbeMatch
+		var locationProbeMatches []LocationProbeMatch
+		for _, loc := range locations {
+			locationProbeMatches = append(locationProbeMatches, LocationProbeMatch{
+				LocationMatch: loc,
+				NearbyProbes:  []Probe{},
+				ProbeCount:    0,
+			})
+		}
+		c.log.Info("Found locations", slog.Int("location_count", len(locations)))
 
-	// Get probes for all locations
-	locationMatches, err := c.client.GetProbesForLocations(ctx, locationProbeMatches)
-	if err != nil {
-		return collector.NewAPIError("get_probes_for_locations", "failed to get probes for locations", err).
-			WithContext("location_count", len(locations))
-	}
+		// Get probes for all locations
+		var err error
+		locationMatches, err = c.client.GetProbesForLocations(ctx, locationProbeMatches)
+		if err != nil {
+			return collector.NewAPIError("get_probes_for_locations", "failed to get probes for locations", err).
+				WithContext("location_count", len(locations))
+		}
 
-	c.log.Info("Found probes for locations", slog.Int("locations_with_probes", len(locationMatches)))
+		c.log.Info("Found probes for locations", slog.Int("locations_with_probes", len(locationMatches)))
 
-	c.mu.Lock()
-	c.probeToLocation = make(map[int]string)
-	for _, match := range locationMatches {
-		if len(match.NearbyProbes) > 0 {
-			// Map the closest probe to this location
-			nearestProbes := getNearestProbesSorted(match.NearbyProbes,
-				match.Latitude, match.Longitude, probesPerLocation)
-			if len(nearestProbes) > 0 {
-				c.probeToLocation[nearestProbes[0].ID] = match.LocationCode
+		c.mu.Lock()
+		c.probeToLocation = make(map[int]string)
+		for _, match := range locationMatches {
+			if len(match.NearbyProbes) > 0 {
+				// Map the closest probe to this location
+				nearestProbes := getNearestProbesSorted(match.NearbyProbes,
+					match.Latitude, match.Longitude, probesPerLocation)
+				if len(nearestProbes) > 0 {
+					c.probeToLocation[nearestProbes[0].ID] = match.LocationCode
 
-				// Calculate and record distance to nearest probe
-				nearestProbe := nearestProbes[0]
-				distance := collector.HaversineDistance(
-					match.Latitude, match.Longitude,
-					nearestProbe.Geometry.Coordinates[1], nearestProbe.Geometry.Coordinates[0])
-				metrics.DistanceFromExchangeToProbe.WithLabelValues("ripeatlas", match.LocationCode).Set(distance)
+					// Calculate and record distance to nearest probe
+					nearestProbe := nearestProbes[0]
+					if len(nearestProbe.Geometry.Coordinates) >= 2 {
+						distance := collector.HaversineDistance(
+							match.Latitude, match.Longitude,
+							nearestProbe.Geometry.Coordinates[1], nearestProbe.Geometry.Coordinates[0])
+						metrics.DistanceFromExchangeToProbe.WithLabelValues("ripeatlas", match.LocationCode).Set(distance)
+					}
+				}
 			}
 		}
+		c.mu.Unlock()
 	}
-	c.mu.Unlock()
 
 	// Configure measurements between locations
 	if err := c.configureMeasurements(ctx, locationMatches, dryRun, probesPerLocation, stateDir, samplingInterval); err != nil {
@@ -814,7 +827,16 @@ func (c *Collector) configureMeasurements(ctx context.Context, locationMatches [
 	// the probe has stopped responding to our measurements and was marked unresponsive in
 	// the local measurement state. Without this pass, generateWantedMeasurements would log
 	// "No responsive probes found for location" and skip the location entirely.
-	locationMatches = c.fetchFallbackProbesForUnresponsiveLocations(ctx, locationMatches, measurementState)
+	//
+	// Cloud mode has no substitute to reach for: a probe outside the region's own list would
+	// measure the public internet instead of the cloud backbone.
+	var liveCloudProbes map[int]bool
+	if c.cloudMode {
+		liveCloudProbes = c.cloudLiveProbes(ctx)
+		locationMatches = c.selectCloudProbes(locationMatches, liveCloudProbes, measurementState)
+	} else {
+		locationMatches = c.fetchFallbackProbesForUnresponsiveLocations(ctx, locationMatches, measurementState)
+	}
 
 	// Step 3: Generate the list of measurements we want, skipping unresponsive probes
 	wantedMeasurements := c.generateWantedMeasurements(locationMatches, probesPerLocation, measurementState)
@@ -987,6 +1009,9 @@ func (c *Collector) configureMeasurements(ctx context.Context, locationMatches [
 
 		// Regenerate wanted measurements now that new probes are marked unresponsive,
 		// so the reconciliation below uses updated probe selections
+		if c.cloudMode {
+			locationMatches = c.selectCloudProbes(locationMatches, liveCloudProbes, measurementState)
+		}
 		wantedMeasurements = c.generateWantedMeasurements(locationMatches, probesPerLocation, measurementState)
 	}
 
@@ -1468,6 +1493,15 @@ func (c *Collector) generateWantedMeasurements(locationMatches []LocationProbeMa
 			}
 
 			if len(sourceLocation.NearbyProbes) == 0 {
+				continue
+			}
+
+			if c.cloudMode {
+				// Selection already named the region's one probe, from its own list.
+				sourceSpecs = append(sourceSpecs, SourceSpec{
+					LocationCode: sourceLocation.LocationCode,
+					Probe:        sourceLocation.NearbyProbes[0],
+				})
 				continue
 			}
 

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector_test.go
@@ -25,6 +25,7 @@ import (
 type MockClient struct {
 	GetProbesInRadiusFunc                func(ctx context.Context, latitude, longitude float64, radiusKm int, anchorsOnly bool) ([]Probe, error)
 	GetProbesForLocationsFunc            func(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error)
+	GetConnectedProbeIDsFunc             func(ctx context.Context, probeIDs []int) (map[int]bool, error)
 	CreateMeasurementFunc                func(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error)
 	GetAllMeasurementsFunc               func(ctx context.Context, env string) ([]Measurement, error)
 	GetMeasurementResultsFunc            func(ctx context.Context, measurementID int) ([]any, error)
@@ -45,6 +46,19 @@ func (m *MockClient) GetProbesForLocations(ctx context.Context, locations []Loca
 		return m.GetProbesForLocationsFunc(ctx, locations)
 	}
 	return []LocationProbeMatch{}, nil
+}
+
+// The default reports every requested probe as Connected, so tests that are not about liveness
+// see the probes their node file names.
+func (m *MockClient) GetConnectedProbeIDs(ctx context.Context, probeIDs []int) (map[int]bool, error) {
+	if m.GetConnectedProbeIDsFunc != nil {
+		return m.GetConnectedProbeIDsFunc(ctx, probeIDs)
+	}
+	connected := make(map[int]bool, len(probeIDs))
+	for _, probeID := range probeIDs {
+		connected[probeID] = true
+	}
+	return connected, nil
 }
 
 func (m *MockClient) CreateMeasurement(ctx context.Context, request MeasurementRequest) (*MeasurementResponse, error) {
@@ -1946,4 +1960,32 @@ func TestInternetLatency_RIPEAtlas_ExportSingleMeasurementResults_LossCountsAsRe
 				"LastResponseAt drives the unresponsive-probe marking, which recreates measurements")
 		})
 	}
+}
+
+func TestInternetLatency_RIPEAtlas_ProbeWithoutGeometryIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	mockClient := &MockClient{
+		GetProbesForLocationsFunc: func(ctx context.Context, locations []LocationProbeMatch) ([]LocationProbeMatch, error) {
+			return []LocationProbeMatch{{
+				LocationMatch: collector.LocationMatch{LocationCode: "ams", Latitude: 52.3, Longitude: 4.9},
+				NearbyProbes:  []Probe{{ID: 100, Address: "1.1.1.1"}},
+				ProbeCount:    1,
+			}}, nil
+		},
+	}
+
+	c := &Collector{
+		client: mockClient,
+		log:    log,
+		env:    "test",
+		getLocationsFunc: func(ctx context.Context) []collector.LocationMatch {
+			return []collector.LocationMatch{{LocationCode: "ams", Latitude: 52.3, Longitude: 4.9}}
+		},
+	}
+
+	err := c.RunRipeAtlasMeasurementCreation(t.Context(), false, 1, t.TempDir(), 10*time.Minute)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Part of measuring latency between AWS regions with the internet latency collector: a node file
switches it into a second mode, the region mode, that measures those regions instead of DoubleZero
exchange locations.

A region with one probe goes dark when that probe disconnects, and the existing recovery fetches
any nearby probe, which for an AWS region could be a home broadband line measuring the public
internet rather than the cloud backbone. This lets the node file list several probe IDs per region,
asks RIPE once per cycle which of them are Connected, and gives each region the first live one from
its own list and nowhere else.

The choice is sticky. A region keeps the probe it already uses while that probe is Connected and not
marked unresponsive, read back from the measurement state with the newest measurement winning. A
region whose candidates are all dead keeps the dead one rather than being rewired to a stranger, and
if the liveness call fails nothing rotates. In the region mode the proximity search and the
nearby-probe fallback do not run at all.

Nothing changes in production: the region mode runs only with a node file, which only a separate
deployment that does not exist yet supplies. One fix does land on the existing path: reading a probe's coordinates now checks the list has two entries first, where a
probe returned without coordinates used to panic with an index out of range.

Test: `go test ./controlplane/internet-latency-collector/internal/ripeatlas/...`
