### PR TITLE
internet-latency-collector: add clickhouse exporter

### DIFF
--- a/controlplane/internet-latency-collector/internal/exporter/clickhouse.go
+++ b/controlplane/internet-latency-collector/internal/exporter/clickhouse.go
@@ -1,0 +1,328 @@
+package exporter
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/metrics"
+)
+
+const (
+	DefaultClickHouseTable = "cloud_region_latency"
+
+	defaultClickHouseBatchSize     = 500
+	defaultClickHouseFlushInterval = 30 * time.Second
+	closeFlushTimeout              = 10 * time.Second
+
+	// 136 region pairs sampled every 10 minutes produce 19,584 records a day, so this holds
+	// about two days of them.
+	defaultClickHouseMaxBufferedRecords = 50_000
+)
+
+// clickHouseColumns lists the target table's columns in the order values are appended.
+var clickHouseColumns = []string{
+	"event_ts",
+	"ingested_at",
+	"origin_cloud",
+	"origin_region",
+	"target_cloud",
+	"target_region",
+	"data_provider",
+	"probe_id",
+	"rtt_us",
+	"packets_sent",
+	"packets_received",
+}
+
+type ClickHouseBatchInserter interface {
+	Insert(ctx context.Context, records []Record) error
+	Close() error
+}
+
+type ClickHouseExporterConfig struct {
+	Logger      *slog.Logger
+	Addr        string
+	Database    string
+	Username    string
+	Password    string
+	TLSDisabled bool
+	Table       string
+
+	BatchSize          int
+	FlushInterval      time.Duration
+	MaxBufferedRecords int
+
+	// Inserter replaces the ClickHouse connection. When nil, a connection is opened from Addr,
+	// Database, Username and Password.
+	Inserter ClickHouseBatchInserter
+}
+
+func (c *ClickHouseExporterConfig) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+	if c.Inserter == nil && c.Addr == "" {
+		return errors.New("clickhouse address is required")
+	}
+	if c.Inserter == nil && c.Database == "" {
+		return errors.New("clickhouse database is required")
+	}
+	return nil
+}
+
+type ClickHouseExporter struct {
+	log                *slog.Logger
+	inserter           ClickHouseBatchInserter
+	table              string
+	batchSize          int
+	flushInterval      time.Duration
+	maxBufferedRecords int
+
+	// flushMu serialises Flush so a failed batch requeues in take order and the oldest stays first.
+	flushMu sync.Mutex
+
+	mu        sync.Mutex
+	pending   []Record
+	lastFlush time.Time
+}
+
+func NewClickHouseExporter(cfg ClickHouseExporterConfig) (*ClickHouseExporter, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate clickhouse exporter config: %w", err)
+	}
+
+	table := cfg.Table
+	if table == "" {
+		table = DefaultClickHouseTable
+	}
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultClickHouseBatchSize
+	}
+	flushInterval := cfg.FlushInterval
+	if flushInterval <= 0 {
+		flushInterval = defaultClickHouseFlushInterval
+	}
+	maxBufferedRecords := cfg.MaxBufferedRecords
+	if maxBufferedRecords <= 0 {
+		maxBufferedRecords = defaultClickHouseMaxBufferedRecords
+	}
+
+	inserter := cfg.Inserter
+	if inserter == nil {
+		chOpts := &clickhouse.Options{
+			Addr: []string{cfg.Addr},
+			Auth: clickhouse.Auth{
+				Database: cfg.Database,
+				Username: cfg.Username,
+				Password: cfg.Password,
+			},
+		}
+		if !cfg.TLSDisabled {
+			chOpts.TLS = &tls.Config{}
+		}
+
+		conn, err := clickhouse.Open(chOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open clickhouse connection: %w", err)
+		}
+		// Open does not dial, so ping to settle the address, credentials and database here. A
+		// bad setting then fails at startup instead of warning on every flush.
+		if err := conn.Ping(context.Background()); err != nil {
+			return nil, fmt.Errorf("clickhouse ping: %w", err)
+		}
+		inserter = &clickHouseConnInserter{
+			conn:     conn,
+			database: cfg.Database,
+			table:    table,
+		}
+	}
+
+	cfg.Logger.Info("Created ClickHouse exporter",
+		slog.String("table", table),
+		slog.Int("batch_size", batchSize),
+		slog.Int("max_buffered_records", maxBufferedRecords))
+
+	return &ClickHouseExporter{
+		log:                cfg.Logger,
+		inserter:           inserter,
+		table:              table,
+		batchSize:          batchSize,
+		flushInterval:      flushInterval,
+		maxBufferedRecords: maxBufferedRecords,
+		lastFlush:          time.Now(),
+	}, nil
+}
+
+// WriteRecords errors only when the buffer is full, so a failing insert does not stall its caller.
+func (e *ClickHouseExporter) WriteRecords(ctx context.Context, records []Record) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	for _, record := range records {
+		if err := record.Validate(); err != nil {
+			return fmt.Errorf("invalid record: %w", err)
+		}
+		if err := record.Cloud.Validate(); err != nil {
+			return fmt.Errorf("invalid record: %w", err)
+		}
+	}
+
+	e.enqueue(records)
+
+	if e.shouldFlush() {
+		if err := e.Flush(ctx); err != nil {
+			e.log.Warn("Failed to flush records to ClickHouse", slog.String("error", err.Error()))
+		}
+	}
+
+	if e.Buffered() >= e.maxBufferedRecords {
+		return fmt.Errorf("clickhouse exporter buffer is full at %d records", e.maxBufferedRecords)
+	}
+	return nil
+}
+
+func (e *ClickHouseExporter) Flush(ctx context.Context) error {
+	e.flushMu.Lock()
+	defer e.flushMu.Unlock()
+
+	for {
+		batch := e.takeBatch()
+		if len(batch) == 0 {
+			return nil
+		}
+
+		if err := e.inserter.Insert(ctx, batch); err != nil {
+			e.requeue(batch)
+			metrics.ExporterClickHouseInsertErrorsTotal.Inc()
+			return fmt.Errorf("failed to insert %d records into %s: %w", len(batch), e.table, err)
+		}
+
+		metrics.ExporterClickHouseRecordsWrittenTotal.Add(float64(len(batch)))
+		e.log.Debug("Wrote records to ClickHouse",
+			slog.String("table", e.table),
+			slog.Int("records", len(batch)))
+	}
+}
+
+func (e *ClickHouseExporter) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), closeFlushTimeout)
+	defer cancel()
+
+	flushErr := e.Flush(ctx)
+	closeErr := e.inserter.Close()
+	return errors.Join(flushErr, closeErr)
+}
+
+func (e *ClickHouseExporter) Buffered() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.pending)
+}
+
+func (e *ClickHouseExporter) enqueue(records []Record) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.pending = append(e.pending, records...)
+	e.dropOldestLocked()
+	metrics.ExporterClickHouseBufferedRecords.Set(float64(len(e.pending)))
+}
+
+func (e *ClickHouseExporter) requeue(batch []Record) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.pending = append(batch, e.pending...)
+	e.dropOldestLocked()
+	metrics.ExporterClickHouseBufferedRecords.Set(float64(len(e.pending)))
+}
+
+// dropOldestLocked trims the buffer back to its cap, oldest first. The caller holds e.mu.
+func (e *ClickHouseExporter) dropOldestLocked() {
+	overflow := len(e.pending) - e.maxBufferedRecords
+	if overflow <= 0 {
+		return
+	}
+
+	e.pending = append([]Record(nil), e.pending[overflow:]...)
+	metrics.ExporterClickHouseRecordsDroppedTotal.Add(float64(overflow))
+	e.log.Warn("ClickHouse exporter buffer full, dropped oldest records",
+		slog.Int("dropped", overflow),
+		slog.Int("max_buffered_records", e.maxBufferedRecords))
+}
+
+func (e *ClickHouseExporter) shouldFlush() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.pending) >= e.batchSize || time.Since(e.lastFlush) >= e.flushInterval
+}
+
+func (e *ClickHouseExporter) takeBatch() []Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if len(e.pending) == 0 {
+		return nil
+	}
+
+	n := min(e.batchSize, len(e.pending))
+	batch := append([]Record(nil), e.pending[:n]...)
+	e.pending = append([]Record(nil), e.pending[n:]...)
+	e.lastFlush = time.Now()
+	metrics.ExporterClickHouseBufferedRecords.Set(float64(len(e.pending)))
+	return batch
+}
+
+type clickHouseConnInserter struct {
+	conn     clickhouse.Conn
+	database string
+	table    string
+}
+
+func (i *clickHouseConnInserter) Insert(ctx context.Context, records []Record) error {
+	query := fmt.Sprintf("INSERT INTO %s.%s (%s)", i.database, i.table, strings.Join(clickHouseColumns, ", "))
+
+	batch, err := i.conn.PrepareBatch(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to prepare batch: %w", err)
+	}
+
+	ingestedAt := time.Now().UTC()
+	for n, record := range records {
+		err := batch.Append(
+			record.Timestamp.UTC(),
+			ingestedAt,
+			record.Cloud.SourceCloud,
+			record.SourceExchangeCode,
+			record.Cloud.TargetCloud,
+			record.TargetExchangeCode,
+			string(record.DataProvider),
+			record.Cloud.ProbeID,
+			uint32(record.RTT.Microseconds()),
+			record.Cloud.PacketsSent,
+			record.Cloud.PacketsReceived,
+		)
+		if err != nil {
+			_ = batch.Abort()
+			return fmt.Errorf("failed to append record %d to batch: %w", n, err)
+		}
+	}
+
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("failed to send batch: %w", err)
+	}
+	return nil
+}
+
+func (i *clickHouseConnInserter) Close() error {
+	return i.conn.Close()
+}

--- a/controlplane/internet-latency-collector/internal/exporter/clickhouse_integration_test.go
+++ b/controlplane/internet-latency-collector/internal/exporter/clickhouse_integration_test.go
@@ -1,0 +1,166 @@
+package exporter_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/exporter"
+	"github.com/malbeclabs/doublezero/telemetry/migrations"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/clickhouse"
+)
+
+func TestInternetLatency_ClickHouseExporter_WritesToClickHouse(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	addr, db := newClickHouseWithMigrations(t)
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		Addr:               addr,
+		Database:           "default",
+		Username:           "default",
+		TLSDisabled:        true,
+		Table:              exporter.DefaultClickHouseTable,
+		BatchSize:          2,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 10,
+	})
+	require.NoError(t, err)
+
+	eventTS := time.Now().UTC().Truncate(time.Second)
+	before := time.Now().UTC().Truncate(time.Second)
+
+	err = e.WriteRecords(t.Context(), []exporter.Record{
+		cloudRecord("eu-west-1", "us-east-1", 1003385, eventTS, 70500*time.Microsecond),
+		{
+			DataProvider:       exporter.DataProviderNameRIPEAtlas,
+			SourceExchangeCode: "sa-east-1",
+			TargetExchangeCode: "eu-north-1",
+			Timestamp:          eventTS,
+			Cloud: &exporter.CloudInfo{
+				SourceCloud:     "aws",
+				TargetCloud:     "aws",
+				ProbeID:         1003391,
+				PacketsSent:     3,
+				PacketsReceived: 0,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, e.Close())
+
+	type row struct {
+		EventTS         time.Time
+		IngestedAt      time.Time
+		OriginCloud     string
+		OriginRegion    string
+		TargetCloud     string
+		TargetRegion    string
+		DataProvider    string
+		ProbeID         uint32
+		RttUs           uint32
+		PacketsSent     uint8
+		PacketsReceived uint8
+	}
+
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT event_ts, ingested_at, origin_cloud, origin_region, target_cloud, target_region,
+		       data_provider, probe_id, rtt_us, packets_sent, packets_received
+		FROM cloud_region_latency
+		ORDER BY origin_region
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var got []row
+	for rows.Next() {
+		var v row
+		require.NoError(t, rows.Scan(&v.EventTS, &v.IngestedAt, &v.OriginCloud, &v.OriginRegion,
+			&v.TargetCloud, &v.TargetRegion, &v.DataProvider, &v.ProbeID, &v.RttUs,
+			&v.PacketsSent, &v.PacketsReceived))
+		got = append(got, v)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 2)
+
+	require.Equal(t, row{
+		EventTS:         eventTS,
+		IngestedAt:      got[0].IngestedAt,
+		OriginCloud:     "aws",
+		OriginRegion:    "eu-west-1",
+		TargetCloud:     "aws",
+		TargetRegion:    "us-east-1",
+		DataProvider:    "ripeatlas",
+		ProbeID:         1003385,
+		RttUs:           70500,
+		PacketsSent:     3,
+		PacketsReceived: 3,
+	}, got[0])
+	require.False(t, got[0].IngestedAt.Before(before), "ingested_at must be stamped at insert time, not left at zero")
+
+	require.Equal(t, row{
+		EventTS:         eventTS,
+		IngestedAt:      got[1].IngestedAt,
+		OriginCloud:     "aws",
+		OriginRegion:    "sa-east-1",
+		TargetCloud:     "aws",
+		TargetRegion:    "eu-north-1",
+		DataProvider:    "ripeatlas",
+		ProbeID:         1003391,
+		RttUs:           0,
+		PacketsSent:     3,
+		PacketsReceived: 0,
+	}, got[1])
+}
+
+func TestInternetLatency_ClickHouseExporter_FailsToConstructWhenDatabaseIsMissing(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	addr, _ := newClickHouseWithMigrations(t)
+
+	_, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:      log,
+		Addr:        addr,
+		Database:    "wrong_database",
+		Username:    "default",
+		TLSDisabled: true,
+		Table:       exporter.DefaultClickHouseTable,
+	})
+	require.ErrorContains(t, err, "clickhouse ping")
+}
+
+func newClickHouseWithMigrations(t *testing.T) (string, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := clickhouse.Run(ctx,
+		"clickhouse/clickhouse-server:23.3.8.21-alpine",
+		clickhouse.WithUsername("default"),
+		clickhouse.WithPassword(""),
+		clickhouse.WithDatabase("default"),
+	)
+	require.NoError(t, err)
+	testcontainers.CleanupContainer(t, container)
+
+	addr, err := container.ConnectionHost(ctx)
+	require.NoError(t, err)
+
+	err = migrations.RunMigrations(addr, "default", "default", "", false, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+
+	db := ch.OpenDB(&ch.Options{
+		Addr: []string{addr},
+		Auth: ch.Auth{Database: "default", Username: "default", Password: ""},
+	})
+	t.Cleanup(func() { _ = db.Close() })
+	return addr, db
+}

--- a/controlplane/internet-latency-collector/internal/exporter/clickhouse_test.go
+++ b/controlplane/internet-latency-collector/internal/exporter/clickhouse_test.go
@@ -1,0 +1,357 @@
+package exporter_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/exporter"
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClickHouseInserter struct {
+	mu        sync.Mutex
+	batches   [][]exporter.Record
+	err       error
+	delay     time.Duration
+	active    int
+	maxActive int
+	closed    bool
+}
+
+func (f *fakeClickHouseInserter) Insert(ctx context.Context, records []exporter.Record) error {
+	f.mu.Lock()
+	if f.err != nil {
+		err := f.err
+		f.mu.Unlock()
+		return err
+	}
+	f.active++
+	if f.active > f.maxActive {
+		f.maxActive = f.active
+	}
+	delay := f.delay
+	f.mu.Unlock()
+
+	time.Sleep(delay)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.active--
+	f.batches = append(f.batches, append([]exporter.Record(nil), records...))
+	return nil
+}
+
+func (f *fakeClickHouseInserter) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+
+func (f *fakeClickHouseInserter) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeClickHouseInserter) inserted() []exporter.Record {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []exporter.Record
+	for _, batch := range f.batches {
+		out = append(out, batch...)
+	}
+	return out
+}
+
+func (f *fakeClickHouseInserter) batchSizes() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]int, 0, len(f.batches))
+	for _, batch := range f.batches {
+		out = append(out, len(batch))
+	}
+	return out
+}
+
+func (f *fakeClickHouseInserter) maxConcurrent() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.maxActive
+}
+
+func (f *fakeClickHouseInserter) wasClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+func cloudRecord(originRegion, targetRegion string, probeID uint32, ts time.Time, rtt time.Duration) exporter.Record {
+	return exporter.Record{
+		DataProvider:       exporter.DataProviderNameRIPEAtlas,
+		SourceExchangeCode: originRegion,
+		TargetExchangeCode: targetRegion,
+		Timestamp:          ts,
+		RTT:                rtt,
+		Cloud: &exporter.CloudInfo{
+			SourceCloud:     "aws",
+			TargetCloud:     "aws",
+			ProbeID:         probeID,
+			PacketsSent:     3,
+			PacketsReceived: 3,
+		},
+	}
+}
+
+func TestInternetLatency_ClickHouseExporter_Validate(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	tests := []struct {
+		name              string
+		cfg               exporter.ClickHouseExporterConfig
+		expectErrContains string
+	}{
+		{
+			name:              "no logger",
+			cfg:               exporter.ClickHouseExporterConfig{Inserter: &fakeClickHouseInserter{}},
+			expectErrContains: "logger is required",
+		},
+		{
+			name:              "no address",
+			cfg:               exporter.ClickHouseExporterConfig{Logger: log, Database: "telemetry"},
+			expectErrContains: "address is required",
+		},
+		{
+			name:              "no database",
+			cfg:               exporter.ClickHouseExporterConfig{Logger: log, Addr: "localhost:9000"},
+			expectErrContains: "database is required",
+		},
+		{
+			name:              "an inserter replaces the connection settings",
+			cfg:               exporter.ClickHouseExporterConfig{Logger: log, Inserter: &fakeClickHouseInserter{}},
+			expectErrContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectErrContains != "" {
+				require.ErrorContains(t, err, tt.expectErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInternetLatency_ClickHouseExporter_BatchedInsert(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	fake := &fakeClickHouseInserter{}
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		Table:              exporter.DefaultClickHouseTable,
+		BatchSize:          2,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 10,
+		Inserter:           fake,
+	})
+	require.NoError(t, err)
+
+	ts := time.Unix(1757462400, 0).UTC()
+
+	err = e.WriteRecords(t.Context(), []exporter.Record{
+		cloudRecord("eu-west-1", "us-east-1", 1003385, ts, 70*time.Millisecond),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, e.Buffered())
+	require.Empty(t, fake.inserted())
+
+	err = e.WriteRecords(t.Context(), []exporter.Record{
+		cloudRecord("eu-west-1", "us-east-1", 1003386, ts, 71*time.Millisecond),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, e.Buffered())
+
+	inserted := fake.inserted()
+	require.Len(t, inserted, 2)
+	require.Equal(t, uint32(1003385), inserted[0].Cloud.ProbeID)
+	require.Equal(t, uint32(1003386), inserted[1].Cloud.ProbeID)
+
+	require.NoError(t, e.Close())
+	require.True(t, fake.wasClosed())
+}
+
+func TestInternetLatency_ClickHouseExporter_SplitsOneWriteIntoBatches(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	fake := &fakeClickHouseInserter{}
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		BatchSize:          2,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 10,
+		Inserter:           fake,
+	})
+	require.NoError(t, err)
+
+	ts := time.Unix(1757462400, 0).UTC()
+	records := make([]exporter.Record, 0, 5)
+	for i := range 5 {
+		records = append(records, cloudRecord("eu-west-1", "us-east-1", uint32(1000+i), ts, 70*time.Millisecond))
+	}
+
+	require.NoError(t, e.WriteRecords(t.Context(), records))
+	require.Equal(t, []int{2, 2, 1}, fake.batchSizes())
+	require.Len(t, fake.inserted(), 5)
+	require.Equal(t, 0, e.Buffered())
+	require.NoError(t, e.Close())
+}
+
+func TestInternetLatency_ClickHouseExporter_RejectsRecordWithoutCloudInfo(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	fake := &fakeClickHouseInserter{}
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		Table:              exporter.DefaultClickHouseTable,
+		BatchSize:          1,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 10,
+		Inserter:           fake,
+	})
+	require.NoError(t, err)
+
+	err = e.WriteRecords(t.Context(), []exporter.Record{{
+		DataProvider:       exporter.DataProviderNameRIPEAtlas,
+		SourceExchangeCode: "eu-west-1",
+		TargetExchangeCode: "us-east-1",
+		Timestamp:          time.Unix(1757462400, 0).UTC(),
+		RTT:                70 * time.Millisecond,
+	}})
+
+	require.ErrorContains(t, err, "no cloud info")
+	require.Equal(t, 0, e.Buffered())
+	require.Empty(t, fake.inserted())
+}
+
+func TestInternetLatency_ClickHouseExporter_FlushesOneBatchAtATime(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+	fake := &fakeClickHouseInserter{delay: 2 * time.Millisecond}
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		BatchSize:          1,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 100,
+		Inserter:           fake,
+	})
+	require.NoError(t, err)
+
+	ts := time.Unix(1757462400, 0).UTC()
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for w := range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 10 {
+				if err := e.WriteRecords(ctx, []exporter.Record{
+					cloudRecord("eu-west-1", "us-east-1", uint32(1000+w*10+i), ts, 70*time.Millisecond),
+				}); err != nil {
+					t.Errorf("write failed: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, fake.maxConcurrent(), "concurrent inserts can reorder the buffer on retry")
+	require.Len(t, fake.inserted(), 40)
+	require.NoError(t, e.Close())
+}
+
+func TestInternetLatency_ClickHouseExporter_DropsOldestWhenBufferFull(t *testing.T) {
+	// Not parallel: this test reads package-level Prometheus counters as deltas.
+	log := logger.With("test", t.Name())
+
+	fake := &fakeClickHouseInserter{}
+	fake.setErr(errors.New("clickhouse is down"))
+
+	e, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:             log,
+		Table:              exporter.DefaultClickHouseTable,
+		BatchSize:          1,
+		FlushInterval:      time.Hour,
+		MaxBufferedRecords: 3,
+		Inserter:           fake,
+	})
+	require.NoError(t, err)
+
+	droppedBefore := testutil.ToFloat64(metrics.ExporterClickHouseRecordsDroppedTotal)
+	errorsBefore := testutil.ToFloat64(metrics.ExporterClickHouseInsertErrorsTotal)
+	writtenBefore := testutil.ToFloat64(metrics.ExporterClickHouseRecordsWrittenTotal)
+
+	ts := time.Unix(1757462400, 0).UTC()
+	for i := range 5 {
+		err := e.WriteRecords(t.Context(), []exporter.Record{
+			cloudRecord("eu-west-1", "us-east-1", uint32(1000+i), ts.Add(time.Duration(i)*time.Minute), 70*time.Millisecond),
+		})
+		if i < 2 {
+			require.NoError(t, err, "a failed insert the buffer absorbs must not fail the write")
+		} else {
+			require.ErrorContains(t, err, "buffer is full at 3 records")
+		}
+	}
+
+	require.Equal(t, 3, e.Buffered(), "the buffer must stay at its cap")
+	require.Equal(t, float64(3), testutil.ToFloat64(metrics.ExporterClickHouseBufferedRecords))
+	require.Equal(t, float64(2), testutil.ToFloat64(metrics.ExporterClickHouseRecordsDroppedTotal)-droppedBefore,
+		"the two oldest records must be counted as dropped")
+	require.Equal(t, float64(5), testutil.ToFloat64(metrics.ExporterClickHouseInsertErrorsTotal)-errorsBefore)
+
+	fake.setErr(nil)
+	require.NoError(t, e.Flush(t.Context()))
+
+	inserted := fake.inserted()
+	require.Len(t, inserted, 3)
+	require.Equal(t, uint32(1002), inserted[0].Cloud.ProbeID)
+	require.Equal(t, uint32(1003), inserted[1].Cloud.ProbeID)
+	require.Equal(t, uint32(1004), inserted[2].Cloud.ProbeID)
+	require.Equal(t, float64(3), testutil.ToFloat64(metrics.ExporterClickHouseRecordsWrittenTotal)-writtenBefore)
+
+	require.NoError(t, e.Close())
+}
+
+func TestInternetLatency_ClickHouseExporter_FailsToConstructWhenClickHouseIsUnreachable(t *testing.T) {
+	t.Parallel()
+
+	log := logger.With("test", t.Name())
+
+	_, err := exporter.NewClickHouseExporter(exporter.ClickHouseExporterConfig{
+		Logger:      log,
+		Addr:        "127.0.0.1:1",
+		Database:    "telemetry",
+		Username:    "default",
+		TLSDisabled: true,
+		Table:       exporter.DefaultClickHouseTable,
+	})
+	require.ErrorContains(t, err, "clickhouse ping")
+}

--- a/controlplane/internet-latency-collector/internal/metrics/metrics.go
+++ b/controlplane/internet-latency-collector/internal/metrics/metrics.go
@@ -59,6 +59,26 @@ var (
 		Help: "Number of times the exporter has encountered a submitter account full error",
 	}, []string{"data_provider", "source_exchange_pk", "target_exchange_pk", "epoch"})
 
+	ExporterClickHouseRecordsWrittenTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_internet_latency_collector_exporter_clickhouse_records_written_total",
+		Help: "Total number of records written to ClickHouse by the exporter",
+	})
+
+	ExporterClickHouseRecordsDroppedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_internet_latency_collector_exporter_clickhouse_records_dropped_total",
+		Help: "Total number of records dropped from the ClickHouse exporter buffer because it was full",
+	})
+
+	ExporterClickHouseInsertErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "doublezero_internet_latency_collector_exporter_clickhouse_insert_errors_total",
+		Help: "Total number of failed ClickHouse inserts from the exporter",
+	})
+
+	ExporterClickHouseBufferedRecords = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "doublezero_internet_latency_collector_exporter_clickhouse_buffered_records",
+		Help: "Number of records currently buffered in the ClickHouse exporter",
+	})
+
 	LatencySamplesPerCollectionIntervalExpected = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "doublezero_internet_latency_collector_latency_samples_per_collection_interval_expected",
 		Help: "Expected number of exchange pair latency samples per collection interval",


### PR DESCRIPTION
Part of measuring latency between AWS regions with the internet latency collector, which needs
those samples in ClickHouse.

The collector writes latency samples to the DoubleZero ledger or to CSV, and has no way to write to
ClickHouse. This adds a ClickHouse exporter behind the same exporter interface, so a caller can use
either.

It buffers records and inserts them in batches of 500. A failed insert puts the batch back at the
front of the queue, so a ClickHouse restart delays records instead of losing them. The buffer holds
50,000 records, about two days, and drops the oldest beyond that rather than growing without limit.
The constructor pings ClickHouse, so a wrong address, password or database name fails at startup
instead of warning on every flush. Four Prometheus metrics report records written, records dropped,
insert errors and buffer depth.

Nothing builds this exporter yet, so merging changes nothing that runs today.

Test: `go test ./controlplane/internet-latency-collector/internal/exporter/...`. The tests that
start a real ClickHouse container need Docker.
