### PR TITLE
internet-latency-collector: export total packet loss in cloud mode

### DIFF
--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud.go
@@ -32,8 +32,10 @@ type CloudNode struct {
 
 func NewCloudCollector(logger *slog.Logger, exporter exporter.Exporter, env string, nodes []CloudNode) *Collector {
 	byCode := make(map[string]CloudNode, len(nodes))
+	clouds := make(map[string]string, len(nodes))
 	for _, node := range nodes {
 		byCode[node.Code] = node
+		clouds[node.Code] = node.Cloud
 	}
 
 	return &Collector{
@@ -44,6 +46,7 @@ func NewCloudCollector(logger *slog.Logger, exporter exporter.Exporter, env stri
 		probeToLocation: make(map[int]string),
 		cloudMode:       true,
 		cloudNodes:      byCode,
+		cloudByLocation: clouds,
 		getLocationsFunc: func(_ context.Context) []collector.LocationMatch {
 			locations := make([]collector.LocationMatch, 0, len(nodes))
 			for _, node := range nodes {
@@ -56,6 +59,84 @@ func NewCloudCollector(logger *slog.Logger, exporter exporter.Exporter, env stri
 			return locations
 		},
 	}
+}
+
+// SetCloudExport turns on cloud export, mapping each location code to its cloud ("us-east-1" to
+// "aws"). Records then carry cloud identity, and a result that got no reply is exported at zero RTT.
+func (c *Collector) SetCloudExport(clouds map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cloudByLocation = clouds
+}
+
+func (c *Collector) cloudExportEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cloudByLocation) > 0
+}
+
+// originCode is the location that was pinged, targetCode the location it was pinged from.
+func (c *Collector) cloudInfoFor(originCode, targetCode string, probeID, sent, received int) (*exporter.CloudInfo, bool) {
+	c.mu.RLock()
+	originCloud := c.cloudByLocation[originCode]
+	targetCloud := c.cloudByLocation[targetCode]
+	c.mu.RUnlock()
+
+	if originCloud == "" || targetCloud == "" || probeID <= 0 {
+		c.log.Warn("Incomplete cloud identity, skipping record",
+			slog.String("origin_code", originCode),
+			slog.String("target_code", targetCode),
+			slog.Int("probe_id", probeID))
+		return nil, false
+	}
+
+	return &exporter.CloudInfo{
+		SourceCloud:     originCloud,
+		TargetCloud:     targetCloud,
+		ProbeID:         uint32(probeID),
+		PacketsSent:     clampPacketCount(sent),
+		PacketsReceived: clampPacketCount(received),
+	}, true
+}
+
+// RIPE reports the counts as "sent" and "rcvd"; without them, an entry carrying an rtt is a reply.
+func parsePacketCountsFromResult(result any) (int, int) {
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		return 0, 0
+	}
+
+	if sent, ok := resultMap["sent"].(float64); ok && sent > 0 {
+		received, _ := resultMap["rcvd"].(float64)
+		return int(sent), int(received)
+	}
+
+	sent := 0
+	received := 0
+	if pings, ok := resultMap["result"].([]any); ok {
+		for _, ping := range pings {
+			pingMap, ok := ping.(map[string]any)
+			if !ok {
+				continue
+			}
+			sent++
+			if rtt, ok := pingMap["rtt"].(float64); ok && rtt > 0 {
+				received++
+			}
+		}
+	}
+
+	return sent, received
+}
+
+func clampPacketCount(n int) uint8 {
+	if n < 0 {
+		return 0
+	}
+	if n > 255 {
+		return 255
+	}
+	return uint8(n)
 }
 
 func (c *Collector) timestampFileName() string {

--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud_export_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud_export_test.go
@@ -1,0 +1,278 @@
+package ripeatlas
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/malbeclabs/doublezero/controlplane/internet-latency-collector/internal/exporter"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	cloudExportSampleProbe = 1003385
+	cloudExportLossProbe   = 1003386
+	cloudExportSampleTS    = 1757462400
+	cloudExportLossTS      = 1757462460
+)
+
+func answeredResult(probeID int, unixSeconds int64, rttMillis float64) map[string]any {
+	return map[string]any{
+		"prb_id":    float64(probeID),
+		"timestamp": float64(unixSeconds),
+		"sent":      float64(3),
+		"rcvd":      float64(3),
+		"result": []any{
+			map[string]any{"rtt": rttMillis},
+			map[string]any{"rtt": rttMillis + 0.4},
+			map[string]any{"rtt": rttMillis + 0.6},
+		},
+	}
+}
+
+// lostResult is what RIPE returns for a ping that got no reply: the counts disagree and no
+// entry carries an rtt.
+func lostResult(probeID int, unixSeconds int64) map[string]any {
+	return map[string]any{
+		"prb_id":    float64(probeID),
+		"timestamp": float64(unixSeconds),
+		"sent":      float64(3),
+		"rcvd":      float64(0),
+		"result": []any{
+			map[string]any{"x": "*"},
+			map[string]any{"x": "*"},
+			map[string]any{"x": "*"},
+		},
+	}
+}
+
+func cloudExportCollector(t *testing.T, results []any) (*Collector, *recordingExporter, *MeasurementState) {
+	t.Helper()
+
+	e := &recordingExporter{}
+	c := &Collector{
+		client: &MockClient{
+			GetMeasurementResultsIncrementalFunc: func(ctx context.Context, measurementID int, startTimestamp int64) ([]any, error) {
+				return results, nil
+			},
+		},
+		log:      logger.With("test", t.Name()),
+		exporter: e,
+	}
+
+	measurementState := NewMeasurementState(filepath.Join(t.TempDir(), TimestampFileName))
+	measurementState.SetMetadata(1, MeasurementMeta{
+		TargetLocation: "us-east-1",
+		Sources: []SourceProbeMeta{
+			{LocationCode: "eu-west-1", ProbeID: cloudExportSampleProbe},
+			{LocationCode: "eu-west-2", ProbeID: cloudExportLossProbe},
+		},
+		CreatedAt: time.Now().Unix(),
+	})
+
+	return c, e, measurementState
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_TotalLossBecomesAZeroRTTRecord(t *testing.T) {
+	t.Parallel()
+
+	results := []any{
+		answeredResult(cloudExportSampleProbe, cloudExportSampleTS, 70.5),
+		lostResult(cloudExportLossProbe, cloudExportLossTS),
+	}
+	c, e, measurementState := cloudExportCollector(t, results)
+	c.SetCloudExport(map[string]string{
+		"us-east-1": "aws",
+		"eu-west-1": "aws",
+		"eu-west-2": "aws",
+	})
+
+	count, records, err := c.exportSingleMeasurementResults(t.Context(), Measurement{ID: 1}, measurementState)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	require.Len(t, records, 2)
+	require.Equal(t, records, e.written())
+
+	sample := records[0]
+	require.Equal(t, "us-east-1", sample.SourceExchangeCode)
+	require.Equal(t, "eu-west-1", sample.TargetExchangeCode)
+	require.Equal(t, 70500*time.Microsecond, sample.RTT)
+	require.Equal(t, &exporter.CloudInfo{
+		SourceCloud:     "aws",
+		TargetCloud:     "aws",
+		ProbeID:         cloudExportSampleProbe,
+		PacketsSent:     3,
+		PacketsReceived: 3,
+	}, sample.Cloud)
+
+	loss := records[1]
+	require.Equal(t, "us-east-1", loss.SourceExchangeCode)
+	require.Equal(t, "eu-west-2", loss.TargetExchangeCode)
+	require.Equal(t, time.Duration(0), loss.RTT)
+	require.True(t, loss.Timestamp.Equal(time.Unix(cloudExportLossTS, 0).UTC()))
+	require.Equal(t, &exporter.CloudInfo{
+		SourceCloud:     "aws",
+		TargetCloud:     "aws",
+		ProbeID:         cloudExportLossProbe,
+		PacketsSent:     3,
+		PacketsReceived: 0,
+	}, loss.Cloud)
+
+	cursor, ok := measurementState.GetLastTimestamp(1)
+	require.True(t, ok)
+	require.Equal(t, int64(cloudExportLossTS), cursor, "a loss row is a sample and advances the cursor")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_ExchangePathDropsTotalLoss(t *testing.T) {
+	t.Parallel()
+
+	results := []any{
+		answeredResult(cloudExportSampleProbe, cloudExportSampleTS, 70.5),
+		lostResult(cloudExportLossProbe, cloudExportLossTS),
+	}
+	c, e, measurementState := cloudExportCollector(t, results)
+
+	count, records, err := c.exportSingleMeasurementResults(t.Context(), Measurement{ID: 1}, measurementState)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.Len(t, records, 1)
+	require.Equal(t, "eu-west-1", records[0].TargetExchangeCode)
+	require.Nil(t, records[0].Cloud)
+	require.Equal(t, records, e.written())
+
+	cursor, ok := measurementState.GetLastTimestamp(1)
+	require.True(t, ok)
+	require.Equal(t, int64(cloudExportSampleTS), cursor, "the lost result must not advance the cursor")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_SkipsSampleFromLocationWithoutCloud(t *testing.T) {
+	t.Parallel()
+
+	results := []any{
+		answeredResult(cloudExportSampleProbe, cloudExportSampleTS, 70.5),
+		answeredResult(cloudExportLossProbe, cloudExportLossTS, 71.5),
+	}
+	c, e, measurementState := cloudExportCollector(t, results)
+	// eu-west-2 is deliberately absent.
+	c.SetCloudExport(map[string]string{
+		"us-east-1": "aws",
+		"eu-west-1": "aws",
+	})
+
+	count, records, err := c.exportSingleMeasurementResults(t.Context(), Measurement{ID: 1}, measurementState)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.Len(t, records, 1)
+	require.Equal(t, "eu-west-1", records[0].TargetExchangeCode)
+	require.NotNil(t, records[0].Cloud)
+	require.Equal(t, records, e.written())
+
+	cursor, ok := measurementState.GetLastTimestamp(1)
+	require.True(t, ok)
+	require.Equal(t, int64(cloudExportLossTS), cursor, "a skipped sample still advances the cursor")
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_ResultsThatAreNotLoss(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result any
+	}{
+		{
+			name:   "a probe the measurement does not list",
+			result: lostResult(999999, cloudExportLossTS),
+		},
+		{
+			name: "a result carrying no packets",
+			result: map[string]any{
+				"prb_id":    float64(cloudExportLossProbe),
+				"timestamp": float64(cloudExportLossTS),
+			},
+		},
+		{
+			name: "a result carrying no timestamp",
+			result: map[string]any{
+				"prb_id": float64(cloudExportLossProbe),
+				"sent":   float64(3),
+				"rcvd":   float64(0),
+				"result": []any{map[string]any{"x": "*"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, e, measurementState := cloudExportCollector(t, []any{tt.result})
+			c.SetCloudExport(map[string]string{
+				"us-east-1": "aws",
+				"eu-west-1": "aws",
+				"eu-west-2": "aws",
+			})
+
+			count, records, err := c.exportSingleMeasurementResults(t.Context(), Measurement{ID: 1}, measurementState)
+			require.NoError(t, err)
+			require.Equal(t, 0, count)
+			require.Empty(t, records)
+			require.Empty(t, e.written())
+
+			_, ok := measurementState.GetLastTimestamp(1)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_ParsePacketCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		result       any
+		wantSent     int
+		wantReceived int
+	}{
+		{
+			name:         "reported counts are used",
+			result:       map[string]any{"sent": float64(3), "rcvd": float64(1)},
+			wantSent:     3,
+			wantReceived: 1,
+		},
+		{
+			name: "absent counts are taken from the ping entries",
+			result: map[string]any{"result": []any{
+				map[string]any{"rtt": float64(12.0)},
+				map[string]any{"x": "*"},
+			}},
+			wantSent:     2,
+			wantReceived: 1,
+		},
+		{
+			name:         "a result that is not an object has no packets",
+			result:       "nonsense",
+			wantSent:     0,
+			wantReceived: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sent, received := parsePacketCountsFromResult(tt.result)
+			require.Equal(t, tt.wantSent, sent)
+			require.Equal(t, tt.wantReceived, received)
+		})
+	}
+}
+
+func TestInternetLatency_RIPEAtlas_CloudExport_ClampPacketCount(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint8(0), clampPacketCount(-1))
+	require.Equal(t, uint8(3), clampPacketCount(3))
+	require.Equal(t, uint8(255), clampPacketCount(255))
+	require.Equal(t, uint8(255), clampPacketCount(256))
+}

--- a/controlplane/internet-latency-collector/internal/ripeatlas/cloud_test.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/cloud_test.go
@@ -112,6 +112,8 @@ func TestInternetLatency_RIPEAtlas_Cloud_ConstructorEnablesMode(t *testing.T) {
 	c := newCloudTestCollector(t, log, &MockClient{}, "mainnet-beta", cloudTestNodes())
 
 	require.True(t, c.cloudMode, "NewCloudCollector must enable cloud mode")
+	require.True(t, c.cloudExportEnabled(), "NewCloudCollector must enable cloud export")
+	require.Equal(t, "aws", c.cloudByLocation["us-east-1"])
 	require.Len(t, c.cloudNodes, 2)
 	require.Equal(t, "3.248.0.0", c.cloudNodes["eu-west-1"].PingTarget)
 	require.Equal(t, []int{1000731, 1000732}, c.cloudNodes["us-east-1"].AtlasProbeIDs)

--- a/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
+++ b/controlplane/internet-latency-collector/internal/ripeatlas/collector.go
@@ -84,7 +84,8 @@ type Collector struct {
 	getLocationsFunc func(ctx context.Context) []collector.LocationMatch
 	env              string
 	probeToLocation  map[int]string    // Maps probe IDs to location codes
-	mu               sync.RWMutex      // Protects probeToLocation map
+	cloudByLocation  map[string]string // Maps location codes to cloud names; empty outside cloud export
+	mu               sync.RWMutex      // Protects probeToLocation and cloudByLocation
 	measurementState *MeasurementState // Shared state; initialized in Run()
 	cloudMode        bool              // Measures cloud regions from cloudNodes instead of exchanges
 	cloudNodes       map[string]CloudNode
@@ -629,7 +630,7 @@ func (c *Collector) exportSingleMeasurementResults(ctx context.Context, measurem
 				sourceLocation = loc
 			}
 
-			records = append(records, exporter.Record{
+			record := exporter.Record{
 				DataProvider: exporter.DataProviderNameRIPEAtlas,
 				// Source and target are swapped here to match alphabetical ordering expected by downstream systems.
 				// We alphabetically sort the measurements by exchange code, but from the perspective of the measurement
@@ -638,9 +639,50 @@ func (c *Collector) exportSingleMeasurementResults(ctx context.Context, measurem
 				TargetExchangeCode: sourceLocation,
 				Timestamp:          timestamp,
 				RTT:                latency,
-			})
+			}
+
+			if c.cloudExportEnabled() {
+				sent, received := parsePacketCountsFromResult(result)
+				cloudInfo, ok := c.cloudInfoFor(targetLocation, sourceLocation, probeID, sent, received)
+				if !ok {
+					continue
+				}
+				record.Cloud = cloudInfo
+			}
+
+			records = append(records, record)
 
 			processedResults++
+		} else if c.cloudExportEnabled() {
+			// A result that got no reply is exported with a zero RTT, which keeps total loss
+			// distinguishable from a pair that was never measured.
+			sourceLocation, ok := probeToLocationLocal[probeID]
+			if !ok {
+				continue
+			}
+
+			sent, received := parsePacketCountsFromResult(result)
+			if sent == 0 || received > 0 || timestamp.IsZero() {
+				continue
+			}
+
+			cloudInfo, ok := c.cloudInfoFor(targetLocation, sourceLocation, probeID, sent, received)
+			if !ok {
+				continue
+			}
+
+			if timestamp.After(maxTimestamp) {
+				maxTimestamp = timestamp
+			}
+
+			records = append(records, exporter.Record{
+				DataProvider:       exporter.DataProviderNameRIPEAtlas,
+				SourceExchangeCode: targetLocation,
+				TargetExchangeCode: sourceLocation,
+				Timestamp:          timestamp,
+				RTT:                0,
+				Cloud:              cloudInfo,
+			})
 		}
 	}
 


### PR DESCRIPTION
Part of measuring latency between AWS regions with the internet latency collector.

A region pair that loses every packet writes no row, which looks exactly like a pair nobody
measured. This makes the collector write a row with a zero round-trip time when a measurement ran
and nothing came back.

RIPE Atlas reports how many packets each result sent and received. The new code reads those counts,
falling back to counting the individual ping entries, and turns a result with packets sent and none
received into a record at zero round-trip time carrying both counts. A reader can then tell a broken
path from a missing one. The record is skipped when the probe ID or either end's cloud name is
unknown. This runs only when the collector is given a node file of cloud regions to measure, so the
existing path between DoubleZero exchange locations still drops these results.

Merging changes nothing that runs today. That node file is supplied only by a separate deployment,
which does not exist yet.

Test: `go test ./controlplane/internet-latency-collector/internal/ripeatlas/ -run CloudExport`
