### PR TITLE
serviceability: prefer the accesspass that clears the epoch check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- Client / SDK
+  - `connect` and `GetAccessPassCommand`'s callers (`CreateUserCommand`, `CreateSubscribeUserCommand`) now prefer whichever of the dynamic (`0.0.0.0`) and exact-IP access passes actually clears the epoch check for the user type being created, instead of always taking the dynamic pass when one exists. A dynamic pass left over from a never-epoch-gated EdgeSeat multicast subscription could go stale while a valid exact-IP prepaid pass sat unused at the same address, so `doublezero connect ibrl` picked the stale pass and failed with "Unable to find a valid AccessPass" even though a usable one existed. New `GetAccessPassCommand::execute_usable` (only reads the epoch when both candidates exist); `execute` is unchanged for every other caller. (#4244)
+
 ## [v0.40.0](https://github.com/malbeclabs/doublezero/compare/client/v0.39.0...client/v0.40.0) - 2026-09-11
 
 ### Breaking

--- a/client/doublezero/src/main.rs
+++ b/client/doublezero/src/main.rs
@@ -100,14 +100,16 @@ impl<C: CliCommand + Sync> doublezero_daemon_cli::LedgerClient for LedgerAdapter
         &self,
         client_ip: std::net::Ipv4Addr,
         user_payer: solana_sdk::pubkey::Pubkey,
+        user_type: doublezero_sdk::UserType,
     ) -> eyre::Result<Option<doublezero_serviceability::state::accesspass::AccessPass>> {
         Ok(self
             .client
-            .get_accesspass(
+            .get_accesspass_usable(
                 doublezero_sdk::commands::accesspass::get::GetAccessPassCommand {
                     client_ip,
                     user_payer,
                 },
+                user_type,
             )?
             .map(|(_, accesspass)| accesspass))
     }

--- a/crates/doublezero-daemon-cli/src/connect.rs
+++ b/crates/doublezero-daemon-cli/src/connect.rs
@@ -183,9 +183,10 @@ enum FeedJoinUser {
 fn check_accesspass<L: LedgerClient>(
     ledger: &L,
     client_ip: Ipv4Addr,
+    user_type: UserType,
     enforce_epoch: bool,
 ) -> eyre::Result<bool> {
-    let Some(accesspass) = ledger.get_accesspass(client_ip, ledger.get_payer())? else {
+    let Some(accesspass) = ledger.get_accesspass(client_ip, ledger.get_payer(), user_type)? else {
         return Ok(false);
     };
 
@@ -203,9 +204,10 @@ fn check_accesspass<L: LedgerClient>(
 fn require_accesspass<L: LedgerClient, W: Write>(
     ledger: &L,
     client_ip: Ipv4Addr,
+    user_type: UserType,
     out: &mut W,
 ) -> eyre::Result<AccessPass> {
-    match ledger.get_accesspass(client_ip, ledger.get_payer())? {
+    match ledger.get_accesspass(client_ip, ledger.get_payer(), user_type)? {
         Some(accesspass) => Ok(accesspass),
         None => {
             writeln!(
@@ -522,13 +524,14 @@ impl Connect {
         }
 
         let parsed_mode = self.parse_dz_mode()?;
+        let user_type = proof_user_type(&parsed_mode);
         // Multicast users are not subject to epoch expiry — only verify the AccessPass exists.
         let enforce_epoch = !matches!(
             parsed_mode,
             ParsedDzMode::Multicast { .. } | ParsedDzMode::MulticastFeeds { .. }
         );
 
-        if !check_accesspass(ledger, client_ip, enforce_epoch)? {
+        if !check_accesspass(ledger, client_ip, user_type, enforce_epoch)? {
             writeln!(
                 out,
                 "❌  Unable to find a valid AccessPass for the IP: {client_ip_str} UserPayer: {}",
@@ -547,12 +550,7 @@ impl Connect {
         // bare form runs two legs and builds one per leg; it returned above.) Nothing is
         // requested here — see [`IpProofFetcher`] for why the request waits until a creation
         // path asks for it.
-        let ip_proof = IpProofFetcher::new(
-            proof_client,
-            ledger.get_payer(),
-            proof_user_type(&parsed_mode),
-            client_ip,
-        );
+        let ip_proof = IpProofFetcher::new(proof_client, ledger.get_payer(), user_type, client_ip);
         let ip_proof = &ip_proof;
 
         let provisioned = match parsed_mode {
@@ -625,7 +623,14 @@ impl Connect {
         spinner: &ProgressBar,
         out: &mut W,
     ) -> eyre::Result<()> {
-        let accesspass = require_accesspass(ledger, client_ip, out)?;
+        // Only the IBRL leg is epoch-gated (Multicast is exempt), so the preflight pass must be
+        // the one that leg would actually use.
+        let ibrl_user_type = if self.allocate_addr {
+            UserType::IBRLWithAllocatedIP
+        } else {
+            UserType::IBRL
+        };
+        let accesspass = require_accesspass(ledger, client_ip, ibrl_user_type, out)?;
 
         spinner.inc(1);
         writeln!(out, "    DoubleZero ID: {}", ledger.get_payer())?;
@@ -675,21 +680,16 @@ impl Connect {
                 accesspass.unicast_user_count, accesspass.max_unicast_users
             ))
         } else {
-            let user_type = if self.allocate_addr {
-                UserType::IBRLWithAllocatedIP
-            } else {
-                UserType::IBRL
-            };
             // A proof per leg, not per invocation: the proof binds `user_type`, and this form
             // creates a unicast user and a multicast one. A single proof would be refused
             // onchain by whichever leg it did not name.
             let ip_proof =
-                IpProofFetcher::new(proof_client, ledger.get_payer(), user_type, client_ip);
+                IpProofFetcher::new(proof_client, ledger.get_payer(), ibrl_user_type, client_ip);
             match self
                 .execute_ibrl(
                     ledger,
                     daemon,
-                    user_type,
+                    ibrl_user_type,
                     client_ip,
                     self.tenant.clone(),
                     &ip_proof,
@@ -783,7 +783,7 @@ impl Connect {
             // subscriber allowlist. The pass is guaranteed to exist (validated by
             // check_accesspass before dispatch); the ok_or_else is defensive.
             let accesspass = ledger
-                .get_accesspass(client_ip, ledger.get_payer())?
+                .get_accesspass(client_ip, ledger.get_payer(), UserType::Multicast)?
                 .ok_or_else(|| {
                     eyre::eyre!(
                         "No valid AccessPass found for IP: {} user_payer: {}",
@@ -1511,7 +1511,7 @@ impl Connect {
         // Refuse here what the program would refuse after the create: by then the bare user
         // would already exist, holding a multicast slot and a device seat for nothing.
         let accesspass = ledger
-            .get_accesspass(client_ip, ledger.get_payer())?
+            .get_accesspass(client_ip, ledger.get_payer(), UserType::Multicast)?
             .ok_or_else(|| {
                 eyre::eyre!(
                     "No valid AccessPass found for IP: {client_ip} user_payer: {}",
@@ -1837,7 +1837,7 @@ impl Connect {
                 }
 
                 let accesspass = ledger
-                    .get_accesspass(*client_ip, ledger.get_payer())?
+                    .get_accesspass(*client_ip, ledger.get_payer(), user_type)?
                     .ok_or_else(|| {
                         eyre::eyre!(
                             "No valid AccessPass found for IP: {} user_payer: {}",
@@ -3024,8 +3024,9 @@ mod tests {
                 .with(
                     predicate::eq(Ipv4Addr::new(1, 2, 3, 4)),
                     predicate::eq(payer),
+                    predicate::always(),
                 )
-                .returning_st(move |_, _| Ok(Some(accesspass.lock().unwrap().clone())));
+                .returning_st(move |_, _, _| Ok(Some(accesspass.lock().unwrap().clone())));
 
             let users = fixture.users.clone();
             fixture

--- a/crates/doublezero-daemon-cli/src/ledger.rs
+++ b/crates/doublezero-daemon-cli/src/ledger.rs
@@ -17,7 +17,7 @@ use doublezero_sdk::{
         },
         user::{create::CreateUserCommand, create_subscribe::CreateSubscribeUserCommand},
     },
-    Device, Exchange, Feed, GlobalState, MulticastGroup, Tenant, User,
+    Device, Exchange, Feed, GlobalState, MulticastGroup, Tenant, User, UserType,
 };
 use doublezero_serviceability::state::accesspass::AccessPass;
 use mockall::automock;
@@ -64,12 +64,15 @@ pub trait LedgerClient: Send + Sync {
     /// The current DZ ledger epoch (used for AccessPass expiry enforcement).
     fn get_epoch(&self) -> eyre::Result<u64>;
 
-    /// Fetch the AccessPass for `(client_ip, user_payer)`, or `None` if no
-    /// such pass exists.
+    /// Fetch the AccessPass for `(client_ip, user_payer)` that is actually usable for
+    /// `user_type`, or `None` if no such pass exists. Preferring the pass a subsequent
+    /// `create_user`/`create_subscribe_user` call for the same `user_type` could use keeps
+    /// this preflight from disagreeing with the transaction it gates (#4244).
     fn get_accesspass(
         &self,
         client_ip: Ipv4Addr,
         user_payer: Pubkey,
+        user_type: UserType,
     ) -> eyre::Result<Option<AccessPass>>;
 
     /// Fetch a device by pubkey or code.

--- a/smartcontract/cli/src/doublezerocommand.rs
+++ b/smartcontract/cli/src/doublezerocommand.rs
@@ -114,7 +114,7 @@ use doublezero_sdk::{
     telemetry::LinkLatencyStats,
     DZClient, DZTransaction, Device, DoubleZeroClient, Exchange, Feed, GetGlobalConfigCommand,
     GetGlobalStateCommand, GlobalConfig, GlobalState, Link, Location, MulticastGroup,
-    ResourceExtensionOwned, TopologyInfo, User,
+    ResourceExtensionOwned, TopologyInfo, User, UserType,
 };
 use doublezero_serviceability::state::{
     accesspass::AccessPass, accountdata::AccountData, contributor::Contributor,
@@ -327,6 +327,14 @@ pub trait CliCommand {
     fn get_accesspass(
         &self,
         cmd: GetAccessPassCommand,
+    ) -> eyre::Result<Option<(Pubkey, AccessPass)>>;
+    /// Like `get_accesspass`, but for a caller about to create a `user_type` user: prefers
+    /// whichever candidate pass actually clears the access-pass epoch check for that user type
+    /// (see `GetAccessPassCommand::execute_usable`).
+    fn get_accesspass_usable(
+        &self,
+        cmd: GetAccessPassCommand,
+        user_type: UserType,
     ) -> eyre::Result<Option<(Pubkey, AccessPass)>>;
     fn list_accesspass(
         &self,
@@ -794,6 +802,13 @@ impl CliCommand for CliCommandImpl<'_> {
         cmd: GetAccessPassCommand,
     ) -> eyre::Result<Option<(Pubkey, AccessPass)>> {
         cmd.execute(self.client)
+    }
+    fn get_accesspass_usable(
+        &self,
+        cmd: GetAccessPassCommand,
+        user_type: UserType,
+    ) -> eyre::Result<Option<(Pubkey, AccessPass)>> {
+        cmd.execute_usable(self.client, user_type)
     }
     fn list_accesspass(
         &self,

--- a/smartcontract/sdk/rs/src/commands/accesspass/get.rs
+++ b/smartcontract/sdk/rs/src/commands/accesspass/get.rs
@@ -3,7 +3,11 @@ use std::net::Ipv4Addr;
 use crate::DoubleZeroClient;
 use doublezero_serviceability::{
     pda::get_accesspass_pda,
-    state::{accesspass::AccessPass, accountdata::AccountData, user::User},
+    state::{
+        accesspass::AccessPass,
+        accountdata::AccountData,
+        user::{epoch_allows_connection, User, UserType},
+    },
 };
 use eyre::WrapErr;
 use solana_sdk::pubkey::Pubkey;
@@ -37,6 +41,75 @@ impl GetAccessPassCommand {
         match client.get(pubkey) {
             Ok(AccountData::AccessPass(accesspass)) => Ok(Some((pubkey, accesspass))),
             Ok(_) | Err(_) => Ok(None),
+        }
+    }
+
+    /// Like `execute`, but for a caller about to create a `user_type` user: prefers whichever of
+    /// the dynamic (UNSPECIFIED) and exact-IP candidates actually clears the access-pass epoch
+    /// check for that user type, instead of always taking the dynamic pass when one exists.
+    ///
+    /// A dynamic pass is not epoch-gated to begin with when it only ever backed a multicast
+    /// (EdgeSeat) subscription, so its `last_access_epoch` can go stale while an exact-IP prepaid
+    /// pass at the same address is still valid. `execute` would still return the stale dynamic
+    /// pass, and the caller's own epoch check would then reject it even though a usable pass
+    /// exists — this evaluates both candidates against the epoch check the on-chain program
+    /// actually enforces, so the pass this returns is the same one a subsequent create_user /
+    /// create_subscribe_user call would need to succeed.
+    pub fn execute_usable(
+        &self,
+        client: &dyn DoubleZeroClient,
+        user_type: UserType,
+    ) -> eyre::Result<Option<(Pubkey, AccessPass)>> {
+        let program_id = client.get_program_id();
+
+        let dynamic = if self.client_ip != Ipv4Addr::UNSPECIFIED {
+            let (dynamic_pubkey, _) =
+                get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &self.user_payer);
+            match client.get(dynamic_pubkey) {
+                Ok(AccountData::AccessPass(accesspass)) => Some((dynamic_pubkey, accesspass)),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        // No dynamic pass (or the requested IP already is UNSPECIFIED, so the exact-IP PDA below
+        // *is* the dynamic one): nothing to arbitrate between, same as `execute`.
+        let Some(dynamic) = dynamic else {
+            let (exact_pubkey, _) =
+                get_accesspass_pda(&program_id, &self.client_ip, &self.user_payer);
+            return Ok(match client.get(exact_pubkey) {
+                Ok(AccountData::AccessPass(accesspass)) => Some((exact_pubkey, accesspass)),
+                _ => None,
+            });
+        };
+
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &self.client_ip, &self.user_payer);
+        let exact = match client.get(exact_pubkey) {
+            Ok(AccountData::AccessPass(accesspass)) => Some((exact_pubkey, accesspass)),
+            _ => None,
+        };
+
+        // No exact-IP pass either: only one candidate exists, same as `execute`.
+        let Some(exact) = exact else {
+            return Ok(Some(dynamic));
+        };
+
+        // Both candidates exist: an epoch read is unavoidable to tell which one a subsequent
+        // create_user / create_subscribe_user call would actually be able to use.
+        let current_epoch = client.get_epoch()?;
+        let is_usable = |accesspass: &AccessPass| {
+            epoch_allows_connection(user_type, accesspass.last_access_epoch, current_epoch)
+        };
+
+        if is_usable(&dynamic.1) {
+            Ok(Some(dynamic))
+        } else if is_usable(&exact.1) {
+            Ok(Some(exact))
+        } else {
+            // Neither clears the epoch check; keep `execute`'s dynamic-first default so the
+            // resulting on-chain failure names the same pass the caller's own preflight saw.
+            Ok(Some(dynamic))
         }
     }
 }
@@ -144,7 +217,7 @@ mod tests {
             accesspass::{AccessPass, AccessPassStatus, AccessPassType},
             accountdata::AccountData,
             accounttype::AccountType,
-            user::User,
+            user::{User, UserType},
         },
     };
     use mockall::predicate;
@@ -289,6 +362,156 @@ mod tests {
             user_payer: payer,
         }
         .execute(&client)
+        .unwrap();
+
+        let (pubkey, _) = res.expect("expected a pass");
+        assert_eq!(pubkey, dynamic_pubkey);
+    }
+
+    #[test]
+    fn test_execute_usable_returns_exact_when_dynamic_is_stale() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        // The dynamic pass exists but its epoch has passed (e.g. left over from a
+        // never-epoch-gated EdgeSeat multicast subscription); the exact-IP pass is
+        // still within its epoch. execute_usable must prefer the exact-IP one, unlike
+        // execute (see test_get_accesspass_prefers_dynamic_pass).
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let stale_dynamic_pass = AccessPass {
+            last_access_epoch: 5,
+            ..sample_accesspass(Ipv4Addr::UNSPECIFIED, payer)
+        };
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+        let usable_exact_pass = sample_accesspass(client_ip, payer);
+
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(stale_dynamic_pass.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(usable_exact_pass.clone())));
+        client.expect_get_epoch().returning(|| Ok(10));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute_usable(&client, UserType::IBRL)
+        .unwrap();
+
+        let (pubkey, pass) = res.expect("expected a pass");
+        assert_eq!(pubkey, exact_pubkey);
+        assert_eq!(pass.client_ip, client_ip);
+    }
+
+    #[test]
+    fn test_execute_usable_prefers_dynamic_when_both_are_usable() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let dynamic_pass = sample_accesspass(Ipv4Addr::UNSPECIFIED, payer);
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+        let exact_pass = sample_accesspass(client_ip, payer);
+
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(dynamic_pass.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(exact_pass.clone())));
+        client.expect_get_epoch().returning(|| Ok(10));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute_usable(&client, UserType::IBRL)
+        .unwrap();
+
+        let (pubkey, _) = res.expect("expected a pass");
+        assert_eq!(pubkey, dynamic_pubkey);
+    }
+
+    #[test]
+    fn test_execute_usable_falls_back_to_dynamic_when_neither_clears_epoch_check() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let stale_dynamic_pass = AccessPass {
+            last_access_epoch: 1,
+            ..sample_accesspass(Ipv4Addr::UNSPECIFIED, payer)
+        };
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+        let stale_exact_pass = AccessPass {
+            last_access_epoch: 2,
+            ..sample_accesspass(client_ip, payer)
+        };
+
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(stale_dynamic_pass.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(stale_exact_pass.clone())));
+        client.expect_get_epoch().returning(|| Ok(10));
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute_usable(&client, UserType::IBRL)
+        .unwrap();
+
+        let (pubkey, _) = res.expect("expected a pass");
+        assert_eq!(pubkey, dynamic_pubkey);
+    }
+
+    #[test]
+    fn test_execute_usable_skips_epoch_read_when_only_one_candidate_exists() {
+        let mut client = create_test_client();
+        let program_id = client.get_program_id();
+
+        let client_ip: Ipv4Addr = [10, 0, 0, 1].into();
+        let payer = Pubkey::new_unique();
+
+        let (dynamic_pubkey, _) = get_accesspass_pda(&program_id, &Ipv4Addr::UNSPECIFIED, &payer);
+        let dynamic_pass = sample_accesspass(Ipv4Addr::UNSPECIFIED, payer);
+        let (exact_pubkey, _) = get_accesspass_pda(&program_id, &client_ip, &payer);
+
+        client
+            .expect_get()
+            .with(predicate::eq(dynamic_pubkey))
+            .returning(move |_| Ok(AccountData::AccessPass(dynamic_pass.clone())));
+        client
+            .expect_get()
+            .with(predicate::eq(exact_pubkey))
+            .returning(|_| Err(eyre::eyre!("account not found")));
+        // No expect_get_epoch() set: with only one candidate present, execute_usable
+        // must not need an epoch read to decide — a call would panic (unmocked).
+
+        let res = GetAccessPassCommand {
+            client_ip,
+            user_payer: payer,
+        }
+        .execute_usable(&client, UserType::IBRL)
         .unwrap();
 
         let (pubkey, _) = res.expect("expected a pass");

--- a/smartcontract/sdk/rs/src/commands/user/create.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create.rs
@@ -34,12 +34,14 @@ pub struct CreateUserCommand {
 impl CreateUserCommand {
     pub fn execute(&self, client: &dyn DoubleZeroClient) -> eyre::Result<(Signature, Pubkey)> {
         // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
-        // back to the exact client-IP pass, matching the onchain create_user path.
+        // back to the exact client-IP pass, matching the onchain create_user path. Of those,
+        // execute_usable picks whichever one actually clears the epoch check for self.user_type,
+        // so a stale dynamic pass doesn't shadow a valid exact-IP one (#4244).
         let (accesspass_pk, _) = GetAccessPassCommand {
             client_ip: self.client_ip,
             user_payer: client.get_payer(),
         }
-        .execute(client)?
+        .execute_usable(client, self.user_type)?
         .ok_or_else(|| eyre::eyre!("You have no Access Pass"))?;
 
         let program_id = client.get_program_id();

--- a/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
+++ b/smartcontract/sdk/rs/src/commands/user/create_subscribe.rs
@@ -99,12 +99,14 @@ impl CreateSubscribeUserCommand {
         let accesspass_payer = self.owner.unwrap_or_else(|| client.get_payer());
 
         // GetAccessPassCommand prefers a shared dynamic (UNSPECIFIED) pass and falls
-        // back to the exact client-IP pass, matching the onchain create_user path.
+        // back to the exact client-IP pass, matching the onchain create_user path. Of those,
+        // execute_usable picks whichever one actually clears the epoch check for self.user_type,
+        // so a stale dynamic pass doesn't shadow a valid exact-IP one (#4244).
         let (accesspass_pk, _) = GetAccessPassCommand {
             client_ip: self.client_ip,
             user_payer: accesspass_payer,
         }
-        .execute(client)?
+        .execute_usable(client, self.user_type)?
         .ok_or_else(|| eyre::eyre!("No Access Pass found for owner"))?;
 
         let program_id = client.get_program_id();


### PR DESCRIPTION
## Problem

`GetAccessPassCommand::execute` ([`get.rs:26-38`](https://github.com/malbeclabs/doublezero/blob/main/smartcontract/sdk/rs/src/commands/accesspass/get.rs#L26-L38)) returns the dynamic (`0.0.0.0`) access pass whenever that account exists, and falls back to the exact-IP PDA only when it is absent — it never checks whether the pass it returns is *usable*.

A payer holding an epoch-stale dynamic pass **and** a valid prepaid pass at their exact IP gets turned away: `doublezero connect ibrl` resolves to the stale dynamic pass, the `last_access_epoch >= epoch` check fails, and it prints `Unable to find a valid AccessPass` — even though [`processors/user/create_core.rs`](https://github.com/malbeclabs/doublezero/blob/main/smartcontract/programs/doublezero-serviceability/src/processors/user/create_core.rs#L308) would have accepted either PDA and taken the exact-IP one. An EdgeSeat pass is a realistic source of the stale dynamic half, since multicast is never epoch-gated (`UserType::is_epoch_gated`), so nothing keeps its `last_access_epoch` current.

Closes #4244.

## Fix

New `GetAccessPassCommand::execute_usable(client, user_type)` evaluates both the dynamic and exact-IP candidates against `epoch_allows_connection` — the same check the on-chain program enforces — and prefers whichever one clears it, falling back to the dynamic pass (matching `execute`'s default) only when neither does. It only reads the current epoch when *both* candidates exist, so it's a no-op cost change for the common single-candidate case. `execute` itself, and its existing test coverage, are untouched — every other caller of `GetAccessPassCommand` is unaffected.

`CreateUserCommand` and `CreateSubscribeUserCommand` (the SDK commands that actually build the `create_user`/`create_subscribe_user` transaction) switch to `execute_usable`. So does `doublezero connect`'s own preflight: per the issue, "whatever resolution a pre-flight trusts has to be the resolution that picks the PDA the transaction sends" — `LedgerClient::get_accesspass` gained a `user_type` parameter, threaded through `check_accesspass`/`require_accesspass` in `crates/doublezero-daemon-cli/src/connect.rs`, so the bare `doublezero connect`'s own epoch re-check (which reads the same `AccessPass` `require_accesspass` returns) sees the same pass the IBRL leg's transaction will use.

## Testing Verification

- `smartcontract/sdk/rs/src/commands/accesspass/get.rs`: 4 new tests for `execute_usable` — prefers the exact-IP pass when the dynamic one is epoch-stale (the reported bug), prefers dynamic when both are usable, falls back to dynamic when neither clears the epoch check, and confirms no epoch read happens when only one candidate exists (would panic on the unmocked `get_epoch()` otherwise). `cargo test -p doublezero_sdk` — 216/216 passing, including all pre-existing `execute()` coverage unmodified.
- `cargo test -p doublezero-daemon-cli` — 223/223 passing (covers `connect.rs`'s dispatch, bare-connect, and preflight paths through the updated `LedgerClient` trait).
- `cargo test -p doublezero-serviceability-cli` — 437/437 passing (covers the `CliCommand::get_accesspass_usable` addition).
- `cargo clippy --all-targets -- -Dclippy::all -Dwarnings` clean on every touched crate (`doublezero_sdk`, `doublezero-daemon-cli`, `doublezero-serviceability-cli`, `doublezero`).